### PR TITLE
Harden plugin sandbox against hangs and preserve VM stack traces

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -243,6 +243,27 @@ These produce a build-time error and a runtime error if attempted:
 
 Sandbox invariants are gated by `src/__tests__/architecture/plugin-sandbox-invariants.test.ts`.
 
+### Resource limits and timeouts
+
+VM budgets live in `server/plugins/quickjs/limits.ts`; the host-side RPC timeout lives in `server/plugins/host/workerPool.ts`.
+
+| Limit | Value | Enforced by |
+|---|---|---|
+| VM heap | 64 MB (`DEFAULT_MEMORY_LIMIT_BYTES`) | QuickJS `setMemoryLimit` — allocations beyond it throw inside the VM |
+| VM stack | 1 MB (`DEFAULT_STACK_SIZE_BYTES`) | QuickJS `setMaxStackSize` — fatal for runaway recursion |
+| Eval deadline | 5 s (`DEFAULT_EVAL_TIMEOUT_MS`) | wall-clock interrupt on the QuickJS runtime |
+| Module-pack eval deadline | 2 s (`MODULE_PACK_EVAL_TIMEOUT_MS`) | same interrupt — canvas `render()`/`preview()` are pure sync transforms |
+| Schedule fire | the schedule's `maxDurationMs` (host-capped at 5 min) | replaces the 5 s eval budget for that one call |
+| Worker RPC | 30 s (`DEFAULT_RPC_TIMEOUT_MS`); schedule runs get `maxDurationMs` + 10 s slack | host-side timeout in `requestFromWorker` |
+
+**The eval deadline covers every way plugin code can execute.** Each entry into VM execution — the bootstrap eval, the plugin bundle's top-level eval, every `__run*` dispatch (lifecycle, route, hook, loop, schedule, media), and the pending-jobs pump that runs timer callbacks (`setTimeout`/`setInterval` continuations) — registers a wall-clock deadline in a per-runtime registry (`server/plugins/quickjs/eval.ts`). One persistent interrupt handler aborts the runtime once the clock passes the latest active deadline, so concurrent evals on one context cannot strip each other's protection and a `while (true) {}` anywhere (top level, route handler, timer callback) is interrupted instead of wedging the worker thread.
+
+**What the plugin author sees on a deadline hit:** the call fails with QuickJS's `interrupted` error — schedule runs record it as `status: 'timeout'`, every other entry point surfaces it as an ordinary error (lifecycle failure, route 500, hook listener log line). Plugins that legitimately need more time should yield back to the host (await host calls, split work across schedule fires) rather than block in a tight loop.
+
+**The worker RPC timeout is the backstop for a truly wedged worker.** A worker that hangs never *crashes*, so without it the awaiting HTTP request or publish render would hang forever and crash recovery would never engage. When `requestFromWorker` times out, the call rejects with `Plugin "<id>" did not respond to <kind> within <ms>ms` and the worker goes through the same teardown as a crash (`handleWorkerCrash`): terminated, sibling pending calls rejected, host-side registrations dropped, a crash event recorded for the admin UI, and the sliding-window counter decides auto-respawn vs parking the plugin in `error` state.
+
+**Error stacks:** VM errors keep their QuickJS stack frames (plugin bundles are evaluated with the filename `plugin:<id>`, and the ESM shim adds zero line offset, so frames map 1:1 onto the shipped bundle). The frames travel worker→host on the optional `stack` field of the `*-result` protocol messages and appear in `[plugin:<id>]` server logs only — HTTP responses and API replies carry just the error message.
+
 ### The VM bootstrap (and how to regenerate it)
 
 Before any plugin code runs, the host evaluates a **bootstrap** program inside the
@@ -753,4 +774,6 @@ Manifest:
   - `src/__tests__/plugins/pluginModulePack.test.ts` — module pack activation, re-activation, deactivation, and VM disposal
   - `src/__tests__/server/pluginVmPermissions.test.ts` — VM-side permission check: declared-but-not-granted permissions are denied at the VM boundary before host dispatch
   - `src/__tests__/server/pluginVmLoopDispatch.test.ts` — loop fetch/preview dispatcher robustness (no-return fallbacks, async-preview detection)
+  - `src/__tests__/server/pluginVmDeadlines.test.ts` — hang hardening: top-level loops abort at load, overlapping evals keep their deadlines, runaway timer callbacks are interrupted, VM stacks survive with the `plugin:<id>` filename
+  - `src/__tests__/server/pluginWorkerRpcTimeout.test.ts` — host-side RPC timeout: wedged workers are reset through the crash machinery instead of hanging callers
   - `src/admin/pages/plugins/utils/pluginEventStream.test.ts` — SSE frame validation: well-formed events dispatched, unknown-shape frames dropped with `console.warn`

--- a/server/plugins/host/media.ts
+++ b/server/plugins/host/media.ts
@@ -24,6 +24,7 @@ import type {
 } from '@core/plugin-sdk'
 import { MediaStorageUploadPlanSchema } from '@core/plugin-sdk'
 import { requestFromWorker } from './workerPool'
+import { describeWorkerError, workerCallError } from './workerErrors'
 
 export async function runMediaAdapterCallInWorker(
   pluginId: string,
@@ -44,7 +45,10 @@ export async function runMediaAdapterCallInWorker(
     'media-adapter-call-result',
   )
   if (!result.ok) {
-    throw new Error(result.error ?? `Plugin "${pluginId}" media adapter "${adapterId}.${method}" failed`)
+    throw workerCallError(
+      result.error ?? `Plugin "${pluginId}" media adapter "${adapterId}.${method}" failed`,
+      result.stack,
+    )
   }
   return result.value
 }
@@ -66,7 +70,10 @@ export async function runMediaUrlTransformerInWorker(
     'media-url-transformer-result',
   )
   if (!result.ok) {
-    console.error(`[plugin:${pluginId}] media URL transformer threw:`, result.error)
+    console.error(
+      `[plugin:${pluginId}] media URL transformer threw:`,
+      describeWorkerError(result.error, result.stack, 'unknown error'),
+    )
     return null
   }
   return typeof result.value === 'string' ? result.value : null

--- a/server/plugins/host/rpc.ts
+++ b/server/plugins/host/rpc.ts
@@ -20,8 +20,18 @@ import type { LoadPluginResult } from '../protocol/messages'
 import { normalizeRoutePath } from '../protocol/parser'
 import { hostPlugins } from './registry'
 import { requestFromWorker } from './workerPool'
+import { describeWorkerError, workerCallError } from './workerErrors'
 import { workers } from './workerState'
 import type { HostRouteAccess } from './types'
+
+/**
+ * Transport + teardown slack added on top of a schedule's own VM budget for
+ * the worker RPC timeout. The RPC timeout must outlive the in-VM
+ * `maxDurationMs` deadline so the normal overrun failure mode is a clean
+ * `status: 'timeout'` result from the worker — the host-side reset only
+ * engages when the worker is truly wedged.
+ */
+const SCHEDULE_RPC_SLACK_MS = 10_000
 
 export async function loadPluginInWorker(args: {
   manifest: PluginManifest
@@ -120,7 +130,7 @@ export async function runLifecycleInWorker(
     'lifecycle-result',
   )
   if (!result.ok) {
-    throw new Error(result.error ?? `Plugin "${pluginId}" ${hook} failed`)
+    throw workerCallError(result.error ?? `Plugin "${pluginId}" ${hook} failed`, result.stack)
   }
 }
 
@@ -134,7 +144,7 @@ export async function runMigrateInWorker(
     'lifecycle-result',
   )
   if (!result.ok) {
-    throw new Error(result.error ?? `Plugin "${pluginId}" migrate failed`)
+    throw workerCallError(result.error ?? `Plugin "${pluginId}" migrate failed`, result.stack)
   }
 }
 
