### PR TITLE
Standardize on GHCR; drop the unconfigured Docker Hub mirror

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,67 +86,12 @@ jobs:
             INSTATIC_REVISION=${{ github.sha }}
             INSTATIC_CREATED=${{ steps.version.outputs.created }}
 
-  dockerhub:
-    name: Mirror To Docker Hub
-    runs-on: ubuntu-latest
-    needs: image
-    steps:
-      - name: Resolve release version
-        id: version
-        shell: bash
-        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-
-      - name: Check Docker Hub credentials
-        id: credentials
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        shell: bash
-        run: |
-          if [ -n "$DOCKERHUB_USERNAME" ] && [ -n "$DOCKERHUB_TOKEN" ]; then
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.credentials.outputs.enabled == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      - name: Login to GHCR
-        if: steps.credentials.outputs.enabled == 'true'
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Login to Docker Hub
-        if: steps.credentials.outputs.enabled == 'true'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-      - name: Mirror image
-        if: steps.credentials.outputs.enabled == 'true'
-        run: |
-          docker buildx imagetools create \
-            --tag docker.io/corebunch/instatic:${{ steps.version.outputs.version }} \
-            --tag docker.io/corebunch/instatic:latest \
-            ghcr.io/corebunch/instatic:${{ steps.version.outputs.version }}
-
-      - name: Report skipped mirror
-        if: steps.credentials.outputs.enabled != 'true'
-        run: echo "Docker Hub mirror skipped because DOCKERHUB_USERNAME or DOCKERHUB_TOKEN is not configured."
-
   bundle:
     name: Publish Release Bundle
     runs-on: ubuntu-latest
     needs:
       - verify
       - image
-      - dockerhub
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -39,15 +39,6 @@ docker pull ghcr.io/corebunch/instatic:latest
 docker pull ghcr.io/corebunch/instatic:0.0.3
 ```
 
-Docker Hub is a discoverability mirror:
-
-```sh
-docker pull corebunch/instatic:latest
-docker pull corebunch/instatic:0.0.3
-```
-
-When both registries are available, prefer GHCR in Compose files because it is produced directly by the release workflow.
-
 The v0.0.3 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite

--- a/docs/deployment/release-workflow.md
+++ b/docs/deployment/release-workflow.md
@@ -23,9 +23,8 @@ Release flow:
 3. Tag a version, e.g. `v0.0.1`.
 4. GitHub Actions runs `bun run build`, `bun test`, and `bun run lint`.
 5. GitHub Actions builds `Dockerfile`.
-6. GitHub Actions pushes the semver image, minor image, and `latest`.
-7. GitHub Actions mirrors to Docker Hub when Docker Hub secrets exist.
-8. GitHub Actions creates the GitHub Release and uploads the release bundle.
+6. GitHub Actions pushes the semver image, minor image, and `latest` to GHCR.
+7. GitHub Actions creates the GitHub Release and uploads the release bundle.
 
 ## Pre-Tag Template Updates
 
@@ -119,18 +118,12 @@ The release workflow should:
 - push `latest` for tagged releases
 - create a release bundle with the Compose files and deployment docs
 - include the Render Blueprint templates in the release bundle
-- skip the Docker Hub mirror cleanly when `DOCKERHUB_USERNAME` or `DOCKERHUB_TOKEN` is missing
 
 The first release targets `linux/amd64` because QEMU-based arm64 publishing made the tagged workflow too slow to use as a release gate. Add arm64 as a separate native-runner build before advertising multi-arch images.
 
-## Docker Hub Mirror
+## Image Registry
 
-The release workflow always publishes GHCR. It mirrors to Docker Hub only when these repository secrets exist:
-
-- `DOCKERHUB_USERNAME`
-- `DOCKERHUB_TOKEN`
-
-The mirror target is `docker.io/corebunch/instatic:<tag>`. If the secrets are absent, the workflow prints a skip message and the GHCR release still completes.
+GHCR (`ghcr.io/corebunch/instatic`) is the only published registry. It is produced directly by the release workflow, is public, and has no aggressive anonymous pull-rate limits — use it in every Compose file, template, and deployment guide. There is no Docker Hub mirror; if one is ever wanted, add a `Mirror To Docker Hub` job plus `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` repository secrets.
 
 ## GHCR Visibility
 


### PR DESCRIPTION
GHCR is now the single published image registry. The Docker Hub mirror job had never actually published — the repo has no `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets, so it always took its skip branch while the job still reported green, and `docker.io/corebunch/instatic` was never populated (anonymous pulls return 401). GHCR (`ghcr.io/corebunch/instatic`) is public, has no aggressive anonymous pull-rate limits, and is already what the deployment docs reference.

- Remove the `Mirror To Docker Hub` job from `release.yml` and drop it from the release-bundle job's `needs`.
- Remove the Docker Hub pull block from `docker-image.md`.
- Replace the `Docker Hub Mirror` section of `release-workflow.md` with an `Image Registry` note (GHCR-only, plus how to re-add a mirror if ever wanted).

Re-enabling Docker Hub later is a small revert plus the two secrets. Docs/CI only — no app code changes. `release.yml` validated with js-yaml; jobs are now verify → image → bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)