### PR TITLE
Mask secret plugin settings on every client-facing payload

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -438,6 +438,10 @@ Settings are typed (`string` / `number` / `boolean` / `secret`) and rendered aut
 
 Settings writes go live immediately. When an operator saves the admin form (or the plugin calls `settings.replace`), the host persists the record, refreshes its load-time cache, pushes the merged-with-defaults values into the running VM's mirror (an `update-settings` worker message — a no-op when the plugin isn't loaded), and only then emits the `settings.changed` hook. `api.cms.settings.get(...)` therefore returns the new value without a plugin reload — including inside a `settings.changed` listener.
 
+**Secrets never reach the browser.** A setting declared with `secret: true` is masked to `'***'` on every payload the host sends to the admin UI — the plugins list, install/upgrade/enable/disable/restart responses, the settings GET/PUT responses, admin-page route snapshots (`usePluginSettings`), and editor-panel settings snapshots. Only server-side plugin code running in the QuickJS worker reads the real value, via `api.cms.settings.get` / `getAll`. Editor-side and admin-app plugin code that needs a secret-derived capability must proxy through a plugin server route instead of reading the value directly.
+
+The settings form round-trips the mask: a PUT where a secret field still carries the `'***'` sentinel keeps the stored value, a PUT with a new string replaces it, and a PUT with an empty string clears it (which also means a secret can never literally be `'***'`). The sentinel logic lives next to the masking helper in `src/core/plugin-sdk/builders/settings.ts` (`maskSecretSettings` / `resolveSecretSettingsUpdate` / `SECRET_SETTING_MASK`).
+
 ### Scheduled jobs — requires `cms.schedule`
 
 ```js

--- a/server/handlers/cms/plugins/install.ts
+++ b/server/handlers/cms/plugins/install.ts
@@ -54,6 +54,7 @@ import { type CmsHandlerOptions } from '../shared'
 import {
   assertPluginPermissionGrants,
   lifecycleErrorMessage,
+  maskPluginSecrets,
   pluginManifestWithGrants,
   pluginsPayload,
   readPermissionGrants,
@@ -106,7 +107,7 @@ export async function handlePluginsCollection(
         version: plugin.version,
         occurredAt: new Date().toISOString(),
       })
-      return jsonResponse({ plugin, ...(await pluginsPayload(db)) }, { status: 201 })
+      return jsonResponse({ plugin: maskPluginSecrets(plugin), ...(await pluginsPayload(db)) }, { status: 201 })
     } catch (err) {
       return badRequest(getErrorMessage(err, 'Invalid plugin manifest'))
     }
@@ -214,7 +215,7 @@ async function installFreshFromPackage(ctx: InstallContext): Promise<Response> {
   const installLifecycle = await runPluginLifecycleHook(db, installed, options, 'install', 'installed')
   if (!installLifecycle.ok) {
     return jsonResponse(
-      { plugin: installLifecycle.plugin, ...(await pluginsPayload(db)) },
+      { plugin: maskPluginSecrets(installLifecycle.plugin), ...(await pluginsPayload(db)) },
       { status: 201 },
     )
   }
@@ -251,7 +252,7 @@ async function installFreshFromPackage(ctx: InstallContext): Promise<Response> {
   })
   return jsonResponse(
     {
-      plugin: activateLifecycle.plugin,
+      plugin: maskPluginSecrets(activateLifecycle.plugin),
       ...(await pluginsPayload(db)),
       pack: packSummary,
     },
@@ -381,7 +382,7 @@ async function installUpgradeFromPackage(ctx: UpgradeContext): Promise<Response>
   })
   return jsonResponse(
     {
-      plugin: finalRow,
+      plugin: maskPluginSecrets(finalRow),
       ...(await pluginsPayload(db)),
       pack: packSummary,
       upgrade: { fromVersion, toVersion: newVersion },

--- a/server/handlers/cms/plugins/settings.ts
+++ b/server/handlers/cms/plugins/settings.ts
@@ -16,7 +16,7 @@ import { getInstalledPlugin } from '../../../repositories/plugins'
 import {
   validatePluginSettingsRecord,
   maskSecretSettings,
-  type PluginSettingDefinition,
+  resolveSecretSettingsUpdate,
   type PluginSettingsValues,
 } from '@core/plugin-sdk'
 import { persistAndSyncPluginSettings } from '../../../plugins/host/settingsSync'
@@ -41,7 +41,7 @@ export async function handlePluginSettings(
     )
   }
   const plugin = result.plugin
-  const declared = (plugin.manifest.settings ?? []) as PluginSettingDefinition[]
+  const declared = plugin.manifest.settings ?? []
   if (declared.length === 0) {
     return badRequest(`Plugin "${pluginId}" does not declare settings`)
   }
@@ -63,6 +63,10 @@ export async function handlePluginSettings(
     } catch (err) {
       return badRequest(getErrorMessage(err, 'Invalid settings payload'))
     }
+    // The admin form round-trips the masked GET payload, so an unchanged
+    // secret comes back as the `'***'` sentinel — swap the stored real value
+    // back in before persisting. An empty string still clears the secret.
+    cleaned = resolveSecretSettingsUpdate(declared, cleaned, plugin.settings)
     // Persists, refreshes the host cache, pushes the merged record into the
     // plugin's running VM (no-op when it isn't loaded), then emits
     // `settings.changed` — in that order, so hook listeners reading

--- a/server/handlers/cms/plugins/shared.ts
+++ b/server/handlers/cms/plugins/shared.ts
@@ -35,6 +35,7 @@ import type {
   PluginPermission,
   PluginResource,
 } from '@core/plugin-sdk'
+import { maskSecretSettings } from '@core/plugin-sdk'
 import {
   getInstalledPlugin,
   listInstalledPlugins,
@@ -123,12 +124,30 @@ function brokenPluginStub(
   }
 }
 
+/**
+ * Mask a plugin's secret setting values before the row is serialized onto
+ * any browser-bound response. Secret values must NEVER reach the admin UI
+ * unmasked — server-side plugin code reads the real values through
+ * `api.cms.settings.get`, which never goes through these handlers. Every
+ * route that returns an `InstalledPlugin` (the list payload AND the
+ * single-`plugin` envelopes on install / upgrade / enable / disable /
+ * restart) MUST pass it through here.
+ */
+export function maskPluginSecrets(plugin: InstalledPlugin): InstalledPlugin {
+  const declared = plugin.manifest.settings ?? []
+  if (declared.length === 0) return plugin
+  return { ...plugin, settings: maskSecretSettings(declared, plugin.settings) }
+}
+
 export async function pluginsPayload(db: DbClient) {
   const results = await listInstalledPlugins(db)
   // Materialise every result — ok or broken — as an InstalledPlugin for the
-  // wire. Broken plugins get a stub with lifecycleStatus='error' so the admin
-  // UI can surface the parse error and offer a Remove button.
-  const asPlugins = results.map((r) => (r.kind === 'ok' ? r.plugin : brokenPluginStub(r)))
+  // wire, masking secret setting values. Broken plugins get a stub with
+  // lifecycleStatus='error' so the admin UI can surface the parse error and
+  // offer a Remove button.
+  const asPlugins = results.map((r) =>
+    r.kind === 'ok' ? maskPluginSecrets(r.plugin) : brokenPluginStub(r),
+  )
   // Attach recent crash events per plugin so the admin UI can render the
   // "Recent issues" panel without an extra round trip per card. Cap at 10
   // most recent — older events stay in the DB but the UI only shows the
@@ -141,10 +160,11 @@ export async function pluginsPayload(db: DbClient) {
   )
   // Only properly-parsed plugins contribute admin page nav entries — broken
   // plugins have stub manifests with empty adminPages arrays anyway, but
-  // filtering explicitly makes the intent clear.
+  // filtering explicitly makes the intent clear. Masked rows feed the page
+  // routes too, because each route embeds a `pluginSettings` snapshot.
   const okPlugins = results
     .filter((r): r is Extract<InstalledPluginResult, { kind: 'ok' }> => r.kind === 'ok')
-    .map((r) => r.plugin)
+    .map((r) => maskPluginSecrets(r.plugin))
   return {
     plugins: pluginsWithCrashes,
     adminPages: collectEnabledAdminPages(okPlugins),

--- a/server/handlers/cms/plugins/state.ts
+++ b/server/handlers/cms/plugins/state.ts
@@ -31,6 +31,7 @@ import { Type } from '@core/utils/typeboxHelpers'
 import { type CmsHandlerOptions } from '../shared'
 import {
   lifecycleErrorMessage,
+  maskPluginSecrets,
   pluginNotFound,
   pluginsPayload,
   recordPluginAuditEvent,
@@ -92,7 +93,7 @@ async function setPluginEnabledFromRequest(
     enabled ? 'plugin.enable' : 'plugin.disable',
     pluginId,
   )
-  return jsonResponse({ plugin: lifecycle.plugin, ...(await pluginsPayload(db)) })
+  return jsonResponse({ plugin: maskPluginSecrets(lifecycle.plugin), ...(await pluginsPayload(db)) })
 }
 
 export async function handlePluginItem(
@@ -223,5 +224,5 @@ export async function handlePluginRestart(
   })
   const finalResult = await getInstalledPlugin(db, pluginId)
   const finalRow = (finalResult?.kind === 'ok' ? finalResult.plugin : null) ?? plugin
-  return jsonResponse({ plugin: finalRow, ...(await pluginsPayload(db)) })
+  return jsonResponse({ plugin: maskPluginSecrets(finalRow), ...(await pluginsPayload(db)) })
 }

--- a/server/plugins/host/handlers/settings.ts
+++ b/server/plugins/host/handlers/settings.ts
@@ -12,7 +12,6 @@
  * No permission gate — any active plugin may update its own settings.
  */
 
-import type { PluginSettingDefinition } from '@core/plugin-sdk'
 import { validatePluginSettingsRecord } from '@core/plugin-sdk'
 import type { ApiCallFor } from '../../protocol/apiCallSchema'
 import type { DbClient } from '../../../db/client'
@@ -26,8 +25,7 @@ export async function handleSettingsReplace(
   db: DbClient,
 ): Promise<void> {
   const [next] = msg.args
-  const declared = (entry.manifest.settings ?? []) as PluginSettingDefinition[]
-  const cleaned = validatePluginSettingsRecord(declared, next)
+  const cleaned = validatePluginSettingsRecord(entry.manifest.settings ?? [], next)
   const merged = await persistAndSyncPluginSettings(db, msg.pluginId, cleaned)
   replyApiOk(msg.pluginId, msg.correlationId, merged)
 }

--- a/server/repositories/plugins.ts
+++ b/server/repositories/plugins.ts
@@ -117,7 +117,7 @@ function mergeSettingsWithDefaults(
   stored: unknown,
 ): Record<string, string | number | boolean> {
   const declared = manifest.settings ?? []
-  const defaults = pluginSettingsDefaults(declared as Parameters<typeof pluginSettingsDefaults>[0])
+  const defaults = pluginSettingsDefaults(declared)
   const out: Record<string, string | number | boolean> = { ...defaults }
   if (stored && typeof stored === 'object' && !Array.isArray(stored)) {
     const declaredIds = new Set(declared.map((s) => s.id))
@@ -182,9 +182,7 @@ export async function installPlugin(
   const manifestToStore = { ...manifest, grantedPermissions }
   // Seed settings with the manifest's declared defaults so plugins reading
   // their own settings on first activate see a complete record.
-  const initialSettings = pluginSettingsDefaults(
-    (manifest.settings ?? []) as Parameters<typeof pluginSettingsDefaults>[0],
-  )
+  const initialSettings = pluginSettingsDefaults(manifest.settings ?? [])
   const { rows } = await db<InstalledPluginRow>`
     insert into installed_plugins (id, name, version, manifest_json, granted_permissions_json, settings_json, enabled, lifecycle_status, last_error)
     values (${manifest.id}, ${manifest.name}, ${manifest.version}, ${writeJson(manifestToStore)}, ${writeJson(grantedPermissions)}, ${writeJson(initialSettings)}, true, 'installed', null)