@@ -259,6 +269,11 @@ export async function runRouteInWorker(args: {
     'route-result',
   )
   if (!result.ok || !result.response) {
+    // VM stacks stay in the server log — the HTTP body carries only the message.
+    console.error(
+      `[plugin:${args.pluginId}] route "${routeKey}" handler failed:`,
+      describeWorkerError(result.error, result.stack, 'Plugin route failed'),
+    )
     return Response.json({ error: result.error ?? 'Plugin route failed' }, { status: 500 })
   }
   return materializeResponse(result.response)
@@ -321,7 +336,16 @@ export async function runScheduleInWorker(args: {
       maxDurationMs: args.maxDurationMs,
     },
     'schedule-result',
+    // The RPC budget must outlive the in-VM deadline (see SCHEDULE_RPC_SLACK_MS).
+    { timeoutMs: args.maxDurationMs + SCHEDULE_RPC_SLACK_MS },
   )
+  if (!result.ok && result.stack) {
+    // The run row stores only the message; the VM stack goes to the server log.
+    console.error(
+      `[plugin:${args.pluginId}] schedule "${args.scheduleId}" failed:`,
+      describeWorkerError(result.error, result.stack, 'schedule run failed'),
+    )
+  }
   return {
     status: result.status,
     error: result.error,
@@ -347,7 +371,7 @@ export async function runHookListenerInWorker(
   if (!result.ok) {
     console.error(
       `[plugin:${pluginId}] hook listener for "${event}" threw:`,
-      result.error,
+      describeWorkerError(result.error, result.stack, 'unknown error'),
     )
   }
 }
@@ -365,7 +389,10 @@ export async function runHookFilterInWorker(
     'hook-filter-result',
   )
   if (!result.ok) {
-    console.error(`[plugin:${pluginId}] hook filter "${name}" threw:`, result.error)
+    console.error(
+      `[plugin:${pluginId}] hook filter "${name}" threw:`,
+      describeWorkerError(result.error, result.stack, 'unknown error'),
+    )
     return value
   }
   return result.value
@@ -384,7 +411,7 @@ export async function runLoopFetchInWorker(
   if (!result.ok || !result.value) {
     console.error(
       `[plugin:${pluginId}] loop source "${sourceId}" fetch failed:`,
-      result.error,
+      describeWorkerError(result.error, result.stack, 'unknown error'),
     )
     return { items: [], totalItems: 0 }
   }

--- a/server/plugins/host/workerErrors.ts
+++ b/server/plugins/host/workerErrors.ts
@@ -1,0 +1,30 @@
+/**
+ * Translate worker error payloads (`{ error, stack }` on `*-result`
+ * messages) into host-side errors and log lines.
+ *
+ * The `stack` field carries QuickJS-side frames — plugin sources are
+ * evaluated with the filename `plugin:<id>`, so the frames point into the
+ * plugin bundle. Stacks are for `[plugin:<id>]` server logs ONLY: API
+ * replies and HTTP error envelopes carry just the message.
+ */
+
+/**
+ * Build the host-side `Error` for a failed worker call. The message is what
+ * callers surface (API replies, lifecycle status rows); when the worker
+ * forwarded a VM stack, `.stack` is rewritten to show those frames so any
+ * `console.error('[plugin:<id>]', err)` along the way prints them.
+ */
+export function workerCallError(message: string, stack?: string): Error {
+  const err = new Error(message)
+  if (stack) err.stack = `Error: ${message}\n${stack}`
+  return err
+}
+
+/**
+ * Format a worker failure for a `[plugin:<id>]` console line — the message,
+ * plus the VM stack frames on following lines when the worker sent them.
+ */
+export function describeWorkerError(error: string | undefined, stack: string | undefined, fallback: string): string {
+  const message = error ?? fallback
+  return stack ? `${message}\n${stack}` : message
+}

--- a/server/plugins/host/workerPool.ts
+++ b/server/plugins/host/workerPool.ts
@@ -51,15 +51,49 @@ function sendTo(pluginId: string, msg: MainToWorkerMessage): void {
   ensureWorkerFor(pluginId).postMessage(msg)
 }
 
+/**
+ * Default budget for one host→worker RPC round-trip. Generous compared to
+ * the VM's own 5 s eval deadline — its real job is to bound the damage of a
+ * *wedged* worker (plugin code spinning past every in-VM guard), not to
+ * race healthy calls.
+ */
+export const DEFAULT_RPC_TIMEOUT_MS = 30_000
+
+export interface RequestFromWorkerOptions {
+  /**
+   * Wall-clock budget for the worker's reply. Schedule runs pass a budget
+   * derived from their declared `maxDurationMs`; everything else
+   * (load / lifecycle / route / hook / loop / media calls) uses the default.
+   */
+  timeoutMs?: number
+}
+
 export function requestFromWorker<TKind extends WorkerToMainMessage['kind']>(
   pluginId: string,
   msg: MainToWorkerMessage,
   expectedKind: TKind,
+  options: RequestFromWorkerOptions = {},
 ): Promise<Extract<WorkerToMainMessage, { kind: TKind }>> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_RPC_TIMEOUT_MS
   return new Promise<Extract<WorkerToMainMessage, { kind: TKind }>>((resolve, reject) => {
+    // A wedged worker never crashes on its own, so without a deadline this
+    // pending promise — and the HTTP request / publish render awaiting it —
+    // would hang forever while crash recovery never engages. On expiry we
+    // reject the call AND route the worker through the same teardown as a
+    // crash: terminate it, reject its sibling pendings, unregister its
+    // host-side state, record a crash event the admin UI surfaces, and let
+    // the sliding-window counter decide respawn vs park.
+    const timer = setTimeout(() => {
+      if (!pendingRequests.has(msg.correlationId)) return
+      pendingRequests.delete(msg.correlationId)
+      const reason = `Plugin "${pluginId}" did not respond to ${msg.kind} within ${timeoutMs}ms`
+      reject(new Error(reason))
+      handleWorkerCrash(pluginId, reason)
+    }, timeoutMs)
     pendingRequests.set(msg.correlationId, {
       pluginId,
       resolve: (value) => {
+        clearTimeout(timer)
         const v = value as WorkerToMainMessage
         if (v.kind !== expectedKind) {
           reject(new Error(`Plugin worker returned unexpected message kind "${v.kind}"`))
@@ -67,7 +101,10 @@ export function requestFromWorker<TKind extends WorkerToMainMessage['kind']>(
         }
         resolve(v as Extract<WorkerToMainMessage, { kind: TKind }>)
       },
-      reject,
+      reject: (err) => {
+        clearTimeout(timer)
+        reject(err)
+      },
     })
     sendTo(pluginId, msg)
   })

--- a/server/plugins/pluginWorker.ts
+++ b/server/plugins/pluginWorker.ts
@@ -49,6 +49,7 @@ import type {
   WorkerToMainMessage,
 } from './protocol/messages'
 import { createPluginVm, type PluginVm } from './quickjs/vm'
+import { vmStackOf } from './quickjs/eval'
 import { wrapEsmAsGlobal } from './quickjs/esmShim'
 
 // ---------------------------------------------------------------------------
@@ -81,6 +82,20 @@ function callHostApi(pluginId: string, target: ApiCall['target'], args: unknown[
     pendingApiCalls.set(correlationId, { resolve, reject })
     send({ kind: 'api-call', correlationId, pluginId, target, args })
   })
+}
+
+/**
+ * Convert a caught VM error into the wire `{ error, stack }` pair. The
+ * message is what API replies / HTTP error envelopes may surface; the
+ * optional `stack` carries QuickJS-side frames (plugin sources eval with
+ * the filename `plugin:<id>`) for host-side logging only.
+ */
+function errorFields(err: unknown): { error: string; stack?: string } {
+  if (err instanceof Error) {
+    const stack = vmStackOf(err)
+    return stack !== undefined ? { error: err.message, stack } : { error: err.message }
+  }
+  return { error: String(err) }
 }
 
 function handleApiReply(reply: ApiReply): void {
@@ -141,7 +156,7 @@ async function handleLoadPlugin(msg: LoadPluginRequest): Promise<void> {
       kind: 'load-plugin-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -184,7 +199,7 @@ async function handleRunLifecycle(msg: RunLifecycleRequest): Promise<void> {
       kind: 'lifecycle-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -212,7 +227,7 @@ async function handleRunMigrate(msg: RunMigrateRequest): Promise<void> {
       kind: 'lifecycle-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -236,7 +251,7 @@ async function handleRunRoute(msg: RunRouteRequest): Promise<void> {
       kind: 'route-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -280,7 +295,7 @@ async function handleRunHookListener(msg: RunHookListenerRequest): Promise<void>
       kind: 'hook-listener-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -299,7 +314,7 @@ async function handleRunHookFilter(msg: RunHookFilterRequest): Promise<void> {
       kind: 'hook-filter-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -323,7 +338,7 @@ async function handleRunLoopFetch(msg: RunLoopFetchRequest): Promise<void> {
       kind: 'loop-fetch-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -347,7 +362,7 @@ async function handleRunLoopPreview(msg: RunLoopPreviewRequest): Promise<void> {
       kind: 'loop-preview-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -376,20 +391,20 @@ async function handleRunSchedule(msg: RunScheduleRequest): Promise<void> {
       durationMs: Date.now() - startedAt,
     })
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err)
+    const fields = errorFields(err)
     // The QuickJS interrupt handler raises `InternalError: interrupted`
-    // when the per-eval deadline kicks in (see withDeadline in
-    // quickjsHost.ts). Surface this as a distinct status so the admin UI
+    // when the per-eval deadline kicks in (see the deadline registry in
+    // quickjs/eval.ts). Surface this as a distinct status so the admin UI
     // and consecutive-failures logic can treat timeouts separately from
     // logical errors.
     const status: 'timeout' | 'error' =
-      message.toLowerCase().includes('interrupted') ? 'timeout' : 'error'
+      fields.error.toLowerCase().includes('interrupted') ? 'timeout' : 'error'
     send({
       kind: 'schedule-result',
       correlationId: msg.correlationId,
       ok: false,
       status,
-      error: message,
+      ...fields,
       durationMs: Date.now() - startedAt,
     })
   }
@@ -418,7 +433,7 @@ async function handleRunMediaAdapterCall(msg: RunMediaAdapterCallRequest): Promi
       kind: 'media-adapter-call-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }
@@ -442,7 +457,7 @@ async function handleRunMediaUrlTransformer(msg: RunMediaUrlTransformerRequest):
       kind: 'media-url-transformer-result',
       correlationId: msg.correlationId,
       ok: false,
-      error: err instanceof Error ? err.message : String(err),
+      ...errorFields(err),
     })
   }
 }

