### PR TITLE
Add force-uninstall escape hatch and run deactivate before uninstall

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -167,6 +167,12 @@ export function uninstall(api)      {}
 export function migrate(ctx, api)   {} // ctx = { fromVersion: '1.0.0' }
 ```
 
+### Force-uninstall
+
+A throwing (or unloadable) hook must never be able to block removal permanently. When a normal uninstall fails on a hook error, the plugin stays installed (parked in `error` with `lastError` set) and the response says force-remove is available. `DELETE /admin/api/cms/plugins/:id?force=true` skips the lifecycle hooks entirely and tears everything down anyway: the worker, canvas modules, the DB row (settings live on it; records and schedules cascade via FK), crash events and schedule run history (no FK — swept explicitly), and the plugin's whole `uploads/plugins/<id>/` tree, including stale version dirs left behind by interrupted upgrades. The same teardown serves corrupt-manifest plugins, which have no valid code to run hooks on.
+
+The admin UI offers force-removal as "Remove anyway" after a failed uninstall, behind an explicit confirmation that warns the plugin's own cleanup code is skipped — external resources the plugin set up (webhooks, third-party registrations) may remain. Capability and step-up requirements are identical to a normal uninstall (`plugins.install` + step-up); the audit event carries `forced: true`.
+
 ### Crash recovery
 
 Each plugin's server entrypoint runs in its own worker. If the worker crashes:

--- a/server/handlers/cms/plugins/index.ts
+++ b/server/handlers/cms/plugins/index.ts
@@ -9,7 +9,8 @@
  *   POST   /admin/api/cms/plugins/inspect-package                   — read a plugin .zip without installing
  *   POST   /admin/api/cms/plugins/package                           — install (or upgrade) from a .zip
  *   PATCH  /admin/api/cms/plugins/:id                               — enable / disable an installed plugin
- *   DELETE /admin/api/cms/plugins/:id                               — uninstall + delete on-disk assets
+ *   DELETE /admin/api/cms/plugins/:id[?force=true]                  — uninstall + delete on-disk assets
+ *                                                                     (`force` skips lifecycle hooks)
  *   POST   /admin/api/cms/plugins/:id/pack/install                  — manual pack re-sync into the draft site
  *   GET    /admin/api/cms/plugins/:id/settings                      — masked settings
  *   PUT    /admin/api/cms/plugins/:id/settings                      — update settings, push into the running VM, fire `settings.changed`

--- a/server/handlers/cms/plugins/shared.ts
+++ b/server/handlers/cms/plugins/shared.ts
@@ -8,8 +8,9 @@
  *    `assertPluginPermissionGrants`, `pluginManifestWithGrants`) — every
  *    route that loads a manifest needs to re-attach the user's granted
  *    permission set before passing it to the runtime.
- *  - `removePluginAssets` / `writePluginPackageFiles` / `readPluginPackageForm`
- *    — the on-disk side of zip install / uninstall.
+ *  - `removeAllPluginAssets` / `removePluginVersionAssets` /
+ *    `writePluginPackageFiles` / `readPluginPackageForm` — the on-disk side
+ *    of zip install / upgrade / uninstall.
  *  - `recordPluginAuditEvent` — the audit envelope shared by every mutation
  *    endpoint (install / update / enable / disable / delete).
  *  - `getEnabledPluginResource` — DB lookup used by the record CRUD routes.
@@ -311,20 +312,23 @@ export async function writePluginPackageFiles(
   }
 }
 
-export async function removePluginAssets(plugin: InstalledPlugin, uploadsDir?: string): Promise<void> {
-  const assetBasePath = plugin.manifest.assetBasePath
-  if (!uploadsDir || !assetBasePath?.startsWith('/uploads/plugins/')) return
-  const relativeBasePath = assetBasePath.replace(/^\/uploads\/?/, '')
-  const target = join(uploadsDir, relativeBasePath)
-  // Defense-in-depth: a string-prefix match on `/uploads/plugins/` does not
-  // block `..` traversal that the schema is supposed to reject — re-assert
+/**
+ * Delete a plugin's entire on-disk tree — `uploads/plugins/<id>/` with every
+ * version dir inside it. Used by uninstall (normal, forced, and corrupt-
+ * manifest), which must also sweep stale version dirs left behind by
+ * interrupted upgrades — deleting only the current version's dir would leak
+ * them forever once the DB row is gone.
+ */
+export async function removeAllPluginAssets(uploadsDir: string, pluginId: string): Promise<void> {
+  const target = join(uploadsDir, 'plugins', pluginId)
+  // Defense-in-depth: the manifest schema rejects ids with path separators
+  // and the caller only passes ids that exist as DB rows, but re-assert
   // containment after `path.join` normalises the segments so a corrupted
-  // stored manifest (or a future schema regression) can't trigger an
-  // arbitrary `rm -rf`.
+  // stored id can't trigger an arbitrary `rm -rf`.
   try {
     assertPathWithin(uploadsDir, target)
   } catch (err) {
-    console.error('[plugins] removePluginAssets refused to delete escaping path:', err)
+    console.error('[plugins] removeAllPluginAssets refused to delete escaping path:', err)
     return
   }
   await rm(target, { recursive: true, force: true })
@@ -333,7 +337,7 @@ export async function removePluginAssets(plugin: InstalledPlugin, uploadsDir?: s
 /**
  * Delete a specific plugin version's on-disk dir. Used by the upgrade flow
  * (drop the old version after a successful upgrade, drop the new version
- * during rollback). `removePluginAssets` deletes the entire plugin tree;
+ * during rollback). `removeAllPluginAssets` deletes the entire plugin tree;
  * this one is version-scoped.
  */
 export async function removePluginVersionAssets(

--- a/server/handlers/cms/plugins/state.ts
+++ b/server/handlers/cms/plugins/state.ts
@@ -1,14 +1,19 @@
 /**
  * Plugin state-mutation routes — flip enabled, uninstall, restart.
  *
- *   PATCH  /admin/api/cms/plugins/:id            — enable / disable
- *   DELETE /admin/api/cms/plugins/:id            — uninstall + delete on-disk assets
- *   POST   /admin/api/cms/plugins/:id/restart    — manual restart for a parked plugin
+ *   PATCH  /admin/api/cms/plugins/:id              — enable / disable
+ *   DELETE /admin/api/cms/plugins/:id[?force=true] — uninstall + delete on-disk assets
+ *   POST   /admin/api/cms/plugins/:id/restart      — manual restart for a parked plugin
  *
  * Every route runs the matching lifecycle hook (`activate`, `deactivate`,
  * `uninstall`), broadcasts the event, and emits one audit record. The
- * uninstall route additionally removes the on-disk asset dir and re-activates
- * the surviving plugins so they pick their hooks back up.
+ * uninstall route runs `deactivate` first when the plugin is active, then
+ * `uninstall`; `?force=true` skips the hooks entirely (the escape hatch for
+ * a throwing or unloadable hook). All uninstall variants — normal, forced,
+ * corrupt-manifest — converge on one teardown (`removePluginCompletely`)
+ * that drops the worker, the DB row, crash bookkeeping, schedule run
+ * history, and the plugin's whole on-disk tree, then re-activates the
+ * surviving plugins so they pick their hooks back up.
  */
 import type { DbClient } from '../../../db/client'
 import type { AuthUser } from '../../../repositories/users'
@@ -28,6 +33,8 @@ import {
 import { broadcastPluginEvent } from '../../../plugins/eventBroadcaster'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../../http'
 import { Type } from '@core/utils/typeboxHelpers'
+import { deactivatePluginModulePack } from '@core/plugins/modulePackLoader'
+import { clearPluginScheduleRuns } from '../../../repositories/pluginSchedules'
 import { type CmsHandlerOptions } from '../shared'
 import {
   lifecycleErrorMessage,
@@ -35,10 +42,10 @@ import {
   pluginNotFound,
   pluginsPayload,
   recordPluginAuditEvent,
-  removePluginAssets,
-  removePluginVersionAssets,
+  removeAllPluginAssets,
 } from './shared'
 import { runPluginLifecycleHook } from './lifecycle'
+import type { InstalledPlugin } from '@core/plugin-sdk'
 
 /**
  * PATCH `enabled` on a single plugin. Both branches flip the enabled flag,
@@ -121,49 +128,95 @@ export async function handlePluginItem(
   }
 
   if (req.method === 'DELETE') {
+    const force = new URL(req.url).searchParams.get('force') === 'true'
     const lookup = await getInstalledPlugin(db, pluginId)
     if (!lookup) return pluginNotFound()
 
-    if (lookup.kind === 'broken') {
-      // Manifest is corrupt — skip lifecycle hooks (no valid plugin to uninstall).
-      // Delete the DB row and do a best-effort asset removal using the version
-      // stored in the row's own columns (reliable even when manifest_json is broken).
-      const deleted = await deletePlugin(db, pluginId)
-      if (!deleted) return pluginNotFound()
-      if (options.uploadsDir) {
-        await removePluginVersionAssets(options.uploadsDir, lookup.id, lookup.version)
+    // Lifecycle hooks run only on the normal path with a parseable manifest:
+    // `?force=true` is the operator's escape hatch for a throwing or
+    // unloadable hook, and a corrupt manifest has no valid plugin to run
+    // hooks on. Both skip straight to teardown.
+    if (!force && lookup.kind === 'ok') {
+      let current = lookup.plugin
+      // Uninstall contract: "(if active) deactivate → uninstall". Run
+      // deactivate first so the plugin tears down its active-state
+      // resources before the uninstall hook does its permanent cleanup.
+      if (current.lifecycleStatus === 'active') {
+        const deactivated = await runPluginLifecycleHook(db, current, options, 'deactivate', 'disabled')
+        if (!deactivated.ok) return uninstallHookFailure('deactivate', deactivated.plugin)
+        current = deactivated.plugin
       }
-      await activateInstalledServerPlugins(db, options.uploadsDir)
-      await recordPluginAuditEvent(db, user, req, 'plugin.delete', lookup.id)
-      broadcastPluginEvent({
-        kind: 'uninstalled',
-        pluginId: lookup.id,
-        occurredAt: new Date().toISOString(),
-      })
-      return jsonResponse({ ok: true })
+      const uninstalled = await runPluginLifecycleHook(db, current, options, 'uninstall', current.lifecycleStatus)
+      if (!uninstalled.ok) return uninstallHookFailure('uninstall', uninstalled.plugin)
     }
 
-    const current = lookup.plugin
-    const lifecycle = await runPluginLifecycleHook(db, current, options, 'uninstall', current.lifecycleStatus)
-    if (!lifecycle.ok) {
-      return badRequest(lifecycle.plugin.lastError ?? 'Plugin uninstall failed')
-    }
-
-    const deleted = await deletePlugin(db, pluginId)
-    if (!deleted) return pluginNotFound()
-    await unloadPlugin(pluginId)
-    await removePluginAssets(current, options.uploadsDir)
-    await activateInstalledServerPlugins(db, options.uploadsDir)
-    await recordPluginAuditEvent(db, user, req, 'plugin.delete', pluginId)
-    broadcastPluginEvent({
-      kind: 'uninstalled',
-      pluginId,
-      occurredAt: new Date().toISOString(),
-    })
-    return jsonResponse({ ok: true })
+    return removePluginCompletely(req, db, options, user, pluginId, force)
   }
 
   return methodNotAllowed()
+}
+
+/**
+ * 400 for a lifecycle hook that threw during a normal uninstall. The plugin
+ * row survives (parked in `error` with `lastError` set by the hook runner);
+ * the message tells the operator the force-remove escape hatch exists so a
+ * broken hook can never permanently block removal.
+ */
+function uninstallHookFailure(
+  hook: 'deactivate' | 'uninstall',
+  plugin: InstalledPlugin,
+): Response {
+  const detail = plugin.lastError ?? 'Plugin lifecycle hook failed'
+  return badRequest(
+    `Plugin ${hook} hook failed during uninstall: ${detail} — the plugin is still installed. Fix the plugin, or force-remove it to skip its cleanup hooks.`,
+  )
+}
+
+/**
+ * The single uninstall teardown — every removal variant (normal after
+ * successful hooks, `?force=true`, corrupt manifest) lands here. Drops the
+ * DB row (settings live on it; records and schedules cascade via FK), the
+ * worker, host-side canvas modules, crash bookkeeping and schedule run
+ * history (neither has an FK, so they'd outlive the row without an explicit
+ * sweep), and the plugin's whole `uploads/plugins/<id>/` tree — including
+ * stale version dirs left behind by interrupted upgrades.
+ */
+async function removePluginCompletely(
+  req: Request,
+  db: DbClient,
+  options: CmsHandlerOptions,
+  user: AuthUser,
+  pluginId: string,
+  forced: boolean,
+): Promise<Response> {
+  const deleted = await deletePlugin(db, pluginId)
+  if (!deleted) return pluginNotFound()
+  // Idempotent on the normal path (the uninstall hook runner already
+  // unloaded the worker and deactivated the module pack) — required on the
+  // force / corrupt-manifest paths, which skip the hook runner.
+  await unloadPlugin(pluginId)
+  deactivatePluginModulePack(pluginId)
+  clearPluginCrashCounter(pluginId)
+  await clearPluginCrashes(db, pluginId)
+  await clearPluginScheduleRuns(db, pluginId)
+  if (options.uploadsDir) {
+    await removeAllPluginAssets(options.uploadsDir, pluginId)
+  }
+  await activateInstalledServerPlugins(db, options.uploadsDir)
+  await recordPluginAuditEvent(
+    db,
+    user,
+    req,
+    'plugin.delete',
+    pluginId,
+    forced ? { forced: true } : {},
+  )
+  broadcastPluginEvent({
+    kind: 'uninstalled',
+    pluginId,
+    occurredAt: new Date().toISOString(),
+  })
+  return jsonResponse({ ok: true })
 }
 
 /**

--- a/server/repositories/pluginSchedules.ts
+++ b/server/repositories/pluginSchedules.ts
@@ -543,3 +543,13 @@ export async function trimScheduleRunHistory(
     )
   `
 }
