### PR TITLE
Namespace plugin-emitted hook events to plugin.<id>.*

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -369,10 +369,13 @@ Plugin storage is per-plugin, per-collection. The collection name must match a `
 ```js
 api.cms.hooks.on('publish.after', async (event) => { /* … */ })
 api.cms.hooks.filter('publish.html', async (html) => html + '<!-- plugin -->')
-await api.cms.hooks.emit('my.plugin.signal', { /* … */ })
+const name = await api.cms.hooks.emit('sync.done', { /* … */ })
+// name === 'plugin.<your-plugin-id>.sync.done'
 ```
 
-Hook channels include `publish.before`, `publish.html`, `publish.after`, `media.uploaded`, plus plugin-emitted custom channels.
+**Host-emitted events** (the reserved core list, `CORE_HOOK_EVENTS` in `src/core/plugins/hookBus.ts`): `publish.before`, `publish.after`, `content.entry.created`, `content.entry.updated`, `content.entry.deleted`, `settings.changed`. **Filters**: `publish.html`, `publish.headers`, `content.entry.cells`.
+
+**Plugin emits are namespaced.** The host rewrites every `emit('<name>', …)` to `plugin.<your-plugin-id>.<name>` (a name already in your own namespace passes through unchanged), so event provenance is unforgeable — a plugin cannot fire `content.entry.created` or any other core event at other listeners, and emitting a name in *another* plugin's namespace (`plugin.<other-id>.*`) is rejected with an error. `emit` resolves to the canonical namespaced name. Cross-plugin eventing still works: subscribing is unrestricted, so a plugin listens to another plugin's events by their full namespaced name, e.g. `api.cms.hooks.on('plugin.acme.analytics.page-view', …)`.
 
 ### Loop sources — requires `loops.register`
 

--- a/server/plugins/host/handlers/hooks.ts
+++ b/server/plugins/host/handlers/hooks.ts
@@ -7,7 +7,7 @@
  * and filters are thin shims that round-trip to the plugin's worker via the RPC layer.
  */
 
-import { hookBus } from '@core/plugins/hookBus'
+import { canonicalPluginEventName, hookBus } from '@core/plugins/hookBus'
 import type { ApiCallFor } from '../../protocol/apiCallSchema'
 import type { DbClient } from '../../../db/client'
 import { replyApiOk } from '../apiReplies'
@@ -47,6 +47,15 @@ export async function handleHooksEmit(
   _db: DbClient,
 ): Promise<void> {
   const [{ event, payload }] = msg.args
-  await hookBus.emit(event, payload)
-  replyApiOk(msg.pluginId, msg.correlationId)
+  // SECURITY: plugin emits are force-namespaced to `plugin.<id>.<name>` so a
+  // plugin can never forge a core/host event (`settings.changed`,
+  // `content.entry.*`, `publish.*`) or impersonate another plugin's namespace
+  // (that throws, surfacing as an api-error reply via dispatchApiCall).
+  // `msg.pluginId` is the host-verified worker identity (validated against
+  // the worker in workerPool), never plugin-supplied data.
+  const canonicalEvent = canonicalPluginEventName(msg.pluginId, event)
+  await hookBus.emit(canonicalEvent, payload)
+  // Resolve the emit with the canonical name so plugin authors can log /
+  // share the exact name other plugins must subscribe to.
+  replyApiOk(msg.pluginId, msg.correlationId, canonicalEvent)
 }

--- a/server/plugins/quickjs/bootstrap/src/buildApi.ts
+++ b/server/plugins/quickjs/bootstrap/src/buildApi.ts
@@ -128,6 +128,9 @@ globalThis.__buildApi = function buildApi() {
     globalThis.__plugin_handlers.filters[filterId] = handler as BootstrapFn
     return call('cms.hooks.filter', [{ name: String(name), filterId: filterId }])
   }
+  // Plugin emits are force-namespaced by the host: `emit('x', …)` is
+  // delivered as `plugin.<id>.x`, names in another plugin's namespace are
+  // rejected, and the call resolves to the canonical (namespaced) name.
   function emit(event: unknown, payload: unknown) {
     assertTargetPermission('cms.hooks.emit')
     return call('cms.hooks.emit', [{ event: String(event), payload: payload === undefined ? null : payload }])

--- a/src/__tests__/plugins/pluginHookBus.test.ts
+++ b/src/__tests__/plugins/pluginHookBus.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { hookBus } from '@core/plugins/hookBus'
+import { canonicalPluginEventName, hookBus } from '@core/plugins/hookBus'
 
 afterEach(() => {
   hookBus.reset()
@@ -30,13 +30,13 @@ describe('hookBus', () => {
 
   it('isolates listener errors so other listeners still run', async () => {
     const calls: string[] = []
-    hookBus.on('plugin.bad', 'evt', () => {
+    hookBus.on('plugin.bad', 'plugin.x.evt', () => {
       throw new Error('boom')
     })
-    hookBus.on('plugin.good', 'evt', () => {
+    hookBus.on('plugin.good', 'plugin.x.evt', () => {
       calls.push('good')
     })
-    await hookBus.emit('evt', {})
+    await hookBus.emit('plugin.x.evt', {})
     expect(calls).toEqual(['good'])
   })
 
@@ -48,6 +48,15 @@ describe('hookBus', () => {
     expect(await hookBus.applyFilter('pipe', 'seed')).toBe('seed-good')
   })
 
+  it('delivers host emits of core events to listeners on the bare core name', async () => {
+    const seen: unknown[] = []
+    hookBus.on('acme.x', 'settings.changed', (payload) => {
+      seen.push(payload)
+    })
+    await hookBus.emit('settings.changed', { pluginId: 'acme.x' })
+    expect(seen).toEqual([{ pluginId: 'acme.x' }])
+  })
+
   it('unregisterPlugin removes both events and filters for that plugin id', async () => {
     hookBus.on('plugin.x', 'evt', () => {})
     hookBus.filter('plugin.x', 'pipe', (v) => v)
@@ -56,5 +65,38 @@ describe('hookBus', () => {
 
     expect(hookBus.hasListenersFor('evt')).toBe(true) // y still registered
     expect(hookBus.hasFiltersFor('pipe')).toBe(false)
+  })
+})
+
+describe('canonicalPluginEventName', () => {
+  it('namespaces a bare event name to plugin.<id>.<name>', () => {
+    expect(canonicalPluginEventName('acme.x', 'sync.done')).toBe('plugin.acme.x.sync.done')
+  })
+
+  it('namespaces a reserved core name so it cannot reach core-name listeners', async () => {
+    const canonical = canonicalPluginEventName('acme.x', 'content.entry.created')
+    expect(canonical).toBe('plugin.acme.x.content.entry.created')
+
+    const coreSeen: unknown[] = []
+    const namespacedSeen: unknown[] = []
+    hookBus.on('victim.plugin', 'content.entry.created', (payload) => {
+      coreSeen.push(payload)
+    })
+    hookBus.on('observer.plugin', canonical, (payload) => {
+      namespacedSeen.push(payload)
+    })
+    await hookBus.emit(canonical, { forged: true })
+    expect(coreSeen).toEqual([])
+    expect(namespacedSeen).toEqual([{ forged: true }])
+  })
+
+  it('does not double-prefix a name already in the plugin\'s own namespace', () => {
+    expect(canonicalPluginEventName('acme.x', 'plugin.acme.x.sync.done')).toBe('plugin.acme.x.sync.done')
+  })
+
+  it('rejects a name in another plugin\'s namespace (impersonation)', () => {
+    expect(() => canonicalPluginEventName('acme.x', 'plugin.zeta.y.sync.done')).toThrow(
+      /Plugin "acme\.x" cannot emit "plugin\.zeta\.y\.sync\.done"/,
+    )
   })
 })

--- a/src/__tests__/server/cmsPlugins.test.ts
+++ b/src/__tests__/server/cmsPlugins.test.ts
@@ -670,7 +670,8 @@ describe('CMS plugin handlers', () => {
     function attachListener(): void {
       // Idempotent — drop any prior 'test' listener so this never double-fires.
       hookBus.unregisterPlugin('test')
-      hookBus.on('test', 'lifecycle.mark', async (payload: unknown) => {
+      // Plugin emits arrive force-namespaced as `plugin.<id>.<name>`.
+      hookBus.on('test', 'plugin.acme.lifecycle.lifecycle.mark', async (payload: unknown) => {
         if (payload && typeof payload === 'object') {
           const p = payload as { name?: unknown; pluginId?: unknown }
           if (typeof p.name === 'string' && typeof p.pluginId === 'string') {
@@ -914,7 +915,8 @@ describe('CMS plugin handlers', () => {
     function attachListener(): void {
       // Idempotent — drop any prior 'test' listener so this never double-fires.
       hookBus.unregisterPlugin('test')
-      hookBus.on('test', 'upgrade.mark', async (payload: unknown) => {
+      // Plugin emits arrive force-namespaced as `plugin.<id>.<name>`.
+      hookBus.on('test', 'plugin.acme.upgrade.upgrade.mark', async (payload: unknown) => {
         if (payload && typeof payload === 'object' && typeof (payload as { line?: unknown }).line === 'string') {
           markers.push(String((payload as { line: string }).line))
         }
@@ -1192,7 +1194,8 @@ describe('CMS plugin handlers', () => {
     const markers: string[] = []
     function attachListener(): void {
       hookBus.unregisterPlugin('test')
-      hookBus.on('test', 'restart.mark', async () => { markers.push('activate') })
+      // Plugin emits arrive force-namespaced as `plugin.<id>.<name>`.
+      hookBus.on('test', 'plugin.test.restart.restart.mark', async () => { markers.push('activate') })
     }
     attachListener()
     try {

--- a/src/__tests__/server/pluginServerRuntime.test.ts
+++ b/src/__tests__/server/pluginServerRuntime.test.ts
@@ -398,7 +398,8 @@ describe('server plugin runtime SDK', () => {
     // the sandbox-safe cross-context channel: the plugin emits a hook event
     // with its metadata, and the host subscribes to capture it.
     const captured: Array<Record<string, unknown>> = []
-    hookBus.on('test', 'plugin.metadata.observed', async (payload: unknown) => {
+    // Plugin emits arrive force-namespaced as `plugin.<id>.<name>`.
+    hookBus.on('test', 'plugin.acme.workflow.metadata.observed', async (payload: unknown) => {
       if (payload && typeof payload === 'object') {
         captured.push(payload as Record<string, unknown>)
       }
@@ -409,7 +410,7 @@ describe('server plugin runtime SDK', () => {
         manifest: { ...baseManifest, permissions: ['cms.routes', 'cms.hooks'] },
         serverEntrypoint: `
           export async function activate(api) {
-            await api.cms.hooks.emit('plugin.metadata.observed', {
+            await api.cms.hooks.emit('metadata.observed', {
               id: api.plugin.id,
               version: api.plugin.version,
               permissions: api.plugin.permissions.slice().sort().join(','),
@@ -576,6 +577,80 @@ describe('server plugin runtime SDK', () => {
       )
       expect(await res.json()).toEqual({ observed: 'rotated' })
     } finally {
+      await rm(uploadsDir, { recursive: true, force: true })
+    }
+  })
+
+  it('force-namespaces plugin emits and rejects impersonation of other plugins', async () => {
+    const uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-hook-namespace-'))
+    const db = makeFakeDb()
+    const cookie = await createCookie(db)
+
+    const seen: Array<{ event: string; payload: unknown }> = []
+    const subscribe = (event: string) => {
+      hookBus.on('test', event, async (payload: unknown) => {
+        seen.push({ event, payload })
+      })
+    }
+    // (b) a forged core name must never reach core-name listeners…
+    subscribe('content.entry.created')
+    // …it arrives namespaced instead.
+    subscribe('plugin.acme.workflow.content.entry.created')
+    // (a) a bare custom name lands namespaced; (c) an emit pre-prefixed with
+    // the plugin's own id is not double-prefixed (both resolve to this name).
+    subscribe('plugin.acme.workflow.sync.done')
+    // (d) the impersonation rejection the plugin observed in its catch.
+    subscribe('plugin.acme.workflow.rejection.observed')
+
+    try {
+      const install = await installPlugin({
+        manifest: { ...baseManifest, permissions: ['cms.routes', 'cms.hooks'] },
+        serverEntrypoint: `
+          export async function activate(api) {
+            const bare = await api.cms.hooks.emit('sync.done', { via: 'bare' })
+            const prefixed = await api.cms.hooks.emit('plugin.acme.workflow.sync.done', { via: 'prefixed', bare: bare })
+            await api.cms.hooks.emit('content.entry.created', { forged: true })
+            // (d) another plugin's namespace is rejected with a clear error.
+            let rejection = 'none'
+            try {
+              await api.cms.hooks.emit('plugin.zeta.other.evil', {})
+            } catch (err) {
+              rejection = String((err && err.message) || err)
+            }
+            await api.cms.hooks.emit('rejection.observed', { rejection: rejection, prefixed: prefixed })
+          }
+        `,
+        grantedPermissions: ['cms.routes', 'cms.hooks'],
+        uploadsDir,
+        db,
+        cookie,
+      })
+      expect(install.status).toBe(201)
+
+      // The cross-namespace emit was rejected with the impersonation error.
+      const rejected = seen.find((s) => s.event === 'plugin.acme.workflow.rejection.observed')
+      expect(rejected?.payload).toMatchObject({
+        rejection: expect.stringContaining(
+          'Plugin "acme.workflow" cannot emit "plugin.zeta.other.evil"',
+        ),
+      })
+
+      // The forged core emit never reached the core-name listener.
+      expect(seen.filter((s) => s.event === 'content.entry.created')).toEqual([])
+      expect(seen.filter((s) => s.event === 'plugin.acme.workflow.content.entry.created')).toEqual([
+        { event: 'plugin.acme.workflow.content.entry.created', payload: { forged: true } },
+      ])
+      // Bare and self-prefixed emits land on the SAME canonical name, and the
+      // emit call resolved to that canonical name.
+      expect(seen.filter((s) => s.event === 'plugin.acme.workflow.sync.done')).toEqual([
+        { event: 'plugin.acme.workflow.sync.done', payload: { via: 'bare' } },
+        {
+          event: 'plugin.acme.workflow.sync.done',
+          payload: { via: 'prefixed', bare: 'plugin.acme.workflow.sync.done' },
+        },
+      ])
+    } finally {
+      hookBus.unregisterPlugin('test')
       await rm(uploadsDir, { recursive: true, force: true })
     }
   })

--- a/src/__tests__/server/pluginVmPermissions.test.ts
+++ b/src/__tests__/server/pluginVmPermissions.test.ts
@@ -111,7 +111,7 @@ describe('VM-side permission enforcement', () => {
         ;(function () {
           const __plugin_exports = (globalThis.__plugin_exports = {});
           __plugin_exports.activate = async function activate(api) {
-            await api.cms.hooks.emit('plugin.perms', api.plugin.permissions.slice().sort());
+            await api.cms.hooks.emit('perms.observed', api.plugin.permissions.slice().sort());
           };
         })();
       `,
@@ -133,8 +133,10 @@ describe('VM-side permission enforcement', () => {
       const emit = calls.find((c) => c.target === 'cms.hooks.emit')
       expect(emit).toBeDefined()
       // `api.plugin.permissions` mirrors the authoritative granted set.
+      // The VM sends the RAW name — namespacing to `plugin.<id>.*` is the
+      // host dispatcher's job (canonicalPluginEventName in handleHooksEmit).
       expect(emit?.args?.[0]).toMatchObject({
-        event: 'plugin.perms',
+        event: 'perms.observed',
         payload: ['cms.hooks', 'cms.routes'],
       })
     } finally {

--- a/src/core/plugin-sdk/types/hooks.ts
+++ b/src/core/plugin-sdk/types/hooks.ts
@@ -42,8 +42,10 @@ export interface CmsServerEvents {
   // Plugin-defined events fall through. The host does not pre-define any
   // frontend-specific event channels — plugins that ingest events from
   // their own published-page bundles register their own `routes.public.post`
-  // endpoints and (optionally) re-emit on the hook bus under a namespaced
-  // name (`instatic.analytics.page-view`) for cross-plugin coordination.
+  // endpoints and (optionally) re-emit on the hook bus for cross-plugin
+  // coordination. Plugin emits are always namespaced by the host, so the
+  // name other plugins subscribe to is `plugin.<emitter-id>.<name>` (e.g.
+  // `plugin.instatic.analytics.page-view`).
   [key: string]: Record<string, unknown>
 }
 
@@ -101,8 +103,17 @@ export interface ServerPluginHooksApi {
       | (K extends keyof CmsServerFilters ? CmsServerFilters[K] : unknown)
       | Promise<K extends keyof CmsServerFilters ? CmsServerFilters[K] : unknown>,
   ) => void
-  emit: <K extends keyof CmsServerEvents | string>(
-    event: K,
-    payload: K extends keyof CmsServerEvents ? CmsServerEvents[K] : Record<string, unknown>,
-  ) => Promise<void>
+  /**
+   * Emit a custom event on the hook bus. The host force-namespaces the name
+   * to the emitting plugin: `emit('sync.done', …)` is delivered as
+   * `plugin.<your-id>.sync.done`. A name already in your own namespace
+   * passes through unchanged; a name in another plugin's namespace
+   * (`plugin.<other-id>.*`) is rejected. Core host events (`publish.*`,
+   * `content.entry.*`, `settings.changed`) therefore cannot be forged —
+   * emitting one just yields `plugin.<your-id>.<name>`.
+   *
+   * Resolves to the canonical (namespaced) event name — the exact string
+   * other plugins must pass to `on()` to receive your events.
+   */
+  emit: (event: string, payload: unknown) => Promise<string>
 }

--- a/src/core/plugins/hookBus.ts
+++ b/src/core/plugins/hookBus.ts
@@ -18,7 +18,65 @@
  *
  * Plugin registration is keyed by plugin id so `unregisterPlugin(pluginId)`
  * cleanly tears everything down on disable/uninstall.
+ *
+ * Event-name provenance: only the HOST emits the reserved core events in
+ * `CORE_HOOK_EVENTS`. Plugin-emitted events (via `cms.hooks.emit`) are
+ * force-namespaced to `plugin.<pluginId>.<name>` through
+ * `canonicalPluginEventName` before they reach `emit`, so a plugin can never
+ * forge a core event or impersonate another plugin. `emit` is typed against
+ * exactly those two name spaces — a new host emit site cannot introduce a
+ * core event without adding it to `CORE_HOOK_EVENTS` first.
  */
+
+/**
+ * Reserved host-emitted event names — the single source of truth. Plugins can
+ * LISTEN to these freely, but cannot emit them: plugin emits are always
+ * canonicalized into the `plugin.<pluginId>.*` namespace.
+ */
+export const CORE_HOOK_EVENTS = [
+  'settings.changed',
+  'content.entry.created',
+  'content.entry.updated',
+  'content.entry.deleted',
+  'publish.before',
+  'publish.after',
+] as const
+
+export type CoreHookEvent = (typeof CORE_HOOK_EVENTS)[number]
+
+/** A plugin-emitted event name, always of the form `plugin.<pluginId>.<name>`. */
+export type PluginScopedHookEvent = `plugin.${string}`
+
+/**
+ * Canonical name for a plugin-emitted hook event.
+ *
+ * Rules (one coherent contract — auto-prefix, never spoof):
+ *   • already in the plugin's own namespace (`plugin.<pluginId>.…`) — returned
+ *     unchanged (no double prefix)
+ *   • in the `plugin.*` namespace but NOT the plugin's own — thrown as an
+ *     impersonation attempt
+ *   • any other name (including reserved core names) — prefixed with
+ *     `plugin.<pluginId>.`, so e.g. a raw emit of `content.entry.created`
+ *     becomes the harmless `plugin.<pluginId>.content.entry.created`
+ *
+ * `pluginId` must be the host-verified worker identity (validated in
+ * `workerPool`), never a plugin-supplied value.
+ */
+export function canonicalPluginEventName(pluginId: string, event: string): PluginScopedHookEvent {
+  const ownNamespace = `plugin.${pluginId}.` as const
+  if (event.startsWith(ownNamespace)) {
+    // startsWith doesn't narrow string → template-literal type; the prefix
+    // check above is exactly the PluginScopedHookEvent shape.
+    return event as PluginScopedHookEvent
+  }
+  if (event.startsWith('plugin.')) {
+    throw new Error(
+      `Plugin "${pluginId}" cannot emit "${event}": the plugin.* event namespace is reserved per plugin. ` +
+        `Emit "${ownNamespace}<name>" or a bare name, which is namespaced to "${ownNamespace}<name>" automatically.`,
+    )
+  }
+  return `${ownNamespace}${event}`
+}
 
 type HookListener = (payload: unknown) => void | Promise<void>
 type HookFilterHandler = (
@@ -79,8 +137,12 @@ class HookBus {
    * Fire an event. Listeners run sequentially; an error in one listener is
    * logged and does not stop the others. Returns when every listener has
    * resolved or rejected.
+   *
+   * The name type is the enforcement that `CORE_HOOK_EVENTS` cannot drift:
+   * host emit sites must use a listed core name, and everything else must
+   * already be plugin-namespaced (the output of `canonicalPluginEventName`).
    */
-  async emit(event: string, payload: unknown): Promise<void> {
+  async emit(event: CoreHookEvent | PluginScopedHookEvent, payload: unknown): Promise<void> {
     const entries = this.listeners.get(event)
     if (!entries) return
     for (const entry of entries) {


### PR DESCRIPTION
## Summary

Security fix: any plugin granted `cms.hooks` could forge core/system events. `handleHooksEmit` (`server/plugins/host/handlers/hooks.ts`) passed the plugin-supplied event name straight to `hookBus.emit`, so plugin A could fire a fake `content.entry.created` at plugin B's listeners or spoof `settings.changed` / `publish.before` / `publish.after`.

Plugin-emitted events are now **force-namespaced to `plugin.<pluginId>.<name>`** by the host, making event provenance explicit and unforgeable. The contract (one coherent rule — auto-prefix, never spoof):

- a bare name (`sync.done`) is delivered as `plugin.<id>.sync.done` — including reserved core names, so a raw emit of `content.entry.created` becomes the harmless `plugin.<id>.content.entry.created`
- a name already in the plugin's **own** namespace passes through unchanged (no double prefix)
- a name in **another** plugin's namespace (`plugin.<other-id>.*`) is rejected with a clear impersonation error
- subscriptions (`cms.hooks.on`) stay unrestricted — cross-plugin eventing works by listening to the full namespaced name
- `cms.hooks.emit` now resolves to the canonical namespaced name

## Changes

- `server/plugins/host/handlers/hooks.ts` — kernel of correctness: `handleHooksEmit` canonicalizes via the worker-verified `msg.pluginId` (never plugin-supplied data) and replies with the canonical name
- `src/core/plugins/hookBus.ts` — `canonicalPluginEventName()` + `CORE_HOOK_EVENTS` as the single source of truth for reserved host events (`settings.changed`, `content.entry.created/updated/deleted`, `publish.before/after`); `HookBus.emit` is typed `CoreHookEvent | PluginScopedHookEvent`, so a host emit site cannot introduce a core event without adding it to the list (compile-time anti-drift)
- `src/core/plugin-sdk/types/hooks.ts` — `ServerPluginHooksApi.emit` documents the namespacing and returns `Promise<string>` (the canonical name); fixed the cross-plugin naming example
- `server/plugins/quickjs/bootstrap/src/buildApi.ts` — VM-side contract comment; `bun run bootstrap:sync` ran (generated artifacts byte-identical — comments are stripped by bundling; `plugin-bootstrap-fresh.test.ts` green)
- `docs/features/plugin-system.md` — namespace rule, reserved host-event list, cross-plugin listening; removed the phantom `media.uploaded` event (documented but never emitted)
- Editor-side plugin API exposes no hook emit (`src/core/plugins/runtime.ts` / `events.ts` are unrelated surfaces) — nothing to change there
- `examples/plugins/template/` does not use `hooks.emit` — unchanged

## Tests

- `src/__tests__/plugins/pluginHookBus.test.ts` — unit coverage of all four canonicalization rules + host core emits still reaching bare-name listeners
- `src/__tests__/server/pluginServerRuntime.test.ts` — new end-to-end test through real plugin install/activate: bare emit lands namespaced; forged `content.entry.created` never reaches core-name listeners; self-prefixed emit not double-prefixed; other-namespace emit rejected with a clear error; emit resolves to the canonical name
- Updated existing tests that listened on raw plugin-emitted names (`cmsPlugins.test.ts`, `pluginServerRuntime.test.ts`, `pluginVmPermissions.test.ts`)

## Verification

- `bun test` — 4915 pass, 0 fail
- `bun run build` (`tsc -b && vite build`) — clean
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)