### PR TITLE
[codex] Fix data table step-up flow

### DIFF
--- a/docs/features/auth-and-access.md
+++ b/docs/features/auth-and-access.md
@@ -237,7 +237,7 @@ if (stepUp) return stepUp
 
 ## Step-up auth
 
-Sensitive actions (delete user, revoke another device, sign out all devices, change owner email, regenerate MFA) call `requireStepUp(req, db, user)` in `server/auth/authz.ts`, passing the user the handler already resolved. When `users.step_up_auth_mode = 'required'`, the current session must have `sessions.step_up_expires_at > now()`. The default policy is required with a 15-minute window; Account -> Security can change the mode to `disabled` or set `users.step_up_window_minutes` to 5, 15, 30, or 60.
+Sensitive actions (delete user, revoke another device, sign out all devices, change owner email, regenerate MFA, mutate Data table schemas, replace-import a site bundle) call `requireStepUp(req, db, user)` in `server/auth/authz.ts`, passing the user the handler already resolved. When `users.step_up_auth_mode = 'required'`, the current session must have `sessions.step_up_expires_at > now()`. The default policy is required with a 15-minute window; Account -> Security can change the mode to `disabled` or set `users.step_up_window_minutes` to 5, 15, 30, or 60.
 
 The Account -> Security policy endpoint (`PATCH /admin/api/cms/me/security/step-up`) calls `requireStepUp(req, db, user, { policy: 'always' })`, so changing the policy itself still requires a fresh password even when normal sensitive-action step-up is disabled.
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,14 +5,18 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import reactCompiler from 'eslint-plugin-react-compiler'
 import tseslint from 'typescript-eslint'
 import { defineConfig, globalIgnores } from 'eslint/config'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 // React Compiler ESLint rule surfaces functions the compiler can't safely
 // memoize (Rules-of-React violations, mutating render-time state, etc.) so
 // they're caught at lint time rather than as a build-time bailout. The
 // compiler itself is wired in `vite.config.ts`.
 