+
+/**
+ * Drop the full run history for one plugin. Called on uninstall —
+ * `plugin_schedule_runs` carries no FK to `installed_plugins` (unlike
+ * `plugin_schedules`, which cascades), so without this sweep the history
+ * rows would outlive the plugin row forever.
+ */
+export async function clearPluginScheduleRuns(db: DbClient, pluginId: string): Promise<void> {
+  await db`delete from plugin_schedule_runs where plugin_id = ${pluginId}`
+}

--- a/server/repositories/plugins.ts
+++ b/server/repositories/plugins.ts
@@ -542,7 +542,7 @@ export async function listPluginCrashes(
   return rows.map(mapPluginCrashEvent)
 }
 
-/** Drop every crash event for a plugin. Called on uninstall + on manual restart. */
+/** Drop every crash event for a plugin. Called on every uninstall path + on manual restart. */
 export async function clearPluginCrashes(db: DbClient, pluginId: string): Promise<void> {
   await db`delete from plugin_crash_events where plugin_id = ${pluginId}`
 }

--- a/src/__tests__/architecture/plugin-boot-resilience.test.ts
+++ b/src/__tests__/architecture/plugin-boot-resilience.test.ts
@@ -259,14 +259,22 @@ describe('plugin boot resilience — boot loop structure', () => {
     expect(source).toMatch(/setPluginEnabled[\s\S]*?Promise<InstalledPluginResult \| null>/)
   })
 
