### PR TITLE
Fix plugin useCanvasNodeRect: measure real canvas nodes, not admin chrome

### DIFF
--- a/src/__tests__/plugins/useCanvasNodeRect.test.tsx
+++ b/src/__tests__/plugins/useCanvasNodeRect.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * useCanvasNodeRect — plugin canvas overlay geometry.
+ *
+ * The hook must resolve the node inside the per-breakpoint canvas IFRAMES
+ * (never the admin document, where layers-tree rows / overlay rings carry the
+ * same `data-node-id`) and translate the iframe-internal rect through the
+ * canvas zoom into overlay-layer-relative coordinates.
+ *
+ * happy-dom reports zero rects for everything, so the fixtures stub
+ * `getBoundingClientRect` / `offsetWidth` with known geometry.
+ */
+
+import { describe, it, expect, afterEach } from 'bun:test'
+import { renderHook, cleanup } from '@testing-library/react'
+import { useCanvasNodeRect } from '@admin/plugin-host-hooks'
+
+afterEach(() => {
+  cleanup()
+  document.body.innerHTML = ''
+})
+
+function stubRect(el: Element, rect: { left: number; top: number; width: number; height: number }) {
+  Object.defineProperty(el, 'getBoundingClientRect', {
+    configurable: true,
+    value: () => ({
+      ...rect,
+      right: rect.left + rect.width,
+      bottom: rect.top + rect.height,
+      x: rect.left,
+      y: rect.top,
+      toJSON: () => rect,
+    }),
+  })
+}
+
+/** Overlay layer + one canvas frame containing the node, with known geometry. */
+function setUpCanvas(nodeId: string) {
+  const layer = document.createElement('div')
+  layer.setAttribute('data-canvas-overlay-layer', 'true')
+  stubRect(layer, { left: 100, top: 50, width: 800, height: 600 })
+  document.body.appendChild(layer)
+
+  const frame = document.createElement('iframe')
+  document.body.appendChild(frame)
+  const frameDoc = frame.contentDocument!
+  frameDoc.body.setAttribute('data-breakpoint-id', 'bp-desktop')
+  // The iframe element renders at half its internal width → canvas zoom 0.5.
+  Object.defineProperty(frame, 'offsetWidth', { configurable: true, value: 1440 })
+  stubRect(frame, { left: 200, top: 80, width: 720, height: 450 })
+
+  const node = frameDoc.createElement('div')
+  node.setAttribute('data-node-id', nodeId)
+  frameDoc.body.appendChild(node)
+  stubRect(node, { left: 40, top: 20, width: 100, height: 60 })
+
+  return { layer, frame, node }
+}
+
+describe('useCanvasNodeRect', () => {
+  it('measures the canvas-frame node, zoom-translated, relative to the overlay layer', () => {
+    setUpCanvas('hero')
+    // An admin-document carrier of the same id (e.g. a layers-tree row) must
+    // not shadow the rendered node.
+    const treeRow = document.createElement('div')
+    treeRow.setAttribute('data-node-id', 'hero')
+    stubRect(treeRow, { left: 1, top: 2, width: 3, height: 4 })
+    document.body.appendChild(treeRow)
+
+    const { result } = renderHook(() => useCanvasNodeRect('hero'))
+
+    // zoom = 720 / 1440 = 0.5
+    // left = (frame.left + node.left * 0.5) - layer.left = 200 + 20 - 100
+    // top  = (frame.top  + node.top  * 0.5) - layer.top  =  80 + 10 -  50
+    expect(result.current).toEqual({ left: 120, top: 40, width: 50, height: 30 })
+  })
+
+  it('returns null when the node renders in no canvas frame, even if admin chrome carries the id', () => {
+    setUpCanvas('other-node')
+    const ring = document.createElement('div')
+    ring.setAttribute('data-node-id', 'hero')
+    ring.setAttribute('data-canvas-selection-ring', 'true')
+    stubRect(ring, { left: 5, top: 5, width: 10, height: 10 })
+    document.body.appendChild(ring)
+
+    const { result } = renderHook(() => useCanvasNodeRect('hero'))
+    expect(result.current).toBeNull()
+  })
+
+  it('returns null for a null node id', () => {
+    setUpCanvas('hero')
+    const { result } = renderHook(() => useCanvasNodeRect(null))
+    expect(result.current).toBeNull()
+  })
+})