+const configDir = path.dirname(fileURLToPath(import.meta.url))
+
 export default defineConfig([
-  globalIgnores(['dist', '.worktrees']),
+  globalIgnores(['dist', '.worktrees', '.claude']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -24,6 +28,9 @@ export default defineConfig([
     ],
     languageOptions: {
       globals: globals.browser,
+      parserOptions: {
+        tsconfigRootDir: configDir,
+      },
     },
     rules: {
       // `varsIgnorePattern` includes `Schema$` because TypeBox's idiom is

--- a/src/__tests__/admin/data/dataTableStepUp.test.tsx
+++ b/src/__tests__/admin/data/dataTableStepUp.test.tsx
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import React, { type ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from '@admin/lib/routing'
+import { AdminSessionProvider } from '@admin/session'
+import { StepUpProvider } from '@admin/shared/StepUp'
+import { DataPage } from '@admin/pages/data/DataPage'
+import { useEditorStore } from '@site/store/store'
+import { makeSite } from '../../fixtures'
+import { CORE_CAPABILITIES } from '@core/capabilities'
+import type { CmsCurrentUser } from '@core/persistence'
+
+const originalFetch = globalThis.fetch
+const now = '2026-06-10T10:00:00.000Z'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function adminUser(): CmsCurrentUser {
+  return {
+    id: 'data-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin',
+    status: 'active',
+    role: {
+      id: 'owner',
+      slug: 'owner',
+      name: 'Owner',
+      description: '',
+      isSystem: true,
+      capabilities: [...CORE_CAPABILITIES],
+    },
+    capabilities: [...CORE_CAPABILITIES],
+    lastLoginAt: null,
+    failedLoginCount: 0,
+    lockedUntil: null,
+    passwordUpdatedAt: null,
+    mfaEnabled: false,
+    mfaEnabledAt: null,
+    mfaRecoveryCodesRemaining: 0,
+    stepUpAuthMode: 'required',
+    stepUpWindowMinutes: 15,
+    avatarMediaId: null,
+    avatarUrl: null,
+    gravatarHash: '',
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/admin/data']}>
+      <AdminSessionProvider user={adminUser()}>
+        <StepUpProvider>{children}</StepUpProvider>
+      </AdminSessionProvider>
+    </MemoryRouter>
+  )
+}
+
+function setupEditorShell(): void {
+  const site = makeSite({ name: 'Data Shell Site' })
+  useEditorStore.setState({
+    site,
+    activePageId: site.pages[0].id,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    activeBreakpointId: 'desktop',
+    propertiesPanel: { collapsed: false, x: 0, y: 0, width: 360 },
+    leftSidebarWidth: 320,
+    dataSidebarCollapsed: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+describe('Data table step-up flow', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.history.replaceState({}, '', '/')
+    setupEditorShell()
+  })
+
+  afterEach(() => {
+    cleanup()
+    globalThis.fetch = originalFetch
+  })
+
+  it('opens the shared step-up dialog and retries when creating a custom table requires step-up', async () => {
+    let createAttempts = 0
+    const stepUpRequests: Array<Record<string, unknown>> = []
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === '/admin/api/cms/data/tables' && init?.method !== 'POST') {
+        return json({
+          tables: [{
+            id: 'components',
+            name: 'Components',
+            slug: 'components',
+            kind: 'component',
+            routeBase: '',
+            singularLabel: 'Component',
+            pluralLabel: 'Components',
+            primaryFieldId: 'name',
+            fields: [{ type: 'text', id: 'name', label: 'Name', required: true }],
+            system: true,
+            rowCount: 0,
+            createdByUserId: null,
+            updatedByUserId: null,
+            createdAt: now,
+            updatedAt: now,
+          }],
+        })
+      }
+
+      if (url === '/admin/api/cms/data/tables/components/rows' && init?.method === 'GET') {
+        return json({ rows: [] })
+      }
+
+      if (url === '/admin/api/cms/data/tables/custom-table/rows' && init?.method === 'GET') {
+        return json({ rows: [] })
+      }
+
+      if (url === '/admin/api/cms/data/tables' && init?.method === 'POST') {
+        createAttempts += 1
+        if (createAttempts === 1) return json({ error: 'step_up_required' }, 401)
+        return json({
+          table: {
+            id: 'custom-table',
+            name: 'custom table',
+            slug: 'custom-table',
+            kind: 'data',
+            routeBase: '',
+            singularLabel: 'custom table',
+            pluralLabel: 'custom tables',
+            primaryFieldId: 'name',
+            fields: [{ type: 'text', id: 'name', label: 'Name', required: true }],
+            system: false,
+            createdByUserId: 'data-admin',
+            updatedByUserId: 'data-admin',
+            createdAt: now,
+            updatedAt: now,
+          },
+        }, 201)
+      }
+
+      if (url === '/admin/api/cms/auth/step-up' && init?.method === 'POST') {
+        stepUpRequests.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+        return json({ ok: true, stepUpExpiresAt: '2026-06-10T10:15:00.000Z' })
+      }
+
+      if (url.endsWith('/admin/api/cms/plugins')) return json({ plugins: [], adminPages: [] })
+      if (url.endsWith('/admin/api/cms/site')) return json({ site: null }, 404)
+      if (url.endsWith('/admin/api/cms/publish/status')) return json({ ok: false }, 404)
+
+      return json({ error: `Unhandled ${url}` }, 500)
+    }) as typeof fetch
+
+    render(
+      <Providers>
+        <DataPage />
+      </Providers>,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New table' }))
+    const dialog = await screen.findByRole('dialog', { name: 'New table' })
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'custom table' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create' }))
+
+    expect(await screen.findByTestId('step-up-dialog')).toBeTruthy()
+    expect(screen.queryByText('step_up_required')).toBeNull()
+
+    fireEvent.change(screen.getByTestId('step-up-password'), {
+      target: { value: 'long-enough-password' },
+    })
+    fireEvent.click(screen.getByTestId('step-up-confirm'))
+
+    await waitFor(() => {
+      expect(createAttempts).toBe(2)
+    })
+    expect(stepUpRequests).toEqual([{ password: 'long-enough-password' }])
+    expect(screen.queryByTestId('step-up-dialog')).toBeNull()
+    expect(screen.queryByRole('dialog', { name: 'New table' })).toBeNull()
+    expect(await screen.findByRole('option', { name: /custom tables/i })).toBeTruthy()
+  })
+})

--- a/src/__tests__/architecture/module-size-budgets.test.ts
+++ b/src/__tests__/architecture/module-size-budgets.test.ts
@@ -111,7 +111,6 @@ const GRANDFATHERED: Record<string, number> = {
   'src/admin/pages/site/panels/TypographyPanel/FontsSection/AddGoogleFontDialog.tsx': 751,
   'src/core/markdown/markdownDocument.ts': 748,
   'src/admin/pages/dashboard/DashboardPage.tsx': 732,
-  'src/admin/pages/data/components/NewFieldDialog/NewFieldDialog.tsx': 704,
 }
 
 // ---------------------------------------------------------------------------

--- a/src/admin/pages/data/DataPage.tsx
+++ b/src/admin/pages/data/DataPage.tsx
@@ -10,6 +10,7 @@ import { useAuthenticatedAdminUser } from '@admin/sessionContext'
 import { useNavigate } from '@admin/lib/routing'
 import { useEditorStore } from '@site/store/store'
 import { useConfirmDelete } from '@admin/shared/dialogs/ConfirmDeleteDialog'
+import { StepUpCancelledMessage, useStepUp } from '@admin/shared/StepUp'
 import { CMS_SITE_BUNDLE_IMPORTED_EVENT } from '@admin/state/adminEvents'
 import { useAdminUi } from '@admin/state/adminUi'
 import {
@@ -62,6 +63,7 @@ export function DataPage() {
   const setPropertiesPanel = useEditorStore((s) => s.setPropertiesPanel)
   const openSiteImport = useAdminUi((s) => s.openSiteImport)
   const confirmDelete = useConfirmDelete()
+  const { runStepUp } = useStepUp()
 
   const [newTableDialogOpen, setNewTableDialogOpen] = useState(false)
   const [exportDialog, setExportDialog] = useState<ExportDialogState>({ kind: 'closed' })
@@ -165,7 +167,8 @@ export function DataPage() {
         : 'This cannot be undone.',
       confirmLabel: 'Delete table',
       commit: () => {
-        workspace.deleteTable(tableId).catch((err) => {
+        runStepUp(() => workspace.deleteTable(tableId)).catch((err) => {
+          if (err instanceof Error && err.message === StepUpCancelledMessage) return
           console.error('[DataPage] Delete table failed:', err)
         })
       },
@@ -208,10 +211,10 @@ export function DataPage() {
       rows={workspace.rows}
       onSaveRow={handleSaveRow}
       onUpdateTable={async (input) => {
-        return workspace.updateTable(selectedTable.id, input)
+        return runStepUp(() => workspace.updateTable(selectedTable.id, input))
       }}
       onDeleteTable={async () => {
-        await workspace.deleteTable(selectedTable.id)
+        await runStepUp(() => workspace.deleteTable(selectedTable.id))
       }}
       onEditInContent={handleEditInContent}
       onOpenInSiteEditor={handleOpenInSiteEditor}
@@ -287,7 +290,7 @@ export function DataPage() {
           open={newTableDialogOpen}
           onClose={() => setNewTableDialogOpen(false)}
           onCreate={async (input) => {
-            await workspace.createTable(input)
+            await runStepUp(() => workspace.createTable(input))
             setNewTableDialogOpen(false)
           }}
         />

--- a/src/admin/pages/data/components/DataInspector/FieldsSection.tsx
+++ b/src/admin/pages/data/components/DataInspector/FieldsSection.tsx
@@ -14,6 +14,7 @@ import { Button } from '@ui/components/Button'
 import { PlusIcon } from 'pixel-art-icons/icons/plus'
 import { NewFieldDialog } from '@admin/pages/data/components/NewFieldDialog/NewFieldDialog'
 import { useConfirmDelete } from '@admin/shared/dialogs/ConfirmDeleteDialog'
+import { StepUpCancelledMessage } from '@admin/shared/StepUp'
 import {
   POST_TYPE_OPTIONAL_BUILTIN_FIELD_IDS,
   type DataField,
@@ -45,6 +46,10 @@ import styles from './DataInspector.module.css'
 // when nested inside a component function).
 // ---------------------------------------------------------------------------
 
+function isStepUpCancelled(err: unknown): boolean {
+  return err instanceof Error && err.message === StepUpCancelledMessage
+}
+
 async function saveFieldEdit(
   editingFieldId: string,
   editState: FieldEditState,
@@ -69,6 +74,7 @@ async function saveFieldEdit(
     setEditingFieldId(null)
     setEditState(null)
   } catch (err) {
+    if (isStepUpCancelled(err)) return
     console.error('[FieldsSection] Save failed:', err)
     setEditError(getErrorMessage(err, 'Could not save field'))
   } finally {
@@ -156,6 +162,7 @@ export function FieldsSection({
 
     setUpdateError(null)
     onUpdateTable({ fields: reordered }).catch((err) => {
+      if (isStepUpCancelled(err)) return
       console.error('[FieldsSection] Reorder failed:', err)
       setUpdateError(getErrorMessage(err, 'Could not reorder fields'))
     })
@@ -238,6 +245,7 @@ export function FieldsSection({
         const updatedFields = table.fields.filter((f) => f.id !== field.id)
         setUpdateError(null)
         onUpdateTable({ fields: updatedFields }).catch((err) => {
+          if (isStepUpCancelled(err)) return
           console.error('[FieldsSection] Delete field failed:', err)
           setUpdateError(getErrorMessage(err, 'Could not delete field'))
         })

--- a/src/admin/pages/data/components/DataInspector/TableSettings.tsx
+++ b/src/admin/pages/data/components/DataInspector/TableSettings.tsx
@@ -12,6 +12,7 @@ import { ListBoxSolidIcon } from 'pixel-art-icons/icons/list-box-solid'
 import { BoxSolidIcon } from 'pixel-art-icons/icons/box-solid'
 import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
 import { useConfirmDelete } from '@admin/shared/dialogs/ConfirmDeleteDialog'
+import { StepUpCancelledMessage } from '@admin/shared/StepUp'
 import type { DataTable, DataRow, UpdateDataTableInput } from '@core/data/schemas'
 import { FieldsSection } from './FieldsSection'
 import styles from './DataInspector.module.css'
@@ -42,6 +43,10 @@ interface SettingsDraft {
   primaryFieldId: string
 }
 
+function isStepUpCancelled(err: unknown): boolean {
+  return err instanceof Error && err.message === StepUpCancelledMessage
+}
+
 // ---------------------------------------------------------------------------
 // Module-level helpers — extracted so the React Compiler can auto-memoize the
 // TableSettings component body (try/catch in async causes compiler bailout
@@ -62,8 +67,10 @@ async function saveTableField(
   try {
     await onUpdateTable({ [key]: value })
   } catch (err) {
-    console.error('[TableSettings] Save failed:', err)
-    setSaveError(getErrorMessage(err, 'Could not save'))
+    if (!isStepUpCancelled(err)) {
+      console.error('[TableSettings] Save failed:', err)
+      setSaveError(getErrorMessage(err, 'Could not save'))
+    }
     // Revert the draft field to the last known-good value from the table.
     setDraft((prev) => ({
       ...prev,
@@ -87,8 +94,10 @@ async function savePrimaryField(
   try {
     await onUpdateTable({ primaryFieldId: fieldId })
   } catch (err) {
-    console.error('[TableSettings] Primary field save failed:', err)
-    setSaveError(getErrorMessage(err, 'Could not save'))
+    if (!isStepUpCancelled(err)) {
+      console.error('[TableSettings] Primary field save failed:', err)
+      setSaveError(getErrorMessage(err, 'Could not save'))
+    }
     setDraft((prev) => ({ ...prev, primaryFieldId: table.primaryFieldId }))
   } finally {
     setSaving(false)
@@ -174,6 +183,7 @@ export function TableSettings({
       confirmLabel: 'Delete table',
       commit: () => {
         onDeleteTable().catch((err) => {
+          if (isStepUpCancelled(err)) return
           console.error('[TableSettings] Delete table failed:', err)
         })
       },

--- a/src/admin/pages/data/components/NewFieldDialog/NewFieldDialog.tsx
+++ b/src/admin/pages/data/components/NewFieldDialog/NewFieldDialog.tsx
@@ -9,79 +9,26 @@ import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
 import { DataFieldSchema, type DataField, type DataFieldType, type DataSelectOption, type DataTable } from '@core/data/schemas'
 import { buildPostTypeDefaultFields } from '@core/data/fields'
 import { safeParseValue, formatValueErrors } from '@core/utils/typeboxHelpers'
+import { StepUpCancelledMessage } from '@admin/shared/StepUp'
 import styles from './NewFieldDialog.module.css'
 import { getErrorMessage } from '@core/utils/errorMessage'
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const FIELD_TYPE_OPTIONS: ReadonlyArray<{ value: DataFieldType; label: string }> = [
-  { value: 'text', label: 'Text' },
-  { value: 'longText', label: 'Long text' },
-  { value: 'richText', label: 'Rich text' },
-  { value: 'number', label: 'Number' },
-  { value: 'boolean', label: 'Boolean' },
-  { value: 'date', label: 'Date' },
-  { value: 'dateTime', label: 'Date & time' },
-  { value: 'select', label: 'Select' },
-  { value: 'multiSelect', label: 'Multi-select' },
-  { value: 'url', label: 'URL' },
-  { value: 'email', label: 'Email' },
-  { value: 'media', label: 'Media' },
-  { value: 'relation', label: 'Relation' },
-]
-
-const FIELD_ID_PATTERN = /^[a-z][a-z0-9_]*$/
-
-const RICH_TEXT_FORMAT_OPTIONS = [
-  { value: 'markdown', label: 'Markdown' },
-  { value: 'html', label: 'HTML' },
-]
-
-const NUMBER_FORMAT_OPTIONS = [
-  { value: 'number', label: 'Number' },
-  { value: 'currency', label: 'Currency' },
-  { value: 'percent', label: 'Percent' },
-]
-
-const MEDIA_KIND_OPTIONS = [
-  { value: 'any', label: 'Any' },
-  { value: 'image', label: 'Image' },
-  { value: 'video', label: 'Video' },
-]
-
-// ---------------------------------------------------------------------------
-// Draft option type (pre-uuid assignment)
-// ---------------------------------------------------------------------------
-
-interface DraftOption {
-  id: string
-  label: string
-  value: string
-}
+import {
+  FIELD_TYPE_OPTIONS,
+  MEDIA_KIND_OPTIONS,
+  NUMBER_FORMAT_OPTIONS,
+  RICH_TEXT_FORMAT_OPTIONS,
+  fieldIdError,
+  makeOption,
+  slugifyOptionValue,
+  type DraftOption,
+} from './newFieldDialogModel'
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function slugifyOptionValue(label: string): string {
-  return label
-    .toLowerCase()
-    .trim()
-    .replace(/[^a-z0-9]+/g, '_')
-    .replace(/^_+|_+$/g, '')
-}
-
-function makeOption(label: string): DraftOption {
-  return { id: crypto.randomUUID(), label, value: slugifyOptionValue(label) }
-}
-
-function fieldIdError(id: string, existingIds: string[]): string | null {
-  if (!id) return null
-  if (!FIELD_ID_PATTERN.test(id)) return 'Must start with a lowercase letter; use letters, numbers, underscores only.'
-  if (existingIds.includes(id)) return 'This ID is already in use.'
-  return null
+function isStepUpCancelled(err: unknown): boolean {
+  return err instanceof Error && err.message === StepUpCancelledMessage
 }
 
 // ---------------------------------------------------------------------------
@@ -353,6 +300,10 @@ export function NewFieldDialog({
       await onCreate(result.value)
       resetForm()
     } catch (err) {
+      if (isStepUpCancelled(err)) {
+        setSaving(false)
+        return
+      }
       setSubmitError(getErrorMessage(err, 'Could not create field').replace(/^\[[^\]]+\]\s*/, ''))
       setSaving(false)
     }
@@ -373,6 +324,10 @@ export function NewFieldDialog({
       await onCreate(field)
       handleClose()
     } catch (err) {
+      if (isStepUpCancelled(err)) {
+        setSaving(false)
+        return
+      }
       setSubmitError(getErrorMessage(err, 'Could not add field').replace(/^\[[^\]]+\]\s*/, ''))
       setSaving(false)
     }

--- a/src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts
+++ b/src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts
@@ -1,0 +1,61 @@
+import type { DataFieldType } from '@core/data/schemas'
+
+export interface DraftOption {
+  id: string
+  label: string
+  value: string
+}
+
+export const FIELD_TYPE_OPTIONS: ReadonlyArray<{ value: DataFieldType; label: string }> = [
+  { value: 'text', label: 'Text' },
+  { value: 'longText', label: 'Long text' },
+  { value: 'richText', label: 'Rich text' },
+  { value: 'number', label: 'Number' },
+  { value: 'boolean', label: 'Boolean' },
+  { value: 'date', label: 'Date' },
+  { value: 'dateTime', label: 'Date & time' },
+  { value: 'select', label: 'Select' },
+  { value: 'multiSelect', label: 'Multi-select' },
+  { value: 'url', label: 'URL' },
+  { value: 'email', label: 'Email' },
+  { value: 'media', label: 'Media' },
+  { value: 'relation', label: 'Relation' },
+]
+
+export const RICH_TEXT_FORMAT_OPTIONS = [
+  { value: 'markdown', label: 'Markdown' },
+  { value: 'html', label: 'HTML' },
+]
+
+export const NUMBER_FORMAT_OPTIONS = [
+  { value: 'number', label: 'Number' },
+  { value: 'currency', label: 'Currency' },
+  { value: 'percent', label: 'Percent' },
+]
+
+export const MEDIA_KIND_OPTIONS = [
+  { value: 'any', label: 'Any' },
+  { value: 'image', label: 'Image' },
+  { value: 'video', label: 'Video' },
+]
+
+const FIELD_ID_PATTERN = /^[a-z][a-z0-9_]*$/
+
+export function slugifyOptionValue(label: string): string {
+  return label
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+}
+
+export function makeOption(label: string): DraftOption {
+  return { id: crypto.randomUUID(), label, value: slugifyOptionValue(label) }
+}
+
+export function fieldIdError(id: string, existingIds: string[]): string | null {
+  if (!id) return null
+  if (!FIELD_ID_PATTERN.test(id)) return 'Must start with a lowercase letter; use letters, numbers, underscores only.'
+  if (existingIds.includes(id)) return 'This ID is already in use.'
+  return null
+}

--- a/src/admin/pages/data/components/NewTableDialog/NewTableDialog.tsx
+++ b/src/admin/pages/data/components/NewTableDialog/NewTableDialog.tsx
@@ -5,6 +5,7 @@ import { Input } from '@ui/components/Input'
 import { SegmentedControl } from '@ui/components/SegmentedControl'
 import { buildPostTypeDefaultFields } from '@core/data/fields'
 import { type CreateDataTableInput, type DataTableKind } from '@core/data/schemas'
+import { StepUpCancelledMessage } from '@admin/shared/StepUp'
 import styles from './NewTableDialog.module.css'
 import { getErrorMessage } from '@core/utils/errorMessage'
 
@@ -131,6 +132,10 @@ export function NewTableDialog({
       await onCreate(input)
       resetForm()
     } catch (err) {
+      if (err instanceof Error && err.message === StepUpCancelledMessage) {
+        setSaving(false)
+        return
+      }
       setSubmitError(errorMessage(err))
       setSaving(false)
     }


### PR DESCRIPTION
## Summary
- Route data table schema mutations through the shared step-up flow so `step_up_required` opens the password dialog and retries instead of rendering raw text.
- Swallow the shared step-up cancellation sentinel across table and field schema mutation UI.
- Extract `NewFieldDialog` model helpers and remove it from the module-size grandfather list.
- Pin ESLint's TypeScript config root and ignore local agent worktrees to avoid `.claude` root ambiguity during lint.

## Verification
- `bun run build`
- `bun run lint`
- `bun test`
- `bunx react-doctor@latest --verbose --diff main --blocking warning`
- Browser smoke on `http://localhost:5178/admin/data` with a disposable local stack: verified the step-up dialog appears, raw `step_up_required` does not render, and password confirmation retries table creation successfully.