### PR TITLE
Require editor.code permission for unsandboxed admin-window plugin code

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -83,7 +83,10 @@ All `.js` entrypoints are pre-bundled IIFEs that assign to a host-recognized glo
   "permissions": [
     "cms.routes",
     "cms.storage",
-    "cms.hooks"
+    "cms.hooks",
+    "admin.navigation",   // required by adminPages[]
+    "editor.code",        // required by entrypoints.editor (unsandboxed admin-window code)
+    "modules.register"    // required by entrypoints.modules
   ],
 
   "entrypoints": {
@@ -220,6 +223,20 @@ The client-side `EventSource` connection is lazy: it opens on the first subscrib
 ## The sandbox
 
 Plugin server code and canvas module packs run inside QuickJS compiled to WebAssembly. The sandbox is a separate JavaScript engine — it has its own globals, its own runtime, no FFI, no syscalls.
+
+### What is NOT sandboxed — `editor.code`
+
+Editor entrypoints (`entrypoints.editor`) and app-kind admin pages (`adminPages[].content.kind === "app"`) are **not sandboxed**. The host dynamically `import()`s those bundles into the main admin window, where they run with the same privileges as the admin UI itself: every admin API with the operator's session cookie, browser storage, the full DOM. This is deliberate — editor extensions need real React and real host UI — but it is a categorically different trust level than the QuickJS surfaces.
+
+That trust level is gated by one permission: **`editor.code`** (risk: dangerous).
+
+- The manifest parser rejects an editor entrypoint or app-kind admin page that doesn't declare `editor.code` (`parsePluginManifest` coherence checks; `instatic-plugin lint` reports the same error pre-upload).
+- The editor loader (`src/core/plugins/editorPluginLoader.ts`) refuses to import an editor entrypoint without the `editor.code` *grant*, and records a visible "permission not granted" failure on the plugin card instead of skipping silently. Module packs get the same treatment for `modules.register`.
+- The admin-app loader (`src/core/plugins/adminRuntime.ts`) refuses to import an app page without the grant; the page body renders the refusal.
+- `adminPages[].content.assetPath` is pinned to the plugin's own `/uploads/plugins/{id}/{version}` subtree so a manifest can't point the dynamic import at foreign code.
+- The install review dialog (always shown — even for zero-permission plugins) calls out `editor.code` with a dedicated unsandboxed-code warning.
+
+Inside the admin window, plugin React surfaces (panels, app pages, canvas overlays) mount under a `PluginContext` carrying the granted permission set; permission-gated host hooks enforce against it — `useEditorStore` from `@instatic/host-hooks` requires `editor.store.read` and exposes no write accessor (writes go through `api.editor.store.transaction`, which requires `editor.store.write`).
 
 ### What's available inside
 
@@ -602,6 +619,8 @@ The DNS SSRF guard in `performGatedFetch` remains the load-bearing defense; the 
 
 Permissions are requested in `plugin.json` and approved by the site owner at install time. Granted permissions are stored on the plugin row. Every SDK call checks the **granted** permission set, not just the request.
 
+The install endpoints enforce **grants = declared**, in both directions: every declared permission must be granted (install is all-or-nothing — there is no optional-permissions concept), and every granted permission must be declared (`assertPluginPermissionGrants` in `server/handlers/cms/plugins/shared.ts` rejects a tampered client that grants capabilities the manifest never disclosed). The install review dialog is shown for **every** install and upgrade — a zero-permission plugin renders "No permissions requested" rather than installing silently.
+
 **One authority, three checkpoints.** The declared `permissions` array (what the
 plugin *asked for*) is used only by the install/consent UI. Enforcement always
 validates against `grantedPermissions` (what the operator *approved*), at three
@@ -634,7 +653,8 @@ Risk levels:
 
 | Permission                  | Surface              | Risk      | Meaning                                                                 |
 |-----------------------------|----------------------|-----------|-------------------------------------------------------------------------|
-| `admin.navigation`          | Admin                | Low       | Add admin navigation entries                                            |
+| `admin.navigation`          | Admin                | Medium    | Add admin navigation entries (declarative pages; app pages also need `editor.code`) |
+| `editor.code`               | Admin / editor       | Dangerous | Run plugin JavaScript **unsandboxed** in the admin window (editor entrypoint, app-kind admin pages) |
 | `cms.storage`               | Admin / editor / server| Medium  | Read/write plugin-owned records                                         |
 | `cms.routes`                | Server               | High      | Register authenticated backend routes                                   |
 | `cms.hooks`                 | Server               | High      | Listen to CMS events / filter values                                    |

--- a/examples/plugins/template/README.md
+++ b/examples/plugins/template/README.md
@@ -97,10 +97,13 @@ The template requests:
 | Permission | Why |
 |---|---|
 | `cms.routes` | Register a `/status` health-check route |
+| `editor.code` | Required for `entrypoints.editor` — editor entrypoints run **unsandboxed** in the admin window |
 | `editor.commands` | Register commands + palette commands and providers |
 | `editor.toolbar` | Add a toolbar button |
 
 Remove permissions you don't need — users see the full permission list before installing.
+A plugin that drops its editor entrypoint (and any app-kind admin pages) can drop
+`editor.code` too; everything else then runs inside the QuickJS sandbox.
 
 ## Further reading
 

--- a/examples/plugins/template/plugin.json
+++ b/examples/plugins/template/plugin.json
@@ -6,6 +6,7 @@
   "description": "Starter template demonstrating the Instatic plugin SDK — server lifecycle hooks, editor commands, and Command Spotlight (⌘K) integration.",
   "permissions": [
     "cms.routes",
+    "editor.code",
     "editor.commands",
     "editor.toolbar"
   ],

--- a/public/runtime/host-hooks.js
+++ b/public/runtime/host-hooks.js
@@ -11,6 +11,12 @@
  * The host's main bundle populates `globalThis.__instatic.hostHooks`
  * with the live hook implementations and the React context they
  * subscribe to.
+ *
+ * Permission-gated hooks enforce the operator's grants per mounted
+ * plugin surface: `useEditorStore` throws without `editor.store.read`.
+ * No write-capable store accessor is exposed here — editor-store
+ * mutations go through `api.editor.store.transaction`
+ * (`editor.store.write`) in the plugin's editor entrypoint.
  */
 const G = globalThis.__instatic?.hostHooks
 if (!G) {

--- a/server/handlers/cms/plugins/shared.ts
+++ b/server/handlers/cms/plugins/shared.ts
@@ -30,6 +30,7 @@ import {
   findPluginResource,
   missingPluginPermissionGrants,
 } from '@core/plugins/manifest'
+import { isPluginPermission } from '@core/plugin-sdk'
 import type {
   InstalledPlugin,
   PluginManifest,
@@ -232,16 +233,39 @@ export function lifecycleErrorMessage(err: unknown): string {
 
 export function readPermissionGrants(value: unknown): PluginPermission[] {
   if (!Array.isArray(value)) return []
-  return value.filter((item): item is PluginPermission => typeof item === 'string') as PluginPermission[]
+  // Boundary validation: only strings that name a registered plugin
+  // permission survive. Unknown strings are dropped here and — if the
+  // client genuinely tried to grant something exotic — rejected by the
+  // grants ⊆ declared check in `assertPluginPermissionGrants`.
+  return value.filter(isPluginPermission)
 }
 
+/**
+ * Validate the operator's grant set against the manifest:
+ *
+ *   1. Every DECLARED permission must be granted (install is all-or-nothing
+ *      today — there is no optional-permissions concept).
+ *   2. Every GRANTED permission must be declared. Without this check a
+ *      tampered admin client could grant capabilities the manifest never
+ *      disclosed, and the runtime — which enforces against
+ *      `grantedPermissions` — would happily honour them.
+ */
 export function assertPluginPermissionGrants(
   manifest: PluginManifest,
   grantedPermissions: PluginPermission[],
 ): Response | null {
   const missing = missingPluginPermissionGrants(manifest, grantedPermissions)
-  if (missing.length === 0) return null
-  return badRequest(`Plugin install requires permission grants: ${missing.join(', ')}`)
+  if (missing.length > 0) {
+    return badRequest(`Plugin install requires permission grants: ${missing.join(', ')}`)
+  }
+  const declared = new Set(manifest.permissions)
+  const undeclared = grantedPermissions.filter((permission) => !declared.has(permission))
+  if (undeclared.length > 0) {
+    return badRequest(
+      `Granted permissions are not declared by the plugin manifest: ${undeclared.join(', ')}`,
+    )
+  }
+  return null
 }
 
 export function pluginManifestWithGrants(plugin: InstalledPlugin): PluginManifest {

--- a/src/__tests__/plugin-sdk/lintCli.test.ts
+++ b/src/__tests__/plugin-sdk/lintCli.test.ts
@@ -120,6 +120,35 @@ describe('instatic-plugin lint', () => {
     expect(offenders[0].message).toContain('require(')
   })
 
+  it('errors when an editor source exists without the editor.code permission', async () => {
+    const result = await withTempPlugin(async (dir) => {
+      await writeConfig(dir)
+      await mkdir(join(dir, 'editor'), { recursive: true })
+      await writeFile(
+        join(dir, 'editor', 'index.ts'),
+        `export function activate() {}\n`,
+        'utf-8',
+      )
+    })
+    const offenders = result.findings.filter((f) => f.severity === 'error')
+    expect(offenders).toHaveLength(1)
+    expect(offenders[0].scope).toBe('manifest')
+    expect(offenders[0].message).toContain('editor.code')
+  })
+
+  it('does not flag an editor source when editor.code is requested', async () => {
+    const result = await withTempPlugin(async (dir) => {
+      await writeConfig(dir, { permissions: ['editor.code'] })
+      await mkdir(join(dir, 'editor'), { recursive: true })
+      await writeFile(
+        join(dir, 'editor', 'index.ts'),
+        `export function activate() {}\n`,
+        'utf-8',
+      )
+    })
+    expect(result.findings).toEqual([])
+  })
+
   it('reports a config-level error when instatic-plugin.config.ts is missing', async () => {
     const result = await withTempPlugin(async () => {
       // Intentionally do not write any config file.

--- a/src/__tests__/plugins/editorPluginLoader.test.ts
+++ b/src/__tests__/plugins/editorPluginLoader.test.ts
@@ -8,8 +8,8 @@ const workflowManifest: PluginManifest = {
   name: 'Workflow Tools',
   version: '1.0.0',
   apiVersion: 1,
-  permissions: ['editor.commands', 'editor.toolbar'],
-  grantedPermissions: ['editor.commands', 'editor.toolbar'],
+  permissions: ['editor.code', 'editor.commands', 'editor.toolbar'],
+  grantedPermissions: ['editor.code', 'editor.commands', 'editor.toolbar'],
   entrypoints: {
     editor: 'editor/index.js',
   },
@@ -33,7 +33,7 @@ describe('installed editor plugin loader', () => {
         enabled: true,
         lifecycleStatus: 'active',
         lastError: null,
-        grantedPermissions: ['editor.commands', 'editor.toolbar'],
+        grantedPermissions: ['editor.code', 'editor.commands', 'editor.toolbar'],
         manifest: workflowManifest,
         installedAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
@@ -93,7 +93,7 @@ describe('installed editor plugin loader', () => {
           enabled: false,
           lifecycleStatus: 'disabled',
           lastError: null,
-          grantedPermissions: ['editor.commands', 'editor.toolbar'],
+          grantedPermissions: ['editor.code', 'editor.commands', 'editor.toolbar'],
           manifest: workflowManifest,
           installedAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -125,7 +125,7 @@ describe('installed editor plugin loader', () => {
           enabled: true,
           lifecycleStatus: 'error',
           lastError: 'activate exploded',
-          grantedPermissions: ['editor.commands', 'editor.toolbar'],
+          grantedPermissions: ['editor.code', 'editor.commands', 'editor.toolbar'],
           manifest: workflowManifest,
           installedAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
@@ -145,5 +145,84 @@ describe('installed editor plugin loader', () => {
       failed: [],
       modulePacksLoaded: [],
     })
+  })
+
+  it('refuses to import an editor entrypoint without the editor.code grant and records a visible failure', async () => {
+    const imported: string[] = []
+
+    const result = await activateInstalledEditorPlugins({
+      fetchImpl: async () => Response.json({
+        adminPages: [],
+        plugins: [{
+          id: workflowManifest.id,
+          name: workflowManifest.name,
+          version: workflowManifest.version,
+          enabled: true,
+          lifecycleStatus: 'active',
+          lastError: null,
+          // Tampered / legacy row: entrypoint declared, grant absent.
+          grantedPermissions: ['editor.commands', 'editor.toolbar'],
+          manifest: workflowManifest,
+          installedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }],
+      } satisfies CmsPluginsPayload),
+      importEditorModule: async (url) => {
+        imported.push(url)
+        return { activate() {} }
+      },
+    })
+
+    // The bundle must never be imported — the gate sits BEFORE the dynamic
+    // import, not just before activate().
+    expect(imported).toEqual([])
+    expect(result.activated).toEqual([])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0].pluginId).toBe('acme.workflow')
+    expect(String((result.failed[0].error as Error).message)).toContain('editor.code')
+  })
+
+  it('records a visible failure for a modules entrypoint without the modules.register grant', async () => {
+    const modulesManifest: PluginManifest = {
+      id: 'acme.blocks',
+      name: 'Blocks',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: ['modules.register'],
+      grantedPermissions: [],
+      entrypoints: { modules: 'modules/index.js' },
+      assetBasePath: '/uploads/plugins/acme.blocks/1.0.0',
+      resources: [],
+      adminPages: [],
+    }
+    const imported: string[] = []
+
+    const result = await activateInstalledEditorPlugins({
+      fetchImpl: async () => Response.json({
+        adminPages: [],
+        plugins: [{
+          id: modulesManifest.id,
+          name: modulesManifest.name,
+          version: modulesManifest.version,
+          enabled: true,
+          lifecycleStatus: 'active',
+          lastError: null,
+          grantedPermissions: [],
+          manifest: modulesManifest,
+          installedAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }],
+      } satisfies CmsPluginsPayload),
+      importModulePack: async (url) => {
+        imported.push(url)
+        return { modules: [] }
+      },
+    })
+
+    expect(imported).toEqual([])
+    expect(result.modulePacksLoaded).toEqual([])
+    expect(result.failed).toHaveLength(1)
+    expect(result.failed[0].pluginId).toBe('acme.blocks')
+    expect(String((result.failed[0].error as Error).message)).toContain('modules.register')
   })
 })

--- a/src/__tests__/plugins/permissionReviewSection.test.tsx
+++ b/src/__tests__/plugins/permissionReviewSection.test.tsx
@@ -70,7 +70,7 @@ describe('computePermissionDiff', () => {
 })
 
 describe('PermissionReviewSection — fresh install', () => {
-  it('shows "Approve Plugin Permissions" + lists every permission with no badges', () => {
+  it('shows the review heading + lists every permission with no badges', () => {
     render(
       <PermissionReviewSection
         pending={{
@@ -81,13 +81,74 @@ describe('PermissionReviewSection — fresh install', () => {
         onConfirm={() => {}}
       />,
     )
-    expect(screen.getByText('Approve Plugin Permissions')).toBeDefined()
+    expect(screen.getByText('Review Acme Plugin')).toBeDefined()
     expect(
       screen.getByRole('button', { name: 'Approve and Install' }),
     ).toBeDefined()
     // Fresh install doesn't show diff badges.
     expect(screen.queryByText('Already approved')).toBeNull()
     expect(screen.queryByText('No longer requested')).toBeNull()
+  })
+
+  it('renders a "no permissions requested" notice for a zero-permission install', () => {
+    render(
+      <PermissionReviewSection
+        pending={{ manifest: { ...baseManifest, permissions: [] } }}
+        uploading={false}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    )
+    const empty = screen.getByTestId('permission-review-empty')
+    expect(empty.textContent).toContain('No permissions requested')
+    expect(
+      screen.getByRole('button', { name: 'Approve and Install' }),
+    ).toBeDefined()
+    // No unsandboxed-code callout for a declarative plugin.
+    expect(screen.queryByTestId('unsandboxed-code-alert')).toBeNull()
+  })
+
+  it('flags editor.code installs with an unsandboxed-code alert', () => {
+    render(
+      <PermissionReviewSection
+        pending={{
+          manifest: {
+            ...baseManifest,
+            permissions: ['editor.code', 'editor.commands'] satisfies PluginPermission[],
+            entrypoints: { editor: 'editor/index.js' },
+          },
+        }}
+        uploading={false}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    )
+    const alert = screen.getByTestId('unsandboxed-code-alert')
+    expect(alert.textContent).toContain('outside the plugin sandbox')
+    expect(alert.textContent).toContain('editor entrypoint')
+  })
+
+  it('names app pages in the unsandboxed-code alert when the manifest ships them', () => {
+    render(
+      <PermissionReviewSection
+        pending={{
+          manifest: {
+            ...baseManifest,
+            permissions: ['admin.navigation', 'editor.code'] satisfies PluginPermission[],
+            adminPages: [{
+              id: 'dashboard',
+              title: 'Dashboard',
+              route: '/admin/plugins/acme.test/dashboard',
+              content: { kind: 'app', heading: 'Dashboard', entry: 'admin/dashboard.js' },
+            }],
+          },
+        }}
+        uploading={false}
+        onCancel={() => {}}
+        onConfirm={() => {}}
+      />,
+    )
+    expect(screen.getByTestId('unsandboxed-code-alert').textContent).toContain('admin app pages')
   })
 })
 

--- a/src/__tests__/plugins/pluginCanvasOverlays.test.tsx
+++ b/src/__tests__/plugins/pluginCanvasOverlays.test.tsx
@@ -24,8 +24,8 @@ const baseManifest: PluginManifest = {
   version: '1.0.0',
   apiVersion: 1,
   description: 'Canvas overlay test plugin',
-  permissions: ['editor.canvas'],
-  grantedPermissions: ['editor.canvas'],
+  permissions: ['editor.code', 'editor.canvas'],
+  grantedPermissions: ['editor.code', 'editor.canvas'],
   entrypoints: { editor: 'editor/index.js' },
   resources: [],
   adminPages: [],
@@ -112,7 +112,7 @@ describe('pluginRuntime canvas overlay registry', () => {
   })
 
   it('returns a referentially stable getCanvasOverlays() snapshot until a mutation', () => {
-    pluginRuntime.registerCanvasOverlay('acme.workflow', {
+    pluginRuntime.registerCanvasOverlay(baseManifest, {
       id: 'acme.workflow.pin',
       component: NoopOverlay,
     })
@@ -120,7 +120,7 @@ describe('pluginRuntime canvas overlay registry', () => {
     const b = pluginRuntime.getCanvasOverlays()
     expect(a).toBe(b)
 
-    pluginRuntime.registerCanvasOverlay('acme.workflow', {
+    pluginRuntime.registerCanvasOverlay(baseManifest, {
       id: 'acme.workflow.ruler',
       component: NoopOverlay,
     })
@@ -130,7 +130,7 @@ describe('pluginRuntime canvas overlay registry', () => {
   })
 
   it('reset() clears registered overlays', () => {
-    pluginRuntime.registerCanvasOverlay('acme.workflow', {
+    pluginRuntime.registerCanvasOverlay(baseManifest, {
       id: 'acme.workflow.pin',
       component: NoopOverlay,
     })
@@ -153,11 +153,11 @@ describe('PluginCanvasOverlayLayer host mount', () => {
     function GoodbyePin() {
       return <span>Goodbye pin</span>
     }
-    pluginRuntime.registerCanvasOverlay('acme.workflow', {
+    pluginRuntime.registerCanvasOverlay(baseManifest, {
       id: 'acme.workflow.hello',
       component: HelloPin,
     })
-    pluginRuntime.registerCanvasOverlay('acme.workflow', {
+    pluginRuntime.registerCanvasOverlay(baseManifest, {
       id: 'acme.workflow.bye',
       component: GoodbyePin,
     })
@@ -174,7 +174,7 @@ describe('PluginCanvasOverlayLayer host mount', () => {
       captured.push(overlay)
       return null
     }
-    pluginRuntime.registerCanvasOverlay('acme.workflow', {
+    pluginRuntime.registerCanvasOverlay(baseManifest, {
       id: 'acme.workflow.cap',
       component: CapturingOverlay,
     })

--- a/src/__tests__/plugins/pluginHostHooks.test.tsx
+++ b/src/__tests__/plugins/pluginHostHooks.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * Permission gating for `@instatic/host-hooks`.
+ *
+ * Plugin React surfaces (editor panels, admin app pages, canvas overlays)
+ * mount under a `PluginContext` carrying the operator-granted permission
+ * set. `useEditorStore` — the only host hook exposing editor state — must
+ * enforce `editor.store.read` against that context: a plugin the operator
+ * never granted store access cannot subscribe to editor state just because
+ * its code runs in the admin window.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import { PluginEditorPanel } from '@site/panels/PluginEditorPanel'
+import { useEditorStore as useHostEditorStore } from '@site/store/store'
+import { useEditorStore } from '@admin/plugin-host-hooks'
+import { pluginRuntime } from '@core/plugins/runtime'
+import type { PluginManifest, PluginPermission } from '@core/plugin-sdk'
+
+function manifestWithGrants(granted: PluginPermission[]): PluginManifest {
+  return {
+    id: 'acme.workflow',
+    name: 'Workflow',
+    version: '1.0.0',
+    apiVersion: 1,
+    permissions: ['editor.code', 'editor.panels', 'editor.store.read'],
+    grantedPermissions: granted,
+    entrypoints: { editor: 'editor/index.js' },
+    resources: [],
+    adminPages: [],
+  }
+}
+
+function BreakpointPanel() {
+  const breakpointId = useEditorStore((s) => s.activeBreakpointId)
+  return <span>breakpoint:{String(breakpointId)}</span>
+}
+
+beforeEach(() => {
+  pluginRuntime.reset()
+})
+
+afterEach(() => {
+  pluginRuntime.reset()
+  cleanup()
+})
+
+describe('useEditorStore permission gate', () => {
+  it('returns editor state for a plugin granted editor.store.read', () => {
+    useHostEditorStore.setState({ activeBreakpointId: 'desktop' })
+    pluginRuntime.registerPanel(
+      manifestWithGrants(['editor.code', 'editor.panels', 'editor.store.read']),
+      {
+        id: 'acme.workflow.review',
+        label: 'Review',
+        iconName: 'box-stack',
+        component: BreakpointPanel,
+      },
+    )
+
+    render(<PluginEditorPanel panelId="acme.workflow.review" />)
+
+    expect(screen.getByText('breakpoint:desktop')).toBeDefined()
+  })
+
+  it('throws a permission error (caught by the boundary) when editor.store.read is not granted', () => {
+    pluginRuntime.registerPanel(
+      manifestWithGrants(['editor.code', 'editor.panels']),
+      {
+        id: 'acme.workflow.review',
+        label: 'Review',
+        iconName: 'box-stack',
+        component: BreakpointPanel,
+      },
+    )
+
+    render(<PluginEditorPanel panelId="acme.workflow.review" />)
+
+    // No editor state leaked; the panel body shows the boundary fallback
+    // instead of the plugin subtree.
+    expect(screen.queryByText('breakpoint:desktop')).toBeNull()
+    expect(
+      (document.body.textContent ?? '').includes('failed to load'),
+    ).toBe(true)
+  })
+
+  it('the thrown error names the plugin and the missing permission', () => {
+    pluginRuntime.registerPanel(
+      manifestWithGrants(['editor.code', 'editor.panels']),
+      {
+        id: 'acme.workflow.review',
+        label: 'Review',
+        iconName: 'box-stack',
+        component: BreakpointPanel,
+      },
+    )
+
+    // Render the panel subtree without relying on the boundary fallback
+    // copy (which is environment-dependent) — capture the boundary log.
+    const errors: unknown[] = []
+    const originalConsoleError = console.error
+    console.error = (...args: unknown[]) => { errors.push(args.join(' ')) }
+    try {
+      render(<PluginEditorPanel panelId="acme.workflow.review" />)
+    } finally {
+      console.error = originalConsoleError
+    }
+    expect(errors.some((line) =>
+      String(line).includes('[plugin:acme.workflow]')
+      && String(line).includes('useEditorStore requires the "editor.store.read" permission'),
+    )).toBe(true)
+  })
+
+  it('throws when called outside any plugin surface', () => {
+    function Bare() {
+      useEditorStore((s) => s.activeBreakpointId)
+      return null
+    }
+    expect(() => render(<Bare />)).toThrow(/outside a plugin surface/)
+  })
+
+  it('exposes no write-capable accessor (getState/setState/subscribe)', () => {
+    // The previous implementation re-exported the raw Zustand hook, which
+    // carried `setState` — letting any admin-window plugin mutate editor
+    // state without the `editor.store.write` grant. The gated wrapper is a
+    // plain function: reads via selector, writes only through
+    // `api.editor.store.transaction`.
+    const accessor = useEditorStore as unknown as Record<string, unknown>
+    expect(accessor.setState).toBeUndefined()
+    expect(accessor.getState).toBeUndefined()
+    expect(accessor.subscribe).toBeUndefined()
+  })
+})

--- a/src/__tests__/plugins/pluginManifest.test.ts
+++ b/src/__tests__/plugins/pluginManifest.test.ts
@@ -14,6 +14,7 @@ describe('plugin manifest validation', () => {
       version: '1.0.0',
       apiVersion: 1,
       description: 'Adds a map workspace to the admin.',
+      permissions: ['admin.navigation'],
       adminPages: [
         {
           id: 'overview',
@@ -45,7 +46,7 @@ describe('plugin manifest validation', () => {
       version: '1.0.0',
       apiVersion: 1,
       description: 'Adds a backend-backed books database.',
-      permissions: ['cms.storage'],
+      permissions: ['cms.storage', 'admin.navigation'],
       resources: [
         {
           id: 'books',
@@ -147,6 +148,7 @@ describe('plugin manifest validation', () => {
       name: 'Insights Dashboard',
       version: '1.0.0',
       apiVersion: 1,
+      permissions: ['admin.navigation', 'editor.code'],
       resources: [
         {
           id: 'metrics',
@@ -184,6 +186,7 @@ describe('plugin manifest validation', () => {
         name: 'Bad App',
         version: '1.0.0',
         apiVersion: 1,
+        permissions: ['admin.navigation', 'editor.code'],
         adminPages: [{
           id: 'dashboard',
           title: 'Dashboard',
@@ -282,6 +285,7 @@ describe('plugin manifest validation', () => {
       name: 'Enabled',
       version: '1.0.0',
       apiVersion: 1,
+      permissions: ['admin.navigation'],
       adminPages: [{ id: 'dashboard', title: 'Enabled', content: { kind: 'markdown', body: 'Visible' } }],
     })
     const disabled = parsePluginManifest({
@@ -289,6 +293,7 @@ describe('plugin manifest validation', () => {
       name: 'Disabled',
       version: '1.0.0',
       apiVersion: 1,
+      permissions: ['admin.navigation'],
       adminPages: [{ id: 'dashboard', title: 'Disabled', content: { kind: 'markdown', body: 'Hidden' } }],
     })
 
@@ -306,6 +311,7 @@ describe('plugin manifest validation', () => {
       name: 'Broken',
       version: '1.0.0',
       apiVersion: 1,
+      permissions: ['admin.navigation'],
       adminPages: [{ id: 'dashboard', title: 'Broken', content: { kind: 'markdown', body: 'Hidden' } }],
     })
 
@@ -322,6 +328,7 @@ describe('plugin manifest validation', () => {
       name: 'Silent',
       version: '1.0.0',
       apiVersion: 1,
+      permissions: ['admin.navigation'],
       adminPages: [{ id: 'dashboard', title: 'Silent', content: { kind: 'markdown', body: 'Hidden' } }],
     })
 
@@ -330,6 +337,151 @@ describe('plugin manifest validation', () => {
         { manifest, enabled: true, grantedPermissions: [] },
       ]),
     ).toEqual([])
+  })
+
+  // -------------------------------------------------------------------------
+  // `editor.code` coherence — unsandboxed admin-window code must be declared.
+  // -------------------------------------------------------------------------
+
+  it('rejects an editor entrypoint without the editor.code permission', () => {
+    expect(() =>
+      parsePluginManifest({
+        id: 'acme.workflow',
+        name: 'Workflow',
+        version: '1.0.0',
+        apiVersion: 1,
+        permissions: ['editor.commands'],
+        entrypoints: { editor: 'editor/index.js' },
+      }),
+    ).toThrow(/`entrypoints\.editor`.*requires the `editor\.code` permission/)
+  })
+
+  it('accepts an editor entrypoint when editor.code is declared', () => {
+    const manifest = parsePluginManifest({
+      id: 'acme.workflow',
+      name: 'Workflow',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: ['editor.code', 'editor.commands'],
+      entrypoints: { editor: 'editor/index.js' },
+    })
+    expect(manifest.entrypoints?.editor).toBe('editor/index.js')
+  })
+
+  it('rejects a modules entrypoint without the modules.register permission', () => {
+    expect(() =>
+      parsePluginManifest({
+        id: 'acme.blocks',
+        name: 'Blocks',
+        version: '1.0.0',
+        apiVersion: 1,
+        permissions: [],
+        entrypoints: { modules: 'modules/index.js' },
+      }),
+    ).toThrow(/`entrypoints\.modules` requires the `modules\.register` permission/)
+  })
+
+  it('rejects app-kind admin pages without the editor.code permission', () => {
+    expect(() =>
+      parsePluginManifest({
+        id: 'acme.insights',
+        name: 'Insights',
+        version: '1.0.0',
+        apiVersion: 1,
+        permissions: ['admin.navigation'],
+        adminPages: [{
+          id: 'dashboard',
+          title: 'Dashboard',
+          content: { kind: 'app', heading: 'Dashboard', entry: 'admin/dashboard.js' },
+        }],
+      }),
+    ).toThrow(/kind "app".*requires the `editor\.code` permission/)
+  })
+
+  it('rejects adminPages without the admin.navigation permission', () => {
+    expect(() =>
+      parsePluginManifest({
+        id: 'acme.silent',
+        name: 'Silent',
+        version: '1.0.0',
+        apiVersion: 1,
+        adminPages: [{ id: 'page', title: 'Page', content: { kind: 'markdown', body: 'Hi' } }],
+      }),
+    ).toThrow(/`adminPages` requires the `admin\.navigation` permission/)
+  })
+
+  // -------------------------------------------------------------------------
+  // `adminPages[].content.assetPath` containment — the only manifest path
+  // that feeds the admin shell's dynamic import() must stay inside the
+  // plugin's own asset subtree.
+  // -------------------------------------------------------------------------
+
+  it('accepts an app page assetPath inside the plugin asset subtree', () => {
+    const manifest = parsePluginManifest({
+      id: 'acme.insights',
+      name: 'Insights',
+      version: '1.0.0',
+      apiVersion: 1,
+      permissions: ['admin.navigation', 'editor.code'],
+      adminPages: [{
+        id: 'dashboard',
+        title: 'Dashboard',
+        content: {
+          kind: 'app',
+          heading: 'Dashboard',
+          entry: 'admin/dashboard.js',
+          assetPath: '/uploads/plugins/acme.insights/1.0.0',
+        },
+      }],
+    })
+    const content = manifest.adminPages[0].content
+    expect(content.kind === 'app' && content.assetPath).toBe('/uploads/plugins/acme.insights/1.0.0')
+  })
+
+  it('rejects an app page assetPath pointing at another plugin', () => {
+    expect(() =>
+      parsePluginManifest({
+        id: 'atk.evil',
+        name: 'Evil',
+        version: '1.0.0',
+        apiVersion: 1,
+        permissions: ['admin.navigation', 'editor.code'],
+        adminPages: [{
+          id: 'dashboard',
+          title: 'Dashboard',
+          content: {
+            kind: 'app',
+            heading: 'Dashboard',
+            entry: 'admin/dashboard.js',
+            assetPath: '/uploads/plugins/legit.workflow/2.0.0',
+          },
+        }],
+      }),
+    ).toThrow(/assetPath must stay within "\/uploads\/plugins\/atk\.evil\/1\.0\.0"/)
+  })
+
+  it('rejects app page assetPath escapes (traversal, remote URLs, foreign paths)', () => {
+    for (const assetPath of [
+      '/uploads/plugins/atk.evil/1.0.0/../../legit.workflow/2.0.0',
+      'https://evil.example.com/bundle',
+      '/uploads/media',
+      '/etc',
+    ]) {
+      expect(() =>
+        parsePluginManifest({
+          id: 'atk.evil',
+          name: 'Evil',
+          version: '1.0.0',
+          apiVersion: 1,
+          permissions: ['admin.navigation', 'editor.code'],
+          adminPages: [{
+            id: 'dashboard',
+            title: 'Dashboard',
+            content: { kind: 'app', heading: 'Dashboard', entry: 'admin/dashboard.js', assetPath },
+          }],
+        }),
+      ).toThrow('Invalid plugin manifest')
+    }
   })
 
   it('validates plugin record input against a declared resource schema', () => {

--- a/src/__tests__/plugins/pluginResourcePage.test.tsx
+++ b/src/__tests__/plugins/pluginResourcePage.test.tsx
@@ -167,6 +167,7 @@ describe('PluginPageRenderer resource pages', () => {
             entry: 'admin/dashboard.js',
             assetPath: '/uploads/plugins/acme.demo/1.0.0',
           },
+          pluginGrantedPermissions: ['editor.code'],
         }}
         importModule={async (url) => {
           // The host appends a `?v=<timestamp>` cache-buster — assert the
@@ -197,6 +198,7 @@ describe('PluginPageRenderer resource pages', () => {
         entry: 'admin/dashboard.js',
         assetPath: '/uploads/plugins/acme.demo/1.0.0',
       },
+      pluginGrantedPermissions: ['editor.code'],
     }
 
     type Resolver = (mod: { default: PluginAdminAppComponent }) => void
@@ -228,5 +230,39 @@ describe('PluginPageRenderer resource pages', () => {
     await waitFor(() => {
       expect(screen.getAllByText('Plugin dashboard subtree')).toHaveLength(1)
     })
+  })
+
+  it('refuses to import an app page without the editor.code grant and renders the refusal', async () => {
+    const appPage: PluginAdminPageRoute = {
+      pluginId: 'acme.demo',
+      pluginName: 'Demo Plugin',
+      id: 'dashboard',
+      title: 'Dashboard',
+      route: '/admin/plugins/acme.demo/dashboard',
+      content: {
+        kind: 'app',
+        heading: 'Demo Dashboard',
+        entry: 'admin/dashboard.js',
+        assetPath: '/uploads/plugins/acme.demo/1.0.0',
+      },
+      // Grant set without `editor.code` — the loader must refuse BEFORE the
+      // dynamic import and the page body must show why.
+      pluginGrantedPermissions: ['admin.navigation'],
+    }
+
+    const imports: string[] = []
+    render(
+      <PluginPageRenderer
+        page={appPage}
+        importModule={async (url) => {
+          imports.push(url)
+          return { default: () => null }
+        }}
+      />,
+    )
+
+    const alert = await screen.findByRole('alert')
+    expect(alert.textContent).toContain('editor.code')
+    expect(imports).toHaveLength(0)
   })
 })

--- a/src/__tests__/plugins/pluginsAdmin.test.tsx
+++ b/src/__tests__/plugins/pluginsAdmin.test.tsx
@@ -16,6 +16,7 @@ const mapManifest = {
   name: 'Map Studio',
   version: '1.0.0',
   apiVersion: 1,
+  permissions: ['admin.navigation'],
   adminPages: [{
     id: 'overview',
     title: 'Map Studio',
@@ -245,6 +246,13 @@ describe('PluginsPage', () => {
       },
     })
 
+    // Every install now goes through the review dialog — nothing installs
+    // silently, even a near-declarative manifest.
+    expect(await screen.findByText('Review Map Studio')).toBeDefined()
+    expect(calls.some((call) => String(call.input) === '/admin/api/cms/plugins' && call.init?.method === 'POST')).toBe(false)
+
+    fireEvent.click(screen.getByRole('button', { name: /approve and install/i }))
+
     await waitFor(() => {
       const installCall = calls.find((call) =>
         String(call.input) === '/admin/api/cms/plugins' &&
@@ -252,9 +260,8 @@ describe('PluginsPage', () => {
       )
       expect(installCall).toBeDefined()
       expect(JSON.parse(String(installCall?.init?.body))).toMatchObject({
-        id: 'local.map',
-        permissions: [],
-        resources: [],
+        manifest: { id: 'local.map' },
+        grantedPermissions: ['admin.navigation'],
       })
     })
   })
@@ -265,7 +272,7 @@ describe('PluginsPage', () => {
       ...mapManifest,
       id: 'acme.workflow',
       name: 'Workflow Tools',
-      permissions: ['editor.toolbar', 'editor.commands', 'editor.store.write', 'cms.storage'],
+      permissions: ['admin.navigation', 'editor.code', 'editor.toolbar', 'editor.commands', 'editor.store.write', 'cms.storage'],
       entrypoints: { editor: 'editor/index.js' },
     }
 
@@ -297,7 +304,7 @@ describe('PluginsPage', () => {
       },
     })
 
-    expect(await screen.findByText('Approve Plugin Permissions')).toBeDefined()
+    expect(await screen.findByText('Review Workflow Tools')).toBeDefined()
     expect(screen.getByText('Add controls to the editor toolbar')).toBeDefined()
     expect(screen.getByText('Register editor commands')).toBeDefined()
     expect(screen.getByText('Allows the plugin to mutate editor store state through a host transaction.')).toBeDefined()

--- a/src/__tests__/server/cmsPluginResources.test.ts
+++ b/src/__tests__/server/cmsPluginResources.test.ts
@@ -250,6 +250,7 @@ const booksPlugin = {
   name: 'Books',
   version: '1.0.0',
   apiVersion: 1,
+  permissions: ['admin.navigation', 'cms.storage'],
   resources: [
     {
       id: 'books',
@@ -289,7 +290,7 @@ describe('CMS plugin resource handlers', () => {
     const install = await handleCmsRequest(cmsRequest('http://localhost/admin/api/cms/plugins', {
       method: 'POST',
       headers: { cookie, 'content-type': 'application/json' },
-      body: JSON.stringify(booksPlugin),
+      body: JSON.stringify({ manifest: booksPlugin, grantedPermissions: booksPlugin.permissions }),
     }), db)
     expect(install.status).toBe(201)
 
@@ -344,7 +345,7 @@ describe('CMS plugin resource handlers', () => {
     await handleCmsRequest(cmsRequest('http://localhost/admin/api/cms/plugins', {
       method: 'POST',
       headers: { cookie, 'content-type': 'application/json' },
-      body: JSON.stringify(booksPlugin),
+      body: JSON.stringify({ manifest: booksPlugin, grantedPermissions: booksPlugin.permissions }),
     }), db)
 
     const res = await handleCmsRequest(cmsRequest(

--- a/src/__tests__/server/cmsPlugins.test.ts
+++ b/src/__tests__/server/cmsPlugins.test.ts
@@ -637,7 +637,7 @@ describe('CMS plugin handlers', () => {
       ...mapManifest,
       id: 'acme.workflow',
       name: 'Workflow Tools',
-      permissions: ['editor.toolbar', 'editor.store.write', 'cms.routes', 'cms.storage'],
+      permissions: ['admin.navigation', 'editor.code', 'editor.toolbar', 'editor.store.write', 'cms.routes', 'cms.storage'],
       entrypoints: {
         editor: 'editor/index.js',
         server: 'server/index.js',
@@ -687,6 +687,33 @@ describe('CMS plugin handlers', () => {
       .toEqual(privilegedManifest.permissions)
   })
 
+  it('rejects grants the manifest never declared (tampered client)', async () => {
+    const db = makeFakeDb()
+    const cookie = await createCookie(db)
+
+    // A tampered admin client tries to grant `cms.routes` (a real
+    // permission) on top of the declared set. The runtime enforces against
+    // grantedPermissions, so an undeclared grant would silently expand the
+    // plugin's capabilities past everything the consent screen showed.
+    const res = await handleCmsRequest(
+      cmsRequest('http://localhost/admin/api/cms/plugins', {
+        method: 'POST',
+        headers: { cookie, 'content-type': 'application/json' },
+        body: JSON.stringify({
+          manifest: mapManifest,
+          grantedPermissions: ['admin.navigation', 'cms.routes'],
+        }),
+      }),
+      db,
+    )
+
+    expect(res.status).toBe(400)
+    expect(await res.json()).toMatchObject({
+      error: expect.stringContaining('not declared'),
+    })
+    expect(db.plugins).toHaveLength(0)
+  })
+
   it('installs zip plugin packages, writes assets, and activates backend routes', async () => {
     const uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-plugins-'))
     const db = makeFakeDb()
@@ -696,7 +723,7 @@ describe('CMS plugin handlers', () => {
       name: 'Workflow Tools',
       version: '1.0.0',
       apiVersion: 1,
-      permissions: ['admin.navigation', 'cms.routes'],
+      permissions: ['admin.navigation', 'editor.code', 'cms.routes'],
       entrypoints: {
         server: 'server/index.js',
       },

--- a/src/__tests__/server/pluginPackage.test.ts
+++ b/src/__tests__/server/pluginPackage.test.ts
@@ -16,7 +16,7 @@ describe('plugin package reader', () => {
       name: 'Workflow Tools',
       version: '1.0.0',
       apiVersion: 1,
-      permissions: ['editor.toolbar', 'editor.commands'],
+      permissions: ['editor.code', 'editor.toolbar', 'editor.commands'],
       entrypoints: {
         editor: 'editor/index.js',
       },
@@ -30,7 +30,7 @@ describe('plugin package reader', () => {
 
     expect(pkg.manifest).toMatchObject({
       id: 'acme.workflow',
-      permissions: ['editor.toolbar', 'editor.commands'],
+      permissions: ['editor.code', 'editor.toolbar', 'editor.commands'],
       entrypoints: { editor: 'editor/index.js' },
     })
     expect(pkg.files['editor/index.js']).toContain('activate')
@@ -42,7 +42,7 @@ describe('plugin package reader', () => {
       name: 'Workflow Tools',
       version: '1.0.0',
       apiVersion: 1,
-      permissions: ['editor.toolbar'],
+      permissions: ['editor.code', 'editor.toolbar'],
       entrypoints: {
         editor: 'editor/index.js',
       },
@@ -60,6 +60,7 @@ describe('plugin package reader', () => {
       name: 'Workflow Tools',
       version: '1.0.0',
       apiVersion: 1,
+      permissions: ['admin.navigation', 'editor.code'],
       adminPages: [{
         id: 'dashboard',
         title: 'Dashboard',

--- a/src/__tests__/server/pluginServerRuntime.test.ts
+++ b/src/__tests__/server/pluginServerRuntime.test.ts
@@ -303,14 +303,16 @@ describe('server plugin runtime SDK', () => {
     const cookie = await createCookie(db)
     try {
       const install = await installPlugin({
-        manifest: baseManifest,
+        // Public-access routes require BOTH cms.routes (to register
+        // anything) AND cms.routes.public (to allow the anonymous form) —
+        // declared in the manifest AND granted (grants must be a subset
+        // of the declared set).
+        manifest: { ...baseManifest, permissions: ['cms.routes', 'cms.routes.public'] },
         serverEntrypoint: `
           export function activate(api) {
             api.cms.routes.public.get('/status', () => ({ ok: true, plugin: api.plugin.id }))
           }
         `,
-        // Public-access routes require BOTH cms.routes (to register
-        // anything) AND cms.routes.public (to allow the anonymous form).
         grantedPermissions: ['cms.routes', 'cms.routes.public'],
         uploadsDir,
         db,

--- a/src/admin/pages/plugins/components/PermissionReviewSection/PermissionReviewSection.module.css
+++ b/src/admin/pages/plugins/components/PermissionReviewSection/PermissionReviewSection.module.css
@@ -47,6 +47,29 @@
     line-height: 1.5;
 }
 
+/*
+ * Unsandboxed-code callout — the strongest warning in the dialog.
+ * `editor.code` plugins run JavaScript in the admin window with full
+ * admin-session privileges, so the alert uses the danger state tokens
+ * instead of the warning tint shared by permission-diff notices.
+ */
+.alertDanger {
+    background: var(--editor-danger-bg);
+    border-color: var(--editor-danger-border);
+    color: var(--editor-danger-text);
+}
+
+/* Zero-permission install — informational, not a warning. */
+.empty {
+    padding: 12px 14px;
+    border-radius: var(--editor-radius-sm);
+    background: var(--editor-bg-subtle);
+    border: 1px solid var(--editor-border);
+    color: var(--editor-text-secondary);
+    font-size: 12px;
+    line-height: 1.5;
+}
+
 .list {
     list-style: none;
     padding: 0;

--- a/src/admin/pages/plugins/components/PermissionReviewSection/PermissionReviewSection.tsx
+++ b/src/admin/pages/plugins/components/PermissionReviewSection/PermissionReviewSection.tsx
@@ -127,6 +127,13 @@ export function PermissionReviewSection({
 
   const newCount = rows.filter((row) => row.status === 'new').length
 
+  // `editor.code` means the host will dynamically import plugin JavaScript
+  // into the admin window — unsandboxed, with full admin-session privileges.
+  // That deserves its own unmissable callout on top of the permission row.
+  const runsUnsandboxedCode = pending.manifest.permissions.includes('editor.code')
+  const hasAppPages = pending.manifest.adminPages.some((page) => page.content.kind === 'app')
+  const hasEditorEntrypoint = Boolean(pending.manifest.entrypoints?.editor)
+
   return (
     <section
       className={styles.review}
@@ -136,14 +143,37 @@ export function PermissionReviewSection({
         <h2 id="plugin-permissions-title">
           {isUpgrade
             ? `Update ${pending.manifest.name}`
-            : 'Approve Plugin Permissions'}
+            : `Review ${pending.manifest.name}`}
         </h2>
         <p>
           {isUpgrade
             ? `Updating from ${pending.upgradeFromVersion} to ${pending.manifest.version}. Existing settings and stored data are preserved; the plugin runs its migrate hook before re-activating.`
-            : `${pending.manifest.name} requests access before activation.`}
+            : rows.length > 0
+              ? `${pending.manifest.name} requests access before activation.`
+              : `${pending.manifest.name} is ready to install.`}
         </p>
       </div>
+
+      {runsUnsandboxedCode && (
+        <div
+          className={`${styles.alert} ${styles.alertDanger}`}
+          role="alert"
+          data-testid="unsandboxed-code-alert"
+        >
+          <span>
+            This plugin runs its own JavaScript <strong>directly in the admin
+            window, outside the plugin sandbox</strong>
+            {hasEditorEntrypoint && hasAppPages
+              ? ' (an editor entrypoint and admin app pages)'
+              : hasAppPages
+                ? ' (admin app pages)'
+                : ' (an editor entrypoint)'}
+            . That code has the same access as the admin UI itself — your
+            admin session, every admin API, and this browser tab. Only
+            continue if you trust the plugin author.
+          </span>
+        </div>
+      )}
 
       {isUpgrade && newCount > 0 && (
         <div className={styles.alert} role="alert" data-testid="permission-diff-alert">
@@ -155,6 +185,13 @@ export function PermissionReviewSection({
       {isUpgrade && newCount === 0 && rows.length > 0 && (
         <div className={styles.alert} role="status" data-testid="permission-diff-noop">
           No new permissions in this update.
+        </div>
+      )}
+
+      {rows.length === 0 && (
+        <div className={styles.empty} role="status" data-testid="permission-review-empty">
+          No permissions requested — this plugin is purely declarative and
+          gets no access to CMS data, editor state, or the network.
         </div>
       )}
 

--- a/src/admin/pages/plugins/components/PluginPageRenderer/PluginPageRenderer.tsx
+++ b/src/admin/pages/plugins/components/PluginPageRenderer/PluginPageRenderer.tsx
@@ -194,6 +194,7 @@ function PluginReactSubtree({
     pluginVersion: page.pluginVersion,
     surfaceId: page.id,
     surfaceLabel: page.title,
+    grantedPermissions: page.pluginGrantedPermissions,
     settings: page.pluginSettings,
     routes: buildPluginRoutesHelper(page.pluginId),
     runCommand: (commandId) => pluginRuntime.runCommand(commandId),

--- a/src/admin/pages/plugins/hooks/usePluginsWorkspace.ts
+++ b/src/admin/pages/plugins/hooks/usePluginsWorkspace.ts
@@ -304,8 +304,7 @@ export function usePluginsWorkspace(): PluginsWorkspaceVM {
 
       // Detect upgrade vs. fresh install client-side so we can render the
       // right copy in the confirmation dialog. The server detects upgrades
-      // independently — this is purely a UX hint (and a way to force the
-      // dialog to show even when no new permissions are being requested).
+      // independently — this is purely a UX hint.
       const existing = payload.plugins.find((p) => p.id === manifest.id)
       const upgradeFromVersion =
         existing && existing.version !== manifest.version ? existing.version : undefined
@@ -314,29 +313,19 @@ export function usePluginsWorkspace(): PluginsWorkspaceVM {
         : undefined
       const previousNetworkAllowedHosts = existing?.manifest.networkAllowedHosts
 
-      // Always show the dialog for upgrades, even with zero new permissions
-      // — including when the only change is the external-host allowlist.
-      // The site owner deserves to see a "yes, upgrade 1.0.0 → 1.1.0"
-      // confirmation before we replace a working plugin, and a network-host
-      // change is just as security-relevant as a permission change.
-      const hasNetworkHosts = (manifest.networkAllowedHosts ?? []).length > 0
-        || (previousNetworkAllowedHosts ?? []).length > 0
-      if (manifest.permissions.length > 0 || upgradeFromVersion || hasNetworkHosts) {
-        setPendingInstall({
-          manifest,
-          file: isZip ? file : undefined,
-          upgradeFromVersion,
-          previouslyGrantedPermissions,
-          ...(previousNetworkAllowedHosts !== undefined
-            ? { previousNetworkAllowedHosts }
-            : {}),
-        })
-      } else {
-        await installPendingPlugin(
-          { manifest, file: isZip ? file : undefined },
-          [],
-        )
-      }
+      // EVERY install and upgrade goes through the review dialog — including
+      // a zero-permission declarative plugin, which renders "No permissions
+      // requested" so the operator consciously approves what lands in their
+      // CMS. Nothing installs silently.
+      setPendingInstall({
+        manifest,
+        file: isZip ? file : undefined,
+        upgradeFromVersion,
+        previouslyGrantedPermissions,
+        ...(previousNetworkAllowedHosts !== undefined
+          ? { previousNetworkAllowedHosts }
+          : {}),
+      })
     } catch (err) {
       setError(getErrorMessage(err, 'Could not install plugin'))
     }

--- a/src/admin/pages/site/canvas/PluginCanvasOverlayLayer/PluginCanvasOverlayLayer.tsx
+++ b/src/admin/pages/site/canvas/PluginCanvasOverlayLayer/PluginCanvasOverlayLayer.tsx
@@ -9,11 +9,20 @@
  * Plugins position children using `useCanvasNodeRect(nodeId)` from
  * `@instatic/host-hooks`, which returns layer-relative coordinates
  * already mapped through any pan/zoom transform on the canvas.
+ *
+ * Each overlay is mounted under a `PluginContext.Provider` carrying the
+ * plugin's identity + granted permissions, so permission-gated hooks
+ * (`useEditorStore` → `editor.store.read`) resolve and enforce correctly.
  */
 import { useEffect, useState, useSyncExternalStore } from 'react'
 import { ErrorBoundary } from '@ui/components/ErrorBoundary'
-import { CANVAS_OVERLAY_LAYER_ATTRIBUTE } from '@admin/plugin-host-hooks'
+import {
+  CANVAS_OVERLAY_LAYER_ATTRIBUTE,
+  PluginContext,
+  type PluginContextValue,
+} from '@admin/plugin-host-hooks'
 import { pluginRuntime } from '@core/plugins/runtime'
+import { buildPluginRoutesHelper } from '@core/plugins/adminRuntime'
 import type { RegisteredPluginCanvasOverlay } from '@core/plugin-sdk'
 import styles from './PluginCanvasOverlayLayer.module.css'
 
@@ -60,6 +69,18 @@ function PluginCanvasOverlaySlot({ overlay }: { overlay: RegisteredPluginCanvasO
     void Component
   }, [Component])
 
+  const manifest = pluginRuntime.getCanvasOverlayManifest(overlay.id)
+  const contextValue: PluginContextValue = {
+    pluginId: overlay.pluginId,
+    pluginVersion: manifest?.version ?? '',
+    surfaceId: overlay.id,
+    surfaceLabel: overlay.id,
+    grantedPermissions: manifest?.grantedPermissions ?? [],
+    settings: pluginRuntime.getPluginSettings(overlay.pluginId),
+    routes: buildPluginRoutesHelper(overlay.pluginId),
+    runCommand: (commandId) => pluginRuntime.runCommand(commandId),
+  }
+
   return (
     <ErrorBoundary
       location="plugin-canvas-overlay"
@@ -70,7 +91,9 @@ function PluginCanvasOverlaySlot({ overlay }: { overlay: RegisteredPluginCanvasO
         data-plugin-id={overlay.pluginId}
         data-overlay-id={overlay.id}
       >
-        <Component overlay={{ id: overlay.id, pluginId: overlay.pluginId }} />
+        <PluginContext.Provider value={contextValue}>
+          <Component overlay={{ id: overlay.id, pluginId: overlay.pluginId }} />
+        </PluginContext.Provider>
       </div>
     </ErrorBoundary>
   )

--- a/src/admin/pages/site/panels/PluginEditorPanel/PluginEditorPanel.tsx
+++ b/src/admin/pages/site/panels/PluginEditorPanel/PluginEditorPanel.tsx
@@ -89,6 +89,7 @@ function PluginEditorPanelContent({ panelId }: PluginEditorPanelProps) {
         panelId={panel.id}
         pluginId={panel.pluginId}
         pluginVersion={manifest.version}
+        grantedPermissions={manifest.grantedPermissions ?? []}
         label={panel.label}
         settings={settings}
         PanelComponent={PanelComponent}
@@ -107,6 +108,7 @@ function PluginPanelSubtree({
   panelId,
   pluginId,
   pluginVersion,
+  grantedPermissions,
   label,
   settings,
   PanelComponent,
@@ -114,6 +116,7 @@ function PluginPanelSubtree({
   panelId: string
   pluginId: string
   pluginVersion: string
+  grantedPermissions: import('@core/plugin-sdk').PluginPermission[]
   label: string
   settings: Record<string, string | number | boolean>
   PanelComponent: import('@core/plugin-sdk').PluginEditorPanelComponent
@@ -123,6 +126,7 @@ function PluginPanelSubtree({
     pluginVersion,
     surfaceId: panelId,
     surfaceLabel: label,
+    grantedPermissions,
     settings,
     routes: buildPluginRoutesHelper(pluginId),
     runCommand: (commandId) => pluginRuntime.runCommand(commandId),

--- a/src/admin/plugin-host-hooks/index.ts
+++ b/src/admin/plugin-host-hooks/index.ts
@@ -12,28 +12,67 @@
  *
  * Like `@instatic/host-ui`, this is an externalized package — plugin
  * bundles compile against the named exports but resolve the runtime at
- * mount time through the host's import map. Plugins still need the
- * matching permission to call mutating hooks (e.g. `useEditorTransaction`
- * requires `editor.store.write`).
+ * mount time through the host's import map.
+ *
+ * Permission-gated hooks resolve the calling plugin from `PluginContext`
+ * (populated per-mount by `PluginEditorPanel`, `PluginPageRenderer`, and
+ * `PluginCanvasOverlayLayer`) and throw when the operator did not grant
+ * the required permission: `useEditorStore` requires `editor.store.read`.
+ * There is NO write-capable store accessor in this package — editor-store
+ * mutations go through `api.editor.store.transaction` in the plugin's
+ * editor entrypoint, which enforces `editor.store.write`.
  */
 import { use, useEffect, useState } from 'react'
-import { useEditorStore } from '@site/store/store'
-import { PluginContext } from './pluginContext'
+import { useEditorStore as useHostEditorStore } from '@site/store/store'
+import type { EditorStore } from '@site/store/types'
+import type { PluginPermission } from '@core/plugin-sdk'
+import { PluginContext, type PluginContextValue } from './pluginContext'
 
 /** Marker attribute the host puts on the canvas overlay layer host element. */
 export const CANVAS_OVERLAY_LAYER_ATTRIBUTE = 'data-canvas-overlay-layer'
 
 /**
+ * Throw a precise, plugin-attributed error when a permission-gated hook is
+ * used without the matching grant (or outside any plugin surface).
+ */
+function assertHookPermission(
+  ctx: PluginContextValue,
+  permission: PluginPermission,
+  hookName: string,
+): void {
+  if (!ctx.pluginId) {
+    throw new Error(`${hookName} called outside a plugin surface`)
+  }
+  if (!ctx.grantedPermissions.includes(permission)) {
+    throw new Error(
+      `[plugin:${ctx.pluginId}] ${hookName} requires the "${permission}" permission, which is not granted.`,
+    )
+  }
+}
+
+/**
  * Subscribe to a slice of the editor store. Same selector signature as the
  * underlying Zustand hook — pass a function that picks the slice you want
- * to react to. Returns `undefined` if called outside an editor surface
- * (admin pages don't have an editor mounted, so the underlying store is
- * empty there).
+ * to react to (or no selector for the full state). Returns `undefined`
+ * slices outside an editor surface (admin pages don't have an editor
+ * mounted, so the underlying store is empty there).
  *
- * Re-exported under the plugin SDK's `@instatic/host-hooks` import-map
- * name so plugin bundles don't need to know the host's internal store path.
+ * Requires the `editor.store.read` permission — throws (caught by the
+ * surface's ErrorBoundary) when the grant is missing. Unlike the host's
+ * internal store hook, this wrapper deliberately does NOT expose
+ * `getState` / `setState` / `subscribe`: reads go through the selector,
+ * writes go through `api.editor.store.transaction` (gated by
+ * `editor.store.write`).
  */
-export { useEditorStore }
+export function useEditorStore(): EditorStore
+export function useEditorStore<T>(selector: (state: EditorStore) => T): T
+export function useEditorStore<T>(selector?: (state: EditorStore) => T): T | EditorStore {
+  const ctx = use(PluginContext)
+  assertHookPermission(ctx, 'editor.store.read', 'useEditorStore')
+  const select: (state: EditorStore) => T | EditorStore =
+    selector ?? ((state: EditorStore) => state)
+  return useHostEditorStore(select)
+}
 
 /**
  * Read the current plugin's persisted settings as a typed snapshot.
@@ -154,8 +193,10 @@ export function useCanvasNodeRect(nodeId: string | null): CanvasNodeRect | null 
 
   // Re-measure on every editor render (selection changes, breakpoint
   // changes, store mutations) by depending on a tick that bumps with each
-  // editor-store emission.
-  const editorTick = useEditorStore((s) => s)
+  // editor-store emission. Uses the host's internal store hook directly —
+  // this exposes no editor state to the plugin (only DOM geometry), so it
+  // is not gated by `editor.store.read`.
+  const editorTick = useHostEditorStore((s) => s)
   void editorTick
 
   useEffect(() => {

--- a/src/admin/plugin-host-hooks/pluginContext.ts
+++ b/src/admin/plugin-host-hooks/pluginContext.ts
@@ -1,10 +1,13 @@
 /**
  * `PluginContext` — shared React context populated by the host's mount
- * components (`PluginEditorPanel`, `PluginPageRenderer`) so plugin code
- * can resolve plugin-scoped APIs through hooks.
+ * components (`PluginEditorPanel`, `PluginPageRenderer`,
+ * `PluginCanvasOverlayLayer`) so plugin code can resolve plugin-scoped
+ * APIs through hooks.
  *
  * The context value is built per-mount and includes:
  *   • Plugin identity (id, version, surface name)
+ *   • The operator-granted permission set — permission-gated hooks
+ *     (`useEditorStore` requires `editor.store.read`) check against it
  *   • A live settings snapshot
  *   • A scoped HTTP routes helper (already namespaced to the plugin's URL)
  *   • A command-runner that delegates to the shared editor command bus
@@ -14,12 +17,15 @@
  */
 import { createContext } from 'react'
 import type { TSchema, Static } from '@sinclair/typebox'
+import type { PluginPermission } from '@core/plugin-sdk'
 
 export interface PluginContextValue {
   pluginId: string
   pluginVersion: string
   surfaceId: string
   surfaceLabel: string
+  /** Permissions the operator granted at install time. */
+  grantedPermissions: readonly PluginPermission[]
   settings: Record<string, string | number | boolean>
   routes: {
     fetch: (path: string, init?: RequestInit) => Promise<Response>
@@ -46,6 +52,7 @@ export const PluginContext = createContext<PluginContextValue>({
   pluginVersion: '',
   surfaceId: '',
   surfaceLabel: '',
+  grantedPermissions: [],
   settings: {},
   routes: defaultRoutes,
   runCommand: defaultRunCommand,

--- a/src/core/plugin-sdk/builders/permissions.ts
+++ b/src/core/plugin-sdk/builders/permissions.ts
@@ -21,6 +21,9 @@ export const permissions = {
   // dialog can flag the plugin as exposing public endpoints.
   cmsRoutesPublic: 'cms.routes.public',
   cmsHooks: 'cms.hooks',
+  // Unsandboxed admin-window code — required for `entrypoints.editor` and
+  // app-kind admin pages. See `capabilities.ts` for the trust implications.
+  editorCode: 'editor.code',
   editorToolbar: 'editor.toolbar',
   editorCommands: 'editor.commands',
   editorStoreRead: 'editor.store.read',

--- a/src/core/plugin-sdk/capabilities.ts
+++ b/src/core/plugin-sdk/capabilities.ts
@@ -15,9 +15,16 @@ export const PLUGIN_CAPABILITIES: PluginCapability[] = [
   {
     permission: 'admin.navigation',
     label: 'Add pages to the admin navigation',
-    description: 'Allows the plugin to add pages to the CMS admin sidebar and plugin page router.',
-    risk: 'low',
+    description: 'Allows the plugin to add pages to the CMS admin sidebar and plugin page router. Declarative page kinds (markdown, map, resource) render host-owned UI; app-kind pages additionally require `editor.code` because they run plugin JavaScript in the admin window.',
+    risk: 'medium',
     surfaces: ['manifest', 'admin'],
+  },
+  {
+    permission: 'editor.code',
+    label: 'Run plugin JavaScript in the admin window (unsandboxed)',
+    description: 'Allows the host to load the plugin\'s editor entrypoint and app-kind admin pages directly into the admin window. This code is NOT sandboxed — it runs with the same privileges as the CMS admin UI itself (admin API calls with your session, browser storage, the full page). Only grant this to plugins whose code you trust.',
+    risk: 'dangerous',
+    surfaces: ['manifest', 'admin', 'editor'],
   },
   {
     permission: 'cms.storage',

--- a/src/core/plugin-sdk/cli/lint.ts
+++ b/src/core/plugin-sdk/cli/lint.ts
@@ -192,9 +192,36 @@ export async function lintPlugin(sourceDir: string): Promise<LintResult> {
   }
   if (definition.modules.length > 0) {
     entrypointSources.push({ kind: 'modules', path: 'modules/' })
+    // Same rationale as the editor check below: the built manifest gets
+    // `entrypoints.modules` auto-added, which the host rejects without
+    // `modules.register`.
+    if (!manifest.permissions.includes('modules.register')) {
+      findings.push({
+        severity: 'error',
+        scope: 'manifest',
+        message:
+          'Canvas modules are defined but the `modules.register` permission is not requested. ' +
+          'Add `permissions.modulesRegister`.',
+      })
+    }
   }
   if (await findEntrypointSource(absoluteSource, 'editor')) {
     entrypointSources.push({ kind: 'editor', path: 'editor/' })
+    // `instatic-plugin build` auto-adds `entrypoints.editor` when an
+    // `editor/` source exists — but the config manifest validated above
+    // doesn't carry that auto-added entrypoint, so the host-side
+    // `editor.code` coherence check can't fire here. Re-check explicitly
+    // so the author learns about the missing permission pre-upload
+    // instead of at install time.
+    if (!manifest.permissions.includes('editor.code')) {
+      findings.push({
+        severity: 'error',
+        scope: 'manifest',
+        message:
+          'An editor entrypoint source exists (`editor/`) but the `editor.code` permission is not requested. ' +
+          'Editor entrypoints run unsandboxed in the admin window and require it — add `permissions.editorCode`.',
+      })
+    }
   }
   if (await findEntrypointSource(absoluteSource, 'frontend')) {
     entrypointSources.push({ kind: 'frontend', path: 'frontend/' })

--- a/src/core/plugin-sdk/types/installedPlugin.ts
+++ b/src/core/plugin-sdk/types/installedPlugin.ts
@@ -71,6 +71,14 @@ export interface PluginAdminPageRoute extends Omit<PluginAdminPage, 'route'> {
   pluginSettings: Record<string, string | number | boolean>
   /** The full settings schema declared by the plugin manifest. */
   pluginSettingsSchema: PluginManifest['settings']
+  /**
+   * Permissions the operator granted to the plugin at install time. The
+   * host's admin-app loader refuses to dynamically import an app page
+   * without `editor.code` here, and plugin-surface hooks
+   * (`useEditorStore`, …) enforce their grants against this set via
+   * `PluginContext`.
+   */
+  pluginGrantedPermissions: PluginPermission[]
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/plugin-sdk/types/permissions.ts
+++ b/src/core/plugin-sdk/types/permissions.ts
@@ -31,6 +31,14 @@ export const PLUGIN_PERMISSION_VALUES = [
   // system tables). Listed separately as `dangerous` because adding a
   // table is a change a future plugin upgrade then has to clean up.
   'cms.content.tables.manage',
+  // Unsandboxed admin-window code. REQUIRED for `entrypoints.editor` and for
+  // `adminPages[].content` of kind `app` — both are plugin JavaScript that
+  // the host dynamically imports into the main admin window, where it runs
+  // with full admin-origin privileges (admin API with credentials,
+  // localStorage, DOM). Everything below in the `editor.*` family gates a
+  // specific host API surface; this one gates whether the plugin's own code
+  // is loaded into the admin window at all.
+  'editor.code',
   // Editor surfaces
   'editor.toolbar',
   'editor.commands',

--- a/src/core/plugins/adminRuntime.ts
+++ b/src/core/plugins/adminRuntime.ts
@@ -94,6 +94,17 @@ export async function loadPluginAdminAppComponent(
   if (page.content.kind !== 'app') {
     throw new Error('Plugin admin app loader requires app page content')
   }
+  // App pages are unsandboxed plugin JavaScript imported into the admin
+  // window — the host refuses to import the module without the explicit
+  // `editor.code` grant. The thrown error surfaces in the page body via
+  // PluginAppPage's error state, so an ungranted page is a visible
+  // refusal rather than a silent skip.
+  if (!page.pluginGrantedPermissions.includes('editor.code')) {
+    throw new Error(
+      `Plugin admin app "${page.pluginId}:${page.id}" requires the "editor.code" permission, ` +
+      `which is not granted. App pages run unsandboxed in the admin window.`,
+    )
+  }
   if (!page.content.assetPath) {
     throw new Error(`Plugin admin app "${page.pluginId}:${page.id}" is missing an asset path`)
   }

--- a/src/core/plugins/editorPluginLoader.ts
+++ b/src/core/plugins/editorPluginLoader.ts
@@ -136,30 +136,55 @@ export async function activateInstalledEditorPlugins(
     // Module pack — load first so plugins that ship both an editor entry
     // AND modules can rely on their modules being registered when the
     // editor entry's `activate()` runs.
-    if (manifest.entrypoints?.modules && plugin.grantedPermissions.includes('modules.register')) {
-      try {
-        const mod = await importModulePack(
-          joinAssetPath(manifest.assetBasePath, manifest.entrypoints.modules),
-          cacheKey,
-        )
-        activatePluginModulePack(manifest, mod, options.componentFactory)
-        result.modulePacksLoaded.push(plugin.id)
-      } catch (error) {
-        result.failed.push({ pluginId: plugin.id, error })
+    if (manifest.entrypoints?.modules) {
+      if (!plugin.grantedPermissions.includes('modules.register')) {
+        // A declared-but-ungranted module pack must surface on the plugin
+        // card, not vanish silently — the site owner installed a plugin
+        // whose modules will never appear in the library.
+        result.failed.push({
+          pluginId: plugin.id,
+          error: new Error(
+            'Module pack was not loaded: the "modules.register" permission is not granted.',
+          ),
+        })
+      } else {
+        try {
+          const mod = await importModulePack(
+            joinAssetPath(manifest.assetBasePath, manifest.entrypoints.modules),
+            cacheKey,
+          )
+          activatePluginModulePack(manifest, mod, options.componentFactory)
+          result.modulePacksLoaded.push(plugin.id)
+        } catch (error) {
+          result.failed.push({ pluginId: plugin.id, error })
+        }
       }
     }
 
     // Editor entrypoint — toolbar, commands, store transactions, etc.
+    // This is unsandboxed plugin JavaScript dynamically imported into the
+    // admin window, so the host refuses to load it without the explicit
+    // `editor.code` grant — even if the bundle is present on disk.
     if (manifest.entrypoints?.editor) {
-      try {
-        const mod = await importEditorModule(
-          joinAssetPath(manifest.assetBasePath, manifest.entrypoints.editor),
-          cacheKey,
-        )
-        await activateEditorPlugin(manifest, mod, fetchImpl)
-        editorActivated = true
-      } catch (error) {
-        result.failed.push({ pluginId: plugin.id, error })
+      if (!plugin.grantedPermissions.includes('editor.code')) {
+        result.failed.push({
+          pluginId: plugin.id,
+          error: new Error(
+            'Editor entrypoint was not loaded: the "editor.code" permission is not granted. ' +
+            'Editor entrypoints run unsandboxed in the admin window and require it.',
+          ),
+        })
+      } else {
+        try {
+          const mod = await importEditorModule(
+            joinAssetPath(manifest.assetBasePath, manifest.entrypoints.editor),
+            cacheKey,
+          )
+          await activateEditorPlugin(manifest, mod, fetchImpl)
+          editorActivated = true
+        } catch (error) {
+          result.failed.push({ pluginId: plugin.id, error })
+        }
       }
     }
 

--- a/src/core/plugins/manifest.ts
+++ b/src/core/plugins/manifest.ts
@@ -16,9 +16,11 @@ import {
 } from '@core/plugin-sdk'
 import { collectEnabledAdminPages, pluginAdminPageRoute } from './manifestAdminPages'
 
-// Admin-page route helpers live in a sibling module (responsibility split);
-// re-exported here so `@core/plugins/manifest` stays the public surface.
+// Admin-page route helpers and resource-record helpers live in sibling
+// modules (responsibility split); re-exported here so
+// `@core/plugins/manifest` stays the public surface.
 export { collectEnabledAdminPages, pluginAdminPageRoute }
+export { findPluginResource, validatePluginRecordData } from './resourceRecords'
 
 const PLUGIN_ID_PATTERN = /^[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+$/
 /**
@@ -43,6 +45,11 @@ const SAFE_ASSET_PATH_PATTERN = /^(?!\/)(?!.*(?:^|\/)\.\.(?:\/|$))[a-zA-Z0-9._/-
 // sinks (`loadServerPluginModule`, `removePluginAssets`).
 const ASSET_BASE_PATH_PATTERN =
   /^\/uploads\/plugins\/[a-z][a-z0-9-]*(?:\.[a-z][a-z0-9-]*)+\/\d+\.\d+\.\d+(?:[-+][0-9a-zA-Z.-]+)?\/?$/
+// `adminPages[].content.assetPath` (app pages) — must look like an uploads
+// path with no `.`/`..` segments. The post-check in `parsePluginManifest`
+// further pins it to the declaring plugin's own asset subtree.
+const ADMIN_APP_ASSET_PATH_PATTERN =
+  /^(?!.*(?:^|\/)\.{1,2}(?:\/|$))\/uploads\/plugins\/[a-zA-Z0-9._/-]+$/
 // Outbound network allowlist: lowercase hostname, optional leading `*.`
 // wildcard. No paths, ports, query strings — just the host. This is the
 // allowlist the host's `network.fetch` bridge checks against.
@@ -84,7 +91,16 @@ const contentSchema = Type.Union([
     kind: Type.Literal('app'),
     heading: Type.String({ minLength: 1, maxLength: 120 }),
     entry: Type.String({ pattern: SAFE_ASSET_PATH_PATTERN.source }),
-    assetPath: Type.Optional(Type.String()),
+    // Optional override for where the host resolves `entry` from; defaults
+    // to the plugin's `assetBasePath`. The schema pattern rejects dot
+    // segments and foreign URL shapes; parsePluginManifest additionally
+    // pins the path to THIS plugin's own `/uploads/plugins/{id}/{version}`
+    // subtree so a manifest can't point the admin shell's dynamic import()
+    // at an arbitrary location.
+    assetPath: Type.Optional(Type.String({
+      pattern: ADMIN_APP_ASSET_PATH_PATTERN.source,
+      maxLength: 500,
+    })),
   }),
 ])
 
@@ -403,6 +419,27 @@ export function parsePluginManifest(input: unknown): PluginManifest {
     }
   }
 
+  // Entrypoint ↔ permission coherence. Editor entrypoints are unsandboxed
+  // plugin JavaScript dynamically imported into the admin window, so they
+  // require the `editor.code` permission — without this check a
+  // "zero-permission" manifest could ship admin-window code that installs
+  // with no consent screen ever naming the capability. Module packs are
+  // similarly gated: declaring `entrypoints.modules` without
+  // `modules.register` would otherwise be silently skipped at load time.
+  if (data.entrypoints?.editor && !data.permissions.includes('editor.code')) {
+    throw new Error(
+      `Invalid plugin manifest: \`entrypoints.editor\` runs unsandboxed JavaScript ` +
+      `in the admin window and requires the \`editor.code\` permission. ` +
+      `Add "editor.code" to \`permissions\`.`,
+    )
+  }
+  if (data.entrypoints?.modules && !data.permissions.includes('modules.register')) {
+    throw new Error(
+      `Invalid plugin manifest: \`entrypoints.modules\` requires the ` +
+      `\`modules.register\` permission. Add "modules.register" to \`permissions\`.`,
+    )
+  }
+
   const duplicateResources = new Set<string>()
   const resources: PluginResource[] = data.resources.map((resource) => {
     if (duplicateResources.has(resource.id)) {
@@ -421,6 +458,17 @@ export function parsePluginManifest(input: unknown): PluginManifest {
     return resource as PluginResource
   })
 
+  // Admin pages mount in the CMS sidebar — that surface is gated by the
+  // `admin.navigation` permission. A manifest declaring pages without the
+  // permission used to be silently skipped at mount time; fail loudly at
+  // parse time instead so the author sees the problem before upload.
+  if (data.adminPages.length > 0 && !data.permissions.includes('admin.navigation')) {
+    throw new Error(
+      `Invalid plugin manifest: \`adminPages\` requires the \`admin.navigation\` ` +
+      `permission. Add "admin.navigation" to \`permissions\`.`,
+    )
+  }
+
   const duplicatePages = new Set<string>()
   const adminPages: PluginAdminPage[] = data.adminPages.map((page) => {
     if (duplicatePages.has(page.id)) {
@@ -429,6 +477,32 @@ export function parsePluginManifest(input: unknown): PluginManifest {
     duplicatePages.add(page.id)
     if (page.content.kind === 'resource' && !duplicateResources.has(page.content.resource)) {
       throw new Error(`Invalid plugin manifest: resource page "${page.id}" references unknown resource "${page.content.resource}"`)
+    }
+    if (page.content.kind === 'app') {
+      // App pages are unsandboxed plugin JavaScript in the admin window —
+      // the same trust surface as `entrypoints.editor`, gated by the same
+      // permission.
+      if (!data.permissions.includes('editor.code')) {
+        throw new Error(
+          `Invalid plugin manifest: admin page "${page.id}" has kind "app", which runs ` +
+          `unsandboxed JavaScript in the admin window and requires the \`editor.code\` ` +
+          `permission. Add "editor.code" to \`permissions\`.`,
+        )
+      }
+      // Pin `assetPath` to THIS plugin's own asset subtree. The schema
+      // pattern already rejects dot segments; this check stops a manifest
+      // from pointing the admin shell's dynamic import() at another
+      // plugin's files (or any other uploads path).
+      if (page.content.assetPath) {
+        const expectedBase = `/uploads/plugins/${data.id}/${data.version}`
+        const normalized = page.content.assetPath.replace(/\/+$/, '')
+        if (normalized !== expectedBase && !normalized.startsWith(`${expectedBase}/`)) {
+          throw new Error(
+            `Invalid plugin manifest: admin page "${page.id}" assetPath must stay within ` +
+            `"${expectedBase}"`,
+          )
+        }
+      }
     }
 
     // Normalise the content: apply the pins default for map pages explicitly,
@@ -617,57 +691,3 @@ export function permissionLabel(permission: PluginPermission): string {
   return sdkPermissionLabel(permission)
 }
 
-export function findPluginResource(
-  manifest: Pick<PluginManifest, 'resources'>,
-  resourceId: string,
-): PluginResource | null {
-  return manifest.resources.find((resource) => resource.id === resourceId) ?? null
-}
-
-export function validatePluginRecordData(
-  resource: PluginResource,
-  input: unknown,
-  options: { partial?: boolean } = {},
-): Record<string, unknown> {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('Plugin record data must be an object')
-  }
-
-  const raw = input as Record<string, unknown>
-  const data: Record<string, unknown> = {}
-
-  for (const field of resource.fields) {
-    const value = raw[field.id]
-    const missing = value === undefined || value === null || value === ''
-
-    if (missing) {
-      if (field.required && !options.partial) {
-        throw new Error(`Missing required field "${field.label}"`)
-      }
-      continue
-    }
-
-    if (field.type === 'number') {
-      if (typeof value !== 'number' || !Number.isFinite(value)) {
-        throw new Error(`Field "${field.label}" must be a number`)
-      }
-      data[field.id] = value
-      continue
-    }
-
-    if (field.type === 'boolean') {
-      if (typeof value !== 'boolean') {
-        throw new Error(`Field "${field.label}" must be a boolean`)
-      }
-      data[field.id] = value
-      continue
-    }
-
-    if (typeof value !== 'string') {
-      throw new Error(`Field "${field.label}" must be text`)
-    }
-    data[field.id] = value.trim()
-  }
-
-  return data
-}

--- a/src/core/plugins/manifestAdminPages.ts
+++ b/src/core/plugins/manifestAdminPages.ts
@@ -50,6 +50,7 @@ export function collectEnabledAdminPages(
           route: page.route ?? pluginAdminPageRoute(plugin.manifest.id, page.id),
           pluginSettings: plugin.settings ?? {},
           pluginSettingsSchema: plugin.manifest.settings,
+          pluginGrantedPermissions: plugin.grantedPermissions ?? [],
         }
       }),
     )

--- a/src/core/plugins/resourceRecords.ts
+++ b/src/core/plugins/resourceRecords.ts
@@ -1,0 +1,65 @@
+/**
+ * Plugin resource-record helpers.
+ *
+ * Split out of `manifest.ts` (which owns manifest parsing + validation):
+ * looking up a declared resource and validating record payloads against its
+ * field schema is the record-CRUD responsibility, consumed by the plugin
+ * record handlers and the editor-side storage SDK. Re-exported through
+ * `@core/plugins/manifest`, which stays the public surface.
+ */
+import type { PluginManifest, PluginResource } from '@core/plugin-sdk'
+
+export function findPluginResource(
+  manifest: Pick<PluginManifest, 'resources'>,
+  resourceId: string,
+): PluginResource | null {
+  return manifest.resources.find((resource) => resource.id === resourceId) ?? null
+}
+
+export function validatePluginRecordData(
+  resource: PluginResource,
+  input: unknown,
+  options: { partial?: boolean } = {},
+): Record<string, unknown> {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Plugin record data must be an object')
+  }
+
+  const raw = input as Record<string, unknown>
+  const data: Record<string, unknown> = {}
+
+  for (const field of resource.fields) {
+    const value = raw[field.id]
+    const missing = value === undefined || value === null || value === ''
+
+    if (missing) {
+      if (field.required && !options.partial) {
+        throw new Error(`Missing required field "${field.label}"`)
+      }
+      continue
+    }
+
+    if (field.type === 'number') {
+      if (typeof value !== 'number' || !Number.isFinite(value)) {
+        throw new Error(`Field "${field.label}" must be a number`)
+      }
+      data[field.id] = value
+      continue
+    }
+
+    if (field.type === 'boolean') {
+      if (typeof value !== 'boolean') {
+        throw new Error(`Field "${field.label}" must be a boolean`)
+      }
+      data[field.id] = value
+      continue
+    }
+
+    if (typeof value !== 'string') {
+      throw new Error(`Field "${field.label}" must be text`)
+    }
+    data[field.id] = value.trim()
+  }
+
+  return data
+}

--- a/src/core/plugins/runtime.ts
+++ b/src/core/plugins/runtime.ts
@@ -126,11 +126,22 @@ interface PanelRecord {
 /** Palette provider stored alongside the registering plugin id. */
 type RegisteredPaletteProvider = PluginPaletteProvider & { pluginId: string }
 
+/**
+ * Internal canvas-overlay record — same shape rationale as `PanelRecord`:
+ * the live manifest rides along so the host's overlay mount can build a
+ * permission-aware `PluginContext` (granted permissions, settings) without
+ * a fresh round-trip to the plugins endpoint.
+ */
+interface CanvasOverlayRecord {
+  overlay: RegisteredPluginCanvasOverlay
+  manifest: PluginManifest
+}
+
 class PluginRuntime {
   private commands = new Map<string, PluginCommand & { pluginId: string }>()
   private toolbarButtons = new Map<string, RegisteredPluginToolbarButton>()
   private panels = new Map<string, PanelRecord>()
-  private canvasOverlays = new Map<string, RegisteredPluginCanvasOverlay>()
+  private canvasOverlays = new Map<string, CanvasOverlayRecord>()
   private paletteProviders = new Map<string, RegisteredPaletteProvider>()
   private pluginSettings = new Map<string, Record<string, string | number | boolean>>()
   private listeners = new Set<RuntimeListener>()
@@ -196,8 +207,8 @@ class PluginRuntime {
     for (const [key, record] of this.panels) {
       if (record.panel.pluginId === pluginId) this.panels.delete(key)
     }
-    for (const [key, overlay] of this.canvasOverlays) {
-      if (overlay.pluginId === pluginId) this.canvasOverlays.delete(key)
+    for (const [key, record] of this.canvasOverlays) {
+      if (record.overlay.pluginId === pluginId) this.canvasOverlays.delete(key)
     }
     for (const [key, provider] of this.paletteProviders) {
       if (provider.pluginId === pluginId) this.paletteProviders.delete(key)
@@ -321,14 +332,21 @@ class PluginRuntime {
    * Register a canvas overlay on behalf of a plugin. Caller MUST have
    * already asserted the `editor.canvas` permission. The overlay id must
    * be namespace-locked under the plugin id (`<pluginId>.<rest>`).
+   *
+   * The manifest is captured alongside the overlay (same as `registerPanel`)
+   * so the host's overlay mount can provide a permission-aware
+   * `PluginContext` to the overlay component.
    */
-  registerCanvasOverlay(pluginId: string, overlay: PluginCanvasOverlay): void {
-    if (!overlay.id.startsWith(`${pluginId}.`)) {
+  registerCanvasOverlay(manifest: PluginManifest, overlay: PluginCanvasOverlay): void {
+    if (!overlay.id.startsWith(`${manifest.id}.`)) {
       throw new Error(
-        `Plugin "${pluginId}" cannot register canvas overlay "${overlay.id}" — id must start with "${pluginId}.".`,
+        `Plugin "${manifest.id}" cannot register canvas overlay "${overlay.id}" — id must start with "${manifest.id}.".`,
       )
     }
-    this.canvasOverlays.set(overlay.id, { ...overlay, pluginId })
+    this.canvasOverlays.set(overlay.id, {
+      overlay: { ...overlay, pluginId: manifest.id },
+      manifest,
+    })
     this.canvasOverlaysSnapshot = null
     this.emit()
   }
@@ -378,9 +396,18 @@ class PluginRuntime {
    */
   getCanvasOverlays(): RegisteredPluginCanvasOverlay[] {
     if (this.canvasOverlaysSnapshot === null) {
-      this.canvasOverlaysSnapshot = [...this.canvasOverlays.values()]
+      this.canvasOverlaysSnapshot = [...this.canvasOverlays.values()].map((record) => record.overlay)
     }
     return this.canvasOverlaysSnapshot
+  }
+
+  /**
+   * Resolve the manifest a canvas overlay was registered with — used by
+   * `PluginCanvasOverlayLayer` to provide a permission-aware
+   * `PluginContext` at mount time. Returns `undefined` for unknown ids.
+   */
+  getCanvasOverlayManifest(overlayId: string): PluginManifest | undefined {
+    return this.canvasOverlays.get(overlayId)?.manifest
   }
 
   async runCommand(commandId: string): Promise<PluginCommandResult> {
@@ -442,7 +469,7 @@ export function createEditorPluginApi(
       canvas: {
         registerOverlay(overlay) {
           assertPluginPermission(manifest, 'editor.canvas')
-          pluginRuntime.registerCanvasOverlay(manifest.id, overlay)
+          pluginRuntime.registerCanvasOverlay(manifest, overlay)
         },
       },
       store: {


### PR DESCRIPTION
## Problem

Editor-side plugin code is NOT sandboxed — editor entrypoints, app-kind admin pages, panels, and widgets are dynamically `import()`-ed into the main admin window and run with full admin-origin privileges. The audit found that this trust level was completely ungated: a zero-permission plugin could ship admin-window code and install silently, host hooks handed every plugin the raw editor store (with `setState`), `assetPath` could point the dynamic import anywhere, and a tampered client could grant permissions the manifest never declared.

Owner mandate: *every API/capability a plugin uses must be triggered by a declared, granted permission.*

## Changes

### 1. New `editor.code` permission (risk: dangerous)
- `src/core/plugin-sdk/types/permissions.ts`, `capabilities.ts`, `builders/permissions.ts` — registry entry with an explicit "NOT sandboxed, same privileges as the admin UI" description.
- Required for `entrypoints.editor` and `adminPages[].content` of kind `app`.

### 2. Manifest coherence (`src/core/plugins/manifest.ts`)
- Editor entrypoint without `editor.code` → friendly parse error. Same for `entrypoints.modules` without `modules.register`, app pages without `editor.code`, and `adminPages` without `admin.navigation` (all were silent skips before).

### 3. Load gates
- `src/core/plugins/editorPluginLoader.ts` — refuses to import an editor entrypoint without the `editor.code` *grant*; the refusal is a visible failure record on the plugin card (via `editorActivationErrors`), not a silent skip. Ungranted module packs get the same treatment.
- `src/core/plugins/adminRuntime.ts` — app-page loader throws before the dynamic import without the grant; the page body renders the refusal. `PluginAdminPageRoute` now carries `pluginGrantedPermissions` (populated in `manifestAdminPages.ts`, flows through `pluginsPayload` untouched).

### 4. Always-on install review (`usePluginsWorkspace.ts`, `PermissionReviewSection`)
- EVERY install/upgrade shows the review dialog. Zero-permission plugins render "No permissions requested". `editor.code` manifests get a dedicated danger-tinted unsandboxed-code callout naming the surfaces (editor entrypoint / app pages).

### 5. Gated host hooks (`src/admin/plugin-host-hooks/`)
- `useEditorStore` is now a wrapper that resolves the calling plugin from `PluginContext` and throws a plugin-attributed error without `editor.store.read`. The raw Zustand hook — whose `setState` bypassed `editor.store.write` — is no longer exposed; writes go only through `api.editor.store.transaction`. `PluginContext` carries `grantedPermissions`; all three mounts provide it (`PluginEditorPanel`, `PluginPageRenderer`, `PluginCanvasOverlayLayer` — overlays now get a full plugin context, with the runtime storing the manifest per overlay like it already did for panels). The false `useEditorTransaction` comment is gone; `public/runtime/host-hooks.js` documents the gate.

### 6. `assetPath` locked (`manifest.ts`)
- `adminPages[].content.assetPath` is pattern-locked (no dot segments, `/uploads/plugins/` shape) and post-checked to the plugin's own `/uploads/plugins/{id}/{version}` subtree — mirror of the existing `assetBasePath` validation.

### 7. Grants ⊆ declared (`server/handlers/cms/plugins/shared.ts`)
- `assertPluginPermissionGrants` rejects granted permissions the manifest never declared (no optional-permissions concept exists, so grants = declared exactly). `readPermissionGrants` validates strings against the permission registry (`isPluginPermission`) instead of casting.

### 8. Risk relabel
- `admin.navigation` low → medium; description notes app pages additionally need `editor.code`.

### Docs / template / CLI
- `docs/features/plugin-system.md` — new "What is NOT sandboxed — editor.code" section, grants ⊆ declared note, capability matrix rows.
- `examples/plugins/template/` — declares `editor.code` (it ships an editor entrypoint); README permission table updated.
- `instatic-plugin lint` reports missing `editor.code` / `modules.register` for auto-detected entrypoints pre-upload (the config manifest doesn't carry build-time-added entrypoints, so the parse-time check alone can't fire there).
- Split `resourceRecords.ts` out of `manifest.ts` (700-line module ceiling, re-exported through the same surface).

## Tests
New: manifest coherence (editor entrypoint / app page / modules / adminPages), assetPath containment + escapes, loader refusals with visible records, app-page mount refusal, grants-superset rejection (server), zero-permission review dialog + unsandboxed callout, `useEditorStore` gate (granted / ungranted / outside surface / no write accessor), lint CLI editor.code findings.

## Verification
- `bun test` — 4914 pass, 1 skip (pre-existing), 0 fail
- `bun run build` — clean (tsc + vite)
- `bun run lint` — clean
- `bun run doctor` — 745 pre-existing warn-tier findings repo-wide, none error-tier; not introduced by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)