--- a/src/admin/pages/site/canvas/canvasNodeLookup.ts
+++ b/src/admin/pages/site/canvas/canvasNodeLookup.ts
@@ -26,7 +26,27 @@ export function findRenderedCanvasNodeElement(
   nodeId: string,
   root: Document = document,
 ): HTMLElement | null {
+  return findRenderedCanvasNodes(nodeId, root)[0]?.element ?? null
+}
+
+/** A rendered canvas node together with the breakpoint iframe hosting it. */
+export interface RenderedCanvasNode {
+  element: HTMLElement
+  frame: HTMLIFrameElement
+}
+
+/**
+ * Every canvas frame's rendered element for a node, in frame order — one per
+ * breakpoint frame that has mounted the node, paired with its hosting iframe
+ * (geometry callers need the frame for zoom/coordinate translation, and
+ * `defaultView.frameElement` is not reliable in every environment).
+ */
+export function findRenderedCanvasNodes(
+  nodeId: string,
+  root: Document = document,
+): RenderedCanvasNode[] {
   const selector = `[data-node-id="${escapeCssAttributeValue(nodeId)}"]`
+  const nodes: RenderedCanvasNode[] = []
   for (const frame of root.querySelectorAll('iframe')) {
     let frameDoc: Document | null
     try {
@@ -38,7 +58,7 @@ export function findRenderedCanvasNodeElement(
     }
     if (!frameDoc?.body?.hasAttribute('data-breakpoint-id')) continue
     const element = frameDoc.querySelector<HTMLElement>(selector)
-    if (element) return element
+    if (element) nodes.push({ element, frame })
   }
-  return null
+  return nodes
 }

--- a/src/admin/plugin-host-hooks/index.ts
+++ b/src/admin/plugin-host-hooks/index.ts
@@ -24,6 +24,8 @@
  */
 import { use, useEffect, useState } from 'react'
 import { useEditorStore as useHostEditorStore } from '@site/store/store'
+import { findRenderedCanvasNodes, type RenderedCanvasNode } from '@site/canvas/canvasNodeLookup'
+import { measureCanvasElementRect } from '@site/canvas/canvasOverlayGeometry'
 import type { EditorStore } from '@site/store/types'
 import type { PluginPermission } from '@core/plugin-sdk'
 import { PluginContext, type PluginContextValue } from './pluginContext'
@@ -158,31 +160,26 @@ function findCanvasOverlayLayer(): HTMLElement | null {
   return document.querySelector<HTMLElement>(`[${CANVAS_OVERLAY_LAYER_ATTRIBUTE}]`)
 }
 
-function findCanvasNodeElement(nodeId: string): HTMLElement | null {
+function findCanvasNode(nodeId: string): RenderedCanvasNode | null {
   if (typeof document === 'undefined') return null
-  // The canvas renders every node with `data-node-id="<id>"` (NodeRenderer.tsx).
-  // We escape via attribute-equals selector so node ids with special chars are
-  // safe.
-  const candidates = document.querySelectorAll<HTMLElement>(`[data-node-id="${cssEscape(nodeId)}"]`)
-  // Multiple matches happen when the same node id appears in more than one
-  // breakpoint frame. Return the first visible one — the host's selection
-  // overlay does the same thing.
+  // Canvas nodes render exclusively inside the per-breakpoint canvas iframes —
+  // the admin document's `data-node-id` carriers (layers-tree rows, overlay
+  // rings, import previews) are chrome, not the node. The node typically
+  // renders once per breakpoint frame; pick the first VISIBLE one, like the
+  // host's selection overlay does.
+  const candidates = findRenderedCanvasNodes(nodeId)
   for (const candidate of candidates) {
-    const rect = candidate.getBoundingClientRect()
+    const rect = candidate.element.getBoundingClientRect()
     if (rect.width > 0 || rect.height > 0) return candidate
   }
   return candidates[0] ?? null
 }
 
-function cssEscape(value: string): string {
-  // Avoid pulling in CSS.escape so this works in tests without a full DOM.
-  return value.replace(/"/g, '\\"')
-}
-
 /**
- * Live `CanvasNodeRect` for a rendered node. Updates on layout changes via
- * `ResizeObserver` and on canvas pan/zoom via the editor store's
- * `selectedNodeId` / `hoveredNodeId` / breakpoint subscription.
+ * Live `CanvasNodeRect` for a rendered node. Re-measured every animation
+ * frame while a node id is set (state only updates when the rect changes),
+ * which uniformly covers layout changes, canvas pan/zoom, and breakpoint
+ * frame remounts.
  *
  *   const rect = useCanvasNodeRect(useEditorStore((s) => s.selectedNodeId))
  *   if (!rect) return null
@@ -191,37 +188,32 @@ function cssEscape(value: string): string {
 export function useCanvasNodeRect(nodeId: string | null): CanvasNodeRect | null {
   const [rect, setRect] = useState<CanvasNodeRect | null>(null)
 
-  // Re-measure on every editor render (selection changes, breakpoint
-  // changes, store mutations) by depending on a tick that bumps with each
-  // editor-store emission. Uses the host's internal store hook directly —
-  // this exposes no editor state to the plugin (only DOM geometry), so it
-  // is not gated by `editor.store.read`.
-  const editorTick = useHostEditorStore((s) => s)
-  void editorTick
-
   useEffect(() => {
-    // The hook's whole purpose is to mirror DOM geometry into React state
-    // — the eslint react-hooks/set-state-in-effect rule expects effects to
-    // synchronize React → external, but `useCanvasNodeRect` synchronizes
-    // external → React. Disable for this hook only.
+    // External-system synchronization (DOM geometry → React state): the
+    // setState calls inside `measure` are the whole point of this hook.
     function measure() {
       if (!nodeId) {
         setRect((prev) => (prev === null ? prev : null))
         return
       }
       const layer = findCanvasOverlayLayer()
-      const node = findCanvasNodeElement(nodeId)
-      if (!layer || !node) {
+      const node = findCanvasNode(nodeId)
+      // The node lives inside a per-breakpoint canvas iframe; its rects are
+      // in the IFRAME's coordinate space. `measureCanvasElementRect` recovers
+      // the canvas zoom from the iframe element, translates into editor
+      // coordinates, and makes the result relative to the overlay layer.
+      const measured = node && layer
+        ? measureCanvasElementRect(node.element, node.frame, layer)
+        : null
+      if (!measured) {
         setRect((prev) => (prev === null ? prev : null))
         return
       }
-      const layerRect = layer.getBoundingClientRect()
-      const nodeRect = node.getBoundingClientRect()
       const next: CanvasNodeRect = {
-        top: nodeRect.top - layerRect.top,
-        left: nodeRect.left - layerRect.left,
-        width: nodeRect.width,
-        height: nodeRect.height,
+        top: measured.y,
+        left: measured.x,
+        width: measured.width,
+        height: measured.height,
       }
       setRect((prev) =>
         prev !== null
@@ -238,26 +230,21 @@ export function useCanvasNodeRect(nodeId: string | null): CanvasNodeRect | null 
 
     if (!nodeId) return undefined
 
-    // Track size changes on the node + layer with ResizeObserver. Track
-    // pan/zoom transforms via a window resize / scroll listener since the
-    // transform layer mutates style.transform directly without React
-    // re-renders.
-    const node = findCanvasNodeElement(nodeId)
-    const layer = findCanvasOverlayLayer()
-    const observer = typeof ResizeObserver !== 'undefined'
-      ? new ResizeObserver(() => measure())
-      : null
-    if (observer) {
-      if (node) observer.observe(node)
-      if (layer) observer.observe(layer)
+    // Re-measure every animation frame while mounted — the same pattern the
+    // host's selection rings use. ResizeObserver can't track elements inside
+    // the canvas iframes from this realm, and the transform layer mutates
+    // pan/zoom styles without React re-renders; a cheap rect read per frame
+    // (state only updates when the rect actually changes) covers layout,
+    // content, pan, zoom, and iframe remounts uniformly.
+    let frameHandle = 0
+    const tick = () => {
+      measure()
+      frameHandle = requestAnimationFrame(tick)
     }
-    window.addEventListener('resize', measure)
-    window.addEventListener('scroll', measure, true)
+    frameHandle = requestAnimationFrame(tick)
 
     return () => {
-      observer?.disconnect()
-      window.removeEventListener('resize', measure)
-      window.removeEventListener('scroll', measure, true)
+      cancelAnimationFrame(frameHandle)
     }
   }, [nodeId])
 


### PR DESCRIPTION
## Summary

The plugin SDK's `useCanvasNodeRect` resolved `data-node-id` in the **admin document** — where only chrome carries it (layers-tree rows, overlay rings, import previews) since the canvas moved to per-breakpoint iframes. The hook "worked" for *selected* nodes only by accidentally measuring the selection ring, and returned `null` (or a tree-row rect) for everything else.

- Resolution now goes through the canonical canvas lookup; new `findRenderedCanvasNodes` returns element+frame **pairs** (`defaultView.frameElement` is not reliable in every environment), preferring the first visible frame — same policy as the host's selection overlay.
- Rects translate from iframe-internal coordinates through the canvas zoom into overlay-layer-relative coordinates via `measureCanvasElementRect` — the same math the host's rings use. The hook's public contract (`CanvasNodeRect` relative to the overlay layer) is unchanged.
- `ResizeObserver` (which cannot watch elements inside the canvas iframes from the admin realm) is replaced with RAF polling + change-detection — the host overlay's own pattern — and the editor-store re-render hack is removed.

## Test plan
- New `useCanvasNodeRect` tests with stubbed geometry: zoom-translated overlay-relative measurement, admin-chrome shadowing regression (tree row / ring must never be measured), null cases
- Full suite: 5038 pass / 0 fail; build + lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)