--- a/server/plugins/protocol/messages.ts
+++ b/server/plugins/protocol/messages.ts
@@ -239,6 +239,12 @@ export interface LoadPluginResult {
   ok: boolean
   error?: string
   /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
+  /**
    * List of hook names the plugin module exports. Lets the host skip the
    * round-trip when calling a non-existent lifecycle hook.
    */
@@ -256,6 +262,12 @@ export interface LifecycleResult {
   correlationId: string
   ok: boolean
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 export interface RouteResult {
@@ -264,6 +276,12 @@ export interface RouteResult {
   ok: boolean
   response?: SerializedResponse
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 export interface HookListenerResult {
@@ -271,6 +289,12 @@ export interface HookListenerResult {
   correlationId: string
   ok: boolean
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 export interface HookFilterResult {
@@ -280,6 +304,12 @@ export interface HookFilterResult {
   /** Plugin-transformed value (when ok). */
   value?: unknown
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 export interface LoopFetchResultMessage {
@@ -289,6 +319,12 @@ export interface LoopFetchResultMessage {
   /** `{ items, totalItems }` shape from the plugin's source — re-validated host-side. */
   value?: { items: unknown[]; totalItems: number }
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 export interface LoopPreviewResult {
@@ -297,6 +333,12 @@ export interface LoopPreviewResult {
   ok: boolean
   value?: unknown[]
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 /**
@@ -313,6 +355,12 @@ export interface ScheduleResult {
   /** 'ok' on success, 'error' on a throw, 'timeout' when the deadline aborted. */
   status: 'ok' | 'error' | 'timeout'
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
   durationMs: number
 }
 
@@ -322,6 +370,12 @@ export interface MediaAdapterCallResult {
   ok: boolean
   value?: unknown
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 export interface MediaUrlTransformerResult {
@@ -332,6 +386,12 @@ export interface MediaUrlTransformerResult {
    *  previous value (chain pass-through). */
   value?: string | null
   error?: string
+  /**
+   * QuickJS-side stack frames of the failure (plugin sources are evaluated
+   * with the filename `plugin:<id>`). For host-side `[plugin:<id>]` logging
+   * only — never sent to HTTP clients.
+   */
+  stack?: string
 }
 
 /**

--- a/server/plugins/quickjs/esmShim.ts
+++ b/server/plugins/quickjs/esmShim.ts
@@ -87,5 +87,10 @@ export function wrapEsmAsGlobal(
     ? `globalThis.${globalName} = __exports.default;`
     : `globalThis.${globalName} = __exports;`
 
-  return `;(function () {\n  const __exports = {};\n${transformed}\n  ${handoff}\n})();\n`
+  // The prelude shares the first physical line with the source's first line
+  // (and the handoff comes after it) so wrapping adds ZERO line offset —
+  // QuickJS stack traces from the wrapped eval (filename `plugin:<id>` /
+  // `module-pack:<id>`) report the same line numbers as the bundle the
+  // author shipped.
+  return `;(function () { const __exports = {}; ${transformed}\n${handoff}\n})();\n`
 }

--- a/server/plugins/quickjs/eval.ts
+++ b/server/plugins/quickjs/eval.ts
@@ -10,46 +10,122 @@
  *      event loop so __hostCall's host-side .then can fire deferred.resolve
  *   5. Once fulfilled/rejected, return the value or throw the error
  *
- * The deadline guard (`withDeadline`) installs a wall-clock interrupt on
- * the runtime for the duration of one eval call — a plugin stuck in a
- * tight loop is aborted within the deadline.
+ * Deadline guard: every entry into VM execution (async eval, sync eval,
+ * timer-callback pump) registers a wall-clock deadline in a per-runtime
+ * registry; ONE persistent interrupt handler aborts the runtime when the
+ * clock passes the latest active deadline. A plugin stuck in a tight loop
+ * is therefore always aborted, no matter which code path it spins on.
  */
 
-import { shouldInterruptAfterDeadline, type QuickJSContext, type QuickJSHandle } from 'quickjs-emscripten'
-import { DEFAULT_EVAL_TIMEOUT_MS } from './limits'
+import type { QuickJSContext, QuickJSHandle, QuickJSRuntime } from 'quickjs-emscripten'
 
 /**
- * Install a wall-clock interrupt on the runtime and return a disposer that
- * removes it. The QuickJS VM cooperatively polls the interrupt flag during
- * execution, so a plugin stuck in a tight loop is aborted within the
- * deadline. This is the single setInterruptHandler/removeInterruptHandler
- * core shared by the async (`withDeadline`) and sync (`withSyncDeadline`)
- * guards below.
+ * Error thrown when plugin code inside the VM throws (or is aborted by the
+ * wall-clock interrupt). `message` is the plugin's own error message and is
+ * safe to surface in API replies / HTTP error envelopes. `vmStack` carries
+ * the QuickJS-side stack frames — plugin sources are evaluated with the
+ * filename `plugin:<pluginId>`, so the frames point into the plugin bundle.
+ * `stack` is rewritten to show those VM frames so host-side
+ * `console.error('[plugin:<id>]', err)` logging prints them. Callers must
+ * never put `.stack` / `.vmStack` into HTTP response bodies.
  */
-function installDeadline(ctx: QuickJSContext, timeoutMs: number): () => void {
-  const deadline = Date.now() + timeoutMs
-  ctx.runtime.setInterruptHandler(shouldInterruptAfterDeadline(deadline))
+export class PluginVmError extends Error {
+  readonly vmStack?: string
+
+  constructor(message: string, vmStack?: string) {
+    super(message)
+    this.name = 'PluginVmError'
+    if (vmStack !== undefined && vmStack.length > 0) {
+      this.vmStack = vmStack
+      this.stack = `${this.name}: ${message}\n${vmStack}`
+    }
+  }
+}
+
+/**
+ * Extract the QuickJS-side stack frames from a VM eval error, if present.
+ * Handles both error shapes the eval paths produce:
+ *   - `PluginVmError` (rejected VM promises) carries `vmStack` directly;
+ *   - `QuickJSUnwrapError` (synchronous throws surfaced by
+ *     `ctx.unwrapResult`) carries the dumped VM error object as `cause`,
+ *     whose `stack` is pure VM frames.
+ */
+export function vmStackOf(err: unknown): string | undefined {
+  if (err instanceof PluginVmError) return err.vmStack
+  if (err instanceof Error && err.cause && typeof err.cause === 'object') {
+    const stack = (err.cause as { stack?: unknown }).stack
+    if (typeof stack === 'string' && stack.length > 0) return stack
+  }
+  return undefined
+}
+
+interface DeadlineToken {
+  expiresAt: number
+}
+
+/**
+ * Active wall-clock deadlines, per runtime. Multiple evals can be in flight
+ * on one context at the same time (the polling pump interleaves them), but
+ * the runtime has only ONE interrupt-handler slot — a naive install-on-start
+ * / remove-on-finish pair would let the first eval to finish strip the
+ * deadline from every eval still running. Instead each guarded execution
+ * registers a token here, and one persistent handler (installed when the
+ * first token arrives, removed when the last one releases) interrupts when
+ * the wall clock passes the MAX of the active deadlines. Max is the safe
+ * aggregation: it never falsely interrupts an eval that still has budget,
+ * while still guaranteeing the runtime cannot spin forever.
+ */
+const deadlinesByRuntime = new Map<QuickJSRuntime, Set<DeadlineToken>>()
+
+function acquireDeadline(ctx: QuickJSContext, timeoutMs: number): () => void {
+  const runtime = ctx.runtime
+  let tokens = deadlinesByRuntime.get(runtime)
+  if (!tokens) {
+    const created = new Set<DeadlineToken>()
+    tokens = created
+    deadlinesByRuntime.set(runtime, created)
+    runtime.setInterruptHandler(() => {
+      if (created.size === 0) return false
+      let latest = 0
+      for (const token of created) {
+        if (token.expiresAt > latest) latest = token.expiresAt
+      }
+      return Date.now() > latest
+    })
+  }
+  const activeTokens = tokens
+  const token: DeadlineToken = { expiresAt: Date.now() + timeoutMs }
+  activeTokens.add(token)
+  let released = false
   return () => {
-    try { ctx.runtime.removeInterruptHandler() } catch { /* runtime may already be disposed */ }
+    if (released) return
+    released = true
+    activeTokens.delete(token)
+    if (activeTokens.size === 0) {
+      deadlinesByRuntime.delete(runtime)
+      try { runtime.removeInterruptHandler() } catch { /* runtime may already be disposed */ }
+    }
   }
 }
 
 function withDeadline<T>(ctx: QuickJSContext, timeoutMs: number, body: () => Promise<T>): Promise<T> {
-  const clearDeadline = installDeadline(ctx, timeoutMs)
-  return body().finally(clearDeadline)
+  const releaseDeadline = acquireDeadline(ctx, timeoutMs)
+  return body().finally(releaseDeadline)
 }
 
 /**
- * Synchronous sibling of `withDeadline` — guards a fully-synchronous eval
- * (no Promise pumping) with the same interrupt deadline. The module-pack VM
- * uses this because canvas render() functions never call into the host.
+ * Synchronous sibling of `withDeadline` — guards a fully-synchronous VM
+ * execution (one-shot eval or a pending-jobs pump) with the same interrupt
+ * deadline. Used by the module-pack VM (canvas render() never calls into
+ * the host), by `createPluginVm`'s bootstrap + plugin-source evals, and by
+ * the timer-callback pumps in `vm.ts`.
  */
 export function withSyncDeadline<T>(ctx: QuickJSContext, timeoutMs: number, body: () => T): T {
-  const clearDeadline = installDeadline(ctx, timeoutMs)
+  const releaseDeadline = acquireDeadline(ctx, timeoutMs)
   try {
     return body()
   } finally {
-    clearDeadline()
+    releaseDeadline()
   }
 }
 
@@ -79,12 +155,12 @@ function evalResolved<T>(
   ctx: QuickJSContext,
   code: string,
   read: (handle: QuickJSHandle) => T,
-  timeoutMs: number = DEFAULT_EVAL_TIMEOUT_MS,
+  timeoutMs: number,
 ): Promise<T> {
   // Run inside a wall-clock deadline — runaway plugin code is aborted
   // with a QuickJS `InternalError: interrupted` rather than blocking
-  // the worker forever. Callers can override the default (5s) for cases
-  // like scheduled jobs that declare a higher `maxDurationMs`.
+  // the worker forever. Schedules pass a higher per-call budget derived
+  // from their declared `maxDurationMs`.
   return withDeadline(ctx, timeoutMs, () => evalResolvedInner(ctx, code, read))
 }
 
@@ -112,9 +188,13 @@ async function evalResolvedInner<T>(
   }
 
   // It IS a Promise — pump VM jobs + host event loop until it settles.
+  // Reuse `initialState` on the first pass: for a settled promise each
+  // `getPromiseState` call allocates a NEW owned result handle, so probing
+  // twice would leak the first one (QuickJS asserts on leaked GC objects at
+  // runtime-free time).
   const MAX_BATCHES = 10_000
   for (let i = 0; i < MAX_BATCHES; i += 1) {
-    const state = ctx.getPromiseState(evalHandle)
+    const state = i === 0 ? initialState : ctx.getPromiseState(evalHandle)
     if (state.type === 'fulfilled') {
       const valueHandle = state.value
       evalHandle.dispose()
@@ -125,18 +205,27 @@ async function evalResolvedInner<T>(
       }
     }
     if (state.type === 'rejected') {
-      const errorHandle = state.error
-      const errorValue = ctx.dump(errorHandle) as { message?: string; stack?: string } | string | undefined
+      // `state.error` is an OWNED heap handle (see getPromiseState) — leaving
+      // it alive trips QuickJS's `list_empty(&rt->gc_obj_list)` assertion
+      // when the runtime is freed. `consume` dumps + disposes in one step.
+      const errorValue = state.error.consume((handle) => ctx.dump(handle)) as
+        | { message?: string; stack?: string }
+        | string
+        | undefined
       evalHandle.dispose()
       // Surface the plugin's own error message verbatim — the host's
       // logging (`[plugin:<id>]`) provides the context, so a "Plugin VM
-      // threw: " prefix would just be redundant noise.
-      const message = typeof errorValue === 'object' && errorValue && errorValue.message
-        ? errorValue.message
-        : typeof errorValue === 'string'
-          ? errorValue
-          : 'VM promise rejected with unknown error'
-      throw new Error(message)
+      // threw: " prefix would just be redundant noise. The VM-side stack
+      // rides along on the PluginVmError for host logs.
+      if (typeof errorValue === 'object' && errorValue && errorValue.message) {
+        throw new PluginVmError(
+          errorValue.message,
+          typeof errorValue.stack === 'string' ? errorValue.stack : undefined,
+        )
+      }
+      throw new PluginVmError(
+        typeof errorValue === 'string' ? errorValue : 'VM promise rejected with unknown error',
+      )
     }
     // Still pending. Drain VM microtasks, then yield to host event loop
     // so any pending __hostCall host-side resolution can fire.
@@ -169,15 +258,15 @@ function drainJobs(ctx: QuickJSContext): number {
   return 0
 }
 
-export function evalVoid(ctx: QuickJSContext, code: string, timeoutMs?: number): Promise<void> {
+export function evalVoid(ctx: QuickJSContext, code: string, timeoutMs: number): Promise<void> {
   return evalResolved(ctx, code, () => undefined, timeoutMs)
 }
 
-export function evalString(ctx: QuickJSContext, code: string, timeoutMs?: number): Promise<string> {
+export function evalString(ctx: QuickJSContext, code: string, timeoutMs: number): Promise<string> {
   return evalResolved(ctx, code, (h) => ctx.getString(h), timeoutMs)
 }
 
-export async function evalJson<T>(ctx: QuickJSContext, code: string, timeoutMs?: number): Promise<T> {
+export async function evalJson<T>(ctx: QuickJSContext, code: string, timeoutMs: number): Promise<T> {
   const raw = await evalString(ctx, `JSON.stringify((${code}))`, timeoutMs)
   return JSON.parse(raw) as T
 }

--- a/server/plugins/quickjs/limits.ts
+++ b/server/plugins/quickjs/limits.ts
@@ -8,9 +8,11 @@
  *     `OutOfMemory` error inside the VM.
  *   • A bounded stack size (`setMaxStackSize`) so a recursive plugin can't
  *     exhaust the host's WASM stack.
- *   • A wall-clock interrupt per eval call (`shouldInterruptAfterDeadline`).
- *     The VM cooperatively checks the interrupt flag during execution; a
- *     plugin stuck in an infinite loop is aborted within the deadline.
+ *   • A wall-clock interrupt per VM execution (the per-runtime deadline
+ *     registry in `eval.ts`). The VM cooperatively checks the interrupt
+ *     flag during execution; a plugin stuck in an infinite loop — at module
+ *     top level, in any `__run*` call, or in a timer callback — is aborted
+ *     within the deadline.
  *
  * Defaults are picked to be invisible for normal plugin work and harsh
  * for runaways. Plugins that legitimately need higher caps will surface

--- a/server/plugins/quickjs/vm.ts
+++ b/server/plugins/quickjs/vm.ts
@@ -30,9 +30,9 @@
 
 import { getQuickJS, type QuickJSContext, type QuickJSHandle, type QuickJSWASMModule } from 'quickjs-emscripten'
 import { BOOTSTRAP_SOURCE } from './bootstrap/index'
-import { DEFAULT_MEMORY_LIMIT_BYTES, DEFAULT_STACK_SIZE_BYTES } from './limits'
+import { DEFAULT_EVAL_TIMEOUT_MS, DEFAULT_MEMORY_LIMIT_BYTES, DEFAULT_STACK_SIZE_BYTES } from './limits'
 import { jsToHandle } from './marshal'
-import { evalJson, evalString, evalVoid } from './eval'
+import { evalJson, evalString, evalVoid, withSyncDeadline } from './eval'
 import type { PluginVm, PluginVmEnv } from './types'
 
 export type { PluginVm, PluginVmEnv } from './types'
@@ -72,7 +72,7 @@ export async function createPluginVm(args: {
 }): Promise<PluginVm> {
   const wasm = await getWasmModule()
   const ctx = wasm.newContext()
-  const defaultEvalTimeoutMs = args.evalTimeoutMs
+  const evalTimeoutMs = args.evalTimeoutMs ?? DEFAULT_EVAL_TIMEOUT_MS
 
   // Apply per-plugin resource limits BEFORE evaluating any plugin code.
   // setMemoryLimit / setMaxStackSize live on the runtime, not the context,
@@ -121,6 +121,31 @@ export async function createPluginVm(args: {
    */
   const pendingDeferreds = new Set<ReturnType<QuickJSContext['newPromise']>>()
 
+  /**
+   * Drain the VM's microtask queue under a wall-clock deadline. Host-call
+   * resolutions and timer fires pump plugin continuations OUTSIDE any
+   * `evalResolved` deadline (e.g. a `setInterval` callback firing long
+   * after the eval that scheduled it returned), so each pump carries its
+   * own deadline — a `while (true) {}` inside a timer callback is
+   * interrupted instead of wedging the worker thread forever. A job the
+   * queue reports as failed (interrupted or otherwise uncaught) is logged
+   * with the plugin prefix and dropped; the VM stays usable.
+   */
+  const pumpPendingJobs = (): void => {
+    withSyncDeadline(ctx, evalTimeoutMs, () => {
+      const result = ctx.runtime.executePendingJobs()
+      if ('error' in result && result.error) {
+        const dumped = result.error.consume((handle) => ctx.dump(handle)) as
+          | { message?: string; stack?: string }
+          | string
+          | undefined
+        const message = typeof dumped === 'object' && dumped?.message ? dumped.message : String(dumped)
+        const stack = typeof dumped === 'object' && typeof dumped?.stack === 'string' ? `\n${dumped.stack}` : ''
+        console.error(`[plugin:${args.env.pluginId}] VM job aborted: ${message}${stack}`)
+      }
+    })
+  }
+
   try {
     // 1. Wire __hostCall as a SYNCHRONOUS VM function. The host returns a
     //    VM-side Promise immediately and resolves it later from JS-land.
@@ -151,7 +176,7 @@ export async function createPluginVm(args: {
               valueHandle.dispose()
             }
             // Drain plugin-side microtasks queued by the resolve.
-            ctx.runtime.executePendingJobs()
+            pumpPendingJobs()
           } catch { /* VM gone — silent drop. */ }
           pendingDeferreds.delete(deferred)
         },
@@ -165,7 +190,7 @@ export async function createPluginVm(args: {
             const errHandle = ctx.newError(message)
             deferred.reject(errHandle)
             errHandle.dispose()
-            ctx.runtime.executePendingJobs()
+            pumpPendingJobs()
           } catch { /* VM gone — silent drop. */ }
           pendingDeferreds.delete(deferred)
         },
@@ -192,7 +217,7 @@ export async function createPluginVm(args: {
         }
         try {
           deferred.resolve(ctx.undefined)
-          ctx.runtime.executePendingJobs()
+          pumpPendingJobs()
         } catch { /* VM gone — silent drop. */ }
         pendingDeferreds.delete(deferred)
       }, safeMs)
@@ -233,15 +258,22 @@ export async function createPluginVm(args: {
     ctx.setProp(ctx.global, '__plugin_settings', settingsHandle)
     settingsHandle.dispose()
 
-    // 4. Evaluate the bootstrap and plugin bundle.
-    ctx.unwrapResult(ctx.evalCode(BOOTSTRAP_SOURCE, 'instatic-bootstrap.js')).dispose()
-    ctx.unwrapResult(ctx.evalCode(args.pluginSource, `plugin:${args.env.pluginId}`)).dispose()
+    // 4. Evaluate the bootstrap and plugin bundle — both under the
+    //    wall-clock interrupt deadline (mirrors modulePackVm.ts). Without
+    //    it, a plugin bundle with a top-level `while (true) {}` would wedge
+    //    the worker thread before any other guard could engage.
+    withSyncDeadline(ctx, evalTimeoutMs, () => {
+      ctx.unwrapResult(ctx.evalCode(BOOTSTRAP_SOURCE, 'instatic-bootstrap.js')).dispose()
+    })
+    withSyncDeadline(ctx, evalTimeoutMs, () => {
+      ctx.unwrapResult(ctx.evalCode(args.pluginSource, `plugin:${args.env.pluginId}`)).dispose()
+    })
 
     // 5. Detect which lifecycle hooks the plugin exported.
     const exportedHooks = await evalJson<Array<'install' | 'activate' | 'deactivate' | 'uninstall' | 'migrate'>>(
       ctx,
       `__detectExportedHooks()`,
-      defaultEvalTimeoutMs,
+      evalTimeoutMs,
     )
 
     const pluginId = args.env.pluginId
@@ -251,11 +283,11 @@ export async function createPluginVm(args: {
       exportedHooks,
 
       async runLifecycle(hook) {
-        await evalVoid(ctx, `__runLifecycle(${JSON.stringify(hook)})`, defaultEvalTimeoutMs)
+        await evalVoid(ctx, `__runLifecycle(${JSON.stringify(hook)})`, evalTimeoutMs)
       },
 
       async runMigrate(fromVersion) {
-        await evalVoid(ctx, `__runMigrate(${JSON.stringify(fromVersion)})`, defaultEvalTimeoutMs)
+        await evalVoid(ctx, `__runMigrate(${JSON.stringify(fromVersion)})`, evalTimeoutMs)
       },
 
       async runRoute(routeKey, routeCtx) {
@@ -263,7 +295,7 @@ export async function createPluginVm(args: {
         const json = await evalString(
           ctx,
           `__runRoute(${JSON.stringify(routeKey)}, ${JSON.stringify(ctxJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
         return JSON.parse(json) as unknown
       },
@@ -273,7 +305,7 @@ export async function createPluginVm(args: {
         await evalVoid(
           ctx,
           `__runHookListener(${JSON.stringify(listenerId)}, ${JSON.stringify(payloadJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
       },
 
@@ -289,7 +321,7 @@ export async function createPluginVm(args: {
         const resultJson = await evalString(
           ctx,
           `__runHookFilter(${JSON.stringify(filterId)}, ${JSON.stringify(valueJson)}, ${JSON.stringify(contextJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
         return JSON.parse(resultJson) as unknown
       },
@@ -299,7 +331,7 @@ export async function createPluginVm(args: {
         const json = await evalString(
           ctx,
           `__runLoopFetch(${JSON.stringify(sourceId)}, ${JSON.stringify(ctxJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
         const parsed = JSON.parse(json) as { items?: unknown[]; totalItems?: number }
         return {
@@ -313,7 +345,7 @@ export async function createPluginVm(args: {
         const json = await evalString(
           ctx,
           `__runLoopPreview(${JSON.stringify(sourceId)}, ${JSON.stringify(ctxJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
         const parsed = JSON.parse(json) as unknown
         return Array.isArray(parsed) ? parsed : []
@@ -321,14 +353,14 @@ export async function createPluginVm(args: {
 
       async runSchedule(scheduleId, maxDurationMs) {
         // Per-schedule deadline replaces the VM's default 5s budget for
-        // this single call. The interrupt is reset by withDeadline's
-        // finally block so subsequent calls fall back to the default.
-        await evalVoid(ctx, `__runSchedule(${JSON.stringify(scheduleId)})`, maxDurationMs ?? defaultEvalTimeoutMs)
+        // this single call only — its registry token is released when the
+        // eval settles, so subsequent calls fall back to the default.
+        await evalVoid(ctx, `__runSchedule(${JSON.stringify(scheduleId)})`, maxDurationMs ?? evalTimeoutMs)
       },
 
       async updateSettings(next) {
         const json = JSON.stringify(next)
-        await evalVoid(ctx, `__updateSettings(${JSON.stringify(json)})`, defaultEvalTimeoutMs)
+        await evalVoid(ctx, `__updateSettings(${JSON.stringify(json)})`, evalTimeoutMs)
       },
 
       async runMediaAdapterCall(adapterId, method, callArgs) {
@@ -336,7 +368,7 @@ export async function createPluginVm(args: {
         const resultJson = await evalString(
           ctx,
           `__runMediaAdapterCall(${JSON.stringify(adapterId)}, ${JSON.stringify(method)}, ${JSON.stringify(argsJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
         return JSON.parse(resultJson) as unknown
       },
@@ -346,7 +378,7 @@ export async function createPluginVm(args: {
         const resultJson = await evalString(
           ctx,
           `__runMediaUrlTransformer(${JSON.stringify(transformerId)}, ${JSON.stringify(payloadJson)})`,
-          defaultEvalTimeoutMs,
+          evalTimeoutMs,
         )
         const parsed = JSON.parse(resultJson) as unknown
         return typeof parsed === 'string' ? parsed : null

--- a/server/plugins/runtime.ts
+++ b/server/plugins/runtime.ts
@@ -56,6 +56,7 @@ import {
   unloadPluginInWorker,
 } from './host/rpc'
 import { dispatchApiCall } from './host/apiDispatch'
+import { workerCallError } from './host/workerErrors'
 import { resetPluginWorker, setApiCallDispatcher } from './host/workerPool'
 import { broadcastPluginEvent } from './eventBroadcaster'
 
@@ -134,7 +135,7 @@ export async function loadPluginServerEntrypoint(
     settings: pluginSettingsCache.get(manifest.id) ?? {},
   })
   if (!result.ok) {
-    throw new Error(result.error ?? `Failed to load plugin "${manifest.id}" in worker`)
+    throw workerCallError(result.error ?? `Failed to load plugin "${manifest.id}" in worker`, result.stack)
   }
   return true
 }

--- a/src/__tests__/server/pluginVmDeadlines.test.ts
+++ b/src/__tests__/server/pluginVmDeadlines.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Sandbox hang hardening — wall-clock deadlines on EVERY way plugin code can
+ * execute inside the QuickJS VM, and VM stack preservation.
+ *
+ * Three hang vectors existed before these guards:
+ *   1. Top-level plugin code ran with no interrupt deadline — a bundle with
+ *      `while (true) {}` at module top level wedged the worker forever.
+ *   2. Concurrent evals on one context clobbered each other's deadline: each
+ *      eval overwrote the runtime's single interrupt handler and the first
+ *      eval to finish removed it, leaving any still-running eval unguarded.
+ *      Fixed by the per-runtime deadline registry in `quickjs/eval.ts`.
+ *   3. Timer-callback pumps (`__hostSleep` resolutions) drove
+ *      `executePendingJobs()` with no deadline — `setTimeout(() => {
+ *      while (true) {} })` wedged the worker permanently.
+ *
+ * Separately, rejected VM promises used to be re-thrown as bare
+ * `new Error(message)`, discarding the QuickJS stack (whose frames carry the
+ * useful `plugin:<id>` filename). `PluginVmError` now preserves it.
+ */
+import { describe, expect, it } from 'bun:test'
+import { createPluginVm, type PluginVmEnv } from '../../../server/plugins/quickjs/vm'
+import { PluginVmError, vmStackOf } from '../../../server/plugins/quickjs/eval'
+
+function makeEnv(pluginId: string): PluginVmEnv {
+  return {
+    pluginId,
+    manifestVersion: '1.0.0',
+    grantedPermissions: ['cms.schedule'],
+    assetBasePath: `/uploads/plugins/${pluginId}/1.0.0`,
+    settings: {},
+    hostCall: async () => null,
+    log: () => { /* swallow */ },
+  }
+}
+
+describe('plugin sandbox: eval deadlines', () => {
+  it('aborts a top-level infinite loop at load time instead of hanging', async () => {
+    const t0 = Date.now()
+    await expect(
+      createPluginVm({
+        env: makeEnv('acme.spinner'),
+        evalTimeoutMs: 300,
+        pluginSource: 'globalThis.__plugin_exports = {}; while (true) {}',
+      }),
+    ).rejects.toThrow(/interrupted/i)
+    // Interrupted within the deadline (+ slack), not after a worker hang.
+    expect(Date.now() - t0).toBeLessThan(3_000)
+  }, 10_000)
+
+  it('keeps the deadline armed for an eval that outlives an overlapping eval', async () => {
+    // `fast` finishes while `spin` is still pending. With the old
+    // install/remove interrupt-handler pair, fast's `finally` stripped the
+    // handler from the runtime and spin's later `while (true) {}` ran with
+    // NO deadline — wedging the thread forever. The deadline registry keeps
+    // one persistent handler armed until the LAST active deadline releases.
+    const vm = await createPluginVm({
+      env: makeEnv('acme.overlap'),
+      evalTimeoutMs: 400,
+      pluginSource: `
+        ;(function () {
+          const __plugin_exports = (globalThis.__plugin_exports = {});
+          __plugin_exports.activate = async function activate(api) {
+            api.cms.schedule.every(5, 'fast', async function () {
+              await new Promise(function (r) { setTimeout(r, 20); });
+            });
+            api.cms.schedule.every(5, 'spin', async function () {
+              await new Promise(function (r) { setTimeout(r, 60); });
+              while (true) {}
+            });
+          };
+        })();
+      `,
+    })
+    try {
+      await vm.runLifecycle('activate')
+      const spin = vm.runSchedule('acme.overlap.spin', 400)
+      const fast = vm.runSchedule('acme.overlap.fast', 400)
+      await fast // must NOT strip spin's deadline when it completes
+      await expect(spin).rejects.toThrow(/interrupted/i)
+    } finally {
+      vm.dispose()
+    }
+  }, 10_000)
+
+  it('interrupts a runaway timer callback and keeps the VM usable', async () => {
+    // The `while (true) {}` runs inside the __hostSleep timer pump — long
+    // after the eval that scheduled it resolved, so no eval deadline covers
+    // it. The pump's own deadline must abort it and the VM must survive.
+    const vm = await createPluginVm({
+      env: makeEnv('acme.timerspin'),
+      evalTimeoutMs: 150,
+      pluginSource: `
+        ;(function () {
+          const __plugin_exports = (globalThis.__plugin_exports = {});
+          __plugin_exports.activate = function activate() {
+            setTimeout(function () { while (true) {} }, 20);
+          };
+        })();
+      `,
+    })
+    try {
+      await vm.runLifecycle('activate')
+      // Let the timer fire and the pump interrupt it (deadline 150ms).
+      await new Promise((res) => setTimeout(res, 300))
+      // The VM is still serviceable after the aborted pump.
+      await vm.updateSettings({ stillAlive: true })
+    } finally {
+      vm.dispose()
+    }
+  }, 10_000)
+})
+
+describe('plugin sandbox: VM stack preservation', () => {
+  it('preserves the VM stack with the plugin:<id> filename on thrown errors', async () => {
+    const vm = await createPluginVm({
+      env: makeEnv('acme.stacky'),
+      pluginSource: `
+        ;(function () {
+          const __plugin_exports = (globalThis.__plugin_exports = {});
+          __plugin_exports.activate = async function activate() {
+            throw new Error('activation exploded');
+          };
+        })();
+      `,
+    })
+    try {
+      const err = await vm.runLifecycle('activate').then(
+        () => null,
+        (e: unknown) => e,
+      )
+      expect(err).toBeInstanceOf(PluginVmError)
+      const vmErr = err as PluginVmError
+      // Message stays clean — it travels into API replies / error envelopes.
+      expect(vmErr.message).toBe('activation exploded')
+      // The QuickJS frames name the plugin bundle's eval filename.
+      expect(vmErr.vmStack).toContain('plugin:acme.stacky')
+      // `.stack` shows the VM frames so `[plugin:<id>]` logs print them.
+      expect(vmErr.stack).toContain('activation exploded')
+      expect(vmErr.stack).toContain('plugin:acme.stacky')
+      expect(vmStackOf(err)).toBe(vmErr.vmStack)
+    } finally {
+      vm.dispose()
+    }
+  })
+
+  it('extracts the VM stack from synchronous top-level eval errors', async () => {
+    // Synchronous throws surface through `ctx.unwrapResult` as
+    // QuickJSUnwrapError, which carries the dumped VM error as `cause` —
+    // vmStackOf must read the frames from there too.
+    const err = await createPluginVm({
+      env: makeEnv('acme.boom'),
+      pluginSource: 'globalThis.__plugin_exports = {};\nthrow new Error(\'top-level boom\');',
+    }).then(
+      () => null,
+      (e: unknown) => e,
+    )
+    expect(err).toBeInstanceOf(Error)
+    expect((err as Error).message).toBe('top-level boom')
+    expect(vmStackOf(err)).toContain('plugin:acme.boom')
+  })
+})

--- a/src/__tests__/server/pluginWorkerRpcTimeout.test.ts
+++ b/src/__tests__/server/pluginWorkerRpcTimeout.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Host-side RPC timeout — `requestFromWorker` must never await a wedged
+ * worker forever.
+ *
+ * A worker whose VM is spinning never *crashes*, so before the timeout
+ * existed a hang was strictly worse than a crash: the pending promise (and
+ * the HTTP install request / publish render awaiting it) hung forever and
+ * crash recovery never engaged. On expiry the call now rejects with a
+ * descriptive error AND the worker is routed through the same teardown as a
+ * crash (`handleWorkerCrash`): terminate, reject sibling pendings, record a
+ * crash event for the admin UI, respawn-or-park via the sliding window.
+ *
+ * Workers here are injected stubs — `workers` / `pendingRequests` are the
+ * real shared host state, so the timeout path exercised is the production
+ * one end to end (minus the actual Bun.Worker).
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { requestFromWorker } from '../../../server/plugins/host/workerPool'
+import { setCrashRecoveryHandler } from '../../../server/plugins/host/crashRecovery'
+import { pendingRequests, workers } from '../../../server/plugins/host/workerState'
+import type { MainToWorkerMessage } from '../../../server/plugins/protocol/messages'
+
+function stubWorker(events: string[]): Worker {
+  return {
+    postMessage: () => { events.push('post') },
+    terminate: () => { events.push('terminate') },
+    addEventListener: () => { /* listeners unused for injected stubs */ },
+  } as unknown as Worker
+}
+
+function lifecycleMsg(pluginId: string, correlationId: string): MainToWorkerMessage {
+  return { kind: 'run-lifecycle', correlationId, pluginId, hook: 'activate' }
+}
+
+afterEach(() => {
+  workers.clear()
+  pendingRequests.clear()
+})
+
+describe('requestFromWorker timeout', () => {
+  it('rejects with a descriptive error and resets the wedged worker', async () => {
+    const events: string[] = []
+    const crashes: Array<{ pluginId: string; reason: string }> = []
+    setCrashRecoveryHandler(async ({ pluginId, reason }) => {
+      crashes.push({ pluginId, reason })
+    })
+    workers.set('acme.wedged-a', stubWorker(events))
+
+    await expect(
+      requestFromWorker('acme.wedged-a', lifecycleMsg('acme.wedged-a', 'corr-timeout'), 'lifecycle-result', {
+        timeoutMs: 40,
+      }),
+    ).rejects.toThrow('Plugin "acme.wedged-a" did not respond to run-lifecycle within 40ms')
+
+    // Crash-style teardown engaged: worker terminated + dropped so the next
+    // call respawns a fresh one, and no pending leaks behind.
+    expect(events).toEqual(['post', 'terminate'])
+    expect(workers.has('acme.wedged-a')).toBe(false)
+    expect(pendingRequests.size).toBe(0)
+
+    // The crash recovery handler (which persists the event the admin UI
+    // surfaces) was invoked with the timeout reason. It runs via
+    // queueMicrotask — yield once to let it land.
+    await new Promise((res) => setTimeout(res, 0))
+    expect(crashes).toEqual([
+      {
+        pluginId: 'acme.wedged-a',
+        reason: 'Plugin "acme.wedged-a" did not respond to run-lifecycle within 40ms',
+      },
+    ])
+  })
+
+  it('rejects sibling pending calls for the same plugin when one call times out', async () => {
+    setCrashRecoveryHandler(async () => { /* recorded elsewhere */ })
+    workers.set('acme.wedged-b', stubWorker([]))
+
+    // Capture rejections through synchronously-attached handlers — the
+    // crash teardown rejects corr-2 in the same tick that times out corr-1,
+    // so a late `.rejects` attachment would trip the unhandled-rejection
+    // reporter.
+    const asError = (e: unknown): Error | null => (e instanceof Error ? e : null)
+    const first = requestFromWorker('acme.wedged-b', lifecycleMsg('acme.wedged-b', 'corr-1'), 'lifecycle-result', {
+      timeoutMs: 40,
+    }).then(() => null, asError)
+    const second = requestFromWorker('acme.wedged-b', lifecycleMsg('acme.wedged-b', 'corr-2'), 'lifecycle-result', {
+      timeoutMs: 60_000,
+    }).then(() => null, asError)
+
+    const firstErr = await first
+    expect(firstErr?.message).toContain('did not respond to run-lifecycle within 40ms')
+    // The wedged worker can't service corr-2 either — crash teardown
+    // rejects it instead of leaving it pending for its full budget.
+    const secondErr = await second
+    expect(secondErr?.message).toMatch(/worker crashed/)
+    expect(pendingRequests.size).toBe(0)
+  })
+
+  it('resolves normally and skips the reset when the reply arrives in time', async () => {
+    const events: string[] = []
+    workers.set('acme.healthy', stubWorker(events))
+
+    const promise = requestFromWorker('acme.healthy', lifecycleMsg('acme.healthy', 'corr-ok'), 'lifecycle-result', {
+      timeoutMs: 50,
+    })
+    // Deliver the worker's reply the same way handleWorkerMessage does:
+    // remove the pending entry, then resolve it.
+    const pending = pendingRequests.get('corr-ok')
+    expect(pending).toBeDefined()
+    pendingRequests.delete('corr-ok')
+    pending!.resolve({ kind: 'lifecycle-result', correlationId: 'corr-ok', ok: true })
+
+    const result = await promise
+    expect(result.ok).toBe(true)
+
+    // Wait past the deadline — the cleared timer must not reset the worker.
+    await new Promise((res) => setTimeout(res, 80))
+    expect(events).toEqual(['post'])
+    expect(workers.has('acme.healthy')).toBe(true)
+  })
+})

--- a/src/__tests__/server/wrapEsmAsGlobal.test.ts
+++ b/src/__tests__/server/wrapEsmAsGlobal.test.ts
@@ -113,3 +113,21 @@ describe('wrapEsmAsGlobal — pass-through', () => {
     expect(wrapEsmAsGlobal(pre, '__module_pack', { unwrapDefault: true })).toBe(pre)
   })
 })
+
+describe('wrapEsmAsGlobal — stack-trace line numbers', () => {
+  it('adds zero line offset so VM stack frames match the shipped bundle', () => {
+    // The IIFE prelude shares the first physical line with the source's
+    // first line; a wrapper that prepended its own lines would shift every
+    // QuickJS stack-trace line number reported under `plugin:<id>`.
+    const src = `const a = 1;\nconst b = 2;\nexport default a + b;`
+    const lines = wrapEsmAsGlobal(src, '__plugin_exports').split('\n')
+    expect(lines[0]).toContain('const a = 1;')
+    expect(lines[1]).toBe('const b = 2;')
+    expect(lines[2]).toContain('__exports.default = a + b;')
+  })
+
+  it('still evaluates correctly with the single-line prelude', () => {
+    const out = run(wrapEsmAsGlobal(`// leading comment\nexport const x = 41 + 1;`, '__plugin_exports'))
+    expect((out.__plugin_exports as Sandbox).x).toBe(42)
+  })
+})


### PR DESCRIPTION
A wedged plugin VM could previously pin a worker thread forever — and because a hung worker never *crashes*, crash recovery never engaged, leaving HTTP requests and publish renders hanging indefinitely. This PR closes every hang vector found in the audit and stops discarding QuickJS stack traces.

## Fixes

**1. Top-level plugin code now runs under an interrupt deadline** (`server/plugins/quickjs/vm.ts`)
The bootstrap and plugin-bundle evals are wrapped in `withSyncDeadline` (mirroring the existing `modulePackVm.ts` precedent). A bundle with `while(true){}` at module top level now fails to load with an `interrupted` error within the 5 s eval budget instead of wedging the worker.

**2. Concurrent evals no longer clobber each other's deadline** (`server/plugins/quickjs/eval.ts`)
The old `installDeadline`/remove pair used the runtime's single interrupt-handler slot per eval — the first eval to finish removed the handler, leaving any still-running eval with NO deadline. Replaced with a per-runtime registry of active deadline tokens: one persistent interrupt handler (installed with the first token, removed with the last) interrupts when the wall clock passes the **max** of active deadlines — never falsely interrupts an eval with remaining budget, still guarantees no infinite hang. `installDeadline`/`removeDeadline` are gone.

**3. Timer-callback pumps run under a deadline** (`server/plugins/quickjs/vm.ts`)
`__hostCall` resolutions and `__hostSleep` timer fires now drain `executePendingJobs()` through `pumpPendingJobs()`, which registers its own deadline and logs aborted jobs with the `[plugin:<id>]` prefix. `setTimeout/setInterval(() => { while(true){} })` is interrupted and the VM stays usable.

**4. Host-side RPC timeout** (`server/plugins/host/workerPool.ts`, `host/rpc.ts`)
`requestFromWorker` takes an options parameter with `timeoutMs` (default `DEFAULT_RPC_TIMEOUT_MS` = 30 s); `runScheduleInWorker` passes `maxDurationMs + 10 s` slack so the normal overrun path stays a clean in-VM `status: 'timeout'`. On expiry the pending call rejects with `Plugin "<id>" did not respond to <kind> within <ms>ms` and the wedged worker is routed through the existing crash machinery (`handleWorkerCrash`): terminated, sibling pendings rejected, host registrations dropped, crash event recorded/broadcast for the admin UI, sliding-window respawn-or-park. A hang is no longer strictly worse than a crash.

**5. VM stack traces are preserved** (`quickjs/eval.ts`, `pluginWorker.ts`, `protocol/messages.ts`, `host/{rpc,media,workerErrors}.ts`, `runtime.ts`)
Rejected VM promises now throw `PluginVmError` carrying the QuickJS frames (plugin bundles eval with filename `plugin:<id>`); `vmStackOf()` also extracts frames from `QuickJSUnwrapError.cause` for synchronous throws. The worker forwards frames on a new optional `stack` field on the `*-result` protocol messages; the host prints them in `[plugin:<id>]` logs and rewrites thrown errors' `.stack` — error **messages** stay clean and HTTP response bodies never carry stacks.

**Also:**
- `quickjs/esmShim.ts`: the IIFE prelude now shares the first physical line with the source, so wrapping adds **zero** stack-trace line offset.
- `quickjs/eval.ts`: fixed an owned-handle leak (double `getPromiseState` probe on settled promises) that tripped QuickJS's `gc_obj_list` assertion at runtime dispose — surfaced by the new rejection tests.
- `docs/features/plugin-system.md`: new "Resource limits and timeouts" section documenting the heap/stack/eval/RPC budgets and what errors plugin authors see.

## Tests

- `src/__tests__/server/pluginVmDeadlines.test.ts` — (a) top-level infinite loop fails to load with an interrupt error in bounded time; (b) an eval that outlives an overlapping eval keeps its deadline; runaway timer callbacks are interrupted and the VM survives; (d) thrown VM errors preserve `vmStack` with the `plugin:<id>` filename (both async-rejection and sync-unwrap paths).
- `src/__tests__/server/pluginWorkerRpcTimeout.test.ts` — (c) timeout rejects with the descriptive error, terminates/resets the worker, invokes the crash-recovery handler with the timeout reason; sibling pendings rejected; in-time replies resolve with no reset.
- `src/__tests__/server/wrapEsmAsGlobal.test.ts` — zero line offset + single-line-prelude evaluation.

## Verification

- `bun run build` — pass (tsc + vite)
- `bun test` — 4919 pass, 0 fail (525 files)
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)