-  test('remove handler handles broken plugins without lifecycle hooks', async () => {
+  test('remove handler skips lifecycle hooks for broken plugins and force removals', async () => {
     const source = await readFile(join(ROOT, 'server/handlers/cms/plugins/state.ts'), 'utf-8')
-    // DELETE path must check kind === 'broken' and take an early bypass.
-    expect(source).toMatch(/lookup\.kind\s*===\s*['"]broken['"]/)
-    // It must call deletePlugin directly (skipping lifecycle hooks).
+    // Hooks run only on the normal path with a parseable manifest — corrupt
+    // manifests and `?force=true` bypass them. The negated-force + kind:'ok'
+    // guard is the single gate in front of the hook runner.
+    expect(source).toMatch(/!force\s*&&\s*lookup\.kind\s*===\s*['"]ok['"]/)
+    // Every removal variant (normal, forced, corrupt manifest) converges on
+    // ONE teardown — no parallel delete implementations.
+    expect(source).toMatch(/removePluginCompletely\(/)
+    // The teardown deletes the DB row and sweeps the plugin's whole on-disk
+    // tree (stale version dirs included), not just the current version.
     expect(source).toContain('deletePlugin(db,')
-    // It must call removePluginVersionAssets with lookup.id and lookup.version.
-    expect(source).toMatch(/removePluginVersionAssets\(/)
+    expect(source).toMatch(/removeAllPluginAssets\(/)
+    // Crash bookkeeping has no FK to installed_plugins — the teardown must
+    // sweep it explicitly so it can't outlive the row.
+    expect(source).toMatch(/clearPluginCrashes\(db,/)
   })
 
   test('PATCH (enable/disable) and restart handlers reject broken plugins with 409', async () => {

--- a/src/__tests__/persistence/cmsPluginsClient.test.ts
+++ b/src/__tests__/persistence/cmsPluginsClient.test.ts
@@ -79,7 +79,7 @@ describe('CMS plugins client', () => {
       })
     })
 
-    await removeCmsPlugin('local.map', async (input, init) => {
+    await removeCmsPlugin('local.map', false, async (input, init) => {
       calls.push({ input, init })
       return new Response(JSON.stringify({ ok: true }), { status: 200 })
     })

--- a/src/__tests__/plugins/pluginsAdmin.test.tsx
+++ b/src/__tests__/plugins/pluginsAdmin.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import React, { type ReactNode } from 'react'
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { MemoryRouter } from '@admin/lib/routing'
 import { PluginsPage } from '@plugins/PluginsPage'
 import { AdminSessionProvider } from '@admin/session'
@@ -315,6 +315,62 @@ describe('PluginsPage', () => {
         manifest: { id: 'acme.workflow' },
         grantedPermissions: privilegedManifest.permissions,
       })
+    })
+  })
+
+  it('offers force-remove after a hook-failed uninstall and confirms before forcing', async () => {
+    const hookError =
+      'Plugin uninstall hook failed during uninstall: uninstall exploded — the plugin is still installed. Fix the plugin, or force-remove it to skip its cleanup hooks.'
+    const calls: Array<{ input: RequestInfo | URL; init?: RequestInit }> = []
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ input, init })
+      const url = String(input)
+      if (url === '/admin/api/cms/plugins' && init?.method === 'GET') {
+        return json({ plugins: [pluginRow(true)], adminPages: [] })
+      }
+      if (url === '/admin/api/cms/plugins/local.map' && init?.method === 'DELETE') {
+        return json({ error: hookError }, 400)
+      }
+      if (url === '/admin/api/cms/plugins/local.map?force=true' && init?.method === 'DELETE') {
+        return json({ ok: true })
+      }
+      const ambient = ambientFetchFallback(url)
+      if (ambient) return ambient
+      return json({ error: `Unhandled ${url}` }, 500)
+    }
+
+    render(
+      <Wrapper>
+        <PluginsPage />
+      </Wrapper>,
+    )
+
+    expect(await screen.findByText('Map Studio')).toBeDefined()
+
+    // Normal removal: card button → confirm dialog → DELETE fails with the
+    // hook error.
+    fireEvent.click(screen.getByRole('button', { name: /remove map studio/i }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Remove plugin' }))
+
+    // Failure surfaces as an alert with the server message and a
+    // "Remove anyway" escape hatch.
+    expect(await screen.findByText(hookError)).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: 'Remove anyway' }))
+
+    // Force-removal is gated by its own confirmation dialog with skip-hooks
+    // warning copy — the forced DELETE only fires after confirming there.
+    const dialog = await screen.findByRole('alertdialog')
+    expect(within(dialog).getByText(/cleanup code will be skipped/i)).toBeDefined()
+    expect(
+      calls.some((call) => String(call.input) === '/admin/api/cms/plugins/local.map?force=true'),
+    ).toBe(false)
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Remove anyway' }))
+
+    await waitFor(() => {
+      expect(calls.some((call) =>
+        String(call.input) === '/admin/api/cms/plugins/local.map?force=true' &&
+        call.init?.method === 'DELETE'
+      )).toBe(true)
     })
   })
 

--- a/src/__tests__/server/cmsPlugins.test.ts
+++ b/src/__tests__/server/cmsPlugins.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { strToU8, zipSync } from 'fflate'
@@ -198,6 +198,11 @@ function makeFakeDb() {
         .filter((c) => c.plugin_id === values[0])
         .slice(0, Number(values[1] ?? 10))
       return { rows: rows as Row[], rowCount: rows.length }
+    }
+    // clearPluginScheduleRuns — values[0]=pluginId (uninstall teardown sweep;
+    // nothing inserts runs in these tests, so deleting is a no-op)
+    if (normalized.includes('delete from plugin_schedule_runs')) {
+      return { rows: [], rowCount: 0 }
     }
     // clearPluginCrashes — values[0]=pluginId
     if (normalized.includes('delete from plugin_crash_events')) {
@@ -985,7 +990,12 @@ describe('CMS plugin handlers', () => {
         { uploadsDir },
       )
       expect(remove.status).toBe(200)
-      expect(readMarkers()).toContain('uninstall:acme.lifecycle')
+      // Uninstall contract: the plugin was active, so `deactivate` runs
+      // before `uninstall` — in that order.
+      expect(readMarkers().slice(-2)).toEqual([
+        'deactivate:acme.lifecycle',
+        'uninstall:acme.lifecycle',
+      ])
       expect(db.plugins).toHaveLength(0)
     } finally {
       hookBus.unregisterPlugin('test')
@@ -1097,6 +1107,152 @@ describe('CMS plugin handlers', () => {
         },
       })
       expect(db.plugins).toHaveLength(1)
+    } finally {
+      await rm(uploadsDir, { recursive: true, force: true })
+    }
+  })
+
+  // ─── Force-uninstall ──────────────────────────────────────────────────────
+  //
+  // A throwing (or unloadable) uninstall hook must never permanently block
+  // removal. The normal DELETE fails with a 400 pointing at the force-remove
+  // escape hatch; `DELETE ?force=true` skips the hooks and tears everything
+  // down: DB row, crash events, and the plugin's whole on-disk tree —
+  // including stale version dirs left behind by interrupted upgrades.
+
+  it('uninstall hook failure leaves the plugin installed; force-remove tears everything down', async () => {
+    const uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-force-'))
+    const db = makeFakeDb()
+    const cookie = await createCookie(db)
+    const manifest = {
+      id: 'acme.stuck',
+      name: 'Stuck Plugin',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: ['cms.routes'],
+      entrypoints: { server: 'server/index.js' },
+      resources: [],
+      adminPages: [],
+    }
+
+    try {
+      const formData = new FormData()
+      formData.set('file', pluginZip({
+        'plugin.json': JSON.stringify(manifest),
+        'server/index.js': `
+          export function activate() {}
+          export function uninstall() { throw new Error('uninstall exploded') }
+        `,
+      }))
+      formData.set('grantedPermissions', JSON.stringify(['cms.routes']))
+      const install = await handleCmsRequest(
+        cmsFormRequest('http://localhost/admin/api/cms/plugins/package', formData, { cookie }),
+        db,
+        { uploadsDir },
+      )
+      expect(install.status).toBe(201)
+
+      // Simulate the hygiene gaps force-remove must sweep: a stale version
+      // dir from an interrupted upgrade, and historical crash events (the
+      // crash table has no FK to installed_plugins).
+      await mkdir(join(uploadsDir, 'plugins/acme.stuck/0.9.0'), { recursive: true })
+      const { recordPluginCrash } = await import('../../../server/repositories/plugins')
+      await recordPluginCrash(db, { id: 'crash_stuck', pluginId: 'acme.stuck', reason: 'old crash' })
+
+      // Normal uninstall — the throwing hook must NOT delete anything, and
+      // the error must point at the force-remove escape hatch.
+      const failed = await handleCmsRequest(
+        cmsRequest('http://localhost/admin/api/cms/plugins/acme.stuck', {
+          method: 'DELETE',
+          headers: { cookie },
+        }),
+        db,
+        { uploadsDir },
+      )
+      expect(failed.status).toBe(400)
+      const failedBody = await failed.json() as { error: string }
+      expect(failedBody.error).toMatch(/uninstall hook failed/)
+      expect(failedBody.error).toMatch(/uninstall exploded/)
+      expect(failedBody.error).toMatch(/force-remove/)
+      expect(db.plugins).toHaveLength(1)
+      expect(db.plugins[0].lifecycle_status).toBe('error')
+
+      // Force remove — skips hooks, drops the row, the crash events, and the
+      // whole on-disk tree (current AND stale version dirs).
+      const forced = await handleCmsRequest(
+        cmsRequest('http://localhost/admin/api/cms/plugins/acme.stuck?force=true', {
+          method: 'DELETE',
+          headers: { cookie },
+        }),
+        db,
+        { uploadsDir },
+      )
+      expect(forced.status).toBe(200)
+      expect(await forced.json()).toEqual({ ok: true })
+      expect(db.plugins).toHaveLength(0)
+      expect(db.crashEvents.filter((c) => c.plugin_id === 'acme.stuck')).toHaveLength(0)
+      const { existsSync } = await import('node:fs')
+      expect(existsSync(join(uploadsDir, 'plugins/acme.stuck'))).toBe(false)
+    } finally {
+      await rm(uploadsDir, { recursive: true, force: true })
+    }
+  })
+
+  it('force-remove works when the server entry file is missing from disk', async () => {
+    const uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-missing-entry-'))
+    const db = makeFakeDb()
+    const cookie = await createCookie(db)
+    // Seed the row directly: the manifest points at an entry file that does
+    // not exist on disk (e.g. the uploads volume was wiped). The lifecycle
+    // hook runner can't even load the entrypoint, so a normal uninstall is
+    // permanently stuck without the force path.
+    db.plugins.push({
+      id: 'acme.gone',
+      name: 'Gone Plugin',
+      version: '1.0.0',
+      enabled: true,
+      lifecycle_status: 'active',
+      last_error: null,
+      manifest_json: JSON.stringify({
+        id: 'acme.gone',
+        name: 'Gone Plugin',
+        version: '1.0.0',
+        apiVersion: 1,
+        permissions: ['cms.routes'],
+        entrypoints: { server: 'server/index.js' },
+        resources: [],
+        adminPages: [],
+        assetBasePath: '/uploads/plugins/acme.gone/1.0.0',
+      }),
+      granted_permissions_json: JSON.stringify(['cms.routes']),
+      settings_json: '{}',
+      installed_at: '2026-05-01T10:00:00.000Z',
+      updated_at: '2026-05-01T10:00:00.000Z',
+    })
+
+    try {
+      const failed = await handleCmsRequest(
+        cmsRequest('http://localhost/admin/api/cms/plugins/acme.gone', {
+          method: 'DELETE',
+          headers: { cookie },
+        }),
+        db,
+        { uploadsDir },
+      )
+      expect(failed.status).toBe(400)
+      expect(((await failed.json()) as { error: string }).error).toMatch(/force-remove/)
+      expect(db.plugins).toHaveLength(1)
+
+      const forced = await handleCmsRequest(
+        cmsRequest('http://localhost/admin/api/cms/plugins/acme.gone?force=true', {
+          method: 'DELETE',
+          headers: { cookie },
+        }),
+        db,
+        { uploadsDir },
+      )
+      expect(forced.status).toBe(200)
+      expect(db.plugins).toHaveLength(0)
     } finally {
       await rm(uploadsDir, { recursive: true, force: true })
     }

--- a/src/admin/pages/plugins/PluginsPage.module.css
+++ b/src/admin/pages/plugins/PluginsPage.module.css
@@ -41,6 +41,20 @@
     text-decoration: underline;
 }
 
+/* Failed-uninstall alert — error message plus the force-remove escape
+   hatch ("Remove anyway") and a dismiss action. */
+.removeFailure {
+    display: grid;
+    gap: 6px;
+    justify-items: start;
+}
+
+.removeFailureActions {
+    display: flex;
+    gap: 8px;
+    margin-top: 4px;
+}
+
 .emptyState {
     padding: 28px;
     border: 1px dashed var(--panel-border);

--- a/src/admin/pages/plugins/PluginsPage.tsx
+++ b/src/admin/pages/plugins/PluginsPage.tsx
@@ -30,6 +30,7 @@ export function PluginsPage() {
     settingsPluginId,
     schedulesPluginId,
     pendingRemove,
+    removeFailure,
   } = vm
 
   return (
@@ -80,6 +81,36 @@ export function PluginsPage() {
           </div>
         )}
 
+        {removeFailure && (
+          <div role="alert" className={styles.removeFailure}>
+            <p className={styles.error}>{removeFailure.message}</p>
+            <p className={styles.errorHint}>
+              Removing anyway skips the plugin&rsquo;s cleanup code — external
+              resources it created (webhooks, third-party registrations) may
+              remain.
+            </p>
+            <div className={styles.removeFailureActions}>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={busyPluginId === removeFailure.plugin.id}
+                onClick={() =>
+                  vm.setPendingRemove({ plugin: removeFailure.plugin, force: true })
+                }
+              >
+                Remove anyway
+              </Button>
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => vm.setRemoveFailure(null)}
+              >
+                Dismiss
+              </Button>
+            </div>
+          </div>
+        )}
+
         {pendingInstall && (
           <PermissionReviewSection
             pending={pendingInstall}
@@ -117,7 +148,7 @@ export function PluginsPage() {
                 onRestart={(p) => void vm.restartPlugin(p)}
                 onReinstall={() => fileInputRef.current?.click()}
                 onToggle={(p) => void vm.togglePlugin(p)}
-                onRemove={(p) => vm.setPendingRemove(p)}
+                onRemove={(p) => vm.setPendingRemove({ plugin: p, force: false })}
               />
             ))
           )}
@@ -151,13 +182,14 @@ export function PluginsPage() {
 
         {pendingRemove && (
           <PluginRemoveDialog
-            plugin={pendingRemove}
-            busy={busyPluginId === pendingRemove.id}
+            plugin={pendingRemove.plugin}
+            force={pendingRemove.force}
+            busy={busyPluginId === pendingRemove.plugin.id}
             onClose={() => vm.setPendingRemove(null)}
             onConfirm={async () => {
               const target = pendingRemove
               vm.setPendingRemove(null)
-              await vm.executeRemovePlugin(target)
+              await vm.executeRemovePlugin(target.plugin, target.force)
             }}
           />
         )}

--- a/src/admin/pages/plugins/components/PluginRemoveDialog/PluginRemoveDialog.module.css
+++ b/src/admin/pages/plugins/components/PluginRemoveDialog/PluginRemoveDialog.module.css
@@ -33,3 +33,12 @@
     color: var(--editor-text-muted);
     font-size: 12px;
 }
+
+/* Force-remove caveat — state color (warning), not decoration: the plugin's
+   own cleanup code is skipped and external resources may remain. */
+.warning {
+    margin: 0;
+    color: var(--editor-warning-text);
+    font-size: 12px;
+    line-height: 1.5;
+}

--- a/src/admin/pages/plugins/components/PluginRemoveDialog/PluginRemoveDialog.tsx
+++ b/src/admin/pages/plugins/components/PluginRemoveDialog/PluginRemoveDialog.tsx
@@ -7,6 +7,11 @@
  * layer-delete flow). Plugin uninstall is a different class of destructive
  * action — drops DB rows, kills routes / hooks / canvas modules, removes
  * plugin records and on-disk assets — so it always confirms.
+ *
+ * `force` switches to the force-remove variant offered after a normal
+ * uninstall failed on a lifecycle-hook error: the server skips the plugin's
+ * own cleanup hooks, so the copy warns that external resources the plugin
+ * set up may be left behind.
  */
 import { Button } from '@ui/components/Button'
 import { Dialog } from '@ui/components/Dialog'
@@ -15,6 +20,7 @@ import styles from './PluginRemoveDialog.module.css'
 
 interface PluginRemoveDialogProps {
   plugin: InstalledPlugin
+  force: boolean
   busy: boolean
   onClose: () => void
   onConfirm: () => void | Promise<void>
@@ -22,6 +28,7 @@ interface PluginRemoveDialogProps {
 
 export function PluginRemoveDialog({
   plugin,
+  force,
   busy,
   onClose,
   onConfirm,
@@ -31,7 +38,7 @@ export function PluginRemoveDialog({
       open
       onClose={busy ? () => {} : onClose}
       tone="danger"
-      eyebrow="Remove plugin"
+      eyebrow={force ? 'Force remove plugin' : 'Remove plugin'}
       title={plugin.name}
       footer={
         <>
@@ -51,21 +58,42 @@ export function PluginRemoveDialog({
             onClick={() => void onConfirm()}
             disabled={busy}
           >
-            {busy ? 'Removing…' : 'Remove plugin'}
+            {busy ? 'Removing…' : force ? 'Remove anyway' : 'Remove plugin'}
           </Button>
         </>
       }
     >
-      <p className={styles.lead}>Removing this plugin will:</p>
-      <ul className={styles.checklist}>
-        <li>Run its <code>uninstall</code> lifecycle hook.</li>
-        <li>Drop its routes, hooks, settings, and canvas modules from the runtime.</li>
-        <li>Delete every record stored under the plugin&rsquo;s declared resources.</li>
-        <li>Remove the plugin&rsquo;s files from <code>{plugin.manifest.assetBasePath ?? 'uploads/plugins/…'}</code>.</li>
-      </ul>
-      <p className={styles.note}>
-        Pack-imported Visual Components, pages, and CSS classes stay on your site.
-      </p>
+      {force ? (
+        <>
+          <p className={styles.lead}>
+            The plugin&rsquo;s own cleanup code will be skipped. Force-removing will:
+          </p>
+          <ul className={styles.checklist}>
+            <li>Skip its <code>deactivate</code> and <code>uninstall</code> lifecycle hooks.</li>
+            <li>Drop its routes, hooks, settings, schedules, and canvas modules from the runtime.</li>
+            <li>Delete every record stored under the plugin&rsquo;s declared resources.</li>
+            <li>Remove all of the plugin&rsquo;s files under <code>uploads/plugins/{plugin.id}/</code>.</li>
+          </ul>
+          <p className={styles.warning}>
+            External resources the plugin set up — webhooks, third-party
+            registrations, scheduled callbacks — may be left behind, because
+            the plugin&rsquo;s cleanup code does not run.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className={styles.lead}>Removing this plugin will:</p>
+          <ul className={styles.checklist}>
+            <li>Run its <code>deactivate</code> and <code>uninstall</code> lifecycle hooks.</li>
+            <li>Drop its routes, hooks, settings, and canvas modules from the runtime.</li>
+            <li>Delete every record stored under the plugin&rsquo;s declared resources.</li>
+            <li>Remove the plugin&rsquo;s files from <code>{plugin.manifest.assetBasePath ?? 'uploads/plugins/…'}</code>.</li>
+          </ul>
+          <p className={styles.note}>
+            Pack-imported Visual Components, pages, and CSS classes stay on your site.
+          </p>
+        </>
+      )}
     </Dialog>
   )
 }

--- a/src/admin/pages/plugins/hooks/usePluginsWorkspace.ts
+++ b/src/admin/pages/plugins/hooks/usePluginsWorkspace.ts
@@ -31,6 +31,7 @@ import {
 import { notifyCmsPluginsChanged } from '../utils/pluginEvents'
 import { subscribePluginEvents } from '../utils/pluginEventStream'
 import { getErrorMessage } from '@core/utils/errorMessage'
+import { ApiError } from '@core/http'
 import { pushToast } from '@ui/components/Toast'
 
 /**
@@ -63,6 +64,26 @@ export interface PendingInstall {
 }
 
 /**
+ * Confirmation-dialog state for plugin removal. `force: true` means the
+ * server will skip the plugin's lifecycle hooks — offered only after a
+ * normal uninstall failed on a hook error.
+ */
+export interface PendingRemove {
+  plugin: InstalledPlugin
+  force: boolean
+}
+
+/**
+ * A normal uninstall that failed because a lifecycle hook (`deactivate` /
+ * `uninstall`) threw or the entry file could not load. Rendered as an alert
+ * with a "Remove anyway" action that re-runs the removal with `force: true`.
+ */
+export interface RemoveFailure {
+  plugin: InstalledPlugin
+  message: string
+}
+
+/**
  * Read-only view-model returned to `PluginsPage`. Splits state, mutators that
  * drive dialogs, and async actions so the render component stays declarative.
  */
@@ -75,13 +96,15 @@ export interface PluginsWorkspaceVM extends WorkspaceLoadState {
   pendingInstall: PendingInstall | null
   settingsPluginId: string | null
   schedulesPluginId: string | null
-  pendingRemove: InstalledPlugin | null
+  pendingRemove: PendingRemove | null
+  removeFailure: RemoveFailure | null
 
   // Dialog open / close mutators.
   setPendingInstall: (value: PendingInstall | null) => void
   setSettingsPluginId: (value: string | null) => void
   setSchedulesPluginId: (value: string | null) => void
-  setPendingRemove: (value: InstalledPlugin | null) => void
+  setPendingRemove: (value: PendingRemove | null) => void
+  setRemoveFailure: (value: RemoveFailure | null) => void
 
   // Async actions.
   loadPlugins: () => Promise<void>
@@ -93,7 +116,7 @@ export interface PluginsWorkspaceVM extends WorkspaceLoadState {
   togglePlugin: (plugin: InstalledPlugin) => Promise<void>
   restartPlugin: (plugin: InstalledPlugin) => Promise<void>
   installPluginPack: (plugin: InstalledPlugin) => Promise<void>
-  executeRemovePlugin: (plugin: InstalledPlugin) => Promise<void>
+  executeRemovePlugin: (plugin: InstalledPlugin, force: boolean) => Promise<void>
 }
 
 const emptyPayload: CmsPluginsPayload = { plugins: [], adminPages: [] }
@@ -161,7 +184,8 @@ export function usePluginsWorkspace(): PluginsWorkspaceVM {
   const [pendingInstall, setPendingInstall] = useState<PendingInstall | null>(null)
   const [settingsPluginId, setSettingsPluginId] = useState<string | null>(null)
   const [schedulesPluginId, setSchedulesPluginId] = useState<string | null>(null)
-  const [pendingRemove, setPendingRemove] = useState<InstalledPlugin | null>(null)
+  const [pendingRemove, setPendingRemove] = useState<PendingRemove | null>(null)
+  const [removeFailure, setRemoveFailure] = useState<RemoveFailure | null>(null)
 
   // Editor-side activation failures (per pluginId → error message). Populated
   // by `useInstalledEditorPlugins` after each refresh; surfaced on the plugin
@@ -374,11 +398,12 @@ export function usePluginsWorkspace(): PluginsWorkspaceVM {
     setBusyPluginId(null)
   }
 
-  async function executeRemovePlugin(plugin: InstalledPlugin): Promise<void> {
+  async function executeRemovePlugin(plugin: InstalledPlugin, force: boolean): Promise<void> {
     setBusyPluginId(plugin.id)
     setError(null)
+    setRemoveFailure(null)
     try {
-      await runStepUp(() => removeCmsPlugin(plugin.id))
+      await runStepUp(() => removeCmsPlugin(plugin.id, force))
       setPayload((current) => ({
         plugins: current.plugins.filter((candidate) => candidate.id !== plugin.id),
         adminPages: current.adminPages.filter((page) => page.pluginId !== plugin.id),
@@ -386,13 +411,20 @@ export function usePluginsWorkspace(): PluginsWorkspaceVM {
       notifyCmsPluginsChanged()
     } catch (err) {
       if (!(err instanceof Error && err.message === StepUpCancelledMessage)) {
-        // The host's DELETE handler runs the plugin's `uninstall` lifecycle
-        // hook, removes runtime registrations, drops the DB row, and deletes
-        // the on-disk asset folder. If that flow returns an error we'd land
-        // in a confusing state where the plugin row may have been deleted
-        // server-side but the UI still shows it. Re-fetch the canonical list
+        const message = getErrorMessage(err, 'Could not remove plugin')
+        // A 400 from the DELETE endpoint means a lifecycle hook
+        // (`deactivate` / `uninstall`) threw, or the entry file could not
+        // load — the one failure class where the server offers the
+        // force-remove escape hatch. Surface it as a removal failure with
+        // a "Remove anyway" action instead of a dead-end error.
+        if (!force && err instanceof ApiError && err.status === 400) {
+          setRemoveFailure({ plugin, message })
+        } else {
+          setError(message)
+        }
+        // The DELETE flow mutates several server-side things before it can
+        // fail (lifecycle status, worker state). Re-fetch the canonical list
         // so the card reflects reality regardless of the failure mode.
-        setError(getErrorMessage(err, 'Could not remove plugin'))
         await loadPlugins()
       }
     }
@@ -440,10 +472,12 @@ export function usePluginsWorkspace(): PluginsWorkspaceVM {
     settingsPluginId,
     schedulesPluginId,
     pendingRemove,
+    removeFailure,
     setPendingInstall,
     setSettingsPluginId,
     setSchedulesPluginId,
     setPendingRemove,
+    setRemoveFailure,
     loadPlugins,
     handleUpload,
     installPendingPlugin,

--- a/src/core/persistence/cmsPlugins.ts
+++ b/src/core/persistence/cmsPlugins.ts
@@ -152,12 +152,20 @@ export async function setCmsPluginEnabled(
   }
 }
 
+/**
+ * DELETE /admin/api/cms/plugins/:id — uninstall a plugin. With `force: true`
+ * the server skips the plugin's lifecycle hooks (`deactivate` / `uninstall`)
+ * and tears everything down anyway — the escape hatch for a plugin whose
+ * uninstall hook throws or whose entry file can no longer load.
+ */
 export async function removeCmsPlugin(
   pluginId: string,
+  force = false,
   fetchImpl: FetchLike = globalThis.fetch.bind(globalThis),
   basePath = '/admin/api/cms',
 ): Promise<void> {
-  await apiRequest(`${basePath}/plugins/${encodeURIComponent(pluginId)}`, {
+  const query = force ? '?force=true' : ''
+  await apiRequest(`${basePath}/plugins/${encodeURIComponent(pluginId)}${query}`, {
     method: 'DELETE',
     fetchImpl,
     fallbackMessage: 'CMS plugin delete failed',


### PR DESCRIPTION
## Problem

A throwing (or unloadable) `uninstall` hook permanently blocked plugin removal: `server/handlers/cms/plugins/state.ts` returned 400 before deleting the DB row, assets, or worker, with no recovery path short of DB surgery. A missing/corrupt entry file failed the same way. Related hygiene gaps: `clearPluginCrashes` claimed to run "on uninstall" but never did, `plugin_crash_events` / `plugin_schedule_runs` rows outlived uninstall (no FK), and interrupted upgrades left stale version dirs under `uploads/plugins/<id>/` forever.

## What changed

**Server** (`server/handlers/cms/plugins/state.ts`, `shared.ts`, `index.ts`)
- `DELETE /admin/api/cms/plugins/:id?force=true` skips lifecycle hooks and proceeds with full teardown. Capability + step-up gating identical to normal uninstall (`plugins.install` + step-up); audit event carries `forced: true`.
- Normal uninstall now runs `deactivate` (when active) **before** `uninstall` — code now matches the documented "(if active) deactivate → uninstall" contract.
- Hook failure returns a 400 naming the failed hook and pointing at the force-remove escape hatch; the plugin row survives, parked in `error`.
- All removal variants — normal, forced, corrupt-manifest — converge on **one** teardown (`removePluginCompletely`): worker unload, canvas module pack deactivation, DB row delete (records/schedules cascade), crash counter + crash events + schedule run history sweep, and removal of the **whole** `uploads/plugins/<id>/` tree including stale version dirs (`removeAllPluginAssets`, `assertPathWithin` guard retained). The old duplicate corrupt-manifest delete path is gone.

**Admin UI** (`src/admin/pages/plugins/`)
- Failed uninstall surfaces as a `role="alert"` with the server message and a "Remove anyway" action; forcing is gated by its own confirmation dialog (shared `<Dialog>` primitive, no native dialogs) warning that the plugin's cleanup code is skipped and external resources (webhooks, third-party registrations) may remain.
- `PluginRemoveDialog` gains a `force` variant; `removeCmsPlugin(pluginId, force)` in `src/core/persistence/cmsPlugins.ts`.

**Docs** — `docs/features/plugin-system.md` gains a "Force-uninstall" section; the lifecycle contract line is now true.

## Tests

- `src/__tests__/server/cmsPlugins.test.ts`: deactivate runs before uninstall (ordered markers); hook failure → 400 with escape-hatch message and plugin still installed; `?force=true` removes row + crash events + entire asset tree (stale `0.9.0` dir included) despite a throwing hook; force removal works when the entry file is missing from disk.
- `src/__tests__/plugins/pluginsAdmin.test.tsx`: failed uninstall → "Remove anyway" → confirm dialog → `DELETE ?force=true`.
- `src/__tests__/architecture/plugin-boot-resilience.test.ts`: gate updated for the unified teardown (drifted rule fixed in the same change per CLAUDE.md).

## Verification

- `bun test` — 4912 pass / 0 fail
- `bun run build` — clean (`tsc -b && vite build`)
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)