### PR TITLE
Fix plugin scheduler: cancel namespacing, pause persistence, disabled-plugin fires, ghost sweep

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -457,6 +457,17 @@ api.cms.schedule.register({
 
 All times are UTC. Each fire runs inside the sandbox with a wall-clock budget. The host's `server/plugins/scheduler.ts` drives dispatch and records run history.
 
+Schedule ids are namespaced as `<pluginId>.<localId>` (the `pluginScheduleFullId` helper in `server/plugins/pluginScheduleRegistration.ts`); both `register` and `cancel` accept the plugin-local id and target the same row.
+
+**Pause vs. cancel — two independent flags on each schedule row:**
+
+- **`enabled` (registration state).** `register` sets it true, `api.cms.schedule.cancel(id)` sets it false. The row stays for audit; a later `register` re-enables it.
+- **`paused` (operator/failure intervention).** Set by the admin **Pause** button and by the auto-pause after 5 consecutive failures; cleared only by the admin **Resume** button (which also resets the failure counter). Registration never touches `paused`, so a pause survives server restarts and plugin re-activations. A paused schedule is skipped by the tick but can still be fired explicitly via **Run now** so the operator can verify a fix before resuming.
+
+A schedule fires only when it is `enabled`, not `paused`, and its plugin is enabled — schedules of disabled plugins never dispatch.
+
+**Orphan sweep.** Schedules must be (re-)registered during `activate()`. After each activation pass the host disables every schedule row of that plugin that was not re-registered during the pass (keyed on the row's `claimed_at` registration stamp — see `disableSchedulesNotReclaimedSince` in `server/repositories/pluginSchedules.ts`). This prevents "ghost" schedules: when a plugin upgrade stops registering a schedule, the old row stops firing after the new version activates instead of dispatching into a VM with no handler forever.
+
 ### CMS content — requires `cms.content.*` + `contentAccess[]`
 
 Plugins read and write CMS content (pages, posts, custom tables) through `api.cms.content.*`. Five permissions are split so most plugins (SEO assistants, translators, search indexers, AI helpers) get only what they need:

--- a/server/db/migrations-pg.ts
+++ b/server/db/migrations-pg.ts
@@ -523,6 +523,18 @@ export const pgMigrations: Migration[] = [
       -- active run per schedule, even across HA host instances (Postgres
       -- advisory locks gate which instance ticks; row-level locks gate which
       -- schedule fires next).
+      --
+      -- Two independent state flags:
+      --   enabled — registration state. Set true by register, false by
+      --             cancel and by the post-activation ghost sweep.
+      --   paused  — operator/failure intervention. Set by the admin pause
+      --             endpoint and the consecutive-failure auto-pause;
+      --             cleared by admin resume. Registration never touches it,
+      --             so a pause survives server restarts.
+      --
+      -- claimed_at marks the most recent register() call for the row — the
+      -- ghost sweep disables rows whose claimed_at predates the plugin's
+      -- latest activate() pass.
 
       create table if not exists plugin_schedules (
         plugin_id text not null references installed_plugins(id) on delete cascade,
@@ -531,6 +543,7 @@ export const pgMigrations: Migration[] = [
         overlap text not null default 'skip',
         max_duration_ms integer not null default 5000,
         enabled boolean not null default true,
+        paused boolean not null default false,
         consecutive_failures integer not null default 0,
         last_run_at timestamptz,
         last_finished_at timestamptz,
@@ -547,7 +560,7 @@ export const pgMigrations: Migration[] = [
       );
 
       create index if not exists plugin_schedules_due_idx
-        on plugin_schedules (enabled, next_run_at);
+        on plugin_schedules (enabled, paused, next_run_at);
 
       -- History — bounded growth via app-level rolling delete in the
       -- scheduler tick. Each tick keeps the latest 200 rows per (plugin_id,

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -489,6 +489,7 @@ export const sqliteMigrations: Migration[] = [
         overlap text not null default 'skip',
         max_duration_ms integer not null default 5000,
         enabled integer not null default 1,
+        paused integer not null default 0,
         consecutive_failures integer not null default 0,
         last_run_at text,
         last_finished_at text,
@@ -505,7 +506,7 @@ export const sqliteMigrations: Migration[] = [
       );
 
       create index if not exists plugin_schedules_due_idx
-        on plugin_schedules (enabled, next_run_at);
+        on plugin_schedules (enabled, paused, next_run_at);
 
       create table if not exists plugin_schedule_runs (
         id text primary key,

--- a/server/handlers/cms/plugins/install.ts
+++ b/server/handlers/cms/plugins/install.ts
@@ -296,7 +296,7 @@ async function installUpgradeFromPackage(ctx: UpgradeContext): Promise<Response>
   // 1. Deactivate the old version. Best-effort — a deactivate failure
   //    shouldn't prevent the upgrade from proceeding (the new version is
   //    about to replace it anyway). We log and move on.
-  await teardownPreviousVersion(pluginId, existing, options.uploadsDir)
+  await teardownPreviousVersion(db, pluginId, existing, options.uploadsDir)
 
   // 2. Write new assets.
   const newManifest = await writePluginPackageFiles(
@@ -335,7 +335,7 @@ async function installUpgradeFromPackage(ctx: UpgradeContext): Promise<Response>
       }
     }
     if (loaded) {
-      await runPluginLifecycle(pluginId, 'activate')
+      await runPluginLifecycle(db, pluginId, 'activate')
     }
     await setPluginLifecycleStatus(db, pluginId, 'active')
   } catch (err) {
@@ -403,6 +403,7 @@ async function installUpgradeFromPackage(ctx: UpgradeContext): Promise<Response>
  * (the new version is about to replace it anyway).
  */
 async function teardownPreviousVersion(
+  db: DbClient,
   pluginId: string,
   plugin: InstalledPlugin,
   uploadsDir: string,
@@ -411,7 +412,7 @@ async function teardownPreviousVersion(
     const manifest = pluginManifestWithGrants(plugin)
     if (manifest.entrypoints?.server) {
       await loadPluginServerEntrypoint(manifest, uploadsDir)
-      await runPluginLifecycle(pluginId, 'deactivate')
+      await runPluginLifecycle(db, pluginId, 'deactivate')
     }
   } catch (err) {
     console.error(`[plugin:${pluginId}] pre-upgrade deactivate failed`, err)
@@ -474,7 +475,7 @@ async function rollbackUpgrade(args: {
     }
     if (restoredManifest.entrypoints?.server) {
       const loaded = await loadPluginServerEntrypoint(restoredManifest, options.uploadsDir)
-      if (loaded) await runPluginLifecycle(pluginId, 'activate')
+      if (loaded) await runPluginLifecycle(db, pluginId, 'activate')
     }
     await setPluginLifecycleStatus(
       db,

--- a/server/handlers/cms/plugins/lifecycle.ts
+++ b/server/handlers/cms/plugins/lifecycle.ts
@@ -73,7 +73,7 @@ export async function runPluginLifecycleHook(
     // plugins without `entrypoints.server`), then run the named hook.
     const loaded = await loadPluginServerEntrypoint(manifest, options.uploadsDir)
     if (loaded) {
-      await runPluginLifecycle(plugin.id, hook)
+      await runPluginLifecycle(db, plugin.id, hook)
     }
 
     // After deactivate / uninstall the plugin should not stay loaded in

--- a/server/handlers/cms/plugins/schedules.ts
+++ b/server/handlers/cms/plugins/schedules.ts
@@ -11,11 +11,13 @@
  *            cannot fire it twice. Returns the outcome row.
  *
  *   POST   /admin/api/cms/plugins/:id/schedules/:scheduleId/pause
- *          → flip `enabled = false`. The tick stops dispatching until
- *            a `resume` arrives or the plugin re-activates.
+ *          → flip `paused = true`. The tick stops dispatching until a
+ *            `resume` arrives. Independent of the registration-owned
+ *            `enabled` flag, so the pause survives server restarts and
+ *            plugin re-activations.
  *
  *   POST   /admin/api/cms/plugins/:id/schedules/:scheduleId/resume
- *          → flip `enabled = true`, reset `consecutive_failures = 0`.
+ *          → flip `paused = false`, reset `consecutive_failures = 0`.
  *
  * The list route requires `plugins.read`; the mutating routes
  * (run-now / pause / resume) require `plugins.lifecycle` AND step-up.
@@ -24,10 +26,10 @@
 import type { DbClient } from '../../../db/client'
 import { jsonResponse, methodNotAllowed } from '../../../http'
 import {
-  enablePluginSchedule,
-  disablePluginSchedule,
   listRecentRuns,
   listSchedulesForPlugin,
+  pauseSchedule,
+  resumeSchedule,
 } from '../../../repositories/pluginSchedules'
 import { runScheduleNow } from '../../../plugins/scheduler'
 
@@ -66,7 +68,7 @@ export async function handlePluginSchedulePause(
   scheduleId: string,
 ): Promise<Response> {
   if (req.method !== 'POST') return methodNotAllowed()
-  await disablePluginSchedule(db, pluginId, scheduleId)
+  await pauseSchedule(db, pluginId, scheduleId, new Date().toISOString())
   return jsonResponse({ ok: true })
 }
 
@@ -77,6 +79,6 @@ export async function handlePluginScheduleResume(
   scheduleId: string,
 ): Promise<Response> {
   if (req.method !== 'POST') return methodNotAllowed()
-  await enablePluginSchedule(db, pluginId, scheduleId)
+  await resumeSchedule(db, pluginId, scheduleId)
   return jsonResponse({ ok: true })
 }

--- a/server/plugins/host/handlers/schedule.ts
+++ b/server/plugins/host/handlers/schedule.ts
@@ -10,7 +10,7 @@
  * disabled in the database.
  */
 
-import { registerPluginSchedule } from '../../pluginScheduleRegistration'
+import { pluginScheduleFullId, registerPluginSchedule } from '../../pluginScheduleRegistration'
 import { disablePluginSchedule } from '../../../repositories/pluginSchedules'
 import type { ApiCallFor } from '../../protocol/apiCallSchema'
 import type { DbClient } from '../../../db/client'
@@ -39,6 +39,8 @@ export async function handleScheduleCancel(
   db: DbClient,
 ): Promise<void> {
   const [{ scheduleId }] = msg.args
-  await disablePluginSchedule(db, msg.pluginId, scheduleId)
+  // Registration stored the row under the namespaced id — cancel must
+  // target the same key or it matches nothing.
+  await disablePluginSchedule(db, msg.pluginId, pluginScheduleFullId(msg.pluginId, scheduleId))
   replyApiOk(msg.pluginId, msg.correlationId)
 }

--- a/server/plugins/pluginScheduleRegistration.ts
+++ b/server/plugins/pluginScheduleRegistration.ts
@@ -105,6 +105,21 @@ export function computeNextRun(cadence: Cadence, from: Date): Date {
 }
 
 /**
+ * Namespace a plugin-local schedule id under its plugin id — same
+ * convention as routes, hooks, and loops (`<pluginId>.<localId>`).
+ * Idempotent on already-namespaced ids. The single source of truth for
+ * the convention on the host side; the VM bootstrap mirrors it in
+ * `buildApi.ts:namespaceScheduleId` (the sandbox cannot import host code).
+ *
+ * BOTH register and cancel must run the caller-supplied id through this —
+ * a cancel against the raw local id would match no row and the schedule
+ * would fire forever.
+ */
+export function pluginScheduleFullId(pluginId: string, scheduleId: string): string {
+  return scheduleId.startsWith(`${pluginId}.`) ? scheduleId : `${pluginId}.${scheduleId}`
+}
+
+/**
  * Upsert a schedule row from a plugin's `api.cms.schedule.register(...)`
  * call. Idempotent on re-activation: a second register with the same
  * (pluginId, scheduleId) keeps the row's last-run history but adopts the
@@ -114,14 +129,10 @@ export async function registerPluginSchedule(
   db: DbClient,
   reg: ScheduleRegistration,
 ): Promise<void> {
-  // Final id is namespaced — same convention as routes, hooks, loops.
-  const fullId = reg.scheduleId.startsWith(`${reg.pluginId}.`)
-    ? reg.scheduleId
-    : `${reg.pluginId}.${reg.scheduleId}`
   const nextRunAt = computeNextRun(reg.cadence, new Date()).toISOString()
   await upsertPluginSchedule(db, {
     pluginId: reg.pluginId,
-    scheduleId: fullId,
+    scheduleId: pluginScheduleFullId(reg.pluginId, reg.scheduleId),
     cadence: reg.cadence,
     overlap: reg.overlap,
     maxDurationMs: reg.maxDurationMs,

--- a/server/plugins/quickjs/bootstrap/src/pluginRuntime.ts
+++ b/server/plugins/quickjs/bootstrap/src/pluginRuntime.ts
@@ -260,10 +260,12 @@ globalThis.__runLoopPreview = function runLoopPreview(sourceId, ctxJson) {
  * pluginScheduleRegistration namespacing so both sides agree.
  *
  * If the handler isn't registered (e.g. plugin upgraded between tick and
- * dispatch, or the schedule row outlived a deactivate), we log and no-op
- * rather than throw — the schedule row will eventually be GC'd by the
- * host once the boot-claim grace window expires. We log so the silent
- * no-op surfaces during development if the handler-key ever drifts again.
+ * dispatch), we log and no-op rather than throw. This window is narrow:
+ * after every `activate()` pass the host disables any schedule row that
+ * was not re-registered during that pass (the ghost sweep in
+ * `runtime.ts:runPluginLifecycle`, keyed on `claimed_at`), so a dropped
+ * handler stops being dispatched after the next activation. We log so the
+ * silent no-op surfaces during development if the handler-key ever drifts.
  */
 globalThis.__runSchedule = async function runSchedule(scheduleId) {
   const handler = globalThis.__plugin_handlers.schedules[scheduleId]

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -37,6 +37,7 @@ import {
   recordPluginCrash,
   setPluginLifecycleStatus,
 } from '../repositories/plugins'
+import { disableSchedulesNotReclaimedSince } from '../repositories/pluginSchedules'
 import type { PluginManifest } from '@core/plugin-sdk'
 import { createModulePackVm, type ModulePackVm } from './modulePackVm'
 import {
@@ -121,12 +122,23 @@ export async function loadPluginServerEntrypoint(
 /**
  * Run a single lifecycle hook on a previously-loaded plugin. No-op if
  * the hook isn't exported by the plugin module.
+ *
+ * After a successful `activate` pass this also runs the schedule ghost
+ * sweep: any schedule row of this plugin that was NOT re-registered during
+ * the pass (its `claimed_at` predates the pass) is disabled. Without the
+ * sweep, a schedule dropped by a plugin upgrade keeps firing forever
+ * against a handler that no longer exists in the VM.
  */
 export async function runPluginLifecycle(
+  db: DbClient,
   pluginId: string,
   hook: 'install' | 'activate' | 'deactivate' | 'uninstall',
 ): Promise<void> {
+  const startedAtIso = new Date().toISOString()
   await runLifecycleInWorker(pluginId, hook)
+  if (hook === 'activate') {
+    await disableSchedulesNotReclaimedSince(db, pluginId, startedAtIso)
+  }
 }
 
 /**
@@ -262,7 +274,7 @@ export async function reloadAndActivatePlugin(
   pluginSettingsCache.set(manifest.id, plugin.settings)
   if (manifest.entrypoints?.server) {
     const loaded = await loadPluginServerEntrypoint(manifest, uploadsDir)
-    if (loaded) await runPluginLifecycle(manifest.id, 'activate')
+    if (loaded) await runPluginLifecycle(db, manifest.id, 'activate')
   }
 }
 
@@ -432,7 +444,7 @@ export async function activateInstalledServerPlugins(
     if (manifest.entrypoints?.server) {
       try {
         const loaded = await loadPluginServerEntrypoint(manifest, uploadsDir)
-        if (loaded) await runPluginLifecycle(manifest.id, 'activate')
+        if (loaded) await runPluginLifecycle(db, manifest.id, 'activate')
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Server entrypoint activation failed'
         console.error(`[plugin:${manifest.id}] boot server-entrypoint failed: ${message}`)

--- a/server/plugins/scheduler.ts
+++ b/server/plugins/scheduler.ts
@@ -27,8 +27,9 @@
  *      leader crash hands off naturally to the next tick on another instance.
  *
  *   5. **Failure cap + auto-pause** — after FAILURE_CAP consecutive
- *      failures, the schedule is paused (enabled=false) and the
- *      operator must explicitly resume from the admin UI.
+ *      failures, the schedule is paused (`paused = true`, independent of
+ *      the registration-owned `enabled` flag, so the pause survives
+ *      restarts) and the operator must explicitly resume from the admin UI.
  *
  * Plugin authors do NOT interact with this module directly. The cadence
  * math, the lock dance, and the dispatch wire format are all contained
@@ -67,7 +68,7 @@ const TICK_INTERVAL_MS = 10_000
 const TICK_BATCH_LIMIT = 50
 /** Plugin's claim is auto-released after `maxDurationMs * 2` so a crashed worker doesn't deadlock the row. */
 const LOCK_MULTIPLIER = 2
-/** Auto-pause threshold. After this many consecutive failures, the row flips `enabled=false`. */
+/** Auto-pause threshold. After this many consecutive failures, the row flips `paused=true`. */
 const FAILURE_CAP = 5
 /** Postgres advisory-lock key — must be a bigint. Derived from the string below for human readability. */
 const ADVISORY_LOCK_KEY = 712830541 // = djb2('instatic-plugin-scheduler') mod 2^31
@@ -139,9 +140,10 @@ export function startScheduler(db: DbClient): void {
 export async function tickPluginScheduler(db: DbClient): Promise<void> {
   await withSchedulerLeaderLock(db, ADVISORY_LOCK_KEY, '[plugin-scheduler]', async () => {
     const now = new Date()
+    // `selectDueSchedules` already filters to enabled, un-paused schedules
+    // of enabled plugins — no re-check needed here.
     const due = await selectDueSchedules(db, now.toISOString(), TICK_BATCH_LIMIT)
     for (const sched of due) {
-      if (!sched.enabled) continue
       await fireSchedule(db, sched, 'tick')
     }
     // Cheap rolling trim — keeps `plugin_schedule_runs` bounded without

--- a/server/repositories/pluginSchedules.ts
+++ b/server/repositories/pluginSchedules.ts
@@ -52,7 +52,10 @@ export interface PluginSchedule {
   cadence: Cadence
   overlap: OverlapPolicy
   maxDurationMs: number
+  /** Registration state — true while the plugin's code still registers this schedule. */
   enabled: boolean
+  /** Operator/failure intervention — admin pause or consecutive-failure auto-pause. */
+  paused: boolean
   consecutiveFailures: number
   lastRunAt: string | null
   lastFinishedAt: string | null
@@ -90,6 +93,7 @@ interface ScheduleRow {
   overlap: string
   max_duration_ms: number
   enabled: boolean | number
+  paused: boolean | number
   consecutive_failures: number
   last_run_at: string | Date | null
   last_finished_at: string | Date | null
@@ -140,6 +144,7 @@ function mapSchedule(row: ScheduleRow): PluginSchedule {
     overlap: parseOverlap(row.overlap),
     maxDurationMs: row.max_duration_ms,
     enabled: Boolean(row.enabled),
+    paused: Boolean(row.paused),
     consecutiveFailures: row.consecutive_failures,
     lastRunAt: isoDateOrNull(row.last_run_at),
     lastFinishedAt: isoDateOrNull(row.last_finished_at),
@@ -188,6 +193,14 @@ export interface ScheduleUpsertInput {
  * cadence + maxDurationMs (the plugin code is the source of truth) but
  * MUST preserve last-run state so a restart doesn't lose history or
  * re-fire schedules that already ran.
+ *
+ * Registration owns `enabled` (registration state) but deliberately never
+ * touches `paused` — an admin pause or failure auto-pause must survive
+ * server restarts, which re-run `activate()` and land here on every boot.
+ *
+ * `claimed_at` is stamped on every register so the post-activation ghost
+ * sweep (`disableSchedulesNotReclaimedSince`) can tell which rows were
+ * re-registered during the latest `activate()` pass.
  */
 export async function upsertPluginSchedule(
   db: DbClient,
@@ -215,10 +228,10 @@ export async function upsertPluginSchedule(
 }
 
 /**
- * Cancel a previously-registered schedule. Soft-disables the row so the
- * tick stops firing it; the row stays for audit. The plugin's `activate`
- * call re-creates / re-enables on next boot if the registration is still
- * there.
+ * Cancel a previously-registered schedule (registration state). Soft-disables
+ * the row so the tick stops firing it; the row stays for audit. The plugin's
+ * `activate` call re-creates / re-enables on next boot if the registration is
+ * still there.
  */
 export async function disablePluginSchedule(
   db: DbClient,
@@ -232,15 +245,27 @@ export async function disablePluginSchedule(
   `
 }
 
-export async function enablePluginSchedule(
+/**
+ * Ghost sweep — disable every still-enabled schedule of `pluginId` whose
+ * `claimed_at` predates the plugin's latest `activate()` pass. A row that
+ * was not re-registered during that pass has no live VM handler, so firing
+ * it would only record healthy-looking no-op runs forever.
+ *
+ * `claimed_at` is stamped by `upsertPluginSchedule` on every register, so
+ * "claimed since activation start" is exactly "re-registered this pass".
+ * ISO-8601 strings compare correctly as text in both dialects.
+ */
+export async function disableSchedulesNotReclaimedSince(
   db: DbClient,
   pluginId: string,
-  scheduleId: string,
+  activationStartedAtIso: string,
 ): Promise<void> {
   await db`
     update plugin_schedules
-    set enabled = ${true}, consecutive_failures = ${0}, updated_at = ${new Date().toISOString()}
-    where plugin_id = ${pluginId} and schedule_id = ${scheduleId}
+    set enabled = ${false}, updated_at = ${new Date().toISOString()}
+    where plugin_id = ${pluginId}
+      and enabled = ${true}
+      and (claimed_at is null or claimed_at < ${activationStartedAtIso})
   `
 }
 
@@ -274,6 +299,11 @@ export async function getSchedule(
  * this then attempts to claim each via `tryClaimSchedule` — the two-step
  * dance is what lets multiple HA instances safely race for the same row
  * without firing twice.
+ *
+ * A schedule is due only when it is registered (`enabled`), not paused by
+ * an operator or the failure cap (`paused`), AND its owning plugin is
+ * enabled — a disabled plugin has no loaded worker, so firing its rows
+ * would just spawn empty workers that record error runs.
  */
 export async function selectDueSchedules(
   db: DbClient,
@@ -281,11 +311,14 @@ export async function selectDueSchedules(
   limit: number,
 ): Promise<PluginSchedule[]> {
   const { rows } = await db<ScheduleRow>`
-    select * from plugin_schedules
-    where enabled = ${true}
-      and next_run_at <= ${nowIso}
-      and (lock_until is null or lock_until <= ${nowIso})
-    order by next_run_at asc
+    select s.* from plugin_schedules s
+    join installed_plugins p on p.id = s.plugin_id
+    where s.enabled = ${true}
+      and s.paused = ${false}
+      and p.enabled = ${true}
+      and s.next_run_at <= ${nowIso}
+      and (s.lock_until is null or s.lock_until <= ${nowIso})
+    order by s.next_run_at asc
     limit ${limit}
   `
   return rows.map(mapSchedule)
@@ -302,6 +335,11 @@ export async function selectDueSchedules(
  * HA instances: only ONE UPDATE statement can transition the token from
  * null to a fresh value because Postgres + SQLite both serialize row
  * updates.
+ *
+ * Requires `enabled` (a cancelled schedule can never fire) but deliberately
+ * NOT `paused = false` — the tick already filters paused rows out in
+ * `selectDueSchedules`, while the admin "Run now" action must still work on
+ * a paused schedule so the operator can verify a fix before resuming.
  */
 export async function tryClaimSchedule(
   db: DbClient,
@@ -393,19 +431,33 @@ export async function markScheduleRunStarted(
 }
 
 /**
- * Pause a schedule that exceeded the consecutive-failure cap. The
- * schedule's row stays but enabled=false; the admin operator must
- * manually resume after fixing the cause.
+ * Pause a schedule — operator intervention (admin "Pause" button) or the
+ * consecutive-failure auto-pause. The pause is independent of the
+ * registration state (`enabled`) and survives server restarts because
+ * registration upserts never touch `paused`. Cleared by `resumeSchedule`.
  */
 export async function pauseSchedule(
   db: DbClient,
   pluginId: string,
   scheduleId: string,
-  reasonIso: string,
+  pausedAtIso: string,
 ): Promise<void> {
   await db`
     update plugin_schedules
-    set enabled = ${false}, updated_at = ${reasonIso}
+    set paused = ${true}, updated_at = ${pausedAtIso}
+    where plugin_id = ${pluginId} and schedule_id = ${scheduleId}
+  `
+}
+
+/** Clear an operator/failure pause and reset the failure counter. */
+export async function resumeSchedule(
+  db: DbClient,
+  pluginId: string,
+  scheduleId: string,
+): Promise<void> {
+  await db`
+    update plugin_schedules
+    set paused = ${false}, consecutive_failures = ${0}, updated_at = ${new Date().toISOString()}
     where plugin_id = ${pluginId} and schedule_id = ${scheduleId}
   `
 }

--- a/src/__tests__/architecture/plugin-schedule-invariants.test.ts
+++ b/src/__tests__/architecture/plugin-schedule-invariants.test.ts
@@ -74,4 +74,24 @@ describe('plugin schedule invariants', () => {
     // pin a worker indefinitely.
     expect(source).toContain('maxDurationMs: Type.Integer({ minimum: 100, maximum: 5 * 60_000 })')
   })
+
+  it('register and cancel share the single schedule-id namespacing helper', async () => {
+    // Registration stores rows under `<pluginId>.<localId>`. If cancel ever
+    // stops running the caller-supplied id through the same helper it will
+    // match no row and the schedule fires forever.
+    const registration = await read('server/plugins/pluginScheduleRegistration.ts')
+    const cancelHandler = await read('server/plugins/host/handlers/schedule.ts')
+    expect(registration).toContain('export function pluginScheduleFullId(')
+    expect(registration).toContain('pluginScheduleFullId(reg.pluginId, reg.scheduleId)')
+    expect(cancelHandler).toContain('pluginScheduleFullId(msg.pluginId, scheduleId)')
+  })
+
+  it('activation runs the schedule ghost sweep', async () => {
+    // A schedule row whose registration was dropped by a plugin upgrade has
+    // no live VM handler — runPluginLifecycle must disable rows that were
+    // not re-claimed during the activate pass.
+    const runtime = await read('server/plugins/runtime.ts')
+    expect(runtime).toContain("if (hook === 'activate')")
+    expect(runtime).toContain('disableSchedulesNotReclaimedSince(db, pluginId, startedAtIso)')
+  })
 })

--- a/src/__tests__/server/cmsPlugins.test.ts
+++ b/src/__tests__/server/cmsPlugins.test.ts
@@ -187,6 +187,11 @@ function makeFakeDb() {
     if (normalized.includes('from data_rows') && normalized.includes('scheduled_publish_at')) {
       return { rows: [], rowCount: 0 }
     }
+    // Post-activation schedule ghost sweep (disableSchedulesNotReclaimedSince)
+    // — these tests register no schedules, so the sweep matches nothing.
+    if (normalized.includes('update plugin_schedules')) {
+      return { rows: [], rowCount: 0 }
+    }
     throw new Error(`Unhandled SQL: ${sql}`)
   }
 

--- a/src/__tests__/server/pluginScheduler.test.ts
+++ b/src/__tests__/server/pluginScheduler.test.ts
@@ -6,6 +6,12 @@
  *   • Atomic claim race (two ticks can't fire the same schedule twice)
  *   • Failure cap auto-pauses a schedule after N consecutive errors
  *   • `runScheduleNow` bypasses cadence but still respects the claim lock
+ *   • Cancel namespacing — `cms.schedule.cancel` with a plugin-local id
+ *     targets the namespaced row that register created
+ *   • Due selection — paused schedules and schedules of disabled plugins
+ *     never fire; re-registration on boot preserves a pause
+ *   • Ghost sweep — schedules not re-registered during an activation pass
+ *     are disabled
  *   • HA leader path (SQLite single-leader sentinel; PG path covered
  *     structurally — we don't spin a real PG in tests)
  *
@@ -26,10 +32,16 @@ import {
   runScheduleNow,
   tickPluginScheduler,
 } from '../../../server/plugins/scheduler'
+import { handleScheduleCancel } from '../../../server/plugins/host/handlers/schedule'
+import type { HostPluginRecord } from '../../../server/plugins/host/types'
 import {
+  disableSchedulesNotReclaimedSince,
   getSchedule,
   insertScheduleRun,
   listRecentRuns,
+  pauseSchedule,
+  resumeSchedule,
+  selectDueSchedules,
 } from '../../../server/repositories/pluginSchedules'
 import type { DbClient } from '../../../server/db/client'
 
@@ -84,17 +96,11 @@ describe('computeNextRun', () => {
 // Live DB tests
 // ---------------------------------------------------------------------------
 
-async function setupDb(): Promise<{ db: DbClient; cleanup: () => Promise<void> }> {
-  const dir = await mkdtemp(join(tmpdir(), 'instatic-scheduler-'))
-  const dbPath = join(dir, 'test.db')
-  const db = createSqliteClient(dbPath)
-  await runMigrations(db, sqliteMigrations)
-  // Bootstrap a fake installed_plugins row — the FK on plugin_schedules
-  // requires it to exist before any registration.
+async function insertTestPlugin(db: DbClient, id: string, enabled = true): Promise<void> {
   await db`
     insert into installed_plugins (id, name, version, enabled, manifest_json)
-    values (${'test.sched'}, ${'Scheduler Test'}, ${'1.0.0'}, ${1}, ${JSON.stringify({
-      id: 'test.sched',
+    values (${id}, ${'Scheduler Test'}, ${'1.0.0'}, ${enabled ? 1 : 0}, ${JSON.stringify({
+      id,
       name: 'Scheduler Test',
       version: '1.0.0',
       apiVersion: 1,
@@ -103,12 +109,31 @@ async function setupDb(): Promise<{ db: DbClient; cleanup: () => Promise<void> }
       adminPages: [],
     })})
   `
+}
+
+async function setupDb(): Promise<{ db: DbClient; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'instatic-scheduler-'))
+  const dbPath = join(dir, 'test.db')
+  const db = createSqliteClient(dbPath)
+  await runMigrations(db, sqliteMigrations)
+  // Bootstrap a fake installed_plugins row — the FK on plugin_schedules
+  // requires it to exist before any registration.
+  await insertTestPlugin(db, 'test.sched')
   return {
     db,
     cleanup: async () => {
       await rm(dir, { recursive: true, force: true })
     },
   }
+}
+
+/** Force a registered schedule to be due immediately. */
+async function makeDue(db: DbClient, pluginId: string, scheduleId: string): Promise<void> {
+  const past = new Date(Date.now() - 60_000).toISOString()
+  await db`
+    update plugin_schedules set next_run_at = ${past}
+    where plugin_id = ${pluginId} and schedule_id = ${scheduleId}
+  `
 }
 
 describe('plugin scheduler — DB', () => {
@@ -211,6 +236,130 @@ describe('plugin scheduler — DB', () => {
       }
       const recent = await listRecentRuns(db, 'test.sched', 'test.sched.noisy', 3)
       expect(recent.length).toBe(3)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('cms.schedule.cancel with a plugin-local id disables the namespaced row', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      await registerPluginSchedule(db, {
+        pluginId: 'test.sched',
+        scheduleId: 'sync',
+        cadence: { interval: 'hourly' },
+        overlap: 'skip',
+        maxDurationMs: 5000,
+      })
+      // The VM sends the RAW local id ('sync') in the cancel api-call —
+      // the handler must namespace it to match the stored row
+      // ('test.sched.sync'). `replyApiOk` no-ops without a live worker.
+      await handleScheduleCancel(
+        {
+          kind: 'api-call',
+          correlationId: 'c1',
+          pluginId: 'test.sched',
+          target: 'cms.schedule.cancel',
+          args: [{ scheduleId: 'sync' }],
+        },
+        {} as unknown as HostPluginRecord,
+        db,
+      )
+      const sched = await getSchedule(db, 'test.sched', 'test.sched.sync')
+      expect(sched?.enabled).toBe(false)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('due selection excludes paused schedules until resumed', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      await registerPluginSchedule(db, {
+        pluginId: 'test.sched',
+        scheduleId: 'pausable',
+        cadence: { interval: 'hourly' },
+        overlap: 'skip',
+        maxDurationMs: 5000,
+      })
+      await makeDue(db, 'test.sched', 'test.sched.pausable')
+      await pauseSchedule(db, 'test.sched', 'test.sched.pausable', new Date().toISOString())
+      expect(await selectDueSchedules(db, new Date().toISOString(), 10)).toEqual([])
+      await resumeSchedule(db, 'test.sched', 'test.sched.pausable')
+      const due = await selectDueSchedules(db, new Date().toISOString(), 10)
+      expect(due.map((s) => s.scheduleId)).toEqual(['test.sched.pausable'])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('due selection excludes schedules whose plugin is disabled', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      await insertTestPlugin(db, 'test.disabled', false)
+      for (const pluginId of ['test.sched', 'test.disabled']) {
+        await registerPluginSchedule(db, {
+          pluginId,
+          scheduleId: 'job',
+          cadence: { interval: 'hourly' },
+          overlap: 'skip',
+          maxDurationMs: 5000,
+        })
+        await makeDue(db, pluginId, `${pluginId}.job`)
+      }
+      const due = await selectDueSchedules(db, new Date().toISOString(), 10)
+      expect(due.map((s) => s.pluginId)).toEqual(['test.sched'])
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('re-registration on boot preserves an existing pause', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const reg = {
+        pluginId: 'test.sched',
+        scheduleId: 'sticky',
+        cadence: { interval: 'hourly' as const },
+        overlap: 'skip' as const,
+        maxDurationMs: 5000,
+      }
+      await registerPluginSchedule(db, reg)
+      await pauseSchedule(db, 'test.sched', 'test.sched.sticky', new Date().toISOString())
+      // Server restart → activate() → register again. The upsert re-asserts
+      // registration state but must NOT clear the operator/failure pause.
+      await registerPluginSchedule(db, reg)
+      const sched = await getSchedule(db, 'test.sched', 'test.sched.sticky')
+      expect(sched?.enabled).toBe(true)
+      expect(sched?.paused).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('ghost sweep disables schedules not re-registered during the activation pass', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const reg = (scheduleId: string) => ({
+        pluginId: 'test.sched',
+        scheduleId,
+        cadence: { interval: 'hourly' as const },
+        overlap: 'skip' as const,
+        maxDurationMs: 5000,
+      })
+      // v1 registered both schedules on a previous boot.
+      await registerPluginSchedule(db, reg('keep'))
+      await registerPluginSchedule(db, reg('drop'))
+      await Bun.sleep(5)
+      // v2 activation pass: only 'keep' is re-registered.
+      const activationStartedAt = new Date().toISOString()
+      await Bun.sleep(5)
+      await registerPluginSchedule(db, reg('keep'))
+      await disableSchedulesNotReclaimedSince(db, 'test.sched', activationStartedAt)
+      const kept = await getSchedule(db, 'test.sched', 'test.sched.keep')
+      const dropped = await getSchedule(db, 'test.sched', 'test.sched.drop')
+      expect(kept?.enabled).toBe(true)
+      expect(dropped?.enabled).toBe(false)
     } finally {
       await cleanup()
     }

--- a/src/__tests__/server/pluginServerRuntime.test.ts
+++ b/src/__tests__/server/pluginServerRuntime.test.ts
@@ -164,6 +164,11 @@ function makeFakeDb() {
       records.push(row)
       return { rows: [row as Row], rowCount: 1 }
     }
+    // Post-activation schedule ghost sweep (disableSchedulesNotReclaimedSince)
+    // — these tests register no schedules, so the sweep matches nothing.
+    if (normalized.includes('update plugin_schedules')) {
+      return { rows: [], rowCount: 0 }
+    }
     throw new Error(`Unhandled SQL: ${sql}`)
   }
 

--- a/src/admin/pages/plugins/components/PluginSchedulesDialog/PluginSchedulesDialog.tsx
+++ b/src/admin/pages/plugins/components/PluginSchedulesDialog/PluginSchedulesDialog.tsx
@@ -161,7 +161,13 @@ function ScheduleRow({ schedule, recent, busy, onRunNow, onPause, onResume }: Sc
         <dt>Last run</dt>
         <dd>{schedule.lastRunAt ? formatDateTime(schedule.lastRunAt) : '—'}</dd>
         <dt>Next run</dt>
-        <dd>{schedule.enabled ? formatDateTime(schedule.nextRunAt) : '— (paused)'}</dd>
+        <dd>
+          {!schedule.enabled
+            ? '— (cancelled)'
+            : schedule.paused
+              ? '— (paused)'
+              : formatDateTime(schedule.nextRunAt)}
+        </dd>
         {schedule.consecutiveFailures > 0 && (
           <>
             <dt>Failures</dt>
@@ -172,26 +178,30 @@ function ScheduleRow({ schedule, recent, busy, onRunNow, onPause, onResume }: Sc
 
       {schedule.lastError && <p className={styles.errorLine}>{schedule.lastError}</p>}
 
-      <div className={styles.scheduleActions}>
-        <Button
-          variant="secondary"
-          size="sm"
-          type="button"
-          onClick={onRunNow}
-          disabled={busy}
-        >
-          {busy ? 'Working...' : 'Run now'}
-        </Button>
-        {schedule.enabled ? (
-          <Button variant="secondary" size="sm" type="button" onClick={onPause} disabled={busy}>
-            Pause
+      {/* A cancelled schedule (enabled=false) has no live registration — the
+          plugin owns that state, so the admin gets no controls for it. */}
+      {schedule.enabled && (
+        <div className={styles.scheduleActions}>
+          <Button
+            variant="secondary"
+            size="sm"
+            type="button"
+            onClick={onRunNow}
+            disabled={busy}
+          >
+            {busy ? 'Working...' : 'Run now'}
           </Button>
-        ) : (
-          <Button variant="secondary" size="sm" type="button" onClick={onResume} disabled={busy}>
-            Resume
-          </Button>
-        )}
-      </div>
+          {schedule.paused ? (
+            <Button variant="secondary" size="sm" type="button" onClick={onResume} disabled={busy}>
+              Resume
+            </Button>
+          ) : (
+            <Button variant="secondary" size="sm" type="button" onClick={onPause} disabled={busy}>
+              Pause
+            </Button>
+          )}
+        </div>
+      )}
 
       {recent.length > 0 && (
         <>
@@ -213,6 +223,9 @@ function ScheduleRow({ schedule, recent, busy, onRunNow, onPause, onResume }: Sc
 
 function StatusBadge({ schedule }: { schedule: CmsPluginScheduleSummary }) {
   if (!schedule.enabled) {
+    return <span className={`${styles.statusBadge} ${styles.statusPaused}`}>Cancelled</span>
+  }
+  if (schedule.paused) {
     return <span className={`${styles.statusBadge} ${styles.statusPaused}`}>Paused</span>
   }
   switch (schedule.lastStatus) {

--- a/src/core/persistence/cmsPlugins.ts
+++ b/src/core/persistence/cmsPlugins.ts
@@ -259,7 +259,10 @@ export async function updateCmsPluginSettings(
 export interface CmsPluginScheduleSummary {
   pluginId: string
   scheduleId: string
+  /** Registration state — false once the plugin cancels the schedule or stops registering it. */
   enabled: boolean
+  /** Operator/failure intervention — true after admin pause or the consecutive-failure auto-pause. */
+  paused: boolean
   cadence: unknown
   overlap: 'skip' | 'queue' | 'parallel'
   maxDurationMs: number


### PR DESCRIPTION
Four verified correctness bugs in the plugin schedule engine, fixed at the source.

## 1. `api.cms.schedule.cancel()` never cancelled anything

Registration namespaces the stored id (`<pluginId>.<localId>`, `registerPluginSchedule`), but `handleScheduleCancel` (`server/plugins/host/handlers/schedule.ts`) passed the raw local id to `disablePluginSchedule` — `cancel('sync')` matched no row and the schedule fired forever. The namespacing convention now lives in ONE exported helper, `pluginScheduleFullId` (`server/plugins/pluginScheduleRegistration.ts`), used by both register and cancel. A new gate in `src/__tests__/architecture/plugin-schedule-invariants.test.ts` locks both call sites to the helper.

## 2. Schedules of disabled plugins kept firing

`selectDueSchedules` (`server/repositories/pluginSchedules.ts`) never consulted `installed_plugins.enabled`, so each fire spawned a fresh empty worker for the unloaded plugin, recorded 5 error runs, and auto-paused with noise. Due selection now joins `installed_plugins` and requires the plugin to be enabled — dialect-naive ANSI SQL, works on both Postgres and SQLite.

## 3. Admin pause / failure auto-pause were undone on every restart

The registration upsert's `on conflict` force-set `enabled = true`, and every boot re-runs `activate()` → register → silent un-pause. The single flag conflated two states, now split:

- **`enabled`** — registration state. Register sets true, cancel and the ghost sweep set false.
- **`paused`** — operator/failure intervention. Admin pause (`server/handlers/cms/plugins/schedules.ts`) and the 5-consecutive-failure auto-pause (`server/plugins/scheduler.ts`) set it; admin resume clears it (and resets the failure counter). Registration never touches it, so pauses survive restarts.

The existing `002_plugin_schedules` migration was edited in place in BOTH `server/db/migrations-pg.ts` and `server/db/migrations-sqlite.ts` (same ID, same semantics — `migration-parity.test.ts` green; pre-release, local DBs are disposable). Due selection requires `enabled AND NOT paused` plus the item-2 plugin check. `enablePluginSchedule` is renamed to `resumeSchedule` to keep names honest. "Run now" deliberately still works on a paused schedule (operator verifies a fix before resuming) but never on a cancelled one. The admin schedules dialog (`PluginSchedulesDialog.tsx`) now distinguishes **Cancelled** (registration gone, no controls) from **Paused** (Resume button), and `CmsPluginScheduleSummary` carries `paused`.

## 4. Ghost schedules — the promised GC didn't exist

The VM bootstrap comment claimed orphan rows "will eventually be GC'd by the host once the boot-claim grace window expires" — false: `claimed_at` was written but never read. The sweep is now real: `runPluginLifecycle` (`server/plugins/runtime.ts`) records the activation start, runs `activate`, then disables every still-enabled schedule row of that plugin whose `claimed_at` predates the pass (`disableSchedulesNotReclaimedSince`). `claimed_at` genuinely marks the registration claim time (stamped by every register upsert), so it stays. All activation paths go through this single choke point (boot loop, crash-recovery reload, admin lifecycle hooks, upgrade + rollback — `runPluginLifecycle` now takes `db`). The misleading VM-side comment in `server/plugins/quickjs/bootstrap/src/pluginRuntime.ts` now describes the real mechanism; `bun run bootstrap:sync` re-run (generated artifacts unchanged — comments are stripped from the bundle).

## Tests

New coverage in `src/__tests__/server/pluginScheduler.test.ts`:
- cancel with a plugin-local id disables the namespaced row (through `handleScheduleCancel`)
- due selection excludes paused schedules until resumed
- due selection excludes schedules of disabled plugins
- re-registration on boot preserves an existing pause
- ghost sweep disables schedules not re-registered during the activation pass

Plus two new architecture invariants (shared namespacing helper, activation sweep). Fake-DB harnesses in `cmsPlugins.test.ts` / `pluginServerRuntime.test.ts` model the new sweep statement.

## Verification

- `bun run build` — clean (`tsc -b && vite build`)
- `bun run lint` — clean
- `bun test` — 4898 pass / 18 fail; all 18 failures are the pre-existing pixel-art-icons catalog gates (`direct-icon-imports`), which fail identically on a clean tree without this change (verified via `git stash` baseline run) and pass when run in isolation. Not touched by this PR.
- Dialect gates green: `db-postgres-isms`, `db-json-column-naming`, `migration-parity`, `plugin-bootstrap-fresh`.

Docs updated: `docs/features/plugin-system.md` scheduling section now documents id namespacing, pause-vs-cancel semantics, and the orphan sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)