### PR TITLE
Make var()/env() declarations engine-proof at the import boundary

### DIFF
--- a/src/__tests__/architecture/module-size-budgets.test.ts
+++ b/src/__tests__/architecture/module-size-budgets.test.ts
@@ -107,7 +107,7 @@ const GRANDFATHERED: Record<string, number> = {
   // clone. See docs/reference/page-tree.md (parentId).
   'src/core/page-tree/mutations.ts': 880,
   'server/plugins/host/handlers/content.ts': 786,
-  'src/core/siteImport/cssToStyleRules.ts': 829,
+  'src/core/siteImport/cssToStyleRules.ts': 742,
   'src/admin/pages/site/panels/TypographyPanel/FontsSection/AddGoogleFontDialog.tsx': 751,
   'src/core/markdown/markdownDocument.ts': 748,
   'src/admin/pages/dashboard/DashboardPage.tsx': 732,

--- a/src/__tests__/htmlImport/mapping.test.ts
+++ b/src/__tests__/htmlImport/mapping.test.ts
@@ -857,6 +857,18 @@ describe('inline style="" → node.inlineStyles', () => {
     expect(Object.keys(node.inlineStyles ?? {}).length).toBeGreaterThan(0)
   })
 
+  it('preserves shorthand+var() declarations byte-faithfully', () => {
+    // CSSOM views of substitution declarations are lossy and engine-divergent;
+    // the harvest re-encodes them as marker custom properties before parsing
+    // (see @core/css-substitution).
+    const node = single(`<div style="border: 1px solid var(--rule); color: var(--ink); padding: 4px">x</div>`)
+    expect(node.inlineStyles?.border).toBe('1px solid var(--rule)')
+    expect(node.inlineStyles?.color).toBe('var(--ink)')
+    expect(node.inlineStyles?.paddingTop).toBe('4px')
+    // No mangled longhand artifacts carrying the bare var() text.
+    expect(node.inlineStyles?.borderLeftWidth).toBeUndefined()
+  })
+
   it('leaves nodes without inline styles free of inlineStyles', () => {
     const result = importHtml('<div><p>Plain</p></div>')
     for (const node of Object.values(result.nodes)) {

--- a/src/__tests__/siteImport/cssToStyleRules-substitution.test.ts
+++ b/src/__tests__/siteImport/cssToStyleRules-substitution.test.ts
@@ -1,150 +1,132 @@
 /**
- * Regression tests for the Chromium "pending-substitution value" drop.
+ * Substitution-declaration fidelity (`var()` / `env()` values).
  *
- * When a CSS *shorthand* (background, transition, gap, padding, …) is set to a
- * value containing `var()`/`env()`, Chromium stores one un-expandable
- * pending-substitution value: `style.length` enumerates the shorthand's
- * LONGHANDS, but `getPropertyValue(longhand)` returns `""` for every one. The
- * old parser's `if (!value) continue` then dropped the whole declaration (e.g.
- * `html, body { background: var(--bg) }` lost its background entirely on import).
+ * CSS engines disagree about what their CSSOM exposes for declarations whose
+ * value contains a substitution function: Chromium enumerates the shorthand's
+ * longhands with EMPTY values (the text survives only in cssText), while
+ * happy-dom destroys the declaration entirely (each longhand reports the bare
+ * `var(...)` text; `1px solid` is gone from cssText too).
  *
- * This behaviour does NOT reproduce under happy-dom (which keeps the shorthand
- * enumerated with its value), so these tests simulate Chromium's CSSStyleDeclaration
- * directly, using values captured from HeadlessChrome 148:
- *   background: var(--bg)  → 9 empty background-* longhands, cssText keeps shorthand
- *   transition: …var(…)    → 5 empty transition-* longhands
- *   gap: var(--g)          → empty row-gap/column-gap
- *   padding: 13px var(--p) → 4 empty padding-* longhands
+ * `@core/css-substitution` removes the divergence at the source: every
+ * substitution declaration is encoded as a marker custom property BEFORE the
+ * engine parse (all engines preserve custom properties verbatim) and decoded
+ * after. These tests run through the REAL engine (happy-dom here, Chromium in
+ * production) and assert byte-faithful output.
  */
 
 import { describe, it, expect } from 'bun:test'
+import { cssToStyleRules } from '@core/siteImport'
 import {
-  parseDeclarations,
-  recoverSubstitutionShorthands,
-} from '@core/siteImport/cssToStyleRules'
-import type { ImportWarning } from '@core/siteImport'
+  encodeSubstitutionDeclarations,
+  encodeSubstitutionDeclarationList,
+  decodeSubstitutionProperty,
+  SUBSTITUTION_PROP_MARKER,
+} from '@core/css-substitution'
 
-// ---------------------------------------------------------------------------
-// Mock CSSStyleDeclaration that mimics Chromium's pending-substitution
-// enumeration: empty longhands + a faithful cssText.
-// ---------------------------------------------------------------------------
+describe('cssToStyleRules — substitution declarations survive verbatim', () => {
+  it('preserves shorthand+var declarations byte-faithfully', () => {
+    const { rules, warnings } = cssToStyleRules(`
+      .plan { padding: 40px; border-left: 1px solid var(--rule); }
+      .plans { border: 1px solid var(--rule); }
+      html, body { background: var(--bg); }
+      .btn { transition: background 140ms var(--easing); gap: var(--g); }
+    `)
 
-function mockStyle(
-  enumerated: Array<[kebab: string, value: string]>,
-  cssText: string,
-): CSSStyleDeclaration {
-  const values = new Map(enumerated)
-  const indexed = enumerated.map(([k]) => k)
-  const obj: Record<string | number, unknown> = {
-    length: indexed.length,
-    cssText,
-    getPropertyValue: (k: string) => values.get(k) ?? '',
-  }
-  indexed.forEach((k, i) => {
-    obj[i] = k
-  })
-  return obj as unknown as CSSStyleDeclaration
-}
-
-// ---------------------------------------------------------------------------
-// parseDeclarations — Chromium pending-substitution recovery
-// ---------------------------------------------------------------------------
-
-describe('parseDeclarations — recovers shorthand+var dropped by Chromium', () => {
-  it('recovers background: var(--bg) from empty background-* longhands', () => {
-    const warnings: ImportWarning[] = []
-    const style = mockStyle(
-      [
-        ['background-image', ''],
-        ['background-position-x', ''],
-        ['background-position-y', ''],
-        ['background-size', ''],
-        ['background-repeat', ''],
-        ['background-attachment', ''],
-        ['background-origin', ''],
-        ['background-clip', ''],
-        ['background-color', ''],
-        ['color', 'var(--ink)'],
-      ],
-      'background: var(--bg); color: var(--ink);',
-    )
-    const decls = parseDeclarations(style, 'html, body', warnings)
-    expect(decls.background).toBe('var(--bg)')
-    // The longhand-with-var is captured by enumeration, not duplicated.
-    expect(decls.color).toBe('var(--ink)')
-    expect(decls.backgroundColor).toBeUndefined()
+    const bySel = Object.fromEntries(rules.map((r) => [r.selector, r.styles]))
+    expect(bySel['.plan'].borderLeft).toBe('1px solid var(--rule)')
+    // The non-var shorthand still expands through the engine as usual.
+    expect(bySel['.plan'].paddingTop).toBe('40px')
+    expect(bySel['.plans'].border).toBe('1px solid var(--rule)')
+    expect(bySel['html, body'].background).toBe('var(--bg)')
+    expect(bySel['.btn'].transition).toBe('background 140ms var(--easing)')
+    expect(bySel['.btn'].gap).toBe('var(--g)')
     expect(warnings).toHaveLength(0)
+
+    // No engine-mangled longhand artifacts (`borderLeftWidth: var(--rule)`).
+    for (const styles of Object.values(bySel)) {
+      for (const [prop, value] of Object.entries(styles)) {
+        if (prop.startsWith('border') && prop !== 'border' && prop !== 'borderLeft') {
+          expect(String(value)).not.toContain('var(')
+        }
+      }
+    }
   })
 
-  it('recovers transition / gap / padding shorthands that use var()', () => {
-    const warnings: ImportWarning[] = []
-    const style = mockStyle(
-      [
-        ['transition-property', ''],
-        ['transition-duration', ''],
-        ['transition-timing-function', ''],
-        ['transition-delay', ''],
-        ['row-gap', ''],
-        ['column-gap', ''],
-        ['padding-top', ''],
-        ['padding-right', ''],
-        ['padding-bottom', ''],
-        ['padding-left', ''],
-      ],
-      'transition: background 140ms var(--easing); gap: var(--g); padding: 13px var(--p);',
-    )
-    const decls = parseDeclarations(style, '.btn', warnings)
-    expect(decls.transition).toBe('background 140ms var(--easing)')
-    expect(decls.gap).toBe('var(--g)')
-    expect(decls.padding).toBe('13px var(--p)')
+  it('preserves longhand var() declarations and authored custom properties', () => {
+    const { rules } = cssToStyleRules(`.x { color: var(--ink); --own: 12px; }`)
+    expect(rules[0].styles.color).toBe('var(--ink)')
+    expect(rules[0].styles['--own']).toBe('12px')
   })
 
-  it('does not clobber a longhand the enumeration already resolved', () => {
-    const warnings: ImportWarning[] = []
-    // backgroundColor resolved (non-var) AND a separate background-image var().
-    const style = mockStyle(
-      [['background-color', 'rgb(255, 0, 0)']],
-      'background-color: rgb(255, 0, 0); background-image: var(--img);',
-    )
-    const decls = parseDeclarations(style, '.x', warnings)
-    expect(decls.backgroundColor).toBe('rgb(255, 0, 0)') // untouched
-    expect(decls.backgroundImage).toBe('var(--img)') // recovered longhand-var
+  it('preserves var() declarations inside @media overrides', () => {
+    const { rules } = cssToStyleRules(`
+      .plan { color: red; }
+      @media (max-width: 700px) { .plan { border-top: 1px solid var(--rule) } }
+    `)
+    const plan = rules.find((r) => r.selector === '.plan')!
+    const contexts = Object.values(plan.contextStyles ?? {})
+    expect(contexts).toHaveLength(1)
+    expect((contexts[0] as Record<string, unknown>).borderTop).toBe('1px solid var(--rule)')
+  })
+
+  it('blocks a security-denied property even when its value uses var()', () => {
+    const { rules, warnings } = cssToStyleRules(`.x { behavior: var(--evil); }`)
+    expect(rules[0]?.styles?.behavior).toBeUndefined()
+    expect(warnings.some((w) => w.kind === 'blocked-property' && w.property === 'behavior')).toBe(true)
+  })
+
+  it('keeps @keyframes raw CSS free of encode markers', () => {
+    const { rules } = cssToStyleRules(`
+      @keyframes pulse { from { opacity: var(--lo); } to { opacity: 1; } }
+      .x { animation: pulse 1s var(--easing) infinite; }
+    `)
+    const keyframes = rules.find((r) => typeof r.rawCss === 'string')
+    expect(keyframes).toBeDefined()
+    expect(keyframes!.rawCss).not.toContain(SUBSTITUTION_PROP_MARKER)
+    expect(rules.find((r) => r.selector === '.x')?.styles.animation).toBe('pulse 1s var(--easing) infinite')
   })
 })
 
-// ---------------------------------------------------------------------------
-// recoverSubstitutionShorthands — unit behaviour
-// ---------------------------------------------------------------------------
-
-describe('recoverSubstitutionShorthands', () => {
-  it('skips declarations already present in decls (longhand var)', () => {
-    const warnings: ImportWarning[] = []
-    const decls: Record<string, unknown> = { color: 'var(--ink)' }
-    recoverSubstitutionShorthands('color: var(--ink); background: var(--bg);', decls, 's', warnings)
-    expect(decls.color).toBe('var(--ink)') // unchanged
-    expect(decls.background).toBe('var(--bg)') // added
+describe('encodeSubstitutionDeclarations', () => {
+  it('rewrites only substitution declarations, byte-preserving everything else', () => {
+    const css = `/* c */ .a:hover { color: red; border: 1px solid var(--x); }`
+    expect(encodeSubstitutionDeclarations(css)).toBe(
+      `/* c */ .a:hover { color: red; ${SUBSTITUTION_PROP_MARKER}border: 1px solid var(--x); }`,
+    )
   })
 
-  it('ignores declarations without a substitution function', () => {
-    const warnings: ImportWarning[] = []
-    const decls: Record<string, unknown> = {}
-    recoverSubstitutionShorthands('background: #fff; margin: 0px;', decls, 's', warnings)
-    expect(Object.keys(decls)).toHaveLength(0)
+  it('does not re-encode custom properties or split values on nested separators', () => {
+    const css = `.a { --token: var(--x); content: "a;b{c}"; background: url("x;y.png") var(--bg); }`
+    const encoded = encodeSubstitutionDeclarations(css)
+    expect(encoded).toContain(`--token: var(--x)`)
+    expect(encoded).toContain(`content: "a;b{c}"`)
+    expect(encoded).toContain(`${SUBSTITUTION_PROP_MARKER}background: url("x;y.png") var(--bg)`)
   })
 
-  it('does not split a value on a `;` nested inside parens', () => {
-    const warnings: ImportWarning[] = []
-    const decls: Record<string, unknown> = {}
-    // A (contrived) nested semicolon inside var() must not terminate the value.
-    recoverSubstitutionShorthands('grid-template: var(--a, "x;y");', decls, 's', warnings)
-    expect(decls.gridTemplate).toBe('var(--a, "x;y")')
+  it('leaves @keyframes and @font-face blocks untouched, including vendor prefixes', () => {
+    const css = [
+      `@keyframes spin { to { transform: rotate(var(--turn)); } }`,
+      `@-webkit-keyframes spin { to { transform: rotate(var(--turn)); } }`,
+      `@font-face { font-family: X; src: local(var(--nope)); }`,
+      `@media (min-width: 700px) { .x { gap: var(--g); } }`,
+    ].join('\n')
+    const encoded = encodeSubstitutionDeclarations(css)
+    expect(encoded.split(SUBSTITUTION_PROP_MARKER)).toHaveLength(2) // only the @media declaration
+    expect(encoded).toContain(`${SUBSTITUTION_PROP_MARKER}gap: var(--g)`)
+    expect(encoded).toContain('transform: rotate(var(--turn))')
   })
 
-  it('handles an empty / undefined cssText without throwing', () => {
-    const warnings: ImportWarning[] = []
-    const decls: Record<string, unknown> = {}
-    recoverSubstitutionShorthands('', decls, 's', warnings)
-    recoverSubstitutionShorthands(undefined, decls, 's', warnings)
-    expect(Object.keys(decls)).toHaveLength(0)
+  it('round-trips through decodeSubstitutionProperty', () => {
+    expect(decodeSubstitutionProperty(`${SUBSTITUTION_PROP_MARKER}border-left`)).toBe('border-left')
+    expect(decodeSubstitutionProperty('--own-prop')).toBeNull()
+    expect(decodeSubstitutionProperty('border-left')).toBeNull()
+  })
+})
+
+describe('encodeSubstitutionDeclarationList — style attributes', () => {
+  it('encodes substitution declarations in a bare declaration list', () => {
+    expect(encodeSubstitutionDeclarationList('color: red; border: 1px solid var(--x)')).toBe(
+      `color: red; ${SUBSTITUTION_PROP_MARKER}border: 1px solid var(--x)`,
+    )
   })
 })

--- a/src/core/css-substitution/index.ts
+++ b/src/core/css-substitution/index.ts
@@ -1,0 +1,210 @@
+/**
+ * substitutionEncode — make CSS declarations that use substitution functions
+ * (`var()` / `env()`) survive ANY CSS engine's parse, byte-faithfully.
+ *
+ * ## The problem
+ *
+ * A declaration whose value contains `var()`/`env()` cannot be expanded at
+ * parse time, and engines disagree about what their CSSOM then exposes:
+ *
+ * - **Chromium** stores a "pending-substitution value": `style.length`
+ *   enumerates the shorthand's longhands, but `getPropertyValue(longhand)`
+ *   returns `""` for every one. The authored text survives only in
+ *   `style.cssText`.
+ * - **happy-dom** (the test environment) is worse: it destroys the
+ *   declaration at parse time — `border-left: 1px solid var(--rule)` becomes
+ *   three longhands that EACH report the value `var(--rule)` (the `1px solid`
+ *   part is gone), and `cssText` serialises the same mangle, so the authored
+ *   declaration is unrecoverable from the CSSOM.
+ *
+ * Importing through either lossy view produced wrong or missing styles
+ * (user-visibly: every `border: … var(--rule)` on an imported template).
+ *
+ * ## The fix — don't let engines see substitution declarations
+ *
+ * Every engine preserves CUSTOM PROPERTY declarations verbatim (validated in
+ * Chromium and happy-dom: both enumerate them with byte-identical values).
+ * So before parsing, each declaration whose value contains `var(`/`env(` is
+ * rewritten to a marker custom property:
+ *
+ *   `border-left: 1px solid var(--rule)`
+ *     → `--instatic-sub-border-left: 1px solid var(--rule)`
+ *
+ * and decoded back to its real property after the engine parse
+ * (`decodeSubstitutionProperty`). The output is identical across engines BY
+ * CONSTRUCTION — no per-engine recovery paths.
+ *
+ * `@keyframes` and `@font-face` blocks are left untouched: keyframes are
+ * captured as raw CSS text (an encoded marker would leak into published
+ * output), and font-face descriptors are read by the @font-face resolver.
+ */
+
+/** Prefix for encoded substitution declarations. */
+export const SUBSTITUTION_PROP_MARKER = '--instatic-sub-'
+
+/** A value that contains a `var(` or `env(` substitution function. */
+export const SUBSTITUTION_FN_RE = /\b(?:var|env)\(/
+
+/** At-rule blocks whose contents must pass through unencoded. */
+const SKIPPED_AT_RULES = new Set(['keyframes', 'font-face'])
+
+/** A plain CSS property name (standard properties only — not `--custom`). */
+const PLAIN_PROPERTY_RE = /^-?[a-zA-Z][a-zA-Z-]*$/
+
+/**
+ * Encode every substitution declaration in a full stylesheet. Everything else
+ * is copied byte-for-byte (comments, whitespace, selectors, at-rules).
+ */
+export function encodeSubstitutionDeclarations(css: string): string {
+  let out = ''
+  let i = 0
+  // One entry per open block: the at-rule name that opened it ('' for plain
+  // selector blocks and unnamed at-rules).
+  const blockStack: string[] = []
+  const inSkippedBlock = () => blockStack.some((name) => SKIPPED_AT_RULES.has(name))
+
+  while (i < css.length) {
+    const ch = css[i]
+
+    if (ch === '/' && css[i + 1] === '*') {
+      const end = css.indexOf('*/', i + 2)
+      const stop = end === -1 ? css.length : end + 2
+      out += css.slice(i, stop)
+      i = stop
+      continue
+    }
+
+    if (ch === '}') {
+      blockStack.pop()
+      out += ch
+      i += 1
+      continue
+    }
+
+    if (/\s/.test(ch)) {
+      out += ch
+      i += 1
+      continue
+    }
+
+    if (ch === '@') {
+      // At-rule prelude runs to `{` (block) or `;` (statement at-rule).
+      const end = scanUntil(css, i, '{;')
+      out += css.slice(i, end)
+      if (end < css.length) {
+        out += css[end]
+        if (css[end] === '{') blockStack.push(atRuleName(css.slice(i, end)))
+      }
+      i = end + 1
+      continue
+    }
+
+    // A chunk is either a selector (terminated by `{`) or a declaration
+    // (terminated by `;` or the block's closing `}`).
+    const end = scanUntil(css, i, '{;}')
+    if (end >= css.length || css[end] === '{') {
+      out += css.slice(i, end)
+      if (end < css.length) {
+        out += '{'
+        blockStack.push('')
+      }
+      i = end + 1
+      continue
+    }
+
+    out += inSkippedBlock() ? css.slice(i, end) : encodeDeclarationChunk(css.slice(i, end))
+    if (css[end] === ';') {
+      out += ';'
+      i = end + 1
+    } else {
+      i = end // leave `}` for the loop to pop the block
+    }
+  }
+
+  return out
+}
+
+/**
+ * Encode a bare declaration list — the payload of a `style="…"` attribute.
+ */
+export function encodeSubstitutionDeclarationList(declarations: string): string {
+  let out = ''
+  let i = 0
+  while (i < declarations.length) {
+    const end = scanUntil(declarations, i, ';')
+    out += encodeDeclarationChunk(declarations.slice(i, end))
+    if (end < declarations.length) out += ';'
+    i = end + 1
+  }
+  return out
+}
+
+/**
+ * The real kebab-case property name behind an encoded declaration, or null
+ * when `kebab` isn't a substitution marker.
+ */
+export function decodeSubstitutionProperty(kebab: string): string | null {
+  return kebab.startsWith(SUBSTITUTION_PROP_MARKER)
+    ? kebab.slice(SUBSTITUTION_PROP_MARKER.length)
+    : null
+}
+
+// ---------------------------------------------------------------------------
+// Internals
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite one `prop: value` chunk to its marker form when the value uses a
+ * substitution function. Custom properties and anything that doesn't parse as
+ * a plain declaration pass through verbatim.
+ */
+function encodeDeclarationChunk(chunk: string): string {
+  const colon = chunk.indexOf(':')
+  if (colon === -1) return chunk
+  const prop = chunk.slice(0, colon).trim()
+  const value = chunk.slice(colon + 1)
+  if (!PLAIN_PROPERTY_RE.test(prop) || !SUBSTITUTION_FN_RE.test(value)) return chunk
+  const leading = chunk.slice(0, chunk.length - chunk.trimStart().length)
+  return `${leading}${SUBSTITUTION_PROP_MARKER}${prop}:${value}`
+}
+
+/** Lower-cased at-rule name with any vendor prefix stripped (`@-webkit-keyframes` → `keyframes`). */
+function atRuleName(prelude: string): string {
+  const match = prelude.match(/^@(?:-[a-z]+-)?([a-zA-Z-]+)/i)
+  return match ? match[1].toLowerCase() : ''
+}
+
+/**
+ * Index of the first occurrence of any `stops` character at top level —
+ * outside comments, strings, parens, and brackets. Returns `css.length` when
+ * none is found.
+ */
+function scanUntil(css: string, start: number, stops: string): number {
+  let depth = 0
+  let quote: '"' | "'" | null = null
+  let i = start
+  while (i < css.length) {
+    const ch = css[i]
+    if (quote) {
+      if (ch === '\\') i += 1
+      else if (ch === quote) quote = null
+      i += 1
+      continue
+    }
+    if (ch === '/' && css[i + 1] === '*') {
+      const end = css.indexOf('*/', i + 2)
+      i = end === -1 ? css.length : end + 2
+      continue
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch
+      i += 1
+      continue
+    }
+    if (ch === '(' || ch === '[') depth += 1
+    else if (ch === ')' || ch === ']') depth = Math.max(0, depth - 1)
+    else if (depth === 0 && stops.includes(ch)) return i
+    i += 1
+  }
+  return css.length
+}

--- a/src/core/htmlImport/inlineStyle.ts
+++ b/src/core/htmlImport/inlineStyle.ts
@@ -19,6 +19,11 @@
  */
 
 import { isEmittableProperty } from '@core/publisher'
+import {
+  decodeSubstitutionProperty,
+  encodeSubstitutionDeclarationList,
+  SUBSTITUTION_FN_RE,
+} from '@core/css-substitution'
 
 /** Match the first `url(...)` payload in a CSS value (quoted or bare). */
 const URL_PAYLOAD_RE = /url\(\s*(['"]?)([^'")\n]+)\1\s*\)/i
@@ -56,9 +61,12 @@ function normalizeBackgroundImage(style: CSSStyleDeclaration, out: Record<string
 export function extractInlineStyles(style: CSSStyleDeclaration): Record<string, string> {
   const out: Record<string, string> = {}
   for (let i = 0; i < style.length; i++) {
-    const kebab = style[i]
-    const value = style.getPropertyValue(kebab).trim()
+    const rawKebab = style[i]
+    const value = style.getPropertyValue(rawKebab).trim()
     if (!value) continue
+    // Substitution declarations were encoded as marker custom properties by
+    // `harvestInlineStyles` so they survive the engine parse verbatim.
+    const kebab = decodeSubstitutionProperty(rawKebab) ?? rawKebab
     const camel = kebabToCamel(kebab)
     if (!isEmittableProperty(camel)) continue
     out[camel] = value
@@ -79,6 +87,17 @@ export function harvestInlineStyles(doc: Document): Map<Element, Record<string, 
     // hand-rolled CSS parser and matches the engine the publisher trusts.
     const styledEl = el as Element & { style?: CSSStyleDeclaration }
     if (!styledEl.style || !el.hasAttribute('style')) continue
+    // Declarations whose value uses `var()`/`env()` are lossy/engine-divergent
+    // through CSSStyleDeclaration (see @core/css-substitution). The authored
+    // attribute text is still at hand here — re-set it with those declarations
+    // encoded as marker custom properties, which every engine preserves
+    // verbatim; `extractInlineStyles` decodes them back. The document is the
+    // importer's own parse artifact and `stripUnsafe` removes the attribute
+    // afterwards, so mutating it is safe.
+    const authored = el.getAttribute('style') ?? ''
+    if (SUBSTITUTION_FN_RE.test(authored)) {
+      el.setAttribute('style', encodeSubstitutionDeclarationList(authored))
+    }
     const bag = extractInlineStyles(styledEl.style)
     if (Object.keys(bag).length > 0) result.set(el, bag)
   }

--- a/src/core/siteImport/cssToStyleRules.ts
+++ b/src/core/siteImport/cssToStyleRules.ts
@@ -42,6 +42,7 @@ import type { StyleRuleKind, Condition, ConditionDef } from '@core/page-tree'
 import { conditionId, makeConditionDef } from '@core/page-tree'
 import { formatVariant } from '@core/fonts'
 import { processKeyframesRule } from './keyframesToStyleRule'
+import { decodeSubstitutionProperty, encodeSubstitutionDeclarations } from '@core/css-substitution'
 import { matchMediaQueryToViewport } from './mediaQueryMatch'
 import type {
   ImportWarning,
@@ -203,10 +204,16 @@ export function parseDeclarations(
 ): Record<string, unknown> {
   const decls: Record<string, unknown> = {}
   for (let i = 0; i < style.length; i++) {
-    const kebab = style[i]
-    const value = style.getPropertyValue(kebab).trim()
+    const rawKebab = style[i]
+    const value = style.getPropertyValue(rawKebab).trim()
     if (!value) continue
 
+    // Substitution declarations (`var()`/`env()` values) were encoded as
+    // marker custom properties before the engine parse so they survive
+    // verbatim in every engine — decode them back to their real property.
+    // See substitutionEncode.ts.
+    const kebab = decodeSubstitutionProperty(rawKebab) ?? rawKebab
+
     const camel = kebabToCamel(kebab)
     if (!isEmittableProperty(camel)) {
       warnings.push({
@@ -220,95 +227,8 @@ export function parseDeclarations(
 
     decls[camel] = value
   }
-
-  // Recover shorthand declarations whose value uses a CSS substitution function
-  // (var()/env()). See `recoverSubstitutionShorthands` — Chromium expands such a
-  // shorthand into longhands that all report an EMPTY getPropertyValue, so the
-  // loop above drops the entire declaration. The shorthand text survives in
-  // `style.cssText`, which is where we recover it from.
-  recoverSubstitutionShorthands(style.cssText, decls, selectorForWarning, warnings)
 
   return decls
-}
-
-/**
- * Split a serialised CSS declaration block (`"a: 1; b: var(--x, y)"`) into
- * `[property, value]` pairs. Declarations are separated by `;` at paren-depth 0
- * so a `;` inside `url(...)` / `var(..., ...)` never splits a value. Each pair
- * is split on its FIRST `:` so values containing `:` (e.g. a `url(http://…)`)
- * stay intact.
- */
-function splitCssDeclarations(cssText: string): Array<[string, string]> {
-  const out: Array<[string, string]> = []
-  let depth = 0
-  let start = 0
-
-  const flush = (end: number): void => {
-    const chunk = cssText.slice(start, end).trim()
-    start = end + 1
-    if (!chunk) return
-    const colon = chunk.indexOf(':')
-    if (colon === -1) return
-    const prop = chunk.slice(0, colon).trim()
-    const value = chunk.slice(colon + 1).trim()
-    if (prop && value) out.push([prop, value])
-  }
-
-  for (let i = 0; i < cssText.length; i++) {
-    const ch = cssText[i]
-    if (ch === '(') depth++
-    else if (ch === ')') depth = Math.max(0, depth - 1)
-    else if (ch === ';' && depth === 0) flush(i)
-  }
-  flush(cssText.length)
-  return out
-}
-
-/** A value that contains a `var(` or `env(` substitution function. */
-const SUBSTITUTION_FN_RE = /\b(?:var|env)\(/
-
-/**
- * Recover shorthand declarations that the CSSStyleDeclaration enumeration
- * dropped because their value is a "pending-substitution value".
- *
- * Chromium behaviour (validated in HeadlessChrome 148): assigning a SHORTHAND
- * (`background`, `transition`, `gap`, `padding`, `font`, `border`, …) a value
- * containing `var()`/`env()` stores one un-expandable pending-substitution
- * value. `style.length` then enumerates the shorthand's LONGHANDS, but
- * `getPropertyValue(longhand)` returns `""` for every one — so the main loop's
- * `if (!value) continue` skips them all and the declaration vanishes. The
- * original shorthand text is preserved verbatim in `style.cssText`.
- *
- * This recovers any such declaration: a cssText entry whose value uses a
- * substitution function and whose camelCase property is NOT already present in
- * `decls`. A longhand-with-var (`color: var(--ink)`) is already captured by the
- * enumeration, so it's skipped here (no duplication). happy-dom keeps the
- * shorthand enumerated with its value, so this is a harmless no-op under test.
- */
-export function recoverSubstitutionShorthands(
-  cssText: string | undefined,
-  decls: Record<string, unknown>,
-  selectorForWarning: string,
-  warnings: ImportWarning[],
-): void {
-  if (!cssText) return
-  for (const [kebab, value] of splitCssDeclarations(cssText)) {
-    if (!SUBSTITUTION_FN_RE.test(value)) continue
-    const camel = kebabToCamel(kebab)
-    if (camel in decls) continue // longhand-with-var already captured
-
-    if (!isEmittableProperty(camel)) {
-      warnings.push({
-        kind: 'blocked-property',
-        message: `Property "${camel}" (${kebab}) is blocked for security and was dropped`,
-        selector: selectorForWarning,
-        property: camel,
-      })
-      continue
-    }
-
-    decls[camel] = value
-  }
 }
 
 /**
@@ -395,7 +315,11 @@ export function cssToStyleRules(
   let sheet: CSSStyleSheet
   try {
     sheet = new SheetCtor()
-    sheet.replaceSync(cssText)
+    // Substitution declarations (`var()`/`env()`) are encoded as marker
+    // custom properties first — every engine preserves custom properties
+    // verbatim, where shorthand-with-var handling is lossy and
+    // engine-divergent. `parseDeclarations` decodes them back.
+    sheet.replaceSync(encodeSubstitutionDeclarations(cssText))
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     warnings.push({


### PR DESCRIPTION
## Summary

Follow-up from the import-fidelity work (#15/#19): the test harness (happy-dom) and production (Chromium) exposed DIFFERENT lossy views of CSS declarations whose value uses `var()`/`env()`:

- **Chromium**: shorthand longhands enumerate empty; authored text survives only in `cssText` (covered by an engine-specific recovery hack).
- **happy-dom**: the declaration is destroyed at parse time — longhands report the bare `var()` text (`1px solid` gone), and `cssText` serialises the same mangle, so the authored declaration is unrecoverable. Tests therefore exercised a lossy path production never sees — exactly the bug class behind "all borders dropped".
- **Inline `style=""` harvesting** had no recovery at all: `style="border: 1px solid var(--x)"` was silently lost in *both* engines.

### Fix — don't let engines see substitution declarations

New `@core/css-substitution` leaf module: before any engine parse, every declaration whose value contains `var(`/`env(` is encoded as a marker custom property (**all engines preserve custom properties verbatim** — validated empirically in Chromium and happy-dom), and decoded back afterwards. Output is byte-faithful and identical across engines **by construction**:

- `cssToStyleRules` encodes before `replaceSync`, decodes in `parseDeclarations`; the Chromium-specific `recoverSubstitutionShorthands` is deleted.
- `harvestInlineStyles` re-encodes the authored `style` attribute — fixing inline shorthand+var declarations lost in both engines.
- `@keyframes` / `@font-face` blocks pass through unencoded (keyframes are captured as raw CSS; a marker would leak into published output) — covered by tests incl. vendor-prefixed keyframes.

`cssToStyleRules.ts` shrank below its grandfathered size cap; ratcheted down per the gate.

## Test plan
- Substitution test file rewritten from Chromium mocks to REAL engine parses: shorthand+var byte-fidelity, @media overrides, blocked properties via var, keyframes marker-leak guard, encoder tokenizer units (strings/comments/nested separators), inline-style regression
- Full suite: 5038 pass / 0 fail; build + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)