--- a/src/__tests__/plugins/pluginSettings.test.ts
+++ b/src/__tests__/plugins/pluginSettings.test.ts
@@ -3,8 +3,10 @@
  */
 import { describe, expect, it } from 'bun:test'
 import {
+  SECRET_SETTING_MASK,
   maskSecretSettings,
   pluginSettingsDefaults,
+  resolveSecretSettingsUpdate,
   stripSecretSettings,
   validatePluginSettingsDefinitions,
   validatePluginSettingsRecord,
@@ -130,6 +132,55 @@ describe('maskSecretSettings / stripSecretSettings', () => {
     })
     expect(stripped).not.toHaveProperty('apiKey')
     expect(stripped.enabled).toBe(true)
+  })
+})
+
+describe('resolveSecretSettingsUpdate', () => {
+  const stored = {
+    apiKey: 'real-secret',
+    enabled: true,
+    count: 5,
+    theme: 'dark',
+    requiredField: 'x',
+  }
+
+  it('keeps the stored secret when the form round-trips the mask sentinel', () => {
+    const resolved = resolveSecretSettingsUpdate(baseSchema, {
+      apiKey: SECRET_SETTING_MASK,
+      enabled: false,
+      count: 9,
+      theme: 'light',
+      requiredField: 'y',
+    }, stored)
+    expect(resolved.apiKey).toBe('real-secret')
+    // Non-secret edits in the same PUT still win.
+    expect(resolved.enabled).toBe(false)
+    expect(resolved.count).toBe(9)
+  })
+
+  it('replaces the secret when the form submits a new value', () => {
+    const resolved = resolveSecretSettingsUpdate(baseSchema, {
+      ...stored,
+      apiKey: 'rotated-secret',
+    }, stored)
+    expect(resolved.apiKey).toBe('rotated-secret')
+  })
+
+  it('clears the secret when the form submits an empty string', () => {
+    const resolved = resolveSecretSettingsUpdate(baseSchema, {
+      ...stored,
+      apiKey: '',
+    }, stored)
+    expect(resolved.apiKey).toBe('')
+  })
+
+  it('does not treat the sentinel specially on non-secret fields', () => {
+    const resolved = resolveSecretSettingsUpdate(baseSchema, {
+      ...stored,
+      apiKey: 'kept',
+      requiredField: SECRET_SETTING_MASK,
+    }, stored)
+    expect(resolved.requiredField).toBe(SECRET_SETTING_MASK)
   })
 })
 

--- a/src/__tests__/server/cmsPlugins.test.ts
+++ b/src/__tests__/server/cmsPlugins.test.ts
@@ -372,6 +372,117 @@ describe('CMS plugin handlers', () => {
     expect(db.plugins).toHaveLength(0)
   })
 
+  it('masks secret settings on every browser-bound payload and round-trips the mask sentinel on PUT', async () => {
+    const db = makeFakeDb()
+    const cookie = await createCookie(db)
+
+    const secretManifest = {
+      ...mapManifest,
+      id: 'local.secret',
+      name: 'Secret Keeper',
+      settings: [
+        { id: 'apiKey', type: 'password', label: 'API key', secret: true },
+        { id: 'mode', type: 'text', label: 'Mode', default: 'fast' },
+      ],
+    }
+
+    const install = await handleCmsRequest(
+      cmsRequest('http://localhost/admin/api/cms/plugins', {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          manifest: secretManifest,
+          grantedPermissions: ['admin.navigation'],
+        }),
+      }),
+      db,
+    )
+    expect(install.status).toBe(201)
+
+    const storedSettings = (): Record<string, unknown> =>
+      JSON.parse(String(db.plugins[0].settings_json)) as Record<string, unknown>
+
+    const putSettings = async (settings: Record<string, unknown>) =>
+      handleCmsRequest(
+        cmsRequest('http://localhost/admin/api/cms/plugins/local.secret/settings', {
+          method: 'PUT',
+          headers: { cookie, 'content-type': 'application/json' },
+          body: JSON.stringify({ settings }),
+        }),
+        db,
+      )
+
+    // Save a real secret — the DB stores it, but the response masks it.
+    const save = await putSettings({ apiKey: 'real-secret', mode: 'turbo' })
+    expect(save.status).toBe(200)
+    expect(await save.json()).toEqual({ settings: { apiKey: '***', mode: 'turbo' } })
+    expect(storedSettings()).toEqual({ apiKey: 'real-secret', mode: 'turbo' })
+
+    // The plugins LIST payload masks the secret too — both on the plugin row
+    // and on the admin-page route's settings snapshot. Non-secrets untouched.
+    const list = await handleCmsRequest(
+      cmsRequest('http://localhost/admin/api/cms/plugins', { headers: { cookie } }),
+      db,
+    )
+    expect(list.status).toBe(200)
+    const listBody = await list.json() as {
+      plugins: Array<{ settings: Record<string, unknown> }>
+      adminPages: Array<{ pluginSettings: Record<string, unknown> }>
+    }
+    expect(listBody.plugins[0].settings).toEqual({ apiKey: '***', mode: 'turbo' })
+    expect(listBody.adminPages[0].pluginSettings).toEqual({ apiKey: '***', mode: 'turbo' })
+
+    // The dedicated settings GET masks as before.
+    const get = await handleCmsRequest(
+      cmsRequest('http://localhost/admin/api/cms/plugins/local.secret/settings', {
+        headers: { cookie },
+      }),
+      db,
+    )
+    expect(get.status).toBe(200)
+    const getBody = await get.json() as { settings: Record<string, unknown> }
+    expect(getBody.settings).toEqual({ apiKey: '***', mode: 'turbo' })
+
+    // PUT that round-trips the masked GET payload unchanged keeps the stored
+    // real secret instead of overwriting it with the literal sentinel.
+    const unchanged = await putSettings({ apiKey: '***', mode: 'slow' })
+    expect(unchanged.status).toBe(200)
+    expect(storedSettings()).toEqual({ apiKey: 'real-secret', mode: 'slow' })
+
+    // A deliberate new value still replaces the secret…
+    const rotate = await putSettings({ apiKey: 'rotated-secret', mode: 'slow' })
+    expect(rotate.status).toBe(200)
+    expect(storedSettings()).toEqual({ apiKey: 'rotated-secret', mode: 'slow' })
+
+    // …and an empty string deliberately clears it. The empty value is not
+    // masked on the way back out.
+    const clear = await putSettings({ apiKey: '', mode: 'slow' })
+    expect(clear.status).toBe(200)
+    expect(storedSettings()).toEqual({ apiKey: '', mode: 'slow' })
+    expect(await clear.json()).toEqual({ settings: { apiKey: '', mode: 'slow' } })
+
+    // State mutations return a single-plugin envelope alongside the list —
+    // it must be masked as well. Re-seed a real secret first.
+    await putSettings({ apiKey: 'real-secret', mode: 'slow' })
+    const disable = await handleCmsRequest(
+      cmsRequest('http://localhost/admin/api/cms/plugins/local.secret', {
+        method: 'PATCH',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({ enabled: false }),
+      }),
+      db,
+    )
+    expect(disable.status).toBe(200)
+    const disableBody = await disable.json() as {
+      plugin: { settings: Record<string, unknown> }
+      plugins: Array<{ settings: Record<string, unknown> }>
+    }
+    expect(disableBody.plugin.settings).toEqual({ apiKey: '***', mode: 'slow' })
+    expect(disableBody.plugins[0].settings).toEqual({ apiKey: '***', mode: 'slow' })
+    // Masking is wire-only — the stored value survives untouched.
+    expect(storedSettings()).toEqual({ apiKey: 'real-secret', mode: 'slow' })
+  })
+
   it('strips caller-supplied assetBasePath from JSON-installed manifests (path-traversal sink)', async () => {
     const db = makeFakeDb()
     const cookie = await createCookie(db)

--- a/src/admin/plugin-host-hooks/index.ts
+++ b/src/admin/plugin-host-hooks/index.ts
@@ -39,6 +39,11 @@ export { useEditorStore }
  * Read the current plugin's persisted settings as a typed snapshot.
  * Updates flow through `setPluginSettings(...)` from `@instatic/host-hooks`
  * (round-trips through the host's settings PUT endpoint).
+ *
+ * Settings declared `secret: true` always read as the mask (`'***'`) here —
+ * real secret values never reach the browser. Server-side plugin code reads
+ * them via `api.cms.settings.get`; proxy through a plugin server route when
+ * an admin surface needs a secret-derived capability.
  */
 export function usePluginSettings<
   T extends Record<string, string | number | boolean> = Record<string, string | number | boolean>,

--- a/src/core/plugin-sdk/builders/index.ts
+++ b/src/core/plugin-sdk/builders/index.ts
@@ -23,7 +23,9 @@ export {
   validatePluginSettingsRecord,
   validatePluginSettingsDefinitions,
   maskSecretSettings,
+  resolveSecretSettingsUpdate,
   stripSecretSettings,
+  SECRET_SETTING_MASK,
 } from './settings'
 export type {
   PluginSettingDefinition,

--- a/src/core/plugin-sdk/builders/settings.ts
+++ b/src/core/plugin-sdk/builders/settings.ts
@@ -40,11 +40,14 @@ interface PluginSettingBase {
   required?: boolean
   /**
    * When true, the value is treated as a secret:
-   *   - Masked in `GET /settings` responses (`'***'`)
+   *   - Masked (`'***'`) on EVERY payload the host sends to the browser —
+   *     the plugins list, the settings GET/PUT responses, admin-page route
+   *     snapshots, and editor-panel settings snapshots
    *   - Stripped from frontend bundles
    *   - Rendered as a password input in the form
-   * Plugin-side reads (server `api.cms.settings.get`, admin app) still
-   * see the real value.
+   * Only server-side plugin code (`api.cms.settings.get` / `getAll` inside
+   * the QuickJS worker) reads the real value. Editor-side and admin-app
+   * plugin code always sees the mask.
    */
   secret?: boolean
 }
@@ -95,6 +98,15 @@ export type PluginSettingDefinition =
 
 export type PluginSettingsValues = Record<string, PluginSettingValue>
 
+/**
+ * Sentinel the host substitutes for secret values on every browser-bound
+ * payload. The settings PUT route treats an incoming secret equal to this
+ * sentinel as "unchanged" and keeps the stored value — see
+ * `resolveSecretSettingsUpdate`. Consequence: a secret can never be
+ * literally `'***'`.
+ */
+export const SECRET_SETTING_MASK = '***'
+
 const SAFE_SETTING_ID = /^[a-zA-Z_][a-zA-Z0-9_-]*$/
 
 /**
@@ -129,7 +141,7 @@ export function validatePluginSettingsDefinitions(
  * a freshly-installed plugin's empty Settings panel.
  */
 export function pluginSettingsDefaults(
-  settings: PluginSettingDefinition[],
+  settings: ReadonlyArray<PluginSettingDefinition>,
 ): PluginSettingsValues {
   const out: PluginSettingsValues = {}
   for (const s of settings) {
@@ -147,7 +159,7 @@ export function pluginSettingsDefaults(
  * record (extra keys dropped, missing required fields throw).
  */
 export function validatePluginSettingsRecord(
-  settings: PluginSettingDefinition[],
+  settings: ReadonlyArray<PluginSettingDefinition>,
   input: unknown,
 ): PluginSettingsValues {
   if (!input || typeof input !== 'object' || Array.isArray(input)) {
@@ -202,18 +214,39 @@ export function validatePluginSettingsRecord(
 }
 
 /**
- * Mask secret values in a settings record before returning to a UI that
- * shouldn't see them (e.g. the admin form re-render after save). Plugins
- * reading their own settings via `api.cms.settings.get` see the real value.
+ * Mask secret values in a settings record before serializing it onto any
+ * browser-bound payload — the plugins list, the settings GET/PUT responses,
+ * admin-page route snapshots, editor-panel snapshots. Only server-side
+ * plugin code reading via `api.cms.settings.get` sees the real value.
  */
 export function maskSecretSettings(
-  settings: PluginSettingDefinition[],
+  settings: ReadonlyArray<PluginSettingDefinition>,
   values: PluginSettingsValues,
 ): PluginSettingsValues {
   const out: PluginSettingsValues = { ...values }
   for (const s of settings) {
     if (s.secret && out[s.id] !== undefined && out[s.id] !== '') {
-      out[s.id] = '***'
+      out[s.id] = SECRET_SETTING_MASK
+    }
+  }
+  return out
+}
+
+/**
+ * Resolve a settings PUT against the stored record: an incoming secret equal
+ * to `SECRET_SETTING_MASK` means the admin form submitted the masked GET
+ * value untouched, so the stored secret is kept. Any other incoming value —
+ * including the empty string, which deliberately clears the secret — wins.
+ */
+export function resolveSecretSettingsUpdate(
+  settings: ReadonlyArray<PluginSettingDefinition>,
+  incoming: PluginSettingsValues,
+  stored: PluginSettingsValues,
+): PluginSettingsValues {
+  const out: PluginSettingsValues = { ...incoming }
+  for (const s of settings) {
+    if (s.secret && out[s.id] === SECRET_SETTING_MASK && stored[s.id] !== undefined) {
+      out[s.id] = stored[s.id]
     }
   }
   return out
@@ -224,7 +257,7 @@ export function maskSecretSettings(
  * frontend bundle / published page where they would otherwise leak.
  */
 export function stripSecretSettings(
-  settings: PluginSettingDefinition[],
+  settings: ReadonlyArray<PluginSettingDefinition>,
   values: PluginSettingsValues,
 ): PluginSettingsValues {
   const out: PluginSettingsValues = {}

--- a/src/core/plugin-sdk/types/installedPlugin.ts
+++ b/src/core/plugin-sdk/types/installedPlugin.ts
@@ -19,9 +19,11 @@ export interface InstalledPlugin {
   /**
    * Current user-edited settings values, keyed by setting id. Always
    * contains every setting declared in `manifest.settings` — defaults
-   * are populated on install. Secret values are masked (`'***'`) when
-   * the plugin row is read by the admin UI; plugins reading their own
-   * settings via `api.cms.settings.get` see the real value.
+   * are populated on install. Secret values are masked (`'***'`) on every
+   * payload the host sends to the browser — list, install/upgrade/state
+   * responses, admin-page snapshots, and editor-panel snapshots — so
+   * editor-side and admin-app plugin code never sees the real value. Only
+   * server-side plugin code reading via `api.cms.settings.get` does.
    */
   settings: Record<string, string | number | boolean>
   installedAt: string
@@ -63,7 +65,8 @@ export interface PluginAdminPageRoute extends Omit<PluginAdminPage, 'route'> {
   /**
    * Snapshot of the plugin's persisted settings at the moment the host
    * rendered the page. Plugin admin apps read via the `usePluginSettings`
-   * hook which returns this snapshot synchronously.
+   * hook which returns this snapshot synchronously. Secret values are
+   * masked (`'***'`) — admin-app code never sees real secrets.
    */
   pluginSettings: Record<string, string | number | boolean>
   /** The full settings schema declared by the plugin manifest. */

--- a/src/core/plugin-sdk/types/settings.ts
+++ b/src/core/plugin-sdk/types/settings.ts
@@ -7,6 +7,8 @@ export interface ServerPluginSettingsApi {
    * Resolve a single setting value, returning `undefined` if unset. Reads
    * the live mirror — settings saved in the admin UI (or via `replace`)
    * are pushed into the running plugin immediately, no reload required.
+   * This server-side read is the ONLY surface that returns real secret
+   * values — every browser-bound payload masks secrets to `'***'`.
    */
   get: <T extends string | number | boolean = string>(key: string) => T | undefined
   /** Snapshot of every declared setting, populated with defaults. */

--- a/src/core/plugins/editorPluginLoader.ts
+++ b/src/core/plugins/editorPluginLoader.ts
@@ -118,6 +118,8 @@ export async function activateInstalledEditorPlugins(
     // synchronously inside their render(). Done unconditionally — even for
     // plugins without an editor entrypoint, since the snapshot might be
     // consulted by another plugin's panel via cross-plugin runCommand etc.
+    // Secret values arrive masked (`'***'`) — the server masks them on every
+    // admin payload, so editor-side code never holds real secrets.
     pluginRuntime.setPluginSettings(plugin.id, plugin.settings)
     if (!plugin.enabled || plugin.lifecycleStatus === 'error' || !manifest.assetBasePath) {
       continue

--- a/src/core/plugins/runtime.ts
+++ b/src/core/plugins/runtime.ts
@@ -213,7 +213,9 @@ class PluginRuntime {
    * Cache the live settings snapshot for a plugin so panel api factories
    * can hand it to the plugin's render code without a per-mount round-trip.
    * Refreshed by `activateInstalledEditorPlugins` on every editor reload
-   * and by the Plugins admin page after a settings PUT.
+   * and by the Plugins admin page after a settings PUT. The snapshot comes
+   * from the admin HTTP payload, where secret values are masked (`'***'`)
+   * — editor-side plugin code never sees real secrets.
    */
   setPluginSettings(pluginId: string, settings: Record<string, string | number | boolean>): void {
     this.pluginSettings.set(pluginId, { ...settings })


### PR DESCRIPTION
## Summary

Plugin settings declared `secret: true` leaked **unmasked** to the browser through `GET /admin/api/cms/plugins` — and through every single-plugin envelope returned by install / upgrade / enable / disable / restart — while only the dedicated settings GET masked them to `'***'`. The raw values then fanned out client-side (`pluginRuntime.setPluginSettings`, admin-page route snapshots, the Spotlight plugin-pages provider).

Decision implemented (owner-approved): **secret values never reach the browser unmasked**. Server-side plugin code (QuickJS workers) keeps reading real values via `api.cms.settings.get` — that path doesn't go through these endpoints. Editor-side / admin-app plugin code deliberately loses access to real secret values.

## Changes

- **One masking source of truth at the wire** — new `maskPluginSecrets()` in `server/handlers/cms/plugins/shared.ts` (built on the existing `maskSecretSettings` SDK helper). Applied in `pluginsPayload()` to every plugin row *and* to the rows feeding `collectEnabledAdminPages` (admin-page routes embed a `pluginSettings` snapshot), plus all six single-`plugin` response envelopes in `state.ts` and `install.ts`. Masking is wire-only: the worker settings cache (`updatePluginSettingsCache` / `refreshPluginSettingsCache`) still reads raw repository rows.
- **PUT sentinel handling** (`server/handlers/cms/plugins/settings.ts`) — the admin settings form round-trips the masked GET payload, so an unchanged secret arrives as `'***'`. Previously that overwrote the stored secret with the literal sentinel. New `resolveSecretSettingsUpdate()` + `SECRET_SETTING_MASK` (in `src/core/plugin-sdk/builders/settings.ts`, next to `maskSecretSettings`) keep the stored value for sentinel-valued secrets; a new string still rotates the secret and an empty string still clears it.
- **Type cleanup** — settings helpers now accept `ReadonlyArray<PluginSettingDefinition>`, deleting the `as PluginSettingDefinition[]` casts in `server/handlers/cms/plugins/settings.ts`, `server/plugins/host/handlers/settings.ts`, and `server/repositories/plugins.ts`.
- **Docs track code** — `docs/features/plugin-system.md` settings section now documents the masking + sentinel contract; SDK doc comments updated (`installedPlugin.ts`, `types/settings.ts`, `builders/settings.ts`, `usePluginSettings` in `src/admin/plugin-host-hooks/index.ts`, `pluginRuntime.setPluginSettings`, `editorPluginLoader.ts`).

## Audit of other serialization points

- SSE plugin events (`server/plugins/eventBroadcaster.ts`, `@core/plugins/events`) carry no settings.
- Audit metadata logs setting **keys** only.
- `inspect-package` returns the manifest (declared schema + defaults), not stored values.
- Spotlight `pluginPagesProvider` and `usePluginsWorkspace` consume the now-masked list payload.

## Tests

- `src/__tests__/server/cmsPlugins.test.ts` — new HTTP-level test: list payload masks secrets on plugin rows *and* `adminPages[].pluginSettings` (non-secrets untouched); settings GET/PUT responses mask; PUT with `'***'` preserves the stored secret; PUT rotates and clears deliberately; PATCH (disable) envelope masks while the DB keeps the real value.
- `src/__tests__/plugins/pluginSettings.test.ts` — unit tests for `resolveSecretSettingsUpdate` (sentinel keep, rotate, clear, non-secret fields unaffected).

## Verification

- `bun test` — 4897 pass / 1 skip / 0 fail
- `bun run build` — clean (`tsc -b && vite build`)
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)