### PR TITLE
perf: fix critical hot paths across publish pipeline, public serving, and editor store

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -218,7 +218,7 @@ Detailed: [`docs/reference/database-dialects.md`](docs/reference/database-dialec
 
 Detailed: [`docs/reference/page-tree.md`](docs/reference/page-tree.md). The rule:
 
-Every mutation in `src/core/page-tree/mutations.ts` takes a `NodeTree<TNode>` and is **tree-agnostic** — it knows nothing about pages vs. Visual Components. The only place that knows which tree is active is `mutateActiveTree(fn)` in `src/admin/pages/site/store/slices/site/`.
+Every mutation in `src/core/page-tree/mutations.ts` takes a `NodeTree<TNode>` and is **tree-agnostic** — it knows nothing about pages vs. Visual Components. The only place that knows which tree is active is `resolveActiveTreeTarget` in `src/admin/pages/site/store/slices/site/helpers.ts`, consumed through `mutateActiveTree(fn)`.
 
 The 11 named tree-mutation store actions (`insertNode`, `deleteNode`, `updateNodeProps`, `setBreakpointOverride`, `clearBreakpointOverride`, `renameNode`, `toggleNodeLocked`, `toggleNodeHidden`, `moveNode`, `duplicateNode`, `wrapNode`) are one-liners that call `mutateActiveTree`. They MUST NOT contain their own `kind === 'visualComponent'` routing branch — gated by `no-vc-mode-branches-in-mutations.test.ts`.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,7 @@ Instatic is a self-hosted CMS with a built-in visual editor. One Bun process ser
 - **One content model**: posts, pages, and visual components all live in `data_tables` + `data_rows`. No separate `pages` table. Page trees and VC trees both use the `NodeTree<TNode>` primitive.
 - **Two frontends, one bundle**: the admin app (`src/admin/`) shells the visual editor (`src/admin/pages/site/`). Both run in the same Vite-built SPA, mounted under `/admin/*`.
 - **Plugins run sandboxed**: server entrypoints and canvas module packs execute inside a QuickJS-WASM VM with no host access. They reach the CMS through the SDK at `src/core/plugin-sdk/`.
-- **One public-route surface, three publishing layers**: every visitor request for HTML — stand-alone pages and content rows alike — flows through `server/publish/publicRouter.ts:renderPublicResolution`. **Layer A** bakes fully-static pages to `uploads/published/current/<route>.html` at publish time via a two-slot symlink swap (atomic). **Layer B** is an in-memory LRU keyed by `(urlPath, queryString)` for dynamic routes — per-entry version tracking; bumps evict lazily on every publish, and version is captured at render start so mid-flight publishes discard results rather than caching stale HTML. **Layer C** auto-detects dynamic nodes (modules flagged `dynamic: true`, request-dependent bindings or loop sources, VC refs containing dynamic content) and emits `<instatic-hole>` placeholders that lazy-fetch their content via `/_instatic/hole/<nodeId>` using a ~668 B `IntersectionObserver` runtime. Authors don't toggle — `findDynamicNodeIds` in `src/core/publisher/dynamicDetection.ts` classifies automatically. The `PublishedPageSnapshot` (JSON) on `data_row_versions.snapshot_json` remains the canonical audit record. Output is plain semantic HTML + a single hashed CSS bundle per page, no framework runtime on the page.
+- **One public-route surface, three publishing layers**: every visitor request for HTML — stand-alone pages and content rows alike — flows through `server/publish/publicRouter.ts:renderPublicResolution`. **Layer A** bakes fully-static pages to `uploads/published/current/<route>.html` at publish time via a two-slot symlink swap (atomic). **Layer B** is an in-memory LRU keyed by `(urlPath, queryString)` for dynamic routes — per-entry version tracking; bumps evict lazily on every publish, and version is captured at render start so mid-flight publishes discard results rather than caching stale HTML. **Layer C** auto-detects dynamic nodes (modules flagged `dynamic: true`, request-dependent bindings or loop sources, VC refs containing dynamic content) and emits `<instatic-hole>` placeholders that lazy-fetch their content via `/_instatic/hole/<nodeId>` using a ~668 B `IntersectionObserver` runtime. Authors don't toggle — `findDynamicNodeIds` in `src/core/publisher/dynamicDetection.ts` classifies automatically. The published `SiteDocument` is stored once per publish in `site_snapshots`; page versions reference it via `data_row_versions.site_snapshot_id`, and the reassembled `PublishedPageSnapshot` remains the canonical audit record. Output is plain semantic HTML + a single hashed CSS bundle per page, no framework runtime on the page.
 - **Multi-instance HA on Postgres**: both schedulers (plugin tick + scheduled publish) share a leader-election primitive in `server/db/advisoryLock.ts` (`withSchedulerLeaderLock`) that wraps `pg_try_advisory_lock`, so running multiple containers behind a load balancer doesn't double-fire scheduled work. Each scheduler passes its own distinct lock key; on SQLite (single-instance by definition) the module returns a no-op sentinel.
 - **Every untyped boundary uses TypeBox.** HTTP responses, request bodies, persisted JSON, plugin manifests, settings. `zod` is banned repo-wide — drivers talk directly to each provider's REST API and pass TypeBox schemas through as JSON Schema; `zod` has been removed from `package.json`. Gated by `ai-driver-isolation.test.ts`.
 
@@ -215,13 +215,16 @@ Editor state (Zustand store)
     ▼
 publishDraftSite / publishDataRow      ← server/repositories/publish.ts
     │
-    │  1. write PublishedPageSnapshot to data_row_versions.snapshot_json
-    │  2. bake CSS bundles + runtime JS to the slot (writeStaticAsset)   ← Layer A
-    │  3. for each page (complete doc, or static shell with <instatic-hole>):
+    │  1. write the SiteDocument once to site_snapshots; each page's
+    │     data_row_versions row references it via site_snapshot_id
+    │  2. for each page (complete doc, or static shell with <instatic-hole>):
     │       render via publishPage + applyPublishedHtmlPipeline
     │       writeArtefact(<inactive slot>, urlPath, html)   ← Layer A
-    │  4. swapSlot — atomic symlink flip of uploads/published/current
-    │  5. bumpPublishVersion()  → invalidates Layer B cache
+    │  3. bake every published data-row route through its entry template
+    │       into the same slot (bakeDataRows.ts)            ← Layer A
+    │  4. bake CSS bundles + runtime JS to the slot (writeStaticAsset)
+    │  5. swapSlot — atomic symlink flip of uploads/published/current
+    │  6. bumpPublishVersion()  → invalidates Layer B cache
     │
     ▼
 visitor request → server/router.ts → tryServePublicRoute
@@ -235,11 +238,12 @@ visitor request → server/router.ts → tryServePublicRoute
     │     hit → stream HTML, 0.6–1.4 ms, no DB, no render
     │
     ├─ Layer B: in-memory LRU cache (live-render fallback)
-    │     resolvePublicRoute → page / row / redirect / not-found
-    │     redirects + not-founds bypass the cache
-    │     pages/rows: getOrRender(key + publishVersion)
-    │       miss → publishPage + applyPublishedHtmlPipeline
-    │       hit  → ~0.8 ms
+    │     warm peek FIRST: a version-matched cached 200 is served with zero
+    │       DB work (route retractions bump publishVersion, so this is safe)
+    │     miss → resolvePublicRoute → page / row / redirect / not-found
+    │       redirects + not-founds bypass the cache
+    │       pages/rows: getOrRender(key + publishVersion)
+    │         → publishPage + applyPublishedHtmlPipeline
     │       single-flight: concurrent identical keys → one factory call
     │     bumpPublishVersion() invalidates lazily on next read
     │
@@ -258,7 +262,7 @@ Key properties:
 - **Atomic publishing.** `uploads/published/current` is a symlink that targets either `slot-a/` or `slot-b/`. Full publishes build the inactive slot then atomic-rename the symlink — `rename(2)` of a symlink is a single-inode swap and is atomic across POSIX filesystems. There is no moment when `current` is missing or partially populated. In-flight readers that already resolved the old symlink hold file descriptors into the old slot — Unix semantics keep those files alive until they close. Incremental row publish (`publishDataRow`) writes a single file via tmp + rename into the active slot.
 - **Auto-detection is the seam.** `findDynamicNodeIds(page, site, registry)` is backed by the single walker that powers Layer A's shell-vs-complete decision and Layer C's placeholder emission. The detection rules — `dynamic: true` modules, request-dependent bindings, request-dependent loop sources, loop-body promotion, VC-ref recursion — live in exactly one file. Cannot drift between layers.
 - **`publish.html` runs at publish time** for static routes (baked into the disk artefact). For dynamic routes, the filter still fires inside the Layer B factory but caches the result so it runs at most once per `(url, querystring, publishVersion)` triple.
-- **Three layers, automatic routing.** Layer A bakes fully-static pages to disk at publish time (`uploads/published/current/<route>.html`, atomic two-slot symlink swap). Layer B is an in-memory LRU keyed by `(urlPath, queryString)` for dynamic routes — single-flight, lazily invalidated on publish; version is captured at render start so a publish landing mid-render discards the result rather than caching stale HTML. Layer C emits `<instatic-hole>` placeholders for nodes that auto-detect as request-dependent; a tiny client runtime lazy-loads each fragment via `IntersectionObserver`. The `PublishedPageSnapshot` (JSON) on `data_row_versions.snapshot_json` remains the canonical audit record from which all three layers derive.
+- **Three layers, automatic routing.** Layer A bakes fully-static pages to disk at publish time (`uploads/published/current/<route>.html`, atomic two-slot symlink swap). Layer B is an in-memory LRU keyed by `(urlPath, queryString)` for dynamic routes — single-flight, lazily invalidated on publish; version is captured at render start so a publish landing mid-render discards the result rather than caching stale HTML. Layer C emits `<instatic-hole>` placeholders for nodes that auto-detect as request-dependent; a tiny client runtime lazy-loads each fragment via `IntersectionObserver`. The published `SiteDocument` lives once per publish in `site_snapshots` (referenced by `data_row_versions.site_snapshot_id`); the reassembled `PublishedPageSnapshot` remains the canonical audit record from which all three layers derive.
 - **Pure render, no framework runtime on the page.** Published HTML is plain semantic HTML + CSS. Plugins can inject frontend assets (`server/publish/frontendInjections.ts`). The only first-party client script is the ~668 B Layer C hole runtime, and it's injected ONLY on pages that contain at least one `<instatic-hole>` — fully-static pages ship zero JS from us.
 - **Sanitization happens at the publisher boundary.** DOMPurify in `src/core/sanitize.ts` cleans rich-text, HTML strings, AND `staticPlaceholder` output before they're frozen into a snapshot or baked into a disk artefact. Browser code uses the browser DOM; the Bun server installs an explicit happy-dom-backed DOMPurify runtime from `server/richtextSanitizer.ts` without adding DOM globals. CSS property values are sanitised at the value level by `sanitiseCssValue` from `src/core/css-sanitize/` — a dependency-free leaf shared by both `@core/publisher` (every value emitted via `bagToCSS` / `bagToInlineStyle`) and `@core/framework` (every `:root {}` token variable), blocking `expression()`, `javascript:`, `{}` selector breakout, and `</` RAWTEXT escape.
 - **Visual components are inlined.** Each VC instance is expanded with its slot fills materialized as locked child nodes in the consumer page tree. The publisher pairs each `base.slot-instance` with the matching `base.slot-outlet` by `slotName`. A VC ref whose definition tree contains any dynamic node becomes a single `<instatic-hole>` at the ref boundary (the inner subtree renders inside the hole endpoint).

--- a/docs/features/content-storage.md
+++ b/docs/features/content-storage.md
@@ -212,15 +212,13 @@ PATCH /admin/api/cms/data/rows/:id  { status: 'published' }
 handlePublishRoute / publishDataRow
     │
     ├─→ load the row (with draft cells)
-    ├─→ freeze the current site shape into a `PublishedPageSnapshot` (JSON)
-    │     and write it to data_row_versions.snapshot_json
     ├─→ insert into data_row_versions with current cells + version_number = next
     ├─→ update row: status = 'published', published_at = now, published_by_user_id, etc.
     ├─→ if dependent pages reference this row (loops / queries), republish them
     └─→ emit publish.after hook
 ```
 
-The `PublishedPageSnapshot` in `data_row_versions.snapshot_json` is the canonical audit record. After it's written, the publisher routes through the three-layer pipeline:
+The published `SiteDocument` is stored ONCE per full publish in `site_snapshots` (with a content hash used by the publish-status check); each page's `data_row_versions` row references it via `site_snapshot_id` and carries only its page-scoped `runtime_assets_json`. Readers reassemble the `PublishedPageSnapshot` from the join — that snapshot is the canonical audit record. After it's written, the publisher routes through the three-layer pipeline:
 
 - **Layer A** — the publisher renders **every** page (for postType rows, the matched entry template), runs the full `applyPublishedHtmlPipeline`, and writes the final HTML to `uploads/published/<inactive-slot>/<route>.html` — a fully-static page bakes a complete document, a page with dynamic nodes bakes a static shell with `<instatic-hole>` placeholders. The CSS bundles + runtime JS are baked into the same slot. After all pages are written the symlink `current` atomic-flips to the new slot. Served entirely from disk — no DB for HTML/CSS/JS.
 - **Layer B** — the in-memory render cache evicts lazily via `bumpPublishVersion()`.

--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -382,17 +382,24 @@ publishDraftSite (server/repositories/publish.ts)
     │
     ├─→ load draft site shell + all page-table rows + all VC rows
     ├─→ build runtime scripts + runtime package importmap
-    ├─→ for each page: freeze into a PublishedPageSnapshot (JSON)
-    ├─→ insert into data_row_versions with snapshot_json = that snapshot
+    ├─→ write the SiteDocument ONCE into site_snapshots (content hash stamped
+    │     for the publish-status check); each page's data_row_versions row
+    │     references it via site_snapshot_id + carries its runtime_assets_json
     ├─→ flip data_rows.status = 'published', set active_version_id
-    │
-    ├─→ Layer A bake — CSS bundles + runtime JS → writeStaticAsset(<slot>)
     │
     ├─→ Layer A bake — every page (complete doc, or static shell with <instatic-hole>):
     │     ├── renderPublishedSnapshot(snapshot, { db, url, publishVersion }) → HTML
     │     ├── applyPublishedHtmlPipeline(rendered, db) → final HTML
     │     │   (plugin filters + frontend asset injection baked in)
     │     └── writeArtefact(<inactiveSlot>, urlPath, html)
+    │
+    ├─→ Layer A bake — every published data-row route (bakeDataRows.ts):
+    │     entry-template render through the same pipeline → writeArtefact
+    │     (without this, the slot swap would strand every row artefact)
+    │
+    ├─→ Layer A bake — CSS bundles + runtime JS → writeStaticAsset(<slot>)
+    │     (page-invariant CSS trio computed once per publish via the
+    │      version-keyed memo in siteCssBundle.ts; userStyles per page)
     │         (atomic per-file: tmp + rename; per-page try/catch)
     │
     ├─→ swapSlot(uploadsDir, newActiveSlot)
@@ -420,13 +427,20 @@ tryServePublicRoute (server/router.ts)
           │     hit → stream HTML (~0.6–1.4 ms, no DB, no render, no filter)
           │     (URLs with only junk params hit Layer A just like bare URLs)
           │
+          ├─→ Layer B peek (warm fast-path): a version-matched cached 200 for
+          │     (urlPath, canonicalQuery) is served immediately — zero DB work.
+          │     Safe because every route retraction (unpublish, soft-delete,
+          │     table move) bumps publishVersion, evicting the whole cache.
+          │
           ├─→ resolvePublicRoute(db, url) → page | row | redirect | not-found
           │     page slug hit skipped when page.template.enabled === true (template pages
           │     are never directly routable — falls through to row/redirect/not-found)
+          │     row resolutions read the site snapshot via the per-version memo
+          │     (publishedSnapshotCache.ts) — no per-request full-site parse
           │     redirects → 301 (not cached)
           │     not-found → null (router falls through to next handler)
           │
-          └─→ Layer B in-memory LRU:
+          └─→ Layer B in-memory LRU (miss path):
                 getOrRender({urlPath, queryString: canonicalQuery}, async () => {
                   publishPage(page, site, registry, options) using snapshot bytes
                   applyPublishedHtmlPipeline (plugin filters)
@@ -443,7 +457,7 @@ The visitor-facing artefacts are:
 2. **In-memory LRU entries** — for dynamic routes (loops, request-dependent bindings). Filled lazily, evicted on every publish.
 3. **`<instatic-hole>` fragment responses** at `/_instatic/hole/<nodeId>` — for dynamic nodes inside otherwise-cacheable pages. Fetched lazily by the IntersectionObserver runtime; also cached in Layer B.
 
-The `PublishedPageSnapshot` (JSON) in `data_row_versions.snapshot_json` remains the canonical audit record — all three layers derive from it.
+The published `SiteDocument` is stored once per publish in `site_snapshots` and referenced by `data_row_versions.site_snapshot_id`; the `PublishedPageSnapshot` reassembled from that join remains the canonical audit record — all three layers derive from it. At request time it is memoised per publish version (`server/publish/publishedSnapshotCache.ts`, shared by the public router's row resolution, the hole endpoint, and the loop endpoint), and `renderPublicResolution` serves a warm Layer B entry *before* any route resolution — a cache hit does zero DB work.
 
 ---
 

--- a/docs/reference/editor-history.md
+++ b/docs/reference/editor-history.md
@@ -108,15 +108,12 @@ All six helpers in `SiteSliceHelpers` delegate to `runHistoricMutation`:
 
 ## Coalescing
 
-Per-keystroke mutations (text edits, number sliders) pass a stable `coalesceKey` such as `props:<nodeId>:<prop>`. While the incoming key matches `_historyCoalesceKey`, `commitHistory` folds the new entry into the existing top entry:
+Per-keystroke mutations (text edits, number sliders) pass a stable `coalesceKey` such as `props:<nodeId>:<prop>`. While the incoming key matches `_historyCoalesceKey`, `commitHistory` folds the new entry into the existing top entry **per patch path** (`foldIntoCoalescedEntry` in `helpers.ts`):
 
-```ts
-// Fold: newest undo first, oldest redo first
-top.inverse = [...entry.inverse, ...top.inverse]
-top.forward = [...top.forward,   ...entry.forward]
-```
+- **inverse**: the OLDEST patch per path wins (undo restores the pre-burst value); new paths append.
+- **forward**: the NEWEST patch's value per path wins (redo replays the final value), preserving the oldest patch's op (an `add` stays an `add` so redo works from the post-undo state where the prop is absent).
 
-A whole typing burst becomes one undo step. Patch arrays for a text burst are tiny (one path per keystroke), so concatenation cost is negligible.
+A whole typing burst becomes one undo step holding at most one inverse + one forward patch per touched path — a 2,000-keystroke burst retains 2 paths' worth of patches, not 4,000 progressively-longer string snapshots.
 
 Any non-coalescing mutation, `undo`, `redo`, or a site (re)load resets `_historyCoalesceKey` to `null`.
 

--- a/docs/reference/page-tree.md
+++ b/docs/reference/page-tree.md
@@ -192,16 +192,16 @@ renameNode, toggleNodeLocked, toggleNodeHidden,
 moveNode, duplicateNode, wrapNode
 ```
 
-Every one of them is a **one-liner** that delegates to `mutateActiveTree(fn)` — the sole place that branches on page-mode vs. VC-mode:
+Every one of them is a **one-liner** that delegates to `mutateActiveTree(fn)`, which routes via `resolveActiveTreeTarget` — the sole implementation of the page-mode vs. VC-mode branch:
 
 ```ts
-// src/admin/pages/site/store/slices/site/ (canonical pattern)
+// src/admin/pages/site/store/slices/site/helpers.ts (canonical pattern)
+function resolveActiveTreeTarget(state): NodeTree<PageNode> {
+  // page mode → the active Page (Page IS NodeTree<PageNode>)
+  // VC mode   → the VC's tree (VCNode === BaseNode structurally)
+}
 function mutateActiveTree(fn: (tree: NodeTree<PageNode>) => void): void {
-  if (mode === 'page') {
-    fn(activePage)                              // Page IS NodeTree<PageNode>
-  } else {
-    fn(vc.tree as NodeTree<PageNode>)           // VCNode === BaseNode structurally
-  }
+  fn(resolveActiveTreeTarget(draft))
 }
 
 // All 11 actions follow this shape:

--- a/docs/server.md
+++ b/docs/server.md
@@ -15,7 +15,7 @@ The server is a single `Bun.serve` process that boots the DB, runs migrations, a
 - **DB:** one `DbClient` interface (`server/db/client.ts`) — tagged-template callable returning `{ rows, rowCount }`. Two adapters: `postgres.ts` (via `Bun.sql`) and `sqlite.ts` (via `bun:sqlite`). Selected by `DATABASE_URL`.
 - **Repositories** (`server/repositories/`) hold all SQL. Handlers never write SQL directly.
 - **Plugins:** `server/plugins/runtime.ts` activates installed plugins at boot; per-plugin code runs in QuickJS-WASM sandboxes (`server/plugins/quickjs/vm.ts`, `modulePackVm.ts`).
-- **Published pages and content rows** are served by `tryServePublicRoute`, which delegates resolution + render to `server/publish/publicRouter.ts` (live render from the JSON snapshot stored in `data_row_versions.snapshot_json`). Uploads + admin SPA assets are served from disk by `tryServeUpload` and `tryServeStaticAsset`.
+- **Published pages and content rows** are served by `tryServePublicRoute`, which delegates resolution + render to `server/publish/publicRouter.ts`. A warm Layer B cache entry is served before any DB work; on a miss the live render reads the published `SiteDocument` from `site_snapshots` (stored once per publish, referenced by `data_row_versions.site_snapshot_id`, memoised per publish version). Uploads + admin SPA assets are served from disk by `tryServeUpload` and `tryServeStaticAsset`.
 
 ---
 
@@ -468,11 +468,14 @@ Authors don't toggle anything. `src/core/publisher/dynamicDetection.ts:findDynam
                                 ↓
             publishDraftSite / publishDataRow
                                 │
-              ├── write PublishedPageSnapshot → data_row_versions.snapshot_json
-              ├── bake CSS bundles + runtime JS → writeStaticAsset(inactiveSlot)
+              ├── write SiteDocument once → site_snapshots
+              │     (page versions reference it via site_snapshot_id)
               ├── for each page (complete doc, or static shell with <instatic-hole>):
               │     publishPage + applyPublishedHtmlPipeline
               │     writeArtefact(inactiveSlot, urlPath, html)
+              ├── bake every published data-row route into the same slot
+              │     (bakeDataRows.ts — entry-template render, same pipeline)
+              ├── bake CSS bundles + runtime JS → writeStaticAsset(inactiveSlot)
               ├── swapSlot — atomic symlink rename of uploads/published/current
               └── bumpPublishVersion() — Layer B cache evicts lazily
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "bench": "bun run scripts/bench/index.ts",
     "bench:bundle": "bun run scripts/bench/index.ts --only=bundle",
     "bench:publisher": "bun run scripts/bench/index.ts --only=publisher",
+    "bench:publish": "bun run scripts/bench/index.ts --only=publish",
     "bench:editor-store": "bun run scripts/bench/index.ts --only=editor-store",
     "bench:http": "bun run scripts/bench/index.ts --only=http",
     "bench:db": "bun run scripts/bench/index.ts --only=db",

--- a/scripts/bench/README.md
+++ b/scripts/bench/README.md
@@ -1,6 +1,6 @@
 # Benchmark suite
 
-A reusable performance suite for the instatic. Spans both ends of the stack: bundle composition, publisher render speed, the editor store under class/tree stress, HTTP latency + throughput, SQLite performance, plugin sandbox cost, repo footprint, and code-health snapshot.
+A reusable performance suite for the instatic. Spans both ends of the stack: bundle composition, publisher render speed, the full publish pipeline + public serving, the editor store under class/tree stress, HTTP latency + throughput, SQLite performance, plugin sandbox cost, repo footprint, and code-health snapshot.
 
 Everything writes to `.tmp/benchmarks/` (gitignored). One run produces a single `REPORT.md` plus per-bench logs.
 
@@ -19,6 +19,7 @@ The orchestrator writes `.tmp/benchmarks/REPORT.md` and prints a one-line summar
 ```bash
 bun run bench:bundle        # just dist/ composition
 bun run bench:publisher     # just the page-tree → HTML pipeline
+bun run bench:publish       # full publish pipeline + public serving (DB-backed)
 bun run bench:editor-store  # editor store mutations + class system stress
 bun run bench:http          # HTTP latency + throughput (auto starts a server)
 bun run bench:db            # SQLite performance
@@ -71,12 +72,25 @@ Drives `publishPage()` (the core page-tree → HTML/CSS function) against synthe
 
 This is the *user-facing output speed* — what visitors will see.
 
+### publish
+Exercises the FULL publish pipeline and the public serving path against an isolated SQLite DB (the same migrations the production server runs), seeded through the real repositories (`saveDraftSite` + `createDataRow`). Each scenario reports an `unavailable: <reason>` row instead of crashing the suite when seeding fails. Scenarios:
+- **Full publish wall time scaling** — `publishDraftSite` over N draft pages of ~150 nodes each (10 / 40; quick 5 / 15), including the snapshot bake and the Layer A artefact write to a tmp uploads dir. Also reports the on-disk SQLite growth (main + WAL) per publish — the snapshot storage amplification.
+- **Publish status check** — `getDraftPublishStatus` on the published site: the draft-vs-published comparison the admin UI polls.
+- **Warm dynamic-route serving** — repeated `renderPublicResolution` for one published page WITHOUT an uploadsDir, forcing the dynamic path (route resolution + the module-level Layer B LRU). The first call warms the cache; the timed calls are real warm hits.
+- **404 probe cost** — `renderPublicResolution` on a missing path plus `getSetupStatus`, modelling what the router pays per unmatched GET.
+- **Published row-route lookup** — `getPublishedDataRowByRoute` against a data table with 10,000 published rows (quick 2,000), each with an active version. Sensitive to indexing on the versions join.
+
+Where the `publisher` bench measures the pure render function, this bench measures the whole DB-backed publish + serve lifecycle.
+
 ### editor-store
 Drives the live Zustand store. **This is the "is the builder laggy at scale?" bench.** Scenarios:
 - **Class creation scaling:** `createClass()` 100 → 100,000 times. Per-op p95 should stay flat — climbing means linear scans somewhere in the slice.
 - **Class lookup throughput:** `site.classes[id]` random reads. Floor below which any class-related UI rendering must live.
 - **Node tree mutations:** `insertNode` / `deleteNode` at 100 / 1k / 5k / 10k node trees.
 - **Node-class assignment with huge catalogues:** `addNodeClass` when there are 100k classes defined.
+- **Multi-delete:** ONE `deleteNodes(ids)` call removing 500 ids (quick 100) spread across all depths of a 10k-node tree (quick 2k), repeated on 3 fresh trees. The canvas multi-select → Delete path.
+- **VC-mode keystroke sweep:** per-keystroke `updateNodeProps` on a text node inside a Visual Component while the site holds 20 pages × 500 nodes (quick 5 × 200). Every VC-mode mutation re-syncs slot instances across all consumer trees, so this answers "does typing inside a VC scale with total site size?".
+- **Undo coalescing burst:** a 2,000-keystroke (quick 300) single-prop typing burst on one text node — the Properties-panel path, which folds the whole burst into one undo entry. Reports per-op p95 plus the JSON size of the retained `_historyPast` stack after the burst.
 
 If the numbers stay reasonable here, any actual UI lag is a rendering problem, not a state problem.
 
@@ -176,6 +190,7 @@ scripts/bench/
   benches/
     bundle.ts                 ← Dist composition
     publisher.ts              ← Page-tree → HTML pipeline
+    publish.ts                ← Full publish pipeline + public serving (DB-backed)
     editor-store.ts           ← Class & tree mutation stress
     http.ts                   ← Network latency + throughput
     db.ts                     ← SQLite performance

--- a/scripts/bench/benches/editor-store.ts
+++ b/scripts/bench/benches/editor-store.ts
@@ -12,6 +12,11 @@
  *   - Node insertion / deletion / movement at 100 / 1k / 10k node trees
  *   - History push (undo stack growth) and memory bookkeeping
  *   - Node-class assignment with huge class catalogues
+ *   - Multi-delete: one `deleteNodes(ids)` batch on a large tree
+ *   - VC-mode keystroke sweep: `updateNodeProps` on a Visual Component text
+ *     node while the site holds many pages (slot-sync propagation cost)
+ *   - Undo coalescing burst: a long single-prop typing burst and the memory
+ *     the history stack retains afterwards
  *
  * The user-facing question this answers:
  *   "If I add 10,000 CSS classes, does the builder start dropping frames?"
@@ -67,6 +72,86 @@ function estimateSiteHeap(useStore: Awaited<ReturnType<typeof loadStore>>): numb
   } catch {
     return -1
   }
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic site assembly — used by the multi-delete and VC-mode scenarios to
+// hydrate a large document through the public `loadSite` action instead of
+// paying N insertNode round-trips per node.
+// ---------------------------------------------------------------------------
+
+interface StoreNode {
+  id: string
+  moduleId: string
+  props: Record<string, unknown>
+  breakpointOverrides: Record<string, unknown>
+  children: string[]
+  classIds: string[]
+}
+
+interface StorePage {
+  id: string
+  slug: string
+  title: string
+  nodes: Record<string, StoreNode>
+  rootNodeId: string
+}
+
+/**
+ * Build a ~`target`-node page (base.body root, base.container / base.text
+ * children, 4 children per parent) — same synthetic shape the publisher bench
+ * uses. Node ids are minted in BFS order, so an even-stride pick over
+ * `Object.keys(nodes)` selects nodes across the whole depth range.
+ */
+function buildStorePage(prefix: string, slug: string, target: number): StorePage {
+  const nodes: Record<string, StoreNode> = {}
+  const rootId = `${prefix}-n0`
+  nodes[rootId] = { id: rootId, moduleId: 'base.body', props: {}, breakpointOverrides: {}, children: [], classIds: [] }
+  let counter = 1
+  const queue: string[] = [rootId]
+  while (counter < target && queue.length > 0) {
+    const parentId = queue.shift()!
+    const childCount = Math.min(4, target - counter)
+    const kids: string[] = []
+    for (let i = 0; i < childCount; i++) {
+      const childId = `${prefix}-n${counter++}`
+      const isContainer = i < 2
+      nodes[childId] = {
+        id: childId,
+        moduleId: isContainer ? 'base.container' : 'base.text',
+        props: isContainer ? { tag: 'div' } : { text: `node ${childId}`, tag: 'p' },
+        breakpointOverrides: {},
+        children: [],
+        classIds: [],
+      }
+      if (isContainer) queue.push(childId)
+      kids.push(childId)
+    }
+    nodes[parentId].children = kids
+  }
+  return { id: `${prefix}-page`, slug, title: `Bench ${prefix}`, nodes, rootNodeId: rootId }
+}
+
+/**
+ * Hydrate the store with a synthetic multi-page document: clone the default
+ * site that `createSite` mints (keeps settings/framework/runtime canonical),
+ * swap in the synthetic pages, and load it through the public `loadSite`
+ * action — which reindexes parents and resets history exactly like a real
+ * site load.
+ */
+function loadSyntheticSite(useStore: Awaited<ReturnType<typeof loadStore>>, pages: StorePage[]): void {
+  setupSite(useStore)
+  const baseSite = (useStore.getState() as { site: object | null }).site
+  if (!baseSite) throw new Error('createSite produced no site — store layout has changed; update editor-store bench.')
+  const clone = structuredClone(baseSite) as { pages: StorePage[] }
+  clone.pages = pages
+  const state = useStore.getState() as { loadSite: (site: unknown) => void }
+  state.loadSite(clone)
+}
+
+function unavailableRow(label: string, err: unknown): BenchRow {
+  const message = err instanceof Error ? err.message : String(err)
+  return { label, metrics: { status: `unavailable: ${message}` } }
 }
 
 interface ClassResults {
@@ -304,6 +389,138 @@ export const editorStoreBench: BenchModule = {
       }
     }
 
+    // ---- Multi-delete -----------------------------------------------------
+    log.step('Multi-delete (one deleteNodes batch)')
+    const multiDeleteRows: BenchRow[] = []
+    {
+      const TREE = ctx.quick ? 2_000 : 10_000
+      const PICK = ctx.quick ? 100 : 500
+      const RUNS = 3
+      try {
+        const totals: number[] = []
+        for (let run = 0; run < RUNS; run++) {
+          const page = buildStorePage(`md${run}`, 'index', TREE)
+          loadSyntheticSite(useStore, [page])
+          // Even-stride pick over BFS-ordered ids → selection spans all depths.
+          const candidates = Object.keys(page.nodes).filter((id) => id !== page.rootNodeId)
+          const ids: string[] = []
+          for (let i = 0; i < PICK; i++) {
+            ids.push(candidates[Math.floor((i * candidates.length) / PICK)])
+          }
+          const state = useStore.getState() as { deleteNodes: (nodeIds: string[]) => void }
+          const t0 = performance.now()
+          state.deleteNodes(ids)
+          totals.push(performance.now() - t0)
+          log.detail(`    run ${run + 1}/${RUNS}: ${fmtMs(totals[totals.length - 1])}`)
+        }
+        const s = summarize(totals)
+        multiDeleteRows.push({
+          label: `delete ${fmtNum(PICK)} of ${fmtNum(TREE)} nodes`,
+          inputs: { tree_nodes: TREE, deleted_ids: PICK, runs: RUNS },
+          metrics: {
+            mean_total: fmtMs(s.mean),
+            min: fmtMs(s.min),
+            max: fmtMs(s.max),
+            mean_per_id: fmtMs(s.mean / PICK),
+          },
+        })
+      } catch (err) {
+        multiDeleteRows.push(unavailableRow(`delete ${fmtNum(PICK)} of ${fmtNum(TREE)} nodes`, err))
+      }
+    }
+
+    // ---- VC-mode keystroke sweep -------------------------------------------
+    log.step('VC-mode keystroke sweep (updateNodeProps on a Visual Component)')
+    const vcSweepRows: BenchRow[] = []
+    {
+      const PAGES = ctx.quick ? 5 : 20
+      const NODES = ctx.quick ? 200 : 500
+      const ITERS = ctx.quick ? 50 : 200
+      try {
+        const pages = Array.from({ length: PAGES }, (_, i) =>
+          buildStorePage(`vcp${i}`, i === 0 ? 'index' : `vc-page-${i}`, NODES),
+        )
+        loadSyntheticSite(useStore, pages)
+        const state = useStore.getState() as {
+          createVisualComponent: (name: string) => string
+          setActiveDocument: (doc: { kind: 'visualComponent'; vcId: string }) => void
+          insertNode: (moduleId: string, defaults: Record<string, unknown>, parentId: string) => string
+          updateNodeProps: (nodeId: string, patch: Record<string, unknown>) => void
+        }
+        const vcId = state.createVisualComponent('Bench VC')
+        state.setActiveDocument({ kind: 'visualComponent', vcId })
+        const vc = (useStore.getState() as {
+          site: { visualComponents: Array<{ id: string; tree: { rootNodeId: string } }> }
+        }).site.visualComponents.find((v) => v.id === vcId)
+        if (!vc) throw new Error('createVisualComponent did not register the VC in site.visualComponents')
+        // insertNode routes through mutateActiveTree → VC mode, so the text
+        // node lands in the VC's own tree.
+        const textNodeId = state.insertNode('base.text', { text: 'seed', tag: 'p' }, vc.tree.rootNodeId)
+        if (!textNodeId) throw new Error('insertNode into the VC tree returned no id')
+        const samples: number[] = []
+        for (let i = 0; i < ITERS; i++) {
+          const t0 = performance.now()
+          state.updateNodeProps(textNodeId, { text: 'x'.repeat(i + 1) })
+          samples.push(performance.now() - t0)
+        }
+        const s = summarize(samples)
+        vcSweepRows.push({
+          label: `${fmtNum(ITERS)} keystrokes, ${fmtNum(PAGES)} pages × ${fmtNum(NODES)} nodes`,
+          inputs: { pages: PAGES, nodes_per_page: NODES, keystrokes: ITERS },
+          metrics: {
+            mean_per_op: fmtMs(s.mean),
+            p95: fmtMs(s.p95),
+            throughput: `${fmtNum(Math.floor(1000 / s.mean))} ops/s`,
+          },
+        })
+        log.detail(`    per-op mean=${fmtMs(s.mean)} p95=${fmtMs(s.p95)}`)
+      } catch (err) {
+        vcSweepRows.push(unavailableRow(`${fmtNum(ITERS)} keystrokes, ${fmtNum(PAGES)} pages × ${fmtNum(NODES)} nodes`, err))
+      }
+    }
+
+    // ---- Undo coalescing burst ----------------------------------------------
+    log.step('Undo coalescing burst (single-prop typing burst + retained history)')
+    const coalesceRows: BenchRow[] = []
+    {
+      const KEYS = ctx.quick ? 300 : 2_000
+      try {
+        setupSite(useStore)
+        const page = readActivePage(useStore)
+        if (!page) throw new Error('No active page after createSite — store layout has changed; update editor-store bench.')
+        const state = useStore.getState() as {
+          insertNode: (moduleId: string, defaults: Record<string, unknown>, parentId: string) => string
+          updateNodeProps: (nodeId: string, patch: Record<string, unknown>) => void
+        }
+        const textNodeId = state.insertNode('base.text', { text: '', tag: 'p' }, page.rootNodeId)
+        // A single-key patch is exactly what the Properties panel sends per
+        // keystroke — `updateNodeProps` derives the `props:<nodeId>:text`
+        // coalesce key from it, so the whole burst folds into ONE undo entry.
+        const samples: number[] = []
+        for (let i = 0; i < KEYS; i++) {
+          const t0 = performance.now()
+          state.updateNodeProps(textNodeId, { text: 'x'.repeat(i + 1) })
+          samples.push(performance.now() - t0)
+        }
+        const s = summarize(samples)
+        const past = (useStore.getState() as { _historyPast: unknown[] })._historyPast
+        const historyBytes = JSON.stringify(past).length
+        coalesceRows.push({
+          label: `${fmtNum(KEYS)}-keystroke burst on one text node`,
+          inputs: { keystrokes: KEYS },
+          metrics: {
+            mean_per_op: fmtMs(s.mean),
+            p95_per_op: fmtMs(s.p95),
+            history_entries: fmtNum(past.length),
+            history_bytes: fmtBytes(historyBytes),
+          },
+        })
+        log.detail(`    per-op p95=${fmtMs(s.p95)} history=${fmtNum(past.length)} entries, ${fmtBytes(historyBytes)}`)
+      } catch (err) {
+        coalesceRows.push(unavailableRow(`${fmtNum(KEYS)}-keystroke burst on one text node`, err))
+      }
+    }
+
     // Headline picks the worst-case class creation so it's visible if it
     // ever becomes bad. The other slots pull whatever the largest tree /
     // lookup test we ran was (covers both quick and full modes).
@@ -311,6 +528,8 @@ export const editorStoreBench: BenchModule = {
     const worstClassP95 = lastResult ? fmtMs(lastResult.perCreateP95) : '—'
     const largestTreeRow = treeRows[treeRows.length - 1]
     const largestLookupRow = lookupRows[lookupRows.length - 1]
+    const multiDeleteRow = multiDeleteRows[0]
+    const vcSweepRow = vcSweepRows[0]
     return {
       name: this.name,
       title: this.title,
@@ -318,6 +537,8 @@ export const editorStoreBench: BenchModule = {
         [`createClass p95 @ ${fmtNum(worstClassN)} classes`]: worstClassP95,
         [`${largestTreeRow?.label ?? 'tree'} insert mean`]: largestTreeRow?.metrics.insert_mean_per_op ?? '—',
         [`${largestLookupRow?.label ?? 'lookup'} ns/op`]: largestLookupRow?.metrics.ns_per_lookup ?? '—',
+        [`multi-${multiDeleteRow?.label ?? 'delete'}`]: multiDeleteRow?.metrics.mean_total ?? '—',
+        [`VC sweep ${vcSweepRow?.label ?? ''} mean`]: vcSweepRow?.metrics.mean_per_op ?? '—',
       },
       sections: [
         {
@@ -342,6 +563,24 @@ export const editorStoreBench: BenchModule = {
           intro:
             'Assigning class IDs to a single node when the site already has N classes defined. Tests whether classlist append is sensitive to catalogue size.',
           rows: assignRows,
+        },
+        {
+          title: 'Multi-delete',
+          intro:
+            'ONE `deleteNodes(ids)` call removing hundreds of ids (spread across all depths) from a large tree, repeated on fresh trees. This is the canvas multi-select → Delete path; it pays per-id depth ordering plus subtree removal in one undo step.',
+          rows: multiDeleteRows,
+        },
+        {
+          title: 'VC-mode keystroke sweep',
+          intro:
+            'Per-keystroke `updateNodeProps` on a text node inside a Visual Component while the site holds many pages. Every VC-mode mutation re-syncs slot instances across all consumer trees, so this measures whether typing inside a VC scales with total site size.',
+          rows: vcSweepRows,
+        },
+        {
+          title: 'Undo coalescing burst',
+          intro:
+            'A long single-prop typing burst on one text node — the Properties-panel per-keystroke path, which coalesces into a single undo entry. `history_bytes` is the JSON size of the retained `_historyPast` stack after the burst: what one typing session keeps pinned in memory.',
+          rows: coalesceRows,
         },
       ],
     }

--- a/scripts/bench/benches/publish.ts
+++ b/scripts/bench/benches/publish.ts
@@ -1,0 +1,474 @@
+/**
+ * Publish pipeline & public serving benchmark.
+ *
+ * Exercises the FULL publish path against an isolated SQLite DB seeded
+ * through the real repositories — `saveDraftSite` + `createDataRow` for the
+ * draft, `publishDraftSite` for the snapshot bake — and then the public
+ * serving path through `renderPublicResolution` exactly as the visitor
+ * router invokes it. Everything goes through stable public APIs so the same
+ * bench code measures before AND after pipeline optimizations.
+ *
+ * Scenarios:
+ *   - Full publish wall time at N draft pages (~150 nodes each), plus the
+ *     SQLite file growth per publish — the snapshot storage amplification.
+ *   - `getDraftPublishStatus` cost on a published site (draft-vs-published
+ *     comparison the admin UI polls).
+ *   - Warm dynamic-route serving: `renderPublicResolution` WITHOUT an
+ *     uploadsDir, so Layer A is skipped and the request exercises route
+ *     resolution + the Layer B LRU. The cache and publishState are
+ *     module-level, so warm hits here are the real warm path.
+ *   - 404 probe: `renderPublicResolution` on a missing path plus
+ *     `getSetupStatus` — what the router pays per unmatched GET.
+ *   - Published row-route lookup: `getPublishedDataRowByRoute` against a
+ *     table with 10k published rows (the `/posts/<slug>` resolution cost).
+ *
+ * Every scenario is wrapped so a seeding/publish failure reports an
+ * `unavailable` row instead of crashing the suite.
+ */
+import { resolve } from 'node:path'
+import { mkdirSync, existsSync, unlinkSync, rmSync, statSync } from 'node:fs'
+import { performance } from 'node:perf_hooks'
+import type { Page, SiteShell } from '../../../src/core/page-tree'
+import type { BenchModule, BenchResult, BenchRow, BenchContext } from '../lib/types'
+import { summarize, fmtMs, fmtBytes, fmtNum } from '../lib/stats'
+import { log } from '../lib/log'
+
+const REPO_ROOT = resolve(import.meta.dir, '../../..')
+const BENCH_DIR = resolve(REPO_ROOT, '.tmp/benchmarks')
+const ADMIN_USER_ID = 'bench-admin'
+const NODES_PER_PAGE = 150
+
+// Lazy imports — keep cold startup fast when this bench is skipped.
+async function loadServer() {
+  // Side effect — registers base modules so the publish renderer finds them.
+  await import('../../../src/modules/base')
+  const { createSqliteClient } = await import('../../../server/db/sqlite')
+  const { runMigrations } = await import('../../../server/db/runMigrations')
+  const { sqliteMigrations } = await import('../../../server/db/migrations-sqlite')
+  const { saveDraftSite } = await import('../../../server/repositories/site')
+  const { publishDraftSite, getDraftPublishStatus } = await import('../../../server/repositories/publish')
+  const { createDataRow } = await import('../../../server/repositories/data')
+  const { getPublishedDataRowByRoute } = await import('../../../server/repositories/data/publish')
+  const { getSetupStatus } = await import('../../../server/repositories/setup')
+  const { renderPublicResolution } = await import('../../../server/publish/publicRouter')
+  const { pageToCells } = await import('../../../src/core/data/pageFromRow')
+  const { normalizeSiteRuntimeConfig } = await import('../../../src/core/site-runtime')
+  return {
+    createSqliteClient,
+    runMigrations,
+    sqliteMigrations,
+    saveDraftSite,
+    publishDraftSite,
+    getDraftPublishStatus,
+    createDataRow,
+    getPublishedDataRowByRoute,
+    getSetupStatus,
+    renderPublicResolution,
+    pageToCells,
+    normalizeSiteRuntimeConfig,
+  }
+}
+
+type ServerApi = Awaited<ReturnType<typeof loadServer>>
+type Db = ReturnType<ServerApi['createSqliteClient']>
+
+// ---------------------------------------------------------------------------
+// DB lifecycle helpers (mirrors benches/db.ts)
+// ---------------------------------------------------------------------------
+
+async function freshDb(api: ServerApi, label: string): Promise<{ db: Db; path: string }> {
+  mkdirSync(BENCH_DIR, { recursive: true })
+  const path = resolve(BENCH_DIR, `publish-bench-${label}-${Date.now()}.db`)
+  cleanupDbFiles(path)
+  const db = api.createSqliteClient(path)
+  await api.runMigrations(db, api.sqliteMigrations)
+  return { db, path }
+}
+
+/** Total on-disk bytes of the SQLite database (main file + WAL + SHM). */
+function dbBytes(path: string): number {
+  let total = 0
+  for (const file of [path, `${path}-wal`, `${path}-shm`]) {
+    if (existsSync(file)) total += statSync(file).size
+  }
+  return total
+}
+
+function cleanupDbFiles(path: string): void {
+  for (const file of [path, `${path}-wal`, `${path}-shm`]) {
+    try {
+      if (existsSync(file)) unlinkSync(file)
+    } catch {
+      // best-effort cleanup
+    }
+  }
+}
+
+function unavailableRow(label: string, err: unknown): BenchRow {
+  const message = err instanceof Error ? err.message : String(err)
+  return { label, metrics: { status: `unavailable: ${message}` } }
+}
+
+// ---------------------------------------------------------------------------
+// Draft-site seeding through the real repositories
+// ---------------------------------------------------------------------------
+
+function makeShell(api: ServerApi): SiteShell {
+  return {
+    id: 'site-bench',
+    name: 'Publish Bench Site',
+    files: [],
+    packageJson: { dependencies: {}, devDependencies: {} },
+    runtime: api.normalizeSiteRuntimeConfig(undefined),
+    breakpoints: [{ id: 'desktop', label: 'Desktop', width: 1440, icon: 'monitor' }],
+    settings: { shortcuts: {} } as SiteShell['settings'],
+    styleRules: {},
+    createdAt: 1000,
+    updatedAt: 2000,
+  }
+}
+
+/**
+ * Build a ~`target`-node page tree (base.body root, base.container /
+ * base.text children) — same synthetic shape as benches/publisher.ts.
+ */
+function makeBenchPage(index: number, target: number): Page {
+  const nodes: Page['nodes'] = {}
+  const rootId = `p${index}-n0`
+  nodes[rootId] = {
+    id: rootId,
+    moduleId: 'base.body',
+    props: {},
+    breakpointOverrides: {},
+    children: [],
+    classIds: [],
+  }
+  let counter = 1
+  const queue: string[] = [rootId]
+  while (counter < target && queue.length > 0) {
+    const parentId = queue.shift()!
+    const childCount = Math.min(4, target - counter)
+    const kids: string[] = []
+    for (let i = 0; i < childCount; i++) {
+      const childId = `p${index}-n${counter++}`
+      const isContainer = i < 2
+      nodes[childId] = {
+        id: childId,
+        moduleId: isContainer ? 'base.container' : 'base.text',
+        props: isContainer
+          ? { tag: 'div' }
+          : { text: `Lorem ipsum dolor sit amet — node ${childId}`, tag: 'p' },
+        breakpointOverrides: {},
+        children: [],
+        classIds: [],
+      }
+      if (isContainer) queue.push(childId)
+      kids.push(childId)
+    }
+    nodes[parentId] = { ...nodes[parentId], children: kids }
+  }
+  return {
+    id: `bench-page-${index}`,
+    slug: index === 0 ? 'index' : `page-${index}`,
+    title: `Bench page ${index}`,
+    nodes,
+    rootNodeId: rootId,
+  }
+}
+
+/** Seed an owner user + site shell + N draft pages via the real repositories. */
+async function seedDraftSite(api: ServerApi, db: Db, pageCount: number): Promise<void> {
+  await db`
+    insert into users (id, email, email_normalized, display_name, password_hash, role_id)
+    values (${ADMIN_USER_ID}, 'bench@example.com', 'bench@example.com', 'Bench Admin', 'bench-hash', 'owner')
+  `
+  await api.saveDraftSite(db, makeShell(api))
+  for (let i = 0; i < pageCount; i++) {
+    const page = makeBenchPage(i, NODES_PER_PAGE)
+    await api.createDataRow(
+      db,
+      { id: page.id, tableId: 'pages', cells: api.pageToCells(page), slug: page.slug },
+      ADMIN_USER_ID,
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Bench module
+// ---------------------------------------------------------------------------
+
+export const publishBench: BenchModule = {
+  name: 'publish',
+  title: 'Publish pipeline & public serving',
+  description: 'Full publishDraftSite wall time + DB growth, publish status check, warm dynamic serving, 404 probe, row-route lookup.',
+
+  async run(ctx: BenchContext): Promise<BenchResult> {
+    const api = await loadServer()
+
+    // ---- Full publish wall time scaling ---------------------------------
+    log.step('Full publish wall time scaling')
+    const publishRows: BenchRow[] = []
+    // The largest-N DB is kept alive for the status / warm-serving / 404
+    // scenarios below (they must run against a real published site).
+    let published: { db: Db; path: string; uploadsDir: string; pageCount: number } | null = null
+    const pageCounts = ctx.quick ? [5, 15] : [10, 40]
+    for (const n of pageCounts) {
+      const isLast = n === pageCounts[pageCounts.length - 1]
+      const uploadsDir = resolve(BENCH_DIR, `publish-bench-uploads-${n}-${Date.now()}`)
+      let fresh: { db: Db; path: string } | null = null
+      try {
+        fresh = await freshDb(api, `pages-${n}`)
+        await seedDraftSite(api, fresh.db, n)
+        const bytesBefore = dbBytes(fresh.path)
+        log.step(`  publishing ${fmtNum(n)} pages × ~${NODES_PER_PAGE} nodes…`)
+        const t0 = performance.now()
+        const result = await api.publishDraftSite(fresh.db, ADMIN_USER_ID, uploadsDir)
+        const wallMs = performance.now() - t0
+        const growth = dbBytes(fresh.path) - bytesBefore
+        if (result.publishedPages !== n) {
+          throw new Error(`expected ${n} published pages, got ${result.publishedPages}`)
+        }
+        publishRows.push({
+          label: `${fmtNum(n)} pages × ~${NODES_PER_PAGE} nodes`,
+          inputs: { pages: n, nodes_per_page: NODES_PER_PAGE },
+          metrics: {
+            wall: fmtMs(wallMs),
+            per_page: fmtMs(wallMs / n),
+            db_growth: fmtBytes(Math.max(0, growth)),
+            db_growth_per_page: fmtBytes(Math.max(0, Math.floor(growth / n))),
+          },
+        })
+        log.detail(`    wall=${fmtMs(wallMs)} db_growth=${fmtBytes(Math.max(0, growth))}`)
+        if (isLast) {
+          published = { db: fresh.db, path: fresh.path, uploadsDir, pageCount: n }
+        } else {
+          cleanupDbFiles(fresh.path)
+          rmSync(uploadsDir, { recursive: true, force: true })
+        }
+      } catch (err) {
+        publishRows.push(unavailableRow(`${fmtNum(n)} pages × ~${NODES_PER_PAGE} nodes`, err))
+        if (fresh) cleanupDbFiles(fresh.path)
+        rmSync(uploadsDir, { recursive: true, force: true })
+      }
+    }
+
+    try {
+      // ---- Publish status check ------------------------------------------
+      log.step('Publish status check (getDraftPublishStatus)')
+      const statusRows: BenchRow[] = []
+      if (published) {
+        try {
+          const iters = ctx.quick ? 5 : 20
+          const samples: number[] = []
+          for (let i = 0; i < iters; i++) {
+            const t0 = performance.now()
+            const status = await api.getDraftPublishStatus(published.db)
+            samples.push(performance.now() - t0)
+            if (status.publishedPages !== published.pageCount) {
+              throw new Error(`status reported ${status.publishedPages} published pages, expected ${published.pageCount}`)
+            }
+          }
+          const s = summarize(samples)
+          statusRows.push({
+            label: `${fmtNum(published.pageCount)} published pages`,
+            inputs: { pages: published.pageCount, iters },
+            metrics: { mean: fmtMs(s.mean), p95: fmtMs(s.p95), max: fmtMs(s.max) },
+          })
+        } catch (err) {
+          statusRows.push(unavailableRow('publish status check', err))
+        }
+      } else {
+        statusRows.push(unavailableRow('publish status check', new Error('publish scenario did not complete')))
+      }
+
+      // ---- Warm dynamic-route serving --------------------------------------
+      log.step('Warm dynamic-route serving (renderPublicResolution, no uploadsDir)')
+      const warmRows: BenchRow[] = []
+      if (published) {
+        try {
+          // No uploadsDir → Layer A is skipped; the request resolves the route
+          // against the DB and hits the module-level Layer B LRU when warm.
+          const url = new URL('http://localhost/page-1')
+          const warmup = await api.renderPublicResolution(published.db, url)
+          if (!warmup || warmup.status !== 200) {
+            throw new Error(`expected 200 for /page-1, got ${warmup?.status ?? 'null'}`)
+          }
+          const iters = ctx.quick ? 50 : 300
+          const samples: number[] = []
+          for (let i = 0; i < iters; i++) {
+            const t0 = performance.now()
+            const res = await api.renderPublicResolution(published.db, url)
+            samples.push(performance.now() - t0)
+            if (!res) throw new Error('warm request unexpectedly resolved to not-found')
+          }
+          const s = summarize(samples)
+          warmRows.push({
+            label: `GET /page-1 (warm, ${fmtNum(published.pageCount)}-page site)`,
+            inputs: { pages: published.pageCount, iters },
+            metrics: {
+              mean: fmtMs(s.mean),
+              p95: fmtMs(s.p95),
+              throughput: `${fmtNum(Math.floor(1000 / s.mean))} req/s`,
+            },
+          })
+        } catch (err) {
+          warmRows.push(unavailableRow('warm dynamic-route serving', err))
+        }
+      } else {
+        warmRows.push(unavailableRow('warm dynamic-route serving', new Error('publish scenario did not complete')))
+      }
+
+      // ---- 404 probe cost ---------------------------------------------------
+      log.step('404 probe cost (route resolution miss + setup status)')
+      const notFoundRows: BenchRow[] = []
+      if (published) {
+        try {
+          const url = new URL('http://localhost/definitely-missing-404')
+          const iters = ctx.quick ? 50 : 300
+          // Warmup
+          for (let i = 0; i < 3; i++) {
+            const res = await api.renderPublicResolution(published.db, url)
+            if (res !== null) throw new Error('404 probe unexpectedly resolved')
+            await api.getSetupStatus(published.db)
+          }
+          const samples: number[] = []
+          for (let i = 0; i < iters; i++) {
+            const t0 = performance.now()
+            await api.renderPublicResolution(published.db, url)
+            await api.getSetupStatus(published.db)
+            samples.push(performance.now() - t0)
+          }
+          const s = summarize(samples)
+          notFoundRows.push({
+            label: 'GET /definitely-missing-404 (resolution + setup status)',
+            inputs: { pages: published.pageCount, iters },
+            metrics: {
+              mean: fmtMs(s.mean),
+              p95: fmtMs(s.p95),
+              throughput: `${fmtNum(Math.floor(1000 / s.mean))} req/s`,
+            },
+          })
+        } catch (err) {
+          notFoundRows.push(unavailableRow('404 probe', err))
+        }
+      } else {
+        notFoundRows.push(unavailableRow('404 probe', new Error('publish scenario did not complete')))
+      }
+
+      // ---- Published row-route lookup --------------------------------------
+      log.step('Published row-route lookup (getPublishedDataRowByRoute)')
+      const rowRouteRows: BenchRow[] = []
+      {
+        const ROWS = ctx.quick ? 2_000 : 10_000
+        let fresh: { db: Db; path: string } | null = null
+        try {
+          fresh = await freshDb(api, 'row-route')
+          await fresh.db`
+            insert into data_tables (id, name, slug, kind, route_base, singular_label, plural_label)
+            values ('bench_posts', 'Bench Posts', 'bench-posts', 'postType', '/posts', 'Post', 'Posts')
+          `
+          log.step(`  seeding ${fmtNum(ROWS)} published rows…`)
+          const db = fresh.db
+          await db.transaction(async (tx) => {
+            for (let i = 0; i < ROWS; i++) {
+              const rowId = `bp-row-${i}`
+              const versionId = `bp-ver-${i}`
+              const slug = `post-${i}`
+              // active_version_id ↔ row_id FKs are circular per row: insert the
+              // row first (active NULL), then the version, then link them.
+              await tx`
+                insert into data_rows (id, table_id, cells_json, slug, status)
+                values (${rowId}, 'bench_posts', ${{ title: `Post ${i}` }}, ${slug}, 'published')
+              `
+              await tx`
+                insert into data_row_versions (id, row_id, version_number, cells_json, slug)
+                values (${versionId}, ${rowId}, 1, ${{ title: `Post ${i}` }}, ${slug})
+              `
+              await tx`update data_rows set active_version_id = ${versionId} where id = ${rowId}`
+            }
+          })
+          const targetSlug = `post-${Math.floor(ROWS * 0.7777)}`
+          // Warmup + sanity
+          for (let i = 0; i < 3; i++) {
+            const row = await api.getPublishedDataRowByRoute(fresh.db, '/posts', targetSlug)
+            if (!row) throw new Error(`seeded row ${targetSlug} not found by route`)
+          }
+          const iters = ctx.quick ? 50 : 200
+          const samples: number[] = []
+          for (let i = 0; i < iters; i++) {
+            const t0 = performance.now()
+            await api.getPublishedDataRowByRoute(fresh.db, '/posts', targetSlug)
+            samples.push(performance.now() - t0)
+          }
+          const s = summarize(samples)
+          rowRouteRows.push({
+            label: `lookup /posts/${targetSlug} among ${fmtNum(ROWS)} published rows`,
+            inputs: { rows: ROWS, iters },
+            metrics: {
+              mean: fmtMs(s.mean),
+              p95: fmtMs(s.p95),
+              throughput: `${fmtNum(Math.floor(1000 / s.mean))} lookups/s`,
+            },
+          })
+        } catch (err) {
+          rowRouteRows.push(unavailableRow(`row-route lookup @ ${fmtNum(ROWS)} rows`, err))
+        } finally {
+          if (fresh) cleanupDbFiles(fresh.path)
+        }
+      }
+
+      const largestPublishRow = publishRows[publishRows.length - 1]
+      const statusRow = statusRows[0]
+      const warmRow = warmRows[0]
+      const rowRouteRow = rowRouteRows[0]
+
+      return {
+        name: this.name,
+        title: this.title,
+        headline: {
+          [`publish ${largestPublishRow?.label ?? '—'}`]: largestPublishRow?.metrics.wall ?? '—',
+          'status check (mean)': statusRow?.metrics.mean ?? '—',
+          'warm dynamic GET (mean)': warmRow?.metrics.mean ?? '—',
+          'row-route lookup (mean)': rowRouteRow?.metrics.mean ?? '—',
+        },
+        sections: [
+          {
+            title: 'Full publish wall time scaling',
+            intro:
+              'End-to-end `publishDraftSite` against an isolated SQLite DB seeded through the real repositories — N draft pages of ~150 nodes each, full snapshot bake + Layer A artefact write. `db_growth` is the on-disk SQLite growth (main + WAL) from one publish: the snapshot storage amplification.',
+            rows: publishRows,
+          },
+          {
+            title: 'Publish status check',
+            intro:
+              'Cost of `getDraftPublishStatus` — the draft-vs-published comparison the admin UI polls. Loads every active published snapshot and canonicalises both sides.',
+            rows: statusRows,
+          },
+          {
+            title: 'Warm dynamic-route serving',
+            intro:
+              'Repeated `renderPublicResolution` for one published page WITHOUT an uploadsDir, forcing the dynamic path: route resolution against the DB plus the module-level Layer B LRU (first call warms it). This is what every dynamic request pays once the cache is hot.',
+            rows: warmRows,
+          },
+          {
+            title: '404 probe cost',
+            intro:
+              'Per-iteration cost of `renderPublicResolution` on a path that matches nothing plus `getSetupStatus` — modelling what the router does for every unmatched GET before answering 404.',
+            rows: notFoundRows,
+          },
+          {
+            title: 'Published row-route lookup',
+            intro:
+              'Cost of `getPublishedDataRowByRoute` (the `/posts/<slug>` public lookup) against a table with thousands of published rows, each with an active version. Sensitive to indexing on the versions join.',
+            rows: rowRouteRows,
+          },
+        ],
+      }
+    } finally {
+      if (published) {
+        cleanupDbFiles(published.path)
+        rmSync(published.uploadsDir, { recursive: true, force: true })
+      }
+    }
+  },
+}

--- a/scripts/bench/index.ts
+++ b/scripts/bench/index.ts
@@ -29,6 +29,7 @@ import type { BenchModule, BenchResult, BenchContext } from './lib/types'
 
 import { bundleBench } from './benches/bundle'
 import { publisherBench } from './benches/publisher'
+import { publishBench } from './benches/publish'
 import { editorStoreBench } from './benches/editor-store'
 import { httpBench } from './benches/http'
 import { dbBench } from './benches/db'
@@ -48,6 +49,7 @@ const REPO_ROOT = resolve(import.meta.dir, '../..')
 const DEFAULT_BENCHES: readonly BenchModule[] = [
   bundleBench,
   publisherBench,
+  publishBench,
   editorStoreBench,
   httpBench,
   dbBench,

--- a/server/auth/rateLimit.ts
+++ b/server/auth/rateLimit.ts
@@ -7,8 +7,12 @@
  * across many attacker IPs.
  *
  * Storage is a `Map<key, number[]>` of attempt timestamps. Old entries fall
- * out of the window lazily on each access; a periodic prune keeps the map
- * from growing unbounded for keys that go quiet.
+ * out of the window lazily on each access; `consume()` additionally runs an
+ * opportunistic full prune — every `PRUNE_INTERVAL` calls, or as soon as the
+ * map exceeds `PRUNE_SIZE_THRESHOLD` keys — so attacker-controlled
+ * `(ip, email)` keys that go quiet cannot grow the map unbounded in a
+ * long-lived process. The common path stays allocation-free: one counter
+ * bump and a size check.
  *
  * Why in-memory instead of Redis or a DB table?
  *   - The CMS deploys as a single Bun process (the SQLite trade-off applies
@@ -39,8 +43,14 @@ export interface RateLimiterOptions {
 }
 
 export class RateLimiter {
+  /** `consume()` calls between opportunistic prune sweeps. */
+  static readonly PRUNE_INTERVAL = 1024
+  /** Bucket count that forces a prune sweep on the next `consume()`. */
+  static readonly PRUNE_SIZE_THRESHOLD = 4096
+
   private readonly buckets = new Map<string, Bucket>()
   private readonly options: RateLimiterOptions
+  private callsSincePrune = 0
 
   constructor(options: RateLimiterOptions) {
     if (options.limit < 1) throw new Error('RateLimiter: limit must be >= 1')
@@ -50,13 +60,27 @@ export class RateLimiter {
 
   /**
    * Record an attempt against `key` and return whether it is allowed under
-   * the current sliding window. Always records — even on rejection — so a
-   * sustained attacker doesn't get to retry the moment the oldest attempt
-   * expires.
+   * the current sliding window. Rejected attempts are NOT recorded
+   * (sliding-window-log semantics): the window stays anchored to accepted
+   * attempts, so a spamming client can neither grow its bucket unboundedly
+   * nor push back the moment its oldest accepted attempt ages out.
    *
    * Pass `now` explicitly in tests; production callers omit it.
    */
   consume(key: string, now: number = Date.now()): RateLimitDecision {
+    // Opportunistic housekeeping (see module header). Runs BEFORE the bucket
+    // lookup so this call can never push onto a bucket the sweep just
+    // deleted. Pruning only drops fully-aged-out attempts, which the
+    // per-bucket filter below ignores anyway — limit decisions are unchanged.
+    this.callsSincePrune += 1
+    if (
+      this.callsSincePrune >= RateLimiter.PRUNE_INTERVAL ||
+      this.buckets.size > RateLimiter.PRUNE_SIZE_THRESHOLD
+    ) {
+      this.callsSincePrune = 0
+      this.prune(now)
+    }
+
     const { limit, windowMs } = this.options
     const cutoff = now - windowMs
 
@@ -94,8 +118,10 @@ export class RateLimiter {
   }
 
   /**
-   * Drop empty / fully-aged-out buckets. Optional housekeeping; the per-call
-   * filter in `consume()` already prevents stale data from affecting decisions.
+   * Drop empty / fully-aged-out buckets. Invoked opportunistically from
+   * `consume()`; the per-call filter there already prevents stale data from
+   * affecting decisions, so pruning only frees memory — it never changes a
+   * limit decision.
    */
   prune(now: number = Date.now()): void {
     const cutoff = now - this.options.windowMs

--- a/server/db/__tests__/sqliteStatementCache.test.ts
+++ b/server/db/__tests__/sqliteStatementCache.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+import { createSqliteClient } from '../sqlite'
+
+/**
+ * The adapter executes through `db.query()`, bun:sqlite's cached-statement
+ * variant of `prepare()` — statements are reused per exact SQL string. These
+ * tests pin the behavioral edges of that reuse: parameters must be rebound on
+ * every call (never replayed), and cached statements must survive schema
+ * changes made after they were first compiled.
+ */
+describe('sqlite adapter statement caching', () => {
+  it('rebinds params on each call of an identical SQL string (template path)', async () => {
+    const db = createSqliteClient(':memory:')
+    await db.unsafe('create table t (id text primary key, n integer)')
+
+    // Identical SQL string per iteration → same cached statement, fresh binds.
+    for (let i = 0; i < 3; i++) {
+      await db`insert into t (id, n) values (${`row-${i}`}, ${i})`
+    }
+
+    const r0 = await db<{ n: number }>`select n from t where id = ${'row-0'}`
+    const r2 = await db<{ n: number }>`select n from t where id = ${'row-2'}`
+    expect(r0.rows[0]?.n).toBe(0)
+    expect(r2.rows[0]?.n).toBe(2)
+  })
+
+  it('rebinds params on each call of an identical SQL string (unsafe path)', async () => {
+    const db = createSqliteClient(':memory:')
+    await db.unsafe('create table u (id text primary key, n integer)')
+    await db.unsafe('insert into u (id, n) values (?, ?)', ['a', 1])
+    await db.unsafe('insert into u (id, n) values (?, ?)', ['b', 2])
+
+    const a = await db.unsafe<{ n: number }>('select n from u where id = ?', ['a'])
+    const b = await db.unsafe<{ n: number }>('select n from u where id = ?', ['b'])
+    expect(a.rows[0]?.n).toBe(1)
+    expect(b.rows[0]?.n).toBe(2)
+  })
+
+  it('cached statements survive a later schema change; multi-statement exec path still works', async () => {
+    const db = createSqliteClient(':memory:')
+    // Multi-statement block must go through db.exec, not a prepared statement.
+    await db.unsafe("create table m (id text primary key); insert into m (id) values ('a');")
+
+    const before = await db<{ id: string }>`select id from m`
+    expect(before.rowCount).toBe(1)
+
+    // ALTER invalidates compiled statements; SQLite re-prepares transparently
+    // when the cached statement for the identical SQL string runs again.
+    await db.unsafe('alter table m add column extra text')
+    const after = await db<{ id: string }>`select id from m`
+    expect(after.rows[0]?.id).toBe('a')
+  })
+
+  it('still auto-parses *_json columns and reports rowCount for writes', async () => {
+    const db = createSqliteClient(':memory:')
+    await db.unsafe('create table j (id text primary key, payload_json text)')
+
+    const write = await db`insert into j (id, payload_json) values (${'x'}, ${{ k: 1 }})`
+    expect(write.rowCount).toBe(1)
+
+    const read = await db<{ payload_json: { k: number } }>`select payload_json from j where id = ${'x'}`
+    expect(read.rows[0]?.payload_json).toEqual({ k: 1 })
+  })
+})

--- a/server/db/migrations-pg.ts
+++ b/server/db/migrations-pg.ts
@@ -584,14 +584,44 @@ export const pgMigrations: Migration[] = [
     `,
   },
   {
-    id: '003_page_version_snapshot',
+    id: '003_published_site_snapshots',
     sql: `
-      -- Add snapshot_json to data_row_versions so the publish pipeline can
-      -- store the full SiteDocument (shell + all pages) alongside each
-      -- published page version. This powers the public renderer without an
-      -- extra DB round-trip for the site shell.
+      -- One published SiteDocument per publish, shared by every page version
+      -- created in that publish. Page versions reference it via
+      -- site_snapshot_id instead of each carrying a full copy of the site —
+      -- publishing N pages stores the site document once, not N times.
+      --
+      -- content_hash is the SHA-256 of the canonical-JSON serialisation of
+      -- site_json, stamped at publish time so the publish-status check can
+      -- compare draft vs published without parsing any snapshot.
+      --
+      -- importmap_body is the pre-serialised runtime package importmap (exact
+      -- bytes the CSP hash was computed over) — TEXT, never re-encoded.
+      create table if not exists site_snapshots (
+        id text primary key,
+        site_json jsonb not null,
+        content_hash text not null,
+        importmap_body text,
+        importmap_sha256 text,
+        created_at timestamptz not null default now()
+      );
+
       alter table data_row_versions
-        add column if not exists snapshot_json jsonb;
+        add column if not exists site_snapshot_id text references site_snapshots(id) on delete set null;
+
+      -- Per-page runtime script manifest (page-scoped, unlike the shared site
+      -- document).
+      alter table data_row_versions
+        add column if not exists runtime_assets_json jsonb;
+
+      -- Published row-route lookup (route_base + version slug): without these
+      -- two indexes the planner enumerates every published row of the table
+      -- and PK-probes its active version per visitor request.
+      create index if not exists data_row_versions_slug_idx
+        on data_row_versions (slug);
+
+      create index if not exists data_rows_active_version_idx
+        on data_rows (active_version_id);
     `,
   },
   {

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -696,6 +696,12 @@ export const sqliteMigrations: Migration[] = [
       create index if not exists data_rows_scheduled_publish_idx
         on data_rows (scheduled_publish_at)
         where status = 'scheduled' and deleted_at is null;
+
+      -- Re-create the published-route join index from migration 003 — the
+      -- drop+rename rebuild above takes every data_rows index with it, so
+      -- ALL of them must be re-created here.
+      create index if not exists data_rows_active_version_idx
+        on data_rows (active_version_id);
     `,
   },
   {

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -525,12 +525,43 @@ export const sqliteMigrations: Migration[] = [
     `,
   },
   {
-    id: '003_page_version_snapshot',
+    id: '003_published_site_snapshots',
     sql: `
-      -- Add snapshot_json to data_row_versions so the publish pipeline can
-      -- store the full SiteDocument (shell + all pages) alongside each
-      -- published page version. SQLite mirror of the Postgres migration.
-      alter table data_row_versions add column snapshot_json text;
+      -- One published SiteDocument per publish, shared by every page version
+      -- created in that publish. Page versions reference it via
+      -- site_snapshot_id instead of each carrying a full copy of the site —
+      -- publishing N pages stores the site document once, not N times.
+      -- SQLite mirror of the Postgres migration.
+      --
+      -- content_hash is the SHA-256 of the canonical-JSON serialisation of
+      -- site_json, stamped at publish time so the publish-status check can
+      -- compare draft vs published without parsing any snapshot.
+      --
+      -- importmap_body is the pre-serialised runtime package importmap (exact
+      -- bytes the CSP hash was computed over) — TEXT, never re-encoded.
+      create table if not exists site_snapshots (
+        id text primary key,
+        site_json text not null,
+        content_hash text not null,
+        importmap_body text,
+        importmap_sha256 text,
+        created_at text not null default (strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+      );
+
+      alter table data_row_versions add column site_snapshot_id text references site_snapshots(id) on delete set null;
+
+      -- Per-page runtime script manifest (page-scoped, unlike the shared site
+      -- document), parsed automatically via the *_json naming convention.
+      alter table data_row_versions add column runtime_assets_json text;
+
+      -- Published row-route lookup (route_base + version slug): without these
+      -- two indexes the planner enumerates every published row of the table
+      -- and PK-probes its active version per visitor request.
+      create index if not exists data_row_versions_slug_idx
+        on data_row_versions (slug);
+
+      create index if not exists data_rows_active_version_idx
+        on data_rows (active_version_id);
     `,
   },
   {

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -90,7 +90,11 @@ export function createSqliteClient(filename: string): DbClient {
     ...values: unknown[]
   ): Promise<DbResult<Row>> => {
     const { sql, params } = renderTemplate(strings, values)
-    const stmt = db.prepare(sql)
+    // db.query() returns a prepared statement cached by the exact SQL string
+    // (db.prepare() recompiles on every call). Tagged-template call sites
+    // render an identical SQL string per site, so steady-state queries skip
+    // compilation entirely; params are still bound fresh on each .all()/.run().
+    const stmt = db.query(sql)
     if (isSelectishStatement(sql)) {
       const rows = stmt.all(...params) as Row[]
       return { rows: rows.map(parseJsonColumns), rowCount: rows.length }
@@ -104,12 +108,14 @@ export function createSqliteClient(filename: string): DbClient {
     params?: unknown[],
   ): Promise<DbResult<Row>> => {
     // Multi-statement migration blocks arrive as a single SQL string with
-    // semicolons. db.exec() handles them correctly; prepare() + all() does not.
+    // semicolons. db.exec() handles them correctly; a prepared statement
+    // (db.query) only runs the first statement.
     if (params === undefined && rawSql.includes(';')) {
       db.exec(rawSql)
       return { rows: [], rowCount: 0 }
     }
-    const stmt = db.prepare(rawSql)
+    // Cached prepared statement — same rationale as the template path above.
+    const stmt = db.query(rawSql)
     const bindParams = (params ?? []).map(toBindable)
     const rows = stmt.all(...bindParams) as Row[]
     return { rows: rows.map(parseJsonColumns), rowCount: rows.length }

--- a/server/handlers/cms/data/preview.ts
+++ b/server/handlers/cms/data/preview.ts
@@ -125,7 +125,7 @@ export async function handleRowPreview(
   }).html
 
   const finalHtml = await applyPublishedHtmlPipeline(
-    { html, pageId: merged.id, slug: merged.slug, siteId: snapshot.site.id },
+    { html, pageId: merged.id, slug: merged.slug, siteId: snapshot.site.id, cssBundle },
     db,
   )
 

--- a/server/handlers/cms/data/rows.ts
+++ b/server/handlers/cms/data/rows.ts
@@ -40,6 +40,7 @@ import {
 import { findUserById } from '../../../repositories/users'
 import { slugForTable } from '@core/data/cells'
 import { badRequest, jsonResponse, readValidatedBody } from '../../../http'
+import { bumpPublishVersionSerialized } from '../../../publish/publishState'
 import type { CmsHandlerOptions } from '../shared'
 import { CMS_API_PREFIX, requestAuditContext } from '../shared'
 import { runRouteTable, type Route, type RouteParams } from '../routeTable'
@@ -213,6 +214,9 @@ async function handleRowItemDelete(
       console.error('[publish:row] failed to remove artefact for deleted row', rowId, err)
     })
   }
+  // Layer B mirror of the artefact prune: a published row's route is
+  // retracted, so the render cache must stop serving it.
+  if (row.status === 'published') await bumpPublishVersionSerialized()
   await emitContentEntryDeleted(db, rowId, { kind: 'user', userId: user.id })
   await recordRowAuditEvent(db, user, req, 'data.row.delete', row)
   return jsonResponse({ row })

--- a/server/handlers/cms/hole.ts
+++ b/server/handlers/cms/hole.ts
@@ -37,10 +37,10 @@ import { registry } from '@core/module-engine'
 import { loopSourceRegistry } from '@core/loops/registry'
 import { renderNode, type RenderConfig, type RenderAccumulators } from '@core/publisher'
 import { buildPageFrame, buildRouteFrame, buildSiteFrame } from '@core/templates/contextFrames'
-import { getLatestPublishedSiteSnapshot } from '../../repositories/publish'
 import { prefetchLoopData } from '../../publish/loopPrefetch'
 import { getOrRender } from '../../publish/renderCache'
-import { createVersionedSingleFlight, getPublishVersion } from '../../publish/publishState'
+import { getPublishedNodeIndexForVersion } from '../../publish/publishedSnapshotCache'
+import { getPublishVersion } from '../../publish/publishState'
 import { HOLE_RUNTIME_JS } from '../../publish/holeRuntime'
 
 const HOLE_RUNTIME_PATH = '/_instatic/hole-runtime.js'
@@ -66,41 +66,9 @@ export interface HoleHandlerContext {
   db: DbClient
 }
 
-// ---------------------------------------------------------------------------
-// Versioned snapshot cache + nodeId → page index
-//
-// The published snapshot (the entire SiteDocument) changes only on publish.
-// Loading + JSON-parsing it on every hole request — then linearly scanning all
-// pages for the node — was the per-fragment cost flagged in the architecture
-// review. Instead we memoise the snapshot for the current publish version and
-// build a `nodeId → page` index once, so request-time lookup is O(1) and warm
-// requests do zero DB I/O. The version-keyed single-flight primitive from
-// `publishState` owns the memo + the concurrent-load dedup + the test reset, so
-// this endpoint carries no bespoke module-level cache state of its own — a
-// version change simply misses and reloads against the fresh snapshot.
-// ---------------------------------------------------------------------------
-
-interface HoleSnapshot {
-  site: SiteDocument
-  nodeIndex: Map<string, Page>
-}
-
-const snapshotCache = createVersionedSingleFlight<HoleSnapshot>()
-
-function loadSnapshotForVersion(db: DbClient, version: number): Promise<HoleSnapshot | null> {
-  return snapshotCache.get(version, async () => {
-    const snapshot = await getLatestPublishedSiteSnapshot(db)
-    if (!snapshot) return null
-    const nodeIndex = new Map<string, Page>()
-    for (const page of snapshot.site.pages) {
-      for (const nodeId of Object.keys(page.nodes)) {
-        // First page wins on the (extremely unlikely) duplicate node id.
-        if (!nodeIndex.has(nodeId)) nodeIndex.set(nodeId, page)
-      }
-    }
-    return { site: snapshot.site, nodeIndex }
-  })
-}
+// The versioned snapshot memo + nodeId → page index live in
+// `publish/publishedSnapshotCache.ts`, shared with the public router and the
+// loop endpoint — request-time lookup is O(1) and warm requests do zero DB I/O.
 
 // ---------------------------------------------------------------------------
 // Request helpers
@@ -218,7 +186,7 @@ export async function handleHoleRequest(
   }
 
   // Load (memoised) snapshot for this version and find the node's page in O(1).
-  const snap = await loadSnapshotForVersion(ctx.db, currentVersion)
+  const snap = await getPublishedNodeIndexForVersion(ctx.db, currentVersion)
   if (!snap) {
     return new Response('Site not published', {
       status: 404,

--- a/server/handlers/cms/loop.ts
+++ b/server/handlers/cms/loop.ts
@@ -30,9 +30,9 @@ import {
   type ResolvedLoopRenderData,
 } from '@core/publisher'
 import { jsonResponse } from '../../http'
-import { getLatestPublishedSiteSnapshot, getPublishedPageBySlug } from '../../repositories/publish'
-import { collectLoopNodes, readLoopProps } from '../../publish/loopPrefetch'
-import { publicSlugFromPath } from '../../publish/publicRouter'
+import { readLoopProps } from '../../publish/loopPrefetch'
+import { getPublishedLoopIndexForVersion } from '../../publish/publishedSnapshotCache'
+import { getPublishVersion } from '../../publish/publishState'
 import { LOOP_RUNTIME_JS } from '../../publish/loopRuntime'
 
 const LOOP_RUNTIME_PATH = '/_instatic/assets/loop-runtime.js'
@@ -72,33 +72,22 @@ export async function handleLoopRequest(
 
   const pageNumberRaw = url.searchParams.get('page') ?? '1'
   const pageNumber = Math.max(1, Number.parseInt(pageNumberRaw, 10) || 1)
-  const pagePath = url.searchParams.get('pagePath') ?? '/'
 
-  // Find the page that contains this loop. We try by slug first (public
-  // pages); content-template loops live inside a published template page
-  // and are addressable via the latest snapshot.
-  const slugSnapshot = await getPublishedPageBySlug(ctx.db, publicSlugFromPath(pagePath))
-  const fallbackSnapshot = slugSnapshot ?? (await getLatestPublishedSiteSnapshot(ctx.db))
-  if (!fallbackSnapshot) {
+  // Find the page that contains this loop via the per-publish-version
+  // loopId → { page, node } index. Every page version in one publish shares
+  // the same site document, so the index covers regular pages and template
+  // pages alike (the runtime's `pagePath` hint is no longer needed) — and the
+  // old per-request full-snapshot parse + all-pages tree walk is gone.
+  const loopIndex = await getPublishedLoopIndexForVersion(ctx.db, getPublishVersion())
+  if (!loopIndex) {
     return jsonResponse({ error: 'Site not published' }, { status: 404 })
   }
-
-  // Search for the loop node across all pages in the snapshot — easiest
-  // way to handle both regular pages and template pages from one entry.
-  let loopNode = null
-  let containingPage = null
-  for (const page of fallbackSnapshot.site.pages) {
-    const nodes = collectLoopNodes(page, fallbackSnapshot.site)
-    const match = nodes.find((n) => n.id === loopId)
-    if (match) {
-      loopNode = match
-      containingPage = page
-      break
-    }
-  }
-  if (!loopNode || !containingPage) {
+  const indexed = loopIndex.loops.get(loopId)
+  if (!indexed) {
     return jsonResponse({ error: 'Loop not found' }, { status: 404 })
   }
+  const { page: containingPage, node: loopNode } = indexed
+  const site = loopIndex.site
 
   const props = readLoopProps(loopNode)
   if (props.pagination !== 'infinite') {
@@ -115,7 +104,7 @@ export async function handleLoopRequest(
   try {
     result = await source.fetch({
       db: ctx.db,
-      site: fallbackSnapshot.site,
+      site,
       filters: props.filters,
       orderBy: props.orderBy || (source.orderByOptions[0]?.id ?? ''),
       direction: props.direction,
@@ -140,7 +129,7 @@ export async function handleLoopRequest(
   }
   const baseConfig: RenderConfig = {
     page: containingPage,
-    site: fallbackSnapshot.site,
+    site,
     registry,
     breakpointId: undefined,
     templateContext: { entryStack: [] },

--- a/server/handlers/cms/pages.ts
+++ b/server/handlers/cms/pages.ts
@@ -42,6 +42,7 @@ import { visualComponentFromRow } from '../../../src/core/data/componentFromRow'
 import { validatePages, SiteValidationError } from '@core/persistence/validate'
 import type { Page } from '@core/page-tree'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../http'
+import { bumpPublishVersionSerialized } from '../../publish/publishState'
 import { Type } from '@core/utils/typeboxHelpers'
 import { CMS_API_PREFIX } from './shared'
 
@@ -115,6 +116,7 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
     }
 
     // Batch reconcile: create / update / soft-delete in a transaction
+    let reapedPublished = false
     await db.transaction(async (tx) => {
       const existingRows = await listDataRows(tx, 'pages')
       const existingById = new Map(existingRows.map((r) => [r.id, r]))
@@ -133,9 +135,16 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
       // Soft-delete only the rows the client knew about and dropped — never a
       // concurrently-created sibling page (ISS-041).
       for (const rowId of pagesToReap([...existingById.keys()], incomingIds, baselineIds)) {
-        await softDeleteDataRow(tx, rowId, user.id)
+        const deleted = await softDeleteDataRow(tx, rowId, user.id)
+        if (deleted?.status === 'published') reapedPublished = true
       }
     })
+
+    // Reaping a published page retracts its public route — invalidate the
+    // render cache AFTER the transaction commits (never inside it: the bump
+    // serializes against the publish lock, which itself waits on the
+    // transaction chain).
+    if (reapedPublished) await bumpPublishVersionSerialized()
 
     return jsonResponse({ ok: true })
   }

--- a/server/plugins/host/handlers/content.ts
+++ b/server/plugins/host/handlers/content.ts
@@ -19,17 +19,11 @@
  */
 
 import type { ApiCallFor } from '../../protocol/apiCallSchema'
-import type {
-  ContentEntry,
-  ContentTableSchema as ContentTableSchemaShape,
-  ContentTableSummary,
-  PublishedSnapshot,
-} from '@core/plugin-sdk/contentSchemas'
-import type { DataField, DataRow, DataTable } from '@core/data/schemas'
+import type { ContentTableSummary, PublishedSnapshot } from '@core/plugin-sdk/contentSchemas'
+import type { DataRow, DataTable } from '@core/data/schemas'
 import { applyTreeOperation, parsePageNodeTree } from '@core/page-tree'
 import { hookBus } from '@core/plugins/hookBus'
 import {
-  listDataTables,
   listDataTablesWithCounts,
   getDataTable,
   createDataTable,
@@ -48,147 +42,23 @@ import {
   publishDataRow,
 } from '../../../repositories/data'
 import { republishAllPages } from '../../../publish/republish'
+import { bumpPublishVersionSerialized } from '../../../publish/publishState'
 import { applyContentEntryCellsFilter } from '../../../publish/contentEvents'
 import type { DbClient } from '../../../db/client'
 import { assertContentTableAccess } from '../registry'
 import { buildContentTableIdLookup, pluginContentFieldsToDataFields } from '../contentFieldMapping'
+import {
+  buildTableSlugLookup,
+  denormalizeSlug,
+  resolveTableBySlug,
+  rowToEntry,
+  tableSchema,
+  tableSummary,
+} from './contentProjection'
 import { replyApiOk } from '../apiReplies'
 import type { HostPluginRecord } from '../types'
 
-// ---------------------------------------------------------------------------
-// Projection helpers — DB → wire shapes
-// ---------------------------------------------------------------------------
-
-/**
- * Project the host's full `DataField` union onto the narrowed
- * `PluginContentField` projection (see `types/content.ts`). Drops the
- * recursive `fieldSchema` type and reduces `relation` / `pageTree` to
- * marker shapes the plugin can introspect.
- *
- * `tableSlugById` maps the host's internal `targetTableId` to the
- * public-facing slug so the plugin boundary never leaks DB ids.
- */
-function projectFields(
-  fields: DataField[],
-  tableSlugById: Map<string, string>,
-): ContentTableSchemaShape['fields'] {
-  const out: ContentTableSchemaShape['fields'] = []
-  for (const f of fields) {
-    switch (f.type) {
-      case 'text':
-      case 'longText':
-      case 'richText':
-      case 'number':
-        out.push({ type: f.type, id: f.id, label: f.label, required: f.required })
-        break
-      case 'boolean':
-      case 'date':
-      case 'dateTime':
-      case 'url':
-      case 'email':
-      case 'media':
-        out.push({ type: f.type, id: f.id, label: f.label })
-        break
-      case 'select':
-      case 'multiSelect':
-        out.push({
-          type: f.type,
-          id: f.id,
-          label: f.label,
-          options: (f.options ?? []).map((o) => ({ value: o.value, label: o.label })),
-        })
-        break
-      case 'relation':
-        out.push({
-          type: 'relation',
-          id: f.id,
-          label: f.label,
-          targetTableSlug: tableSlugById.get(f.targetTableId) ?? '',
-        })
-        break
-      case 'pageTree':
-        out.push({ type: 'pageTree', id: f.id, label: f.label })
-        break
-      case 'fieldSchema':
-        // Intentionally omitted from the v1 projection — too rich/recursive
-        // for the JSON RPC boundary.
-        break
-    }
-  }
-  return out
-}
-
-function tableSummary(
-  table: DataTable,
-  rowCount: number,
-): ContentTableSummary {
-  return {
-    slug: table.slug,
-    name: table.name,
-    kind: table.kind,
-    routeBase: table.routeBase,
-    system: table.system,
-    primaryFieldId: table.primaryFieldId,
-    fieldCount: table.fields.length,
-    rowCount,
-  }
-}
-
-function tableSchema(
-  table: DataTable,
-  rowCount: number,
-  tableSlugById: Map<string, string>,
-): ContentTableSchemaShape {
-  return {
-    ...tableSummary(table, rowCount),
-    singularLabel: table.singularLabel,
-    pluralLabel: table.pluralLabel,
-    fields: projectFields(table.fields, tableSlugById),
-  }
-}
-
-async function buildTableSlugLookup(db: DbClient): Promise<Map<string, string>> {
-  const tables = await listDataTables(db)
-  return new Map(tables.map((t) => [t.id, t.slug]))
-}
-
-function rowToEntry(row: DataRow, tableSlug: string): ContentEntry {
-  return {
-    id: row.id,
-    tableSlug,
-    slug: row.slug,
-    status: row.status,
-    cells: row.cells,
-    authorUserId: row.authorUserId,
-    pluginActorId: (row as { pluginActorId?: string | null }).pluginActorId ?? null,
-    createdAt: row.createdAt,
-    updatedAt: row.updatedAt,
-    publishedAt: row.publishedAt,
-    scheduledPublishAt: row.scheduledPublishAt,
-  }
-}
-
-async function resolveTableBySlug(
-  db: DbClient,
-  slug: string,
-): Promise<DataTable> {
-  const all = await listDataTables(db)
-  const found = all.find((t) => t.slug === slug)
-  if (!found) throw new Error(`Content table "${slug}" not found`)
-  return found
-}
-
-/**
- * Compute the denormalized slug for a row. Mirrors what the host's CMS
- * handlers do at the boundary: prefer `cells.slug` when the table has a
- * slug field; fall back to an empty string for tables without one.
- */
-function denormalizeSlug(table: DataTable, cells: Record<string, unknown>): string {
-  const hasSlugField = table.fields.some((f) => f.id === 'slug')
-  if (!hasSlugField) return ''
-  const value = cells['slug']
-  return typeof value === 'string' ? value : ''
-}
+// Projection helpers (DB → wire shapes) live in `contentProjection.ts`.
 
 // ---------------------------------------------------------------------------
 // Hook emission — actor-attributed `content.entry.*` events
@@ -433,6 +303,8 @@ export async function handleContentEntriesDelete(
   }
   const deleted = await softDeleteDataRow(db, entryId)
   if (deleted) {
+    // A published row's route is retracted — invalidate the render cache.
+    if (deleted.status === 'published') await bumpPublishVersionSerialized()
     await emitEntryDeleted(tableSlug, entryId, { kind: 'plugin', pluginId: msg.pluginId })
   }
   replyApiOk(msg.pluginId, msg.correlationId, undefined)
@@ -574,11 +446,14 @@ export async function handleContentEntriesDeleteMany(
     }
   }
   const result = await softDeleteDataRowMany(db, ids, null)
+  // Published rows' routes were retracted — one cache invalidation per batch.
+  if (result.publishedDeleted > 0) await bumpPublishVersionSerialized()
   const actor: PluginActor = { kind: 'plugin', pluginId: msg.pluginId }
   for (const id of ids) {
     await emitEntryDeleted(tableSlug, id, actor)
   }
-  replyApiOk(msg.pluginId, msg.correlationId, result)
+  // Reply shape is part of the plugin API — only `deleted` is exposed.
+  replyApiOk(msg.pluginId, msg.correlationId, { deleted: result.deleted })
 }
 
 // ---------------------------------------------------------------------------

--- a/server/plugins/host/handlers/contentProjection.ts
+++ b/server/plugins/host/handlers/contentProjection.ts
@@ -1,0 +1,147 @@
+/**
+ * Projection helpers for the `cms.content.*` plugin surface — DB → wire
+ * shapes. Extracted from `content.ts` (which owns the api-call handlers);
+ * everything here is a pure mapping from repository types (`DataTable`,
+ * `DataRow`, `DataField`) to the plugin SDK's content schemas, plus the two
+ * slug-oriented lookups the mappings need.
+ */
+
+import type {
+  ContentEntry,
+  ContentTableSchema as ContentTableSchemaShape,
+  ContentTableSummary,
+} from '@core/plugin-sdk/contentSchemas'
+import type { DataField, DataRow, DataTable } from '@core/data/schemas'
+import type { DbClient } from '../../../db/client'
+import { listDataTables } from '../../../repositories/data'
+
+/**
+ * Project the host's full `DataField` union onto the narrowed
+ * `PluginContentField` projection (see `types/content.ts`). Drops the
+ * recursive `fieldSchema` type and reduces `relation` / `pageTree` to
+ * marker shapes the plugin can introspect.
+ *
+ * `tableSlugById` maps the host's internal `targetTableId` to the
+ * public-facing slug so the plugin boundary never leaks DB ids.
+ */
+function projectFields(
+  fields: DataField[],
+  tableSlugById: Map<string, string>,
+): ContentTableSchemaShape['fields'] {
+  const out: ContentTableSchemaShape['fields'] = []
+  for (const f of fields) {
+    switch (f.type) {
+      case 'text':
+      case 'longText':
+      case 'richText':
+      case 'number':
+        out.push({ type: f.type, id: f.id, label: f.label, required: f.required })
+        break
+      case 'boolean':
+      case 'date':
+      case 'dateTime':
+      case 'url':
+      case 'email':
+      case 'media':
+        out.push({ type: f.type, id: f.id, label: f.label })
+        break
+      case 'select':
+      case 'multiSelect':
+        out.push({
+          type: f.type,
+          id: f.id,
+          label: f.label,
+          options: (f.options ?? []).map((o) => ({ value: o.value, label: o.label })),
+        })
+        break
+      case 'relation':
+        out.push({
+          type: 'relation',
+          id: f.id,
+          label: f.label,
+          targetTableSlug: tableSlugById.get(f.targetTableId) ?? '',
+        })
+        break
+      case 'pageTree':
+        out.push({ type: 'pageTree', id: f.id, label: f.label })
+        break
+      case 'fieldSchema':
+        // Intentionally omitted from the v1 projection — too rich/recursive
+        // for the JSON RPC boundary.
+        break
+    }
+  }
+  return out
+}
+
+export function tableSummary(
+  table: DataTable,
+  rowCount: number,
+): ContentTableSummary {
+  return {
+    slug: table.slug,
+    name: table.name,
+    kind: table.kind,
+    routeBase: table.routeBase,
+    system: table.system,
+    primaryFieldId: table.primaryFieldId,
+    fieldCount: table.fields.length,
+    rowCount,
+  }
+}
+
+export function tableSchema(
+  table: DataTable,
+  rowCount: number,
+  tableSlugById: Map<string, string>,
+): ContentTableSchemaShape {
+  return {
+    ...tableSummary(table, rowCount),
+    singularLabel: table.singularLabel,
+    pluralLabel: table.pluralLabel,
+    fields: projectFields(table.fields, tableSlugById),
+  }
+}
+
+export async function buildTableSlugLookup(db: DbClient): Promise<Map<string, string>> {
+  const tables = await listDataTables(db)
+  return new Map(tables.map((t) => [t.id, t.slug]))
+}
+
+export function rowToEntry(row: DataRow, tableSlug: string): ContentEntry {
+  return {
+    id: row.id,
+    tableSlug,
+    slug: row.slug,
+    status: row.status,
+    cells: row.cells,
+    authorUserId: row.authorUserId,
+    pluginActorId: (row as { pluginActorId?: string | null }).pluginActorId ?? null,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    publishedAt: row.publishedAt,
+    scheduledPublishAt: row.scheduledPublishAt,
+  }
+}
+
+export async function resolveTableBySlug(
+  db: DbClient,
+  slug: string,
+): Promise<DataTable> {
+  const all = await listDataTables(db)
+  const found = all.find((t) => t.slug === slug)
+  if (!found) throw new Error(`Content table "${slug}" not found`)
+  return found
+}
+
+/**
+ * Compute the denormalized slug for a row. Mirrors what the host's CMS
+ * handlers do at the boundary: prefer `cells.slug` when the table has a
+ * slug field; fall back to an empty string for tables without one.
+ */
+export function denormalizeSlug(table: DataTable, cells: Record<string, unknown>): string {
+  const hasSlugField = table.fields.some((f) => f.id === 'slug')
+  if (!hasSlugField) return ''
+  const value = cells['slug']
+  return typeof value === 'string' ? value : ''
+}

--- a/server/publish/bakeDataRows.ts
+++ b/server/publish/bakeDataRows.ts
@@ -1,0 +1,110 @@
+/**
+ * Full-publish baking of data-row Layer A artefacts.
+ *
+ * A full publish wipes the inactive slot, writes every page artefact, and
+ * swaps — which used to strand every row artefact (`/posts/hello-world`)
+ * that incremental publishes had written into the previously-active slot.
+ * After every full publish, ALL row routes fell back to the live renderer
+ * until each row was individually republished.
+ *
+ * `bakePublishedDataRowArtefacts` closes that hole: it enumerates every
+ * published data row whose table has an entry-template chain and bakes its
+ * HTML into the given (still-inactive) slot directory, through the exact
+ * render path the live fallback uses — `renderPublishedDataRowTemplate` +
+ * `applyPublishedHtmlPipeline` — stamped with the publish version that
+ * becomes current at the swap. Output bytes are identical to a live render;
+ * only the serving tier changes.
+ *
+ * One bad row never aborts the bake: per-row failures are logged and the
+ * route falls through to the live renderer at request time, mirroring the
+ * per-page bake behaviour in `publishDraftSite`.
+ */
+
+import type { DbClient } from '../db/client'
+import type { SiteCssBundle } from '@core/publisher'
+import { resolveTemplateChain } from '@core/templates'
+import { normalizeRouteBase } from '@core/templates/templateMatching'
+import {
+  getPublishedDataRowByRoute,
+  listPublishedRowRoutes,
+} from '../repositories/data/publish'
+import { renderPublishedDataRowTemplate } from './publicRenderer'
+import { applyPublishedHtmlPipeline } from './publishedHtmlPipeline'
+import { writeArtefact } from './staticArtefact'
+import { getLatestSnapshotForVersion } from './publishedSnapshotCache'
+
+export interface DataRowBakeResult {
+  /** Routes successfully baked into the slot. */
+  baked: number
+  /**
+   * CSS bundles referenced by the baked HTML. The caller writes their files
+   * into the slot alongside the page bundles — entry-template renders can
+   * carry a merged-page `userStyles` hash no raw page bundle produces.
+   */
+  cssBundles: SiteCssBundle[]
+}
+
+function publicRowPath(routeBase: string, slug: string): string {
+  const normalizedBase = normalizeRouteBase(routeBase)
+  return `${normalizedBase === '/' ? '' : normalizedBase}/${slug}`
+}
+
+/**
+ * Bake every published data-row route into `slotDir`. Called by the full
+ * publish AFTER its transaction commits (the row list and snapshot reads see
+ * the freshly-committed publish) and BEFORE the slot swap.
+ *
+ * `publishVersion` is the NEXT publish version — the bake runs before
+ * `bumpPublishVersion()`, so baked hole shells must carry the version that
+ * becomes current at the swap. Passing it to the versioned snapshot memo
+ * also pre-warms the cache visitors are about to read.
+ */
+export async function bakePublishedDataRowArtefacts(
+  db: DbClient,
+  slotDir: string,
+  publishVersion: number,
+): Promise<DataRowBakeResult> {
+  const result: DataRowBakeResult = { baked: 0, cssBundles: [] }
+
+  const routes = await listPublishedRowRoutes(db)
+  if (routes.length === 0) return result
+
+  const siteSnapshot = await getLatestSnapshotForVersion(db, publishVersion)
+  if (!siteSnapshot) return result
+
+  // Tables without an entry-template chain have no public row routes —
+  // resolve once per table, not once per row.
+  const tableHasChain = new Map<string, boolean>()
+  const hasEntryChain = (tableSlug: string): boolean => {
+    const known = tableHasChain.get(tableSlug)
+    if (known !== undefined) return known
+    const chain = resolveTemplateChain(siteSnapshot.site, { kind: 'entry', tableSlug })
+    const has = chain.length > 0
+    tableHasChain.set(tableSlug, has)
+    return has
+  }
+
+  for (const route of routes) {
+    if (!hasEntryChain(route.tableSlug)) continue
+    const urlPath = publicRowPath(route.tableRouteBase, route.rowSlug)
+    try {
+      const row = await getPublishedDataRowByRoute(db, route.tableRouteBase, route.rowSlug)
+      if (!row) continue
+      const syntheticUrl = new URL(`http://localhost${urlPath}`)
+      const rendered = await renderPublishedDataRowTemplate(siteSnapshot, row, {
+        db,
+        url: syntheticUrl,
+        publishVersion,
+      })
+      if (!rendered) continue
+      const html = await applyPublishedHtmlPipeline(rendered, db)
+      await writeArtefact(slotDir, urlPath, html)
+      result.cssBundles.push(rendered.cssBundle)
+      result.baked++
+    } catch (err) {
+      console.error('[publish:site] failed to bake row artefact for', urlPath, '(falls through to live renderer):', err)
+    }
+  }
+
+  return result
+}

--- a/server/publish/publicRenderer.ts
+++ b/server/publish/publicRenderer.ts
@@ -10,6 +10,7 @@ import { prefetchLoopData, publishedDataRowToLoopItem } from './loopPrefetch'
 import { prefetchMediaAssets } from './mediaPrefetch'
 import { getPublishVersion } from './publishState'
 import type { Page } from '@core/page-tree'
+import type { SiteCssBundle } from '@core/publisher'
 import type { PublishedDataRow } from '@core/data/schemas'
 import type { DbClient } from '../db/client'
 import type { PublishedPageSnapshot } from '../repositories/publish'
@@ -39,6 +40,14 @@ export interface RendererOutput {
   pageId: string
   slug: string
   siteId: string
+  /**
+   * The CSS bundle this render's HTML actually references (`<link href>`
+   * hashes). The publish-time bake writes these exact files into the slot so
+   * every baked artefact's CSS is on disk — including hashes that only exist
+   * for template-composed renders (entry templates wrap rows in a merged page
+   * whose page-scoped `userStyles` hash can differ from any raw page's).
+   */
+  cssBundle: SiteCssBundle
 }
 
 export interface RenderPublishedSnapshotContext {
@@ -68,13 +77,14 @@ async function renderMergedTemplate(
   snapshot: PublishedPageSnapshot,
   templateContext: TemplateRenderDataContext | undefined,
   ctx: RenderPublishedSnapshotContext,
-): Promise<string> {
-  const cssBundle = buildPublishedSiteCssBundle(snapshot.site, registry, merged)
+): Promise<{ html: string; cssBundle: SiteCssBundle }> {
+  const publishVersion = ctx.publishVersion ?? getPublishVersion()
+  const cssBundle = buildPublishedSiteCssBundle(snapshot.site, registry, merged, publishVersion)
   const [loopData, mediaAssets] = await Promise.all([
     prefetchLoopData(merged, snapshot.site, ctx.db, ctx.url),
     prefetchMediaAssets(merged, snapshot.site, registry, ctx.db),
   ])
-  return publishPage(merged, snapshot.site, registry, {
+  const html = publishPage(merged, snapshot.site, registry, {
     templateContext,
     runtimeAssets: snapshot.runtimeAssets,
     runtimePackageImportmap: snapshot.runtimePackageImportmap,
@@ -84,8 +94,9 @@ async function renderMergedTemplate(
     loopData,
     mediaAssets,
     loopEndpointBaseUrl: LOOP_ENDPOINT_BASE_URL,
-    publishVersion: ctx.publishVersion ?? getPublishVersion(),
+    publishVersion,
   }).html
+  return { html, cssBundle }
 }
 
 export async function renderPublishedSnapshot(
@@ -108,8 +119,8 @@ export async function renderPublishedSnapshot(
     ? { entryStack: [], route: buildRouteFrame(ctx.url.toString()) }
     : undefined
 
-  const html = await renderMergedTemplate(merged, snapshot, templateContext, ctx)
-  return { html, pageId: snapshot.pageRowId, slug: page.slug, siteId: snapshot.site.id }
+  const { html, cssBundle } = await renderMergedTemplate(merged, snapshot, templateContext, ctx)
+  return { html, pageId: snapshot.pageRowId, slug: page.slug, siteId: snapshot.site.id, cssBundle }
 }
 
 export async function renderPublishedDataRowTemplate(
@@ -132,6 +143,6 @@ export async function renderPublishedDataRowTemplate(
     ...(ctx.url ? { route: buildRouteFrame(ctx.url.toString()) } : {}),
   }
 
-  const html = await renderMergedTemplate(merged, snapshot, templateContext, ctx)
-  return { html, pageId: merged.id, slug: merged.slug, siteId: snapshot.site.id }
+  const { html, cssBundle } = await renderMergedTemplate(merged, snapshot, templateContext, ctx)
+  return { html, pageId: merged.id, slug: merged.slug, siteId: snapshot.site.id, cssBundle }
 }

--- a/server/publish/publicRouter.ts
+++ b/server/publish/publicRouter.ts
@@ -28,11 +28,15 @@
  *      immediately (no DB, no render). On a miss, it falls through to
  *      `resolvePublicRoute` + Layer B.
  *
- *      Layer B: redirects and not-founds are resolved before the cache
- *      so they are never stored. The render factory is invoked at most
- *      once per concurrent key burst (single-flight) and its result is
+ *      Layer B: a warm cache entry (only ever a 200 render at the current
+ *      publish version) is served BEFORE route resolution, so cache hits do
+ *      zero DB work. On a miss, redirects and not-founds resolve before the
+ *      factory so they are never stored. The render factory is invoked at
+ *      most once per concurrent key burst (single-flight) and its result is
  *      stored in the LRU keyed by (urlPath, queryString, publishVersion).
- *      The cache is invalidated on every publish via `bumpPublishVersion`.
+ *      The cache is invalidated by `bumpPublishVersion`, which fires on
+ *      every mutation that changes what a published URL serves (publish,
+ *      unpublish, soft-delete, table move).
  *
  * The `publicSlugFromPath` helper is exported because the loop runtime
  * (`server/handlers/cms/loop.ts`) needs the same path → slug
@@ -62,17 +66,16 @@ import {
   getDataRowRedirectByRoute,
   getPublishedDataRowByRoute,
 } from '../repositories/data/publish'
-import {
-  getLatestPublishedSiteSnapshot,
-  getPublishedPageBySlug,
-} from '../repositories/publish'
+import { getPublishedPageBySlug } from '../repositories/publish'
 import { applyPublishedHtmlPipeline } from './publishedHtmlPipeline'
 import {
   renderPublishedDataRowTemplate,
   renderPublishedSnapshot,
 } from './publicRenderer'
 import { readArtefact } from './staticArtefact'
-import { getOrRender } from './renderCache'
+import { getOrRender, peek } from './renderCache'
+import { getLatestSnapshotForVersion } from './publishedSnapshotCache'
+import { getPublishVersion } from './publishState'
 import { canonicalRenderQuery } from './loopPrefetch'
 
 // ---------------------------------------------------------------------------
@@ -166,8 +169,9 @@ export async function resolvePublicRoute(
     // into the `pages` table on creation (and the boot backfill catches
     // any pre-existing table that's missing one). So a missing
     // siteSnapshot here means a corrupt install — surface that as
-    // not-found rather than half-rendering.
-    const siteSnapshot = await getLatestPublishedSiteSnapshot(db)
+    // not-found rather than half-rendering. The snapshot is memoised per
+    // publish version, so warm row requests skip the full-site parse.
+    const siteSnapshot = await getLatestSnapshotForVersion(db, getPublishVersion())
     if (!siteSnapshot) return { kind: 'not-found' }
     return { kind: 'row', snapshot: siteSnapshot, row }
   }
@@ -231,8 +235,19 @@ export async function renderPublicResolution(
     }
   }
 
-  // Resolve once outside the cache factory so redirects and not-founds are
-  // never stored in the LRU.
+  // ── Layer B fast-path: serve a warm cached render before resolving ───────
+  // Only 200 renders are ever stored, so a version-matched hit can be served
+  // without touching the DB. Route retractions (unpublish, soft-delete, table
+  // move) bump the publish version, which turns every cached entry into a
+  // miss — a deleted route can never be served from a stale entry.
+  const cacheKey = { urlPath: url.pathname, queryString: canonicalQuery }
+  const warm = peek(cacheKey)
+  if (warm) {
+    return new Response(warm.body, { headers: warm.headers, status: warm.status })
+  }
+
+  // Resolve outside the cache factory so redirects and not-founds are never
+  // stored in the LRU.
   const resolution = await resolvePublicRoute(db, url)
   if (resolution.kind === 'not-found') return null
   if (resolution.kind === 'redirect') {
@@ -244,7 +259,7 @@ export async function renderPublicResolution(
 
   // ── Layer B: in-memory LRU cache for the expensive render path ───────────
   const cached = await getOrRender(
-    { urlPath: url.pathname, queryString: canonicalQuery },
+    cacheKey,
     async () => {
       const rendered = resolution.kind === 'page'
         ? await renderPublishedSnapshot(resolution.snapshot, { db, url })

--- a/server/publish/publishState.ts
+++ b/server/publish/publishState.ts
@@ -48,6 +48,21 @@ export function getPublishVersion(): number {
   return publishVersion
 }
 
+/**
+ * Bump the publish version under the publish lock. The serialization matters
+ * (ISS-038): a bare bump racing a publish's read-version → bake → bump window
+ * would mis-stamp its baked hole shells as permanently stale. Call this from
+ * every content mutation that retracts or moves a published route outside a
+ * publish — unpublish, soft-delete, table move — so the render cache and the
+ * versioned snapshot memos stop serving the retracted route.
+ *
+ * NEVER call inside an open DB transaction: the publish lock may be held by a
+ * publish that is itself queued behind the transaction chain (deadlock).
+ */
+export function bumpPublishVersionSerialized(): Promise<void> {
+  return withPublishLock(async () => { bumpPublishVersion() })
+}
+
 // ---------------------------------------------------------------------------
 // Publish serialization
 // ---------------------------------------------------------------------------

--- a/server/publish/publishedSnapshotCache.ts
+++ b/server/publish/publishedSnapshotCache.ts
@@ -1,0 +1,114 @@
+/**
+ * Version-keyed caches over the latest published site snapshot.
+ *
+ * The published snapshot (the entire SiteDocument) changes only when the
+ * publish version moves, yet three request-time consumers used to load and
+ * JSON-parse it from the DB per request — the per-request cost flagged in the
+ * architecture review:
+ *
+ *   - the public router's row-route resolution (`publicRouter.ts`)
+ *   - the Layer C hole endpoint (`handlers/cms/hole.ts`)
+ *   - the infinite-loop load-more endpoint (`handlers/cms/loop.ts`)
+ *
+ * This module owns ONE snapshot memo plus the two derived per-version indexes
+ * (nodeId → page for holes, loopId → page+node for loops), all built on
+ * `createVersionedSingleFlight` from `publishState.ts`: one concurrent loader
+ * per version, cached until the version changes, reset together with the rest
+ * of the publish state in tests. A publish bump simply makes the next read
+ * miss and reload against the fresh snapshot.
+ *
+ * The publish-time bake may pass `nextPublishVersion` (the version that
+ * becomes current the instant `bumpPublishVersion()` runs after the slot
+ * swap) — that pre-warms the memo for the version visitors are about to hit.
+ */
+
+import type { DbClient } from '../db/client'
+import type { Page, PageNode, SiteDocument } from '@core/page-tree'
+import type { PublishedPageSnapshot } from '../repositories/publish'
+import { getLatestPublishedSiteSnapshot } from '../repositories/publish'
+import { collectLoopNodes } from './loopPrefetch'
+import { createVersionedSingleFlight } from './publishState'
+
+// ---------------------------------------------------------------------------
+// Latest snapshot
+// ---------------------------------------------------------------------------
+
+const snapshotMemo = createVersionedSingleFlight<PublishedPageSnapshot>()
+
+/**
+ * The latest published site snapshot for `version`. Loads (and JSON-parses)
+ * it from the DB once per publish version; warm calls do zero I/O.
+ */
+export function getLatestSnapshotForVersion(
+  db: DbClient,
+  version: number,
+): Promise<PublishedPageSnapshot | null> {
+  return snapshotMemo.get(version, () => getLatestPublishedSiteSnapshot(db))
+}
+
+// ---------------------------------------------------------------------------
+// nodeId → page index (Layer C holes)
+// ---------------------------------------------------------------------------
+
+export interface PublishedNodeIndex {
+  site: SiteDocument
+  /** First page wins on the (extremely unlikely) duplicate node id. */
+  nodeIndex: Map<string, Page>
+}
+
+const nodeIndexMemo = createVersionedSingleFlight<PublishedNodeIndex>()
+
+/**
+ * The published site plus a `nodeId → page` index for `version`, so the hole
+ * endpoint locates a fragment's page in O(1) instead of scanning all pages.
+ */
+export function getPublishedNodeIndexForVersion(
+  db: DbClient,
+  version: number,
+): Promise<PublishedNodeIndex | null> {
+  return nodeIndexMemo.get(version, async () => {
+    const snapshot = await getLatestSnapshotForVersion(db, version)
+    if (!snapshot) return null
+    const nodeIndex = new Map<string, Page>()
+    for (const page of snapshot.site.pages) {
+      for (const nodeId of Object.keys(page.nodes)) {
+        if (!nodeIndex.has(nodeId)) nodeIndex.set(nodeId, page)
+      }
+    }
+    return { site: snapshot.site, nodeIndex }
+  })
+}
+
+// ---------------------------------------------------------------------------
+// loopId → page + node index (infinite-loop load-more)
+// ---------------------------------------------------------------------------
+
+export interface PublishedLoopIndex {
+  site: SiteDocument
+  /** First page wins on a duplicate loop id, matching the old scan order. */
+  loops: Map<string, { page: Page; node: PageNode }>
+}
+
+const loopIndexMemo = createVersionedSingleFlight<PublishedLoopIndex>()
+
+/**
+ * The published site plus a `loopId → { page, node }` index for `version`.
+ * Built once per publish version by walking each page's render tree (the same
+ * `collectLoopNodes` walk the loop endpoint used to repeat per request).
+ */
+export function getPublishedLoopIndexForVersion(
+  db: DbClient,
+  version: number,
+): Promise<PublishedLoopIndex | null> {
+  return loopIndexMemo.get(version, async () => {
+    const snapshot = await getLatestSnapshotForVersion(db, version)
+    if (!snapshot) return null
+    const loops = new Map<string, { page: Page; node: PageNode }>()
+    for (const page of snapshot.site.pages) {
+      for (const node of collectLoopNodes(page, snapshot.site)) {
+        if (!loops.has(node.id)) loops.set(node.id, { page, node })
+      }
+    }
+    return { site: snapshot.site, loops }
+  })
+}

--- a/server/publish/renderCache.ts
+++ b/server/publish/renderCache.ts
@@ -107,6 +107,32 @@ export function __setMaxEntriesForTests(n: number): void {
 }
 
 /**
+ * Return the cached response for `key` if one exists at the current publish
+ * version, WITHOUT invoking any factory. A hit promotes the entry (LRU) and
+ * counts toward the hit statistic; a miss counts nothing — the caller is
+ * expected to follow up with `getOrRender`, which records the miss.
+ *
+ * This is the request fast-path: `renderPublicResolution` peeks BEFORE doing
+ * route resolution, so a warm dynamic route skips its DB round-trips and the
+ * full-site snapshot parse entirely. Safe because every mutation that changes
+ * what a published URL serves — full publish, incremental row publish,
+ * unpublish, soft-delete, table move — bumps the publish version, which makes
+ * every cached entry miss here.
+ */
+export function peek(key: RenderCacheKey): CachedResponse | null {
+  const k = cacheKey(key)
+  const existing = map.get(k)
+  if (existing !== undefined && existing.publishVersion === getPublishVersion()) {
+    // LRU promotion: delete + re-set moves the entry to most-recent position.
+    map.delete(k)
+    map.set(k, existing)
+    hits++
+    return existing.response
+  }
+  return null
+}
+
+/**
  * Return a cached response for `key`, invoking `factory` only on a miss.
  *
  * Hit: entry exists and its publishVersion matches the current version.

--- a/server/publish/siteCssBundle.ts
+++ b/server/publish/siteCssBundle.ts
@@ -20,13 +20,12 @@
  *   memoising across them would cross-contaminate unpublished content.
  *
  * - `buildPublishedSiteCssBundle` is the hot path for the published-snapshot
- *   renderer (`publicRenderer.ts`). There the site is fixed for a given publish
- *   version, so the three page-invariant files (reset / framework / style) are
- *   memoised by `publishVersion` + the site object being rendered and reused
- *   across every render for that pair — the expensive all-pages walk runs once
- *   per publish snapshot, not once per request. Only `userStyles` (page-scoped)
- *   is rebuilt per call. The memo is invalidated automatically by
- *   `bumpPublishVersion()`.
+ *   renderer (`publicRenderer.ts`). There the site content is fixed for a
+ *   given publish version, so the three page-invariant files (reset /
+ *   framework / style) are memoised by `publishVersion` and reused across
+ *   every render at that version — the expensive all-pages walk runs once per
+ *   publish, not once per request. Only `userStyles` (page-scoped) is rebuilt
+ *   per call. The memo is invalidated automatically by `bumpPublishVersion()`.
  */
 
 import { createHash } from 'node:crypto'
@@ -82,24 +81,30 @@ export function buildSiteCssBundle(
 
 /**
  * Published-render variant of `buildSiteCssBundle`. Memoises the three
- * page-invariant files (reset / framework / style) by `publishVersion` and
- * site object, so the O(all-pages) module-CSS walk runs once per published
- * snapshot instead of once per render. Only `userStyles` is rebuilt per call
- * (it is page-scoped).
+ * page-invariant files (reset / framework / style) by `publishVersion`, so
+ * the O(all-pages) module-CSS walk runs once per publish version instead of
+ * once per render. Only `userStyles` is rebuilt per call (it is page-scoped).
  *
- * Safe ONLY for the published-snapshot render path, where all pages in one
- * snapshot share a single `site` object. Callers that pass draft / arbitrary
- * sites at the live version (preview, AI render, CSS-route fallback) must use
- * `buildSiteCssBundle` — sharing a render-path cache across them would serve
- * stale CSS.
+ * Memo key = publish version ALONE. The published site content is fixed for a
+ * given version: `publishDraftSite` is the only snapshot writer and it bumps
+ * the version right after committing, and incremental row publishes never
+ * write the site document (they bump too, which just re-primes the memo with
+ * identical content). The publish-time bake renders the NEXT version's content
+ * before the bump, so it passes `nextPublishVersion` explicitly — its entries
+ * can never collide with pre-publish renders at the old version.
+ *
+ * Safe ONLY for published-snapshot content. Callers that pass draft /
+ * arbitrary sites (preview, AI render) must use `buildSiteCssBundle` —
+ * sharing a render-path cache across them would serve stale CSS.
  */
 export function buildPublishedSiteCssBundle(
   site: SiteDocument,
   registry: IModuleRegistry,
   page?: Page,
+  publishVersion: number = getPublishVersion(),
 ): SiteCssBundle {
   return {
-    ...memoizedPageInvariantBundles(site, registry),
+    ...memoizedPageInvariantBundles(site, registry, publishVersion),
     userStyles: makeBundleFile('userStyles', collectUserStylesheetCss(site, page)),
   }
 }
@@ -119,26 +124,29 @@ function computePageInvariantBundles(
 // Page-invariant bundle memo, keyed by publish version. A bump invalidates it
 // (the next read sees a new version → recompute), so a content change can never
 // serve stale framework/style CSS. Registered with the shared test-reset hook.
-let pageInvariantCache: { version: number; site: SiteDocument; bundles: PageInvariantBundles } | null = null
+//
+// Deliberately NOT keyed on the site object: every consumer loads the snapshot
+// fresh (DB JSON parse per query), so an identity key would never hit — that
+// was exactly the bug that made every Layer B miss re-walk the whole site.
+let pageInvariantCache: { version: number; bundles: PageInvariantBundles } | null = null
 registerVersionedCacheReset(() => {
   pageInvariantCache = null
 })
 
 /**
- * Return the page-invariant bundles for the current publish version + site
- * object, computing them once and reusing the cached files on later renders of
- * the same snapshot.
+ * Return the page-invariant bundles for `version`, computing them once and
+ * reusing the cached files on later renders of the same publish version.
  */
 function memoizedPageInvariantBundles(
   site: SiteDocument,
   registry: IModuleRegistry,
+  version: number,
 ): PageInvariantBundles {
-  const version = getPublishVersion()
-  if (pageInvariantCache && pageInvariantCache.version === version && pageInvariantCache.site === site) {
+  if (pageInvariantCache && pageInvariantCache.version === version) {
     return pageInvariantCache.bundles
   }
   const bundles = computePageInvariantBundles(site, registry)
-  pageInvariantCache = { version, site, bundles }
+  pageInvariantCache = { version, bundles }
   return bundles
 }
 

--- a/server/repositories/data/publish.ts
+++ b/server/repositories/data/publish.ts
@@ -362,6 +362,49 @@ async function readPreviousPublishedRoute(
 // Public-route lookups
 // ---------------------------------------------------------------------------
 
+export interface PublishedRowRoute {
+  rowId: string
+  /** Slug of the row's ACTIVE published version (what the public URL uses). */
+  rowSlug: string
+  tableSlug: string
+  tableRouteBase: string
+}
+
+/**
+ * Every published, non-deleted data row (excluding the `pages` table) with
+ * its active version's slug and its table's route info. The full publish uses
+ * this to bake a Layer A artefact for each row route into the fresh slot —
+ * without it, the slot swap would strand every row artefact written by
+ * incremental publishes.
+ */
+export async function listPublishedRowRoutes(db: DbClient): Promise<PublishedRowRoute[]> {
+  const { rows } = await db<{
+    row_id: string
+    row_slug: string
+    table_slug: string
+    table_route_base: string
+  }>`
+    select data_rows.id as row_id,
+           data_row_versions.slug as row_slug,
+           data_tables.slug as table_slug,
+           data_tables.route_base as table_route_base
+    from data_rows
+    join data_tables on data_tables.id = data_rows.table_id
+    join data_row_versions on data_row_versions.id = data_rows.active_version_id
+    where data_rows.table_id <> 'pages'
+      and data_rows.status = 'published'
+      and data_rows.deleted_at is null
+      and data_tables.deleted_at is null
+    order by data_rows.created_at asc
+  `
+  return rows.map((row) => ({
+    rowId: row.row_id,
+    rowSlug: row.row_slug,
+    tableSlug: row.table_slug,
+    tableRouteBase: normalizeRouteBase(row.table_route_base),
+  }))
+}
+
 /**
  * Resolve a public URL (tableRouteBase + rowSlug) to the active published
  * version of a data row.

--- a/server/repositories/data/rows/bulk.ts
+++ b/server/repositories/data/rows/bulk.ts
@@ -57,19 +57,26 @@ export async function saveDataRowDraftMany(
 /**
  * Bulk-soft-delete N rows in a single transaction. Returns the number of
  * rows that were actually deleted (skips rows that were already missing
- * or soft-deleted).
+ * or soft-deleted), plus how many of those were `published` — callers use
+ * that to invalidate the public render cache AFTER the transaction commits
+ * (a published row's route is retracted by deletion; the bump must never
+ * run inside the transaction because it serializes on the publish lock).
  */
 export async function softDeleteDataRowMany(
   db: DbClient,
   rowIds: ReadonlyArray<string>,
   actorUserId: string | null = null,
-): Promise<{ deleted: number }> {
+): Promise<{ deleted: number; publishedDeleted: number }> {
   return db.transaction(async (tx) => {
     let deleted = 0
+    let publishedDeleted = 0
     for (const id of rowIds) {
       const result = await softDeleteDataRow(tx, id, actorUserId)
-      if (result) deleted++
+      if (result) {
+        deleted++
+        if (result.status === 'published') publishedDeleted++
+      }
     }
-    return { deleted }
+    return { deleted, publishedDeleted }
   })
 }

--- a/server/repositories/data/rows/mutations.ts
+++ b/server/repositories/data/rows/mutations.ts
@@ -19,7 +19,7 @@
 import { nanoid } from 'nanoid'
 import type { DbClient } from '../../../db/client'
 import type { DataRow, DataRowStatus, DeletedRowSummary } from '@core/data/schemas'
-import { bumpPublishVersion, withPublishLock } from '../../../publish/publishState'
+import { bumpPublishVersionSerialized } from '../../../publish/publishState'
 import { type InsertDataRowInput, type UpdateDataRowDraftInput } from './mapper'
 import { isoDateOrNull } from '@core/utils/isoDate'
 import { getDataRow } from './read'
@@ -174,6 +174,10 @@ export async function updateDataRowTable(
   if (!rows[0]) return { ok: false, reason: 'row_not_found' }
   const updated = await getDataRow(db, rows[0].id)
   if (!updated) return { ok: false, reason: 'row_not_found' }
+  // Moving a published row changes its public route (the route base comes
+  // from the table) — invalidate the render cache so the old URL stops
+  // being served.
+  if (row.status === 'published') await bumpPublishVersionSerialized()
   return { ok: true, row: updated }
 }
 
@@ -201,9 +205,8 @@ export async function updateDataRowStatus(
     returning id
   `
   if (!rows[0]) return null
-  // Invalidate the render cache. Serialize the bump with publishes so it can't
-  // strand a concurrent publish's baked shells (ISS-038).
-  await withPublishLock(async () => { bumpPublishVersion() })
+  // Invalidate the render cache — the route's published state changed.
+  await bumpPublishVersionSerialized()
   return getDataRow(db, rows[0].id)
 }
 

--- a/server/repositories/publish.ts
+++ b/server/repositories/publish.ts
@@ -1,10 +1,13 @@
 /**
  * Publish pipeline repository.
  *
- * Pages are stored in `data_rows` (table_id = 'pages'). Each published
- * version is a row in `data_row_versions` that carries `snapshot_json`
- * containing the full `PublishedPageSnapshot` (site document + runtime
- * assets). This replaces the old `page_versions` table.
+ * Pages are stored in `data_rows` (table_id = 'pages'). A full publish
+ * stores the published `SiteDocument` ONCE in `site_snapshots` (with a
+ * content hash and the pre-serialised runtime importmap); each published
+ * page version is a row in `data_row_versions` that references it via
+ * `site_snapshot_id` and carries only its page-scoped `runtime_assets_json`.
+ * Readers reassemble the `PublishedPageSnapshot` shape from the join, so
+ * publishing N pages stores the site document once instead of N times.
  *
  * Public API:
  *   publishDraftSite          — build + store snapshots for all draft pages
@@ -12,10 +15,11 @@
  *   getLatestPublishedSiteSnapshot — first published page snapshot (for 404s etc.)
  *   getDraftPublishStatus     — compare draft vs published state for the UI
  */
+import { createHash } from 'node:crypto'
 import { nanoid } from 'nanoid'
 import type { SiteDocument } from '@core/page-tree'
 import type { PublishedPageRuntimeAssets } from '@core/site-runtime'
-import type { PublishedRuntimePackageImportmap } from '@core/publisher'
+import type { PublishedRuntimePackageImportmap, SiteCssBundle } from '@core/publisher'
 import { normalizeSiteRuntimeConfig } from '@core/site-runtime'
 import { registry } from '@core/module-engine'
 import type { DbClient } from '../db/client'
@@ -35,7 +39,8 @@ import { renderPublishedSnapshot } from '../publish/publicRenderer'
 import { isTemplatePage } from '@core/templates'
 import { applyPublishedHtmlPipeline } from '../publish/publishedHtmlPipeline'
 import { prepareInactiveSlot, writeArtefact, writeStaticAsset, swapSlot } from '../publish/staticArtefact'
-import { buildSiteCssBundle } from '../publish/siteCssBundle'
+import { buildPublishedSiteCssBundle } from '../publish/siteCssBundle'
+import { bakePublishedDataRowArtefacts } from '../publish/bakeDataRows'
 import { bumpPublishVersion, getPublishVersion, withPublishLock } from '../publish/publishState'
 
 // ---------------------------------------------------------------------------
@@ -69,10 +74,19 @@ interface DraftPublishStatus {
   lastPublishedAt?: string
 }
 
-interface ActivePublishedRow {
+interface PublishStatusRow {
   row_id: string
-  snapshot_json: PublishedPageSnapshot
+  content_hash: string
   published_at: string | Date
+}
+
+/** Shared SELECT shape for the snapshot getters below. */
+interface SnapshotQueryRow {
+  row_id: string
+  site_json: SiteDocument
+  runtime_assets_json: PublishedPageRuntimeAssets | null
+  importmap_body: string | null
+  importmap_sha256: string | null
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +106,22 @@ function canonicalJson(value: unknown): string {
   return JSON.stringify(value)
 }
 
+/**
+ * Canonical content hash of a site document, stamped on `site_snapshots` at
+ * publish time. The publish-status check compares the draft's hash against
+ * it — equality is observationally identical to comparing the canonical JSON
+ * strings, without fetching or parsing any stored snapshot.
+ */
+function siteContentHash(site: SiteDocument): string {
+  return createHash('sha256').update(canonicalJson(site)).digest('hex')
+}
+
+/**
+ * Assemble the in-memory snapshot for one page. The `site` object is SHARED
+ * across every snapshot of a publish (it is frozen content — nothing mutates
+ * it after creation), so building N snapshots costs N small objects, not N
+ * deep clones of the whole site.
+ */
 function createSnapshot(
   site: SiteDocument,
   pageRowId: string,
@@ -101,9 +131,24 @@ function createSnapshot(
   return {
     cmsSnapshotVersion: 1,
     pageRowId,
-    site: structuredClone(site),
+    site,
     ...(runtimeAssets && runtimeAssets.scripts.length > 0 ? { runtimeAssets } : {}),
     ...(runtimePackageImportmap ? { runtimePackageImportmap } : {}),
+  }
+}
+
+/** Reassemble the `PublishedPageSnapshot` shape from the getter join. */
+function snapshotFromQueryRow(row: SnapshotQueryRow): PublishedPageSnapshot {
+  return {
+    cmsSnapshotVersion: 1,
+    pageRowId: row.row_id,
+    site: row.site_json,
+    ...(row.runtime_assets_json && row.runtime_assets_json.scripts.length > 0
+      ? { runtimeAssets: row.runtime_assets_json }
+      : {}),
+    ...(row.importmap_body && row.importmap_sha256
+      ? { runtimePackageImportmap: { body: row.importmap_body, sha256: row.importmap_sha256 } }
+      : {}),
   }
 }
 
@@ -135,25 +180,30 @@ export async function getDraftPublishStatus(db: DbClient): Promise<DraftPublishS
     visualComponents,
   }
 
-  const { rows: publishedRows } = await db<ActivePublishedRow>`
+  // Only the per-publish content hash is fetched — never the stored site
+  // document. Comparing the draft's hash against each row's stamped hash is
+  // observationally identical to comparing canonical JSON strings, but costs
+  // one draft serialisation instead of one per published page.
+  const { rows: publishedRows } = await db<PublishStatusRow>`
     select data_rows.id as row_id,
-           data_row_versions.snapshot_json,
+           site_snapshots.content_hash,
            data_row_versions.published_at
     from data_rows
     join data_row_versions on data_row_versions.id = data_rows.active_version_id
+    join site_snapshots on site_snapshots.id = data_row_versions.site_snapshot_id
     where data_rows.table_id = 'pages'
       and data_rows.status = 'published'
       and data_rows.deleted_at is null
     order by data_rows.created_at asc
   `
 
-  const draftSiteJson = canonicalJson(draftSite)
+  const draftSiteHash = siteContentHash(draftSite)
   const draftPageIds = new Set(draftSite.pages.map((page) => page.id))
   const draftMatchesPublished =
     publishedRows.length === draftSite.pages.length &&
     publishedRows.every((row) =>
       draftPageIds.has(row.row_id) &&
-      canonicalJson(row.snapshot_json.site) === draftSiteJson
+      row.content_hash === draftSiteHash
     )
   const lastPublishedAt = publishedRows
     .map((row) => new Date(row.published_at).getTime())
@@ -224,6 +274,21 @@ async function publishDraftSiteLocked(
       })),
     }
 
+    // The site document is stored ONCE per publish; every page version row
+    // references it. The content hash powers the publish-status check without
+    // ever re-fetching the document.
+    const siteSnapshotId = nanoid()
+    await tx`
+      insert into site_snapshots (id, site_json, content_hash, importmap_body, importmap_sha256)
+      values (
+        ${siteSnapshotId},
+        ${publishedSite},
+        ${siteContentHash(publishedSite)},
+        ${serializedImportmap?.body ?? null},
+        ${serializedImportmap?.sha256 ?? null}
+      )
+    `
+
     const snapshots: PublishedPageSnapshot[] = []
     // Runtime JS bytes for every page, collected for the Layer A disk write so
     // published pages serve their scripts straight off disk (not the DB).
@@ -253,14 +318,15 @@ async function publishDraftSiteLocked(
 
       await tx`
         insert into data_row_versions
-          (id, row_id, version_number, cells_json, slug, snapshot_json, published_by_user_id)
+          (id, row_id, version_number, cells_json, slug, site_snapshot_id, runtime_assets_json, published_by_user_id)
         values (
           ${versionId},
           ${page.id},
           ${version},
           ${{ title: page.title, slug: page.slug }},
           ${page.slug},
-          ${snapshot},
+          ${siteSnapshotId},
+          ${snapshot.runtimeAssets ?? null},
           ${adminUserId}
         )
       `
@@ -308,26 +374,27 @@ async function publishDraftSiteLocked(
     try {
       const { slot, slotDir } = await prepareInactiveSlot(uploadsDir)
 
-      // Every distinct static asset referenced by ANY published page.
+      // Every distinct static asset referenced by ANY baked artefact.
       // Content-hashed filenames dedupe identical bytes across pages to a
-      // single write.
+      // single write. The page-invariant CSS trio (reset/framework/style) is
+      // computed ONCE per publish via the version-keyed memo — the all-pages
+      // walk no longer repeats per page. Only `userStyles` is page-scoped.
       const assetsByPath = new Map<string, Uint8Array>()
       const encoder = new TextEncoder()
-      for (const snapshot of snapshots) {
-        const page = snapshot.site.pages.find((p) => p.id === snapshot.pageRowId)
-        if (!page || isTemplatePage(page)) continue // template pages only ever wrap; never baked at their own slug
-        const cssBundle = buildSiteCssBundle(snapshot.site, registry, page)
+      const collectCssFiles = (cssBundle: SiteCssBundle): void => {
         for (const file of [cssBundle.reset, cssBundle.framework, cssBundle.style, cssBundle.userStyles]) {
           if (file.content.length === 0) continue
           const publicPath = `/_instatic/css/${file.filename}`
           if (!assetsByPath.has(publicPath)) assetsByPath.set(publicPath, encoder.encode(file.content))
         }
       }
+      for (const snapshot of snapshots) {
+        const page = snapshot.site.pages.find((p) => p.id === snapshot.pageRowId)
+        if (!page || isTemplatePage(page)) continue // template pages only ever wrap; never baked at their own slug
+        collectCssFiles(buildPublishedSiteCssBundle(snapshot.site, registry, page, nextPublishVersion))
+      }
       for (const asset of runtimeAssetFiles) {
         if (!assetsByPath.has(asset.publicPath)) assetsByPath.set(asset.publicPath, asset.bytes)
-      }
-      for (const [publicPath, bytes] of assetsByPath) {
-        await writeStaticAsset(slotDir, publicPath, bytes)
       }
 
       // HTML artefacts (or hole shells) for every page. A page that fails to
@@ -346,9 +413,23 @@ async function publishDraftSiteLocked(
           })
           const html = await applyPublishedHtmlPipeline(rendered, db)
           await writeArtefact(slotDir, urlPath, html)
+          // The render's own bundle covers template-composed hashes the raw
+          // page bundle above cannot (the merged page's userStyles).
+          collectCssFiles(rendered.cssBundle)
         } catch (err) {
           console.error('[publish:site] failed to bake artefact for', urlPath, '(falls through to live renderer):', err)
         }
+      }
+
+      // Data-row artefacts: every published row whose table has an entry
+      // template bakes into the same slot. Without this the slot swap would
+      // strand every previously-baked row artefact in the inactive slot and
+      // ALL row routes would fall to the live renderer after a full publish.
+      const rowBake = await bakePublishedDataRowArtefacts(db, slotDir, nextPublishVersion)
+      for (const cssBundle of rowBake.cssBundles) collectCssFiles(cssBundle)
+
+      for (const [publicPath, bytes] of assetsByPath) {
+        await writeStaticAsset(slotDir, publicPath, bytes)
       }
       await swapSlot(uploadsDir, slot)
     } catch (err) {
@@ -370,50 +451,65 @@ export async function getPublishedPageBySlug(
   db: DbClient,
   slug: string,
 ): Promise<PublishedPageSnapshot | null> {
-  const { rows } = await db<{ snapshot_json: PublishedPageSnapshot }>`
-    select data_row_versions.snapshot_json
+  const { rows } = await db<SnapshotQueryRow>`
+    select data_rows.id as row_id,
+           site_snapshots.site_json,
+           data_row_versions.runtime_assets_json,
+           site_snapshots.importmap_body,
+           site_snapshots.importmap_sha256
     from data_rows
     join data_row_versions on data_row_versions.id = data_rows.active_version_id
+    join site_snapshots on site_snapshots.id = data_row_versions.site_snapshot_id
     where data_rows.table_id = 'pages'
       and data_rows.slug = ${slug}
       and data_rows.status = 'published'
       and data_rows.deleted_at is null
     limit 1
   `
-  return rows[0]?.snapshot_json ?? null
+  return rows[0] ? snapshotFromQueryRow(rows[0]) : null
 }
 
 export async function getPublishedPageSnapshotById(
   db: DbClient,
   pageId: string,
 ): Promise<PublishedPageSnapshot | null> {
-  const { rows } = await db<{ snapshot_json: PublishedPageSnapshot }>`
-    select data_row_versions.snapshot_json
+  const { rows } = await db<SnapshotQueryRow>`
+    select data_rows.id as row_id,
+           site_snapshots.site_json,
+           data_row_versions.runtime_assets_json,
+           site_snapshots.importmap_body,
+           site_snapshots.importmap_sha256
     from data_rows
     join data_row_versions on data_row_versions.id = data_rows.active_version_id
+    join site_snapshots on site_snapshots.id = data_row_versions.site_snapshot_id
     where data_rows.id = ${pageId}
       and data_rows.table_id = 'pages'
       and data_rows.status = 'published'
       and data_rows.deleted_at is null
     limit 1
   `
-  return rows[0]?.snapshot_json ?? null
+  return rows[0] ? snapshotFromQueryRow(rows[0]) : null
 }
 
 export async function getLatestPublishedSiteSnapshot(
   db: DbClient,
 ): Promise<PublishedPageSnapshot | null> {
-  const { rows } = await db<{ snapshot_json: PublishedPageSnapshot }>`
-    select data_row_versions.snapshot_json
+  const { rows } = await db<SnapshotQueryRow>`
+    select data_rows.id as row_id,
+           site_snapshots.site_json,
+           data_row_versions.runtime_assets_json,
+           site_snapshots.importmap_body,
+           site_snapshots.importmap_sha256
     from data_rows
     join data_row_versions on data_row_versions.id = data_rows.active_version_id
+    join site_snapshots on site_snapshots.id = data_row_versions.site_snapshot_id
     where data_rows.table_id = 'pages'
       and data_rows.status = 'published'
       and data_rows.deleted_at is null
     order by data_rows.created_at asc
     limit 1
   `
-  return rows[0]?.snapshot_json ?? null
+  return rows[0] ? snapshotFromQueryRow(rows[0]) : null
 }
 
 // `listPluginPageSummaries` was removed alongside the `api.cms.pages.*`

--- a/server/repositories/setup.ts
+++ b/server/repositories/setup.ts
@@ -23,6 +23,40 @@ export async function getSetupStatus(db: DbClient): Promise<SetupStatus> {
   return { hasSite, hasAdmin: hasOwner, hasOwner, needsSetup: !hasSite || !hasOwner }
 }
 
+/**
+ * Sticky setup-status memo, keyed by `DbClient` instance.
+ *
+ * `needsSetup` only ever transitions true → false: setup creates the site and
+ * the first owner, and the app refuses to deactivate or delete the last
+ * active owner. Once a status with `needsSetup === false` has been observed
+ * it is final for the process lifetime.
+ *
+ * Keyed by client (WeakMap) rather than a bare module global so tests that
+ * spin up a fresh database per test stay isolated without manual resets.
+ */
+let settledStatusByDb = new WeakMap<DbClient, SetupStatus>()
+
+/**
+ * Like {@link getSetupStatus}, but skips the two COUNT queries once setup is
+ * known to be complete. The router consults setup status on every unmatched
+ * GET (bot probes hit that path forever on a long-lived install), so the hot
+ * path must not query the database. While setup is still pending the status
+ * is re-queried live on every call, so an in-progress setup is observed
+ * immediately.
+ */
+export async function getSetupStatusCached(db: DbClient): Promise<SetupStatus> {
+  const settled = settledStatusByDb.get(db)
+  if (settled) return settled
+  const status = await getSetupStatus(db)
+  if (!status.needsSetup) settledStatusByDb.set(db, status)
+  return status
+}
+
+/** Drop all memoized statuses — for tests that rewind setup state out-of-band (raw SQL deletes). */
+export function resetSetupStatusCacheForTests(): void {
+  settledStatusByDb = new WeakMap()
+}
+
 export async function createSite(
   db: DbClient,
   name: string,

--- a/server/router.ts
+++ b/server/router.ts
@@ -3,8 +3,9 @@ import { handleCmsRequest } from './handlers/cms'
 import type { DbClient } from './db/client'
 import { renderPublicResolution } from './publish/publicRouter'
 import { readStaticAsset } from './publish/staticArtefact'
-import { getLatestPublishedSiteSnapshot } from './repositories/publish'
-import { getSetupStatus } from './repositories/setup'
+import { getLatestSnapshotForVersion } from './publish/publishedSnapshotCache'
+import { getPublishVersion, registerVersionedCacheReset } from './publish/publishState'
+import { getSetupStatusCached } from './repositories/setup'
 import { getPublishedRuntimeAsset } from './repositories/runtimeAsset'
 import { handleLoopRequest, isLoopRuntimeAssetPath, serveLoopRuntimeAsset } from './handlers/cms/loop'
 import { handleHoleRequest, isHoleRuntimeAssetPath, serveHoleRuntimeAsset } from './handlers/cms/hole'
@@ -16,7 +17,7 @@ import { binaryResponse, toArrayBuffer } from './binary'
 import { hardenUploadResponse, serveAdminApp, serveStaticFile } from './static'
 import { registry } from '@core/module-engine'
 import type { CssBundleFile, SiteCssBundleId } from '@core/publisher'
-import { buildSiteCssBundle } from './publish/siteCssBundle'
+import { buildPublishedSiteCssBundle } from './publish/siteCssBundle'
 import { mediaStorageRegistry } from '@core/plugins/mediaStorageRegistry'
 
 const VITE_DEV_URL = 'http://localhost:5173'
@@ -427,7 +428,9 @@ async function tryServePublicRoute(req: Request, runtime: ServerRuntime, url: UR
  */
 async function trySetupRedirect(req: Request, runtime: ServerRuntime, _url: URL, _pathname: string): Promise<Response | null> {
   if (req.method !== 'GET') return null
-  const setupStatus = await getSetupStatus(runtime.db)
+  // Sticky memo: once setup completes, this stops querying. Without it every
+  // unmatched GET (bot probes, 404s) paid two COUNT queries forever.
+  const setupStatus = await getSetupStatusCached(runtime.db)
   return setupStatus.needsSetup
     ? new Response(null, { status: 302, headers: { location: '/admin' } })
     : null
@@ -488,7 +491,23 @@ function adminUiNotBuiltResponse(pathname: string): Response {
  * `reset`/`framework`/`style` are page-invariant; `userStyles` is page-scoped
  * (each stylesheet targets a subset of pages), so the fallback walks the
  * published pages until one produces the requested hash.
+ *
+ * The DB fallback is memoised by `(bundle, hash)` — the hash is content-derived
+ * so an entry can never go stale; it can only stop being requested. Negative
+ * results are cached too (a crafted stale-hash URL would otherwise force the
+ * full rebuild walk per request). The memo resets when the publish version
+ * moves and concurrent first-hits share one in-flight rebuild.
  */
+const cssFallbackCache = new Map<string, string | null>()
+const CSS_FALLBACK_CACHE_MAX = 256
+const cssFallbackInFlight = new Map<string, Promise<string | null>>()
+let cssFallbackVersion = -1
+registerVersionedCacheReset(() => {
+  cssFallbackCache.clear()
+  cssFallbackInFlight.clear()
+  cssFallbackVersion = -1
+})
+
 async function serveSiteCss(db: DbClient, pathname: string, uploadsDir?: string): Promise<Response | null> {
   const filename = pathname.slice('/_instatic/css/'.length)
   const match = filename.match(/^(reset|framework|style|userStyles)-([a-f0-9]{12})\.css$/)
@@ -505,21 +524,61 @@ async function serveSiteCss(db: DbClient, pathname: string, uploadsDir?: string)
     }
   }
 
-  // Fallback: rebuild from the latest published snapshot.
-  const snapshot = await getLatestPublishedSiteSnapshot(db)
-  if (!snapshot) return new Response('Not found', { status: 404 })
+  // Memoised DB fallback.
+  const version = getPublishVersion()
+  if (version !== cssFallbackVersion) {
+    cssFallbackCache.clear()
+    cssFallbackVersion = version
+  }
+  const cacheKey = `${bundleId}:${requestedHash}`
+  const cached = cssFallbackCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached === null ? new Response('Not found', { status: 404 }) : cssResponse(cached, requestedHash)
+  }
+
+  const inflight = cssFallbackInFlight.get(cacheKey)
+  const promise = inflight ?? (async (): Promise<string | null> => {
+    try {
+      const content = await rebuildSiteCssFromSnapshot(db, bundleId, requestedHash, version)
+      if (cssFallbackCache.size >= CSS_FALLBACK_CACHE_MAX) cssFallbackCache.clear()
+      cssFallbackCache.set(cacheKey, content)
+      return content
+    } finally {
+      cssFallbackInFlight.delete(cacheKey)
+    }
+  })()
+  if (!inflight) cssFallbackInFlight.set(cacheKey, promise)
+
+  const content = await promise
+  return content === null ? new Response('Not found', { status: 404 }) : cssResponse(content, requestedHash)
+}
+
+/**
+ * Rebuild the requested CSS bundle file from the latest published snapshot.
+ * Returns the file body, or `null` when no page (nor the page-agnostic view)
+ * produces the requested hash. The page-invariant trio comes from the
+ * version-keyed memo, so only `userStyles` does per-page work here.
+ */
+async function rebuildSiteCssFromSnapshot(
+  db: DbClient,
+  bundleId: SiteCssBundleId,
+  requestedHash: string,
+  version: number,
+): Promise<string | null> {
+  const snapshot = await getLatestSnapshotForVersion(db, version)
+  if (!snapshot) return null
 
   const pages = bundleId === 'userStyles' ? snapshot.site.pages : snapshot.site.pages.slice(0, 1)
   for (const page of pages) {
-    const file: CssBundleFile = buildSiteCssBundle(snapshot.site, registry, page)[bundleId]
-    if (file.hash === requestedHash) return cssResponse(file.content, file.hash)
+    const file: CssBundleFile = buildPublishedSiteCssBundle(snapshot.site, registry, page, version)[bundleId]
+    if (file.hash === requestedHash) return file.content
   }
   // Page-agnostic view (every enabled stylesheet) — covers a hash that
   // predates a scope change but is still referenced somewhere.
-  const fallback: CssBundleFile = buildSiteCssBundle(snapshot.site, registry)[bundleId]
-  if (fallback.hash === requestedHash) return cssResponse(fallback.content, fallback.hash)
+  const fallback: CssBundleFile = buildPublishedSiteCssBundle(snapshot.site, registry, undefined, version)[bundleId]
+  if (fallback.hash === requestedHash) return fallback.content
 
-  return new Response('Not found', { status: 404 })
+  return null
 }
 
 function cssResponse(body: BodyInit, hash: string): Response {

--- a/src/__tests__/architecture/module-size-budgets.test.ts
+++ b/src/__tests__/architecture/module-size-budgets.test.ts
@@ -106,7 +106,8 @@ const GRANDFATHERED: Record<string, number> = {
   // (cloneNode.ts) so the three duplicate/paste/duplicatePage callers share one
   // clone. See docs/reference/page-tree.md (parentId).
   'src/core/page-tree/mutations.ts': 880,
-  'server/plugins/host/handlers/content.ts': 786,
+  // server/plugins/host/handlers/content.ts graduated (786 → 661) when the
+  // DB→wire projection helpers moved to contentProjection.ts.
   'src/core/siteImport/cssToStyleRules.ts': 742,
   'src/admin/pages/site/panels/TypographyPanel/FontsSection/AddGoogleFontDialog.tsx': 751,
   'src/core/markdown/markdownDocument.ts': 748,

--- a/src/__tests__/architecture/publish-bumps-cache-version.test.ts
+++ b/src/__tests__/architecture/publish-bumps-cache-version.test.ts
@@ -1,12 +1,15 @@
 /**
  * Architecture gate: every publish/unpublish entry point in
- * `server/repositories/` calls `bumpPublishVersion()` and imports it from
- * the publish-state module.
+ * `server/repositories/` bumps the publish version — either the bare
+ * `bumpPublishVersion()` (publishes, which already hold the publish lock) or
+ * `bumpPublishVersionSerialized()` (retractions outside a publish: unpublish,
+ * soft-delete, table move) — and imports it from the publish-state module.
  *
  * Covered files:
  *   - server/repositories/publish.ts            (publishDraftSite)
  *   - server/repositories/data/publish.ts       (publishDataRow)
- *   - server/repositories/data/rows/mutations.ts (updateDataRowStatus — unpublish)
+ *   - server/repositories/data/rows/mutations.ts (updateDataRowStatus — unpublish;
+ *                                                 updateDataRowTable — route move)
  *
  * A simple text scan is sufficient — no AST parsing needed. The check matches
  * the pattern used by other architecture tests in this directory.
@@ -35,9 +38,12 @@ const FILES_UNDER_TEST = Object.keys(EXPECTED_IMPORT_PATHS)
 
 describe('publish-bumps-cache-version', () => {
   for (const file of FILES_UNDER_TEST) {
-    it(`${file} calls bumpPublishVersion()`, () => {
+    it(`${file} bumps the publish version`, () => {
       const src = read(file)
-      expect(src).toContain('bumpPublishVersion()')
+      const bumps =
+        src.includes('bumpPublishVersion()') ||
+        src.includes('bumpPublishVersionSerialized()')
+      expect(bumps).toBe(true)
     })
 
     it(`${file} imports bumpPublishVersion from the publish-state module`, () => {

--- a/src/__tests__/editor-store/deleteNodesDepthOrder.test.ts
+++ b/src/__tests__/editor-store/deleteNodesDepthOrder.test.ts
@@ -1,0 +1,145 @@
+/**
+ * depthInTree + deleteNodes batch ordering.
+ *
+ * `depthInTree` walks the O(1) `parentId` pointer chain (no node-map scans).
+ * These tests pin its semantics — root depth 0, parent-chain depth, Infinity
+ * for orphans/missing ids — and the `deleteNodes` contract built on it:
+ * depths are precomputed against the frozen pre-mutation tree, leaves are
+ * deleted before parents, and a batch containing a parent plus its
+ * descendants lands in ONE undo entry with no throw.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { useEditorStore } from '@site/store/store'
+import { depthInTree } from '@site/store/slices/site/helpers'
+import { makeNode, makePage, makeSite, makeVC, makeVCNode, makeVCTree } from '../fixtures'
+import '@modules/base/index'
+
+function freshStore(): void {
+  useEditorStore.setState({
+    site: null,
+    activePageId: null,
+    activeDocument: null,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+beforeEach(freshStore)
+
+describe('depthInTree', () => {
+  // makePage runs reindexNodeParents, mirroring every real load boundary.
+  const page = makePage({
+    id: 'p1',
+    rootNodeId: 'root',
+    nodes: {
+      root: makeNode({ id: 'root', moduleId: 'base.body', children: ['a'] }),
+      a: makeNode({ id: 'a', moduleId: 'base.container', children: ['b'] }),
+      b: makeNode({ id: 'b', moduleId: 'base.container', children: ['c'] }),
+      c: makeNode({ id: 'c', moduleId: 'base.text' }),
+      orphan: makeNode({ id: 'orphan', moduleId: 'base.text' }),
+    },
+  })
+
+  it('returns 0 for the root node', () => {
+    expect(depthInTree(page, 'root')).toBe(0)
+  })
+
+  it('returns the parent-chain length for nested nodes', () => {
+    expect(depthInTree(page, 'a')).toBe(1)
+    expect(depthInTree(page, 'b')).toBe(2)
+    expect(depthInTree(page, 'c')).toBe(3)
+  })
+
+  it('returns Infinity for a node detached from the root', () => {
+    expect(depthInTree(page, 'orphan')).toBe(Infinity)
+  })
+
+  it('returns Infinity for an id not present in the tree', () => {
+    expect(depthInTree(page, 'no-such-node')).toBe(Infinity)
+  })
+})
+
+describe('deleteNodes — batch ordering and routing', () => {
+  it('deletes a parent listed BEFORE its descendants without throwing, in one undo entry', () => {
+    const site = useEditorStore.getState().createSite('Batch')
+    const rootId = site.pages[0].rootNodeId
+    const container = useEditorStore.getState().insertNode('base.container', {}, rootId)
+    const childA = useEditorStore.getState().insertNode('base.text', { text: 'a' }, container)
+    const childB = useEditorStore.getState().insertNode('base.text', { text: 'b' }, container)
+    const sibling = useEditorStore.getState().insertNode('base.text', { text: 's' }, rootId)
+    const baseline = Object.keys(useEditorStore.getState().site!.pages[0].nodes).length
+    const depthBefore = useEditorStore.getState()._historyPast.length
+
+    // Parent first — depth-DESC ordering must delete the leaves first so the
+    // already-deleted descendants hit the "node not found" guard cleanly.
+    useEditorStore.getState().deleteNodes([container, childA, childB, sibling])
+
+    const nodes = useEditorStore.getState().site!.pages[0].nodes
+    expect(nodes[container]).toBeUndefined()
+    expect(nodes[childA]).toBeUndefined()
+    expect(nodes[childB]).toBeUndefined()
+    expect(nodes[sibling]).toBeUndefined()
+    expect(Object.keys(nodes).length).toBe(baseline - 4)
+    expect(useEditorStore.getState()._historyPast.length).toBe(depthBefore + 1)
+
+    // One undo restores the whole batch.
+    useEditorStore.getState().undo()
+    const restored = useEditorStore.getState().site!.pages[0].nodes
+    expect(Object.keys(restored).length).toBe(baseline)
+    expect(restored[container]).toBeDefined()
+    expect(restored[childA]).toBeDefined()
+  })
+
+  it('skips the root id and unknown ids while deleting the rest', () => {
+    const site = useEditorStore.getState().createSite('Batch')
+    const rootId = site.pages[0].rootNodeId
+    const text = useEditorStore.getState().insertNode('base.text', {}, rootId)
+
+    useEditorStore.getState().deleteNodes([rootId, 'no-such-node', text])
+
+    const nodes = useEditorStore.getState().site!.pages[0].nodes
+    expect(nodes[rootId]).toBeDefined()
+    expect(nodes[text]).toBeUndefined()
+  })
+
+  it('is a history no-op when no listed id exists in the tree', () => {
+    useEditorStore.getState().createSite('Batch')
+    const depthBefore = useEditorStore.getState()._historyPast.length
+
+    useEditorStore.getState().deleteNodes(['ghost-1', 'ghost-2'])
+
+    expect(useEditorStore.getState()._historyPast.length).toBe(depthBefore)
+  })
+
+  it('routes to the active VC tree in VC mode', () => {
+    const vc = makeVC({
+      id: 'vc-1',
+      name: 'Card',
+      tree: makeVCTree('vc-root', [
+        makeVCNode({ id: 'vc-root', moduleId: 'base.body', children: ['vc-box'] }),
+        makeVCNode({ id: 'vc-box', moduleId: 'base.container', children: ['vc-text'] }),
+        makeVCNode({ id: 'vc-text', moduleId: 'base.text', props: { text: 'hi' } }),
+      ]),
+    })
+    useEditorStore.getState().loadSite(makeSite({ pages: [makePage({ id: 'p1' })], visualComponents: [vc] }))
+    useEditorStore.setState({
+      activePageId: 'p1',
+      activeDocument: { kind: 'visualComponent', vcId: 'vc-1' },
+    } as Parameters<typeof useEditorStore.setState>[0])
+
+    // Parent before child again — exercises depth ordering against the VC tree.
+    useEditorStore.getState().deleteNodes(['vc-box', 'vc-text'])
+
+    const tree = useEditorStore.getState().site!.visualComponents[0].tree
+    expect(tree.nodes['vc-box']).toBeUndefined()
+    expect(tree.nodes['vc-text']).toBeUndefined()
+    expect(tree.nodes['vc-root']).toBeDefined()
+    expect(tree.nodes['vc-root'].children).toEqual([])
+  })
+})

--- a/src/__tests__/editor-store/historyCoalescingFold.test.ts
+++ b/src/__tests__/editor-store/historyCoalescingFold.test.ts
@@ -1,0 +1,188 @@
+/**
+ * History coalescing fold — per-path patch dedup inside a typing burst.
+ *
+ * `commitHistory` folds consecutive same-`coalesceKey` entries into the top
+ * history entry. The fold must keep AT MOST one inverse and one forward patch
+ * per touched path (oldest inverse wins, newest forward value wins) instead of
+ * accumulating 2K patch pairs over a K-keystroke burst — while keeping
+ * undo/redo results bit-identical:
+ *
+ *   1. Burst on an existing prop: undo → original value, redo → final value.
+ *   2. Burst that CREATES a prop (add-op first keystroke): undo → prop absent,
+ *      redo (from the prop-absent state) → final value.
+ *   3. Burst touching two paths (the prop + the `site.updatedAt` stamp that
+ *      `runHistoricMutation` appends): both paths revert and replay correctly.
+ *   4. Size bound: a 100-keystroke burst leaves at most one patch per touched
+ *      path per direction in the top entry.
+ *   5. Pin the Mutative `apply()` behavior the fold relies on: 'add' and
+ *      'replace' are interchangeable for plain-object keys.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { apply } from 'mutative'
+import type { Patches } from 'mutative'
+import { useEditorStore } from '@site/store/store'
+import '@modules/base/index'
+
+function freshStore(): void {
+  useEditorStore.setState({
+    site: null,
+    activePageId: null,
+    activeDocument: null,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    _historyCoalesceKey: null,
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+beforeEach(freshStore)
+
+/** Create a site with one text node and return its id. */
+function setupTextNode(initialProps: Record<string, unknown> = { text: '' }): string {
+  const site = useEditorStore.getState().createSite('Fold Test')
+  const rootId = site.pages[0].rootNodeId
+  return useEditorStore.getState().insertNode('base.text', initialProps, rootId)
+}
+
+function pathKey(path: Patches[number]['path']): string {
+  return JSON.stringify(path)
+}
+
+describe('history coalescing — fold correctness', () => {
+  it('burst on an existing prop: undo → original value, redo → final value', () => {
+    const nodeId = setupTextNode({ text: 'original' })
+
+    for (const text of ['a', 'ab', 'abc', 'abcd']) {
+      useEditorStore.getState().updateNodeProps(nodeId, { text })
+    }
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('abcd')
+
+    useEditorStore.getState().undo()
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('original')
+
+    useEditorStore.getState().redo()
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('abcd')
+  })
+
+  it('burst that CREATES a prop: undo → prop absent, redo → final value', () => {
+    const nodeId = setupTextNode({ text: 'hello' })
+
+    // `title` does not exist on the node yet — the first keystroke's forward
+    // patch is 'add'-shaped, and the folded forward patch must stay applicable
+    // from the post-undo state where the prop is absent.
+    for (const title of ['t', 'ti', 'tit', 'title']) {
+      useEditorStore.getState().updateNodeProps(nodeId, { title })
+    }
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.title).toBe('title')
+
+    useEditorStore.getState().undo()
+    const propsAfterUndo = useEditorStore.getState().site!.pages[0].nodes[nodeId].props
+    expect('title' in propsAfterUndo).toBe(false)
+    expect(propsAfterUndo.text).toBe('hello')
+
+    useEditorStore.getState().redo()
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.title).toBe('title')
+  })
+
+  it("the folded forward patch for a burst-created prop keeps the oldest 'add' op", () => {
+    const nodeId = setupTextNode({ text: 'hello' })
+    for (const title of ['t', 'ti', 'tit']) {
+      useEditorStore.getState().updateNodeProps(nodeId, { title })
+    }
+
+    const top = useEditorStore.getState()._historyPast.at(-1)!
+    const titlePatch = top.forward.find((p) => Array.isArray(p.path) && p.path.at(-1) === 'title')
+    expect(titlePatch).toBeDefined()
+    expect(titlePatch!.op).toBe('add')
+    expect(titlePatch!.value).toBe('tit')
+  })
+
+  it('burst touching two paths: prop AND site.updatedAt both revert and replay', () => {
+    const nodeId = setupTextNode({ text: 'start' })
+
+    // Force a sentinel timestamp so the pre-burst value is distinguishable
+    // from anything Date.now() can produce during the burst.
+    const site = useEditorStore.getState().site!
+    useEditorStore.setState({ site: { ...site, updatedAt: 1000 } })
+
+    for (const text of ['x', 'xy', 'xyz']) {
+      useEditorStore.getState().updateNodeProps(nodeId, { text })
+    }
+    const updatedAtAfterBurst = useEditorStore.getState().site!.updatedAt
+    expect(updatedAtAfterBurst).not.toBe(1000)
+
+    useEditorStore.getState().undo()
+    expect(useEditorStore.getState().site!.updatedAt).toBe(1000)
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('start')
+
+    useEditorStore.getState().redo()
+    expect(useEditorStore.getState().site!.updatedAt).toBe(updatedAtAfterBurst)
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('xyz')
+  })
+
+  it('undo + redo round-trips a burst bit-identically', () => {
+    const nodeId = setupTextNode({ text: 'seed' })
+    for (let i = 1; i <= 10; i++) {
+      useEditorStore.getState().updateNodeProps(nodeId, { text: 'seed'.repeat(i) })
+    }
+
+    const afterBurst = JSON.stringify(useEditorStore.getState().site)
+    useEditorStore.getState().undo()
+    useEditorStore.getState().redo()
+    expect(JSON.stringify(useEditorStore.getState().site)).toBe(afterBurst)
+  })
+})
+
+describe('history coalescing — fold size bound', () => {
+  it('a 100-keystroke burst keeps at most one patch per path per direction', () => {
+    const nodeId = setupTextNode({ text: '' })
+    const depthBefore = useEditorStore.getState()._historyPast.length
+
+    for (let i = 1; i <= 100; i++) {
+      useEditorStore.getState().updateNodeProps(nodeId, { text: 'x'.repeat(i) })
+    }
+
+    const past = useEditorStore.getState()._historyPast
+    // Still exactly one coalesced entry for the whole burst.
+    expect(past.length).toBe(depthBefore + 1)
+
+    const top = past.at(-1)!
+    for (const direction of [top.inverse, top.forward]) {
+      const paths = direction.map((p) => pathKey(p.path))
+      // No duplicate paths — the burst touched 2 paths (the prop + updatedAt),
+      // so each direction holds at most 2 patches, not ~200.
+      expect(new Set(paths).size).toBe(paths.length)
+      expect(direction.length).toBeLessThanOrEqual(2)
+    }
+
+    // The fold must not have broken undo/redo.
+    useEditorStore.getState().undo()
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('')
+    useEditorStore.getState().redo()
+    expect(useEditorStore.getState().site!.pages[0].nodes[nodeId].props.text).toBe('x'.repeat(100))
+  })
+})
+
+describe('mutative apply() op semantics the fold relies on', () => {
+  it("treats 'add' and 'replace' identically for plain-object keys", () => {
+    // Verified against mutative@1.3.0 src/apply.ts: for plain objects both ops
+    // run `base[key] = value`. (They differ ONLY for array indices, where
+    // 'add' splices — coalescing recipes never patch array tails.) This pin
+    // fails if a mutative upgrade changes that contract.
+    const base = { props: { existing: 1 } as Record<string, unknown> }
+    const viaAdd = apply(base, [{ op: 'add', path: ['props', 'k'], value: 'v' }] as Patches)
+    const viaReplace = apply(base, [{ op: 'replace', path: ['props', 'k'], value: 'v' }] as Patches)
+    expect(viaAdd).toEqual(viaReplace)
+
+    // 'remove' deletes the key, and deleting an absent key is a no-op — the
+    // fold may therefore collapse any op sequence involving 'remove' to the
+    // newest patch wholesale.
+    const removed = apply(base, [{ op: 'remove', path: ['props', 'absent'] }] as Patches)
+    expect(removed).toEqual(base)
+  })
+})

--- a/src/__tests__/editor-store/vcSlotReconcileGate.test.ts
+++ b/src/__tests__/editor-store/vcSlotReconcileGate.test.ts
@@ -1,0 +1,148 @@
+/**
+ * VC slot-reconcile gate — the site-wide `syncAllVCRefSlotInstances` sweep
+ * after a VC-mode mutation runs ONLY when the VC's ordered slot-outlet name
+ * sequence actually changed.
+ *
+ * Skip side (perf contract): a mutation that does not touch the outlet
+ * sequence (per-keystroke prop edits, duplicating a non-outlet node) must
+ * leave every consumer tree untouched — asserted by OBJECT IDENTITY on
+ * `site.pages`, which the old unconditional sweep broke by rewriting each
+ * consumer ref's `children` array on every keystroke.
+ *
+ * Sweep side (behavior pins): outlet rename, reorder (sequence ≠ set — a
+ * set-equality gate would skip this one!), insert, and delete must still
+ * propagate to consumer slot-instances exactly as before.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { useEditorStore } from '@site/store/store'
+import { makeNode, makePage, makeSite, makeVC, makeVCNode, makeVCTree } from '../fixtures'
+import '@modules/base/index'
+
+function freshStore(): void {
+  useEditorStore.setState({
+    site: null,
+    activePageId: null,
+    activeDocument: null,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+/**
+ * Load a site with VC `vc-1` (two slot-outlets 'a' + 'b' and a text node)
+ * consumed by page `p1` via `ref-1` with matching materialized
+ * slot-instances, then enter VC-canvas mode on `vc-1`.
+ */
+function loadVCEditingSite(): void {
+  const vc = makeVC({
+    id: 'vc-1',
+    name: 'Hero',
+    tree: makeVCTree('vc-root', [
+      makeVCNode({ id: 'vc-root', moduleId: 'base.body', children: ['outlet-a', 'outlet-b', 'vc-text'] }),
+      makeVCNode({ id: 'outlet-a', moduleId: 'base.slot-outlet', props: { slotName: 'a' } }),
+      makeVCNode({ id: 'outlet-b', moduleId: 'base.slot-outlet', props: { slotName: 'b' } }),
+      makeVCNode({ id: 'vc-text', moduleId: 'base.text', props: { text: 'hello' } }),
+    ]),
+  })
+  const page = makePage({
+    id: 'p1',
+    rootNodeId: 'root',
+    nodes: {
+      root: makeNode({ id: 'root', moduleId: 'base.body', children: ['ref-1'] }),
+      'ref-1': makeNode({
+        id: 'ref-1',
+        moduleId: 'base.visual-component-ref',
+        props: { componentId: 'vc-1', propOverrides: {} },
+        children: ['inst-a', 'inst-b'],
+      }),
+      'inst-a': makeNode({ id: 'inst-a', moduleId: 'base.slot-instance', props: { slotName: 'a' }, locked: true }),
+      'inst-b': makeNode({ id: 'inst-b', moduleId: 'base.slot-instance', props: { slotName: 'b' }, locked: true }),
+    },
+  })
+  useEditorStore.getState().loadSite(makeSite({ pages: [page], visualComponents: [vc] }))
+  useEditorStore.setState({
+    activePageId: 'p1',
+    activeDocument: { kind: 'visualComponent', vcId: 'vc-1' },
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+beforeEach(() => {
+  freshStore()
+  loadVCEditingSite()
+})
+
+describe('VC slot-reconcile gate — sweep is skipped when outlets are unchanged', () => {
+  it('a non-outlet prop edit leaves consumer pages untouched (object identity)', () => {
+    const pagesBefore = useEditorStore.getState().site!.pages
+
+    useEditorStore.getState().updateNodeProps('vc-text', { text: 'world' })
+
+    const after = useEditorStore.getState().site!
+    expect(after.visualComponents[0].tree.nodes['vc-text'].props.text).toBe('world')
+    // No sweep → no consumer tree was drafted → structural sharing keeps the
+    // exact same pages array (and page objects).
+    expect(after.pages).toBe(pagesBefore)
+    expect(after.pages[0]).toBe(pagesBefore[0])
+  })
+
+  it('duplicating a non-outlet node (mutateActiveTreeAndSite path) leaves consumer pages untouched', () => {
+    const pagesBefore = useEditorStore.getState().site!.pages
+
+    const dupId = useEditorStore.getState().duplicateNode('vc-text')
+    expect(dupId).toBeTruthy()
+
+    const after = useEditorStore.getState().site!
+    expect(after.visualComponents[0].tree.nodes[dupId]).toBeDefined()
+    expect(after.pages).toBe(pagesBefore)
+  })
+
+  it('undo of a skipped-sweep edit restores the VC tree', () => {
+    useEditorStore.getState().updateNodeProps('vc-text', { text: 'world' })
+    useEditorStore.getState().undo()
+    expect(
+      useEditorStore.getState().site!.visualComponents[0].tree.nodes['vc-text'].props.text,
+    ).toBe('hello')
+  })
+})
+
+describe('VC slot-reconcile gate — sweep still runs on outlet changes', () => {
+  it('renaming an outlet (per-keystroke slotName prop edit) renames consumer slot-instances', () => {
+    useEditorStore.getState().updateNodeProps('outlet-a', { slotName: 'hero' })
+
+    const page = useEditorStore.getState().site!.pages[0]
+    expect(page.nodes['inst-a'].props.slotName).toBe('hero')
+    expect(page.nodes['inst-b'].props.slotName).toBe('b')
+  })
+
+  it('reordering outlets reorders consumer slot-instances (sequence change, set unchanged)', () => {
+    useEditorStore.getState().moveNode('outlet-b', 'vc-root', 0)
+
+    const page = useEditorStore.getState().site!.pages[0]
+    expect(page.nodes['ref-1'].children).toEqual(['inst-b', 'inst-a'])
+  })
+
+  it('deleting an outlet cascade-deletes the consumer slot-instance', () => {
+    useEditorStore.getState().deleteNode('outlet-b')
+
+    const page = useEditorStore.getState().site!.pages[0]
+    expect(page.nodes['ref-1'].children).toEqual(['inst-a'])
+    expect(page.nodes['inst-b']).toBeUndefined()
+  })
+
+  it('inserting an outlet materializes a new consumer slot-instance', () => {
+    useEditorStore.getState().insertNode('base.slot-outlet', { slotName: 'c' }, 'vc-root')
+
+    const page = useEditorStore.getState().site!.pages[0]
+    const ref = page.nodes['ref-1']
+    expect(ref.children).toHaveLength(3)
+    const newInst = page.nodes[ref.children[2]]
+    expect(newInst.moduleId).toBe('base.slot-instance')
+    expect(newInst.props.slotName).toBe('c')
+  })
+})

--- a/src/__tests__/module-engine/validateNodeProps.test.ts
+++ b/src/__tests__/module-engine/validateNodeProps.test.ts
@@ -5,13 +5,24 @@
  *   (a) Junk / missing authored props coerce to module defaults via the schema.
  *   (b) Unknown injected fields (e.g. _resolvedMediaByKey) survive validation.
  *   (c) A module with no propsSchema returns rawProps unchanged (pass-through).
+ *   (d) Fast path: already-conforming props return the SAME object reference
+ *       (no clone) when the schema is fast-path eligible.
+ *   (e) Eligibility guards: optional-with-default and Transform schemas must
+ *       NOT take the fast path (Value.Parse output is not value-identical to
+ *       rawProps for them); Ref/recursive/cyclic schemas degrade safely to
+ *       the slow path.
+ *   (f) Every base module's propsSchema is fast-path eligible.
  */
 
 import { describe, it, expect } from 'bun:test'
-import { Type, Value } from '@core/utils/typeboxHelpers'
+import { Type, Value, type TSchema } from '@core/utils/typeboxHelpers'
 import type { AnyModuleDefinition } from '@core/module-engine'
-import { validateNodeProps } from '@core/module-engine'
+import { validateNodeProps, registry } from '@core/module-engine'
 import { SquareSolidIcon } from 'pixel-art-icons/icons/square-solid'
+
+// Side-effect import: registers every base module into the global registry
+// singleton so suite (f) can iterate their real propsSchemas.
+import '@modules/base'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -158,4 +169,223 @@ describe('validateNodeProps — (c) no propsSchema is a pass-through', () => {
     const result = validateNodeProps(def, rawProps)
     expect(result).toStrictEqual({ text: 123, garbage: true })
   })
+})
+
+// ---------------------------------------------------------------------------
+// (d) Fast path — conforming props return the SAME object reference
+// ---------------------------------------------------------------------------
+
+describe('validateNodeProps — (d) fast path for already-conforming props', () => {
+  const def = stubDef({
+    propsSchema: TestPropsSchema,
+    defaults: testDefaults,
+  })
+
+  it('returns the exact same object when props already conform', () => {
+    const rawProps = { text: 'World', count: 99, visible: false }
+    const result = validateNodeProps(def, rawProps)
+    expect(result).toBe(rawProps)
+  })
+
+  it('returns the same object when conforming props carry unknown injected keys', () => {
+    const injected = { img: { url: 'https://example.com/a.jpg' } }
+    const rawProps = {
+      text: 'Hi',
+      count: 1,
+      visible: true,
+      _resolvedMediaByKey: injected,
+      _resolvedAutoSizes: '100vw',
+    }
+    const result = validateNodeProps(def, rawProps)
+    expect(result).toBe(rawProps)
+    expect(result._resolvedMediaByKey).toBe(injected)
+  })
+
+  it('takes the slow path when a required-with-default prop is absent (default materialized)', () => {
+    const rawProps = { count: 1, visible: true } // text missing
+    const result = validateNodeProps(def, rawProps)
+    expect(result).not.toBe(rawProps)
+    expect(result.text).toBe('Hello')
+    expect(result.count).toBe(1)
+  })
+
+  it('takes the slow path when a prop needs coercion (string → number)', () => {
+    const rawProps = { text: 'a', count: '7', visible: true }
+    const result = validateNodeProps(def, rawProps)
+    expect(result).not.toBe(rawProps)
+    expect(result.count).toBe(7)
+  })
+
+  it('handles nested eligible composites (array / union / record / tuple / literal)', () => {
+    const NestedSchema = Type.Object({
+      tags: Type.Array(Type.String(), { default: [] }),
+      align: Type.Union([Type.Literal('left'), Type.Literal('right')], { default: 'left' }),
+      attrs: Type.Record(Type.String(), Type.String(), { default: {} }),
+      pair: Type.Tuple([Type.Number(), Type.Number()]),
+      nothing: Type.Null(),
+    })
+    const nestedDef = stubDef({ propsSchema: NestedSchema, defaults: {} })
+    const rawProps = {
+      tags: ['a', 'b'],
+      align: 'right',
+      attrs: { role: 'note' },
+      pair: [1, 2],
+      nothing: null,
+    }
+    expect(validateNodeProps(nestedDef, rawProps)).toBe(rawProps)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// (e) Eligibility guards — schemas where Check-pass ≠ Parse-identity
+// ---------------------------------------------------------------------------
+
+describe('validateNodeProps — (e) fast-path eligibility guards', () => {
+  it('optional-with-default: absent key passes Check but the default MUST be materialized', () => {
+    // `{}` passes compiled Check (x is optional) — a naive fast path would
+    // return rawProps and silently lose the default. The eligibility guard
+    // must route this schema to Value.Parse.
+    const OptDefaultSchema = Type.Object({
+      x: Type.Optional(Type.String({ default: 'materialized' })),
+    })
+    const def = stubDef({ propsSchema: OptDefaultSchema, defaults: {} })
+    const rawProps = {}
+    const result = validateNodeProps(def, rawProps)
+    expect(result.x).toBe('materialized')
+    expect(result).not.toBe(rawProps)
+  })
+
+  it('optional-with-default: ineligibility is per-schema, even when the value is present', () => {
+    const OptDefaultSchema = Type.Object({
+      x: Type.Optional(Type.String({ default: 'd' })),
+    })
+    const def = stubDef({ propsSchema: OptDefaultSchema, defaults: {} })
+    const rawProps = { x: 'present' }
+    const result = validateNodeProps(def, rawProps)
+    // Slow path always clones — same value, new object.
+    expect(result).not.toBe(rawProps)
+    expect(result.x).toBe('present')
+  })
+
+  it('optional-with-default nested deeper in the tree is also caught', () => {
+    const NestedOptDefault = Type.Object({
+      inner: Type.Object({
+        y: Type.Optional(Type.Number({ default: 5 })),
+      }),
+    })
+    const def = stubDef({ propsSchema: NestedOptDefault, defaults: {} })
+    const rawProps = { inner: {} }
+    const result = validateNodeProps(def, rawProps)
+    expect((result.inner as Record<string, unknown>).y).toBe(5)
+  })
+
+  it('optional WITHOUT default stays eligible (nothing to materialize)', () => {
+    const OptNoDefault = Type.Object({
+      x: Type.Optional(Type.String()),
+      n: Type.Number(),
+    })
+    const def = stubDef({ propsSchema: OptNoDefault, defaults: {} })
+    const absent = { n: 1 }
+    expect(validateNodeProps(def, absent)).toBe(absent)
+    const present = { n: 1, x: 'v' }
+    expect(validateNodeProps(def, present)).toBe(present)
+  })
+
+  it('Unknown without default stays eligible (used by base.loop / base.visual-component-ref)', () => {
+    const UnknownRecord = Type.Object({
+      rec: Type.Record(Type.String(), Type.Unknown(), { default: {} }),
+    })
+    const def = stubDef({ propsSchema: UnknownRecord, defaults: {} })
+    const rawProps = { rec: { a: { nested: [1, 2] }, b: 'str' } }
+    expect(validateNodeProps(def, rawProps)).toBe(rawProps)
+  })
+
+  it('Unknown WITH default is ineligible (present-undefined would be replaced by Parse)', () => {
+    const HazardSchema = Type.Object({
+      rec: Type.Record(Type.String(), Type.Unknown({ default: 'D' })),
+    })
+    const def = stubDef({ propsSchema: HazardSchema, defaults: {} })
+    // `{ k: undefined }` passes Check against Unknown — but Value.Parse
+    // materializes the default. The fast path must not swallow that.
+    const result = validateNodeProps(def, { rec: { k: undefined } })
+    expect((result.rec as Record<string, unknown>).k).toBe('D')
+  })
+
+  it('Transform schema: Decode MUST run even when the encoded value passes Check', () => {
+    const UpperTransform = Type.Transform(Type.String())
+      .Decode((s) => s.toUpperCase())
+      .Encode((s) => s.toLowerCase())
+    const def = stubDef({
+      propsSchema: Type.Object({ name: UpperTransform }),
+      defaults: {},
+    })
+    // 'abc' passes Check against the inner String — a naive fast path would
+    // skip the Decode and return 'abc'.
+    const result = validateNodeProps(def, { name: 'abc' })
+    expect(result.name).toBe('ABC')
+  })
+
+  it('Transform nested inside an array is also caught', () => {
+    const UpperTransform = Type.Transform(Type.String())
+      .Decode((s) => s.toUpperCase())
+      .Encode((s) => s.toLowerCase())
+    const def = stubDef({
+      propsSchema: Type.Object({ tags: Type.Array(UpperTransform) }),
+      defaults: {},
+    })
+    const result = validateNodeProps(def, { tags: ['abc', 'def'] })
+    expect(result.tags).toEqual(['ABC', 'DEF'])
+  })
+
+  it('recursive (This/Ref) schemas degrade to the slow path without crashing', () => {
+    const RecursiveSchema = Type.Recursive((Self) =>
+      Type.Object({
+        name: Type.String(),
+        kids: Type.Array(Self),
+      }),
+    )
+    const def = stubDef({ propsSchema: RecursiveSchema, defaults: {} })
+    const rawProps = { name: 'root', kids: [{ name: 'child', kids: [] }] }
+    const result = validateNodeProps(def, rawProps)
+    expect(result).not.toBe(rawProps) // conservative: slow path
+    expect(result.name).toBe('root')
+    expect(result.kids).toEqual([{ name: 'child', kids: [] }])
+  })
+
+  it('a literally cyclic schema object terminates the eligibility walk (slow path)', () => {
+    // Hand-built degenerate input: the schema object references itself. The
+    // eligibility walk must terminate (cycle guard) and report ineligible —
+    // compiling such a schema would never finish.
+    const cyclic = Type.Object({ name: Type.String() })
+    ;(cyclic.properties as Record<string, TSchema>).self = Type.Optional(cyclic)
+    const def = stubDef({ propsSchema: cyclic, defaults: {} })
+    const rawProps = { name: 'x' }
+    const result = validateNodeProps(def, rawProps)
+    expect(result).not.toBe(rawProps) // slow path took over
+    expect(result.name).toBe('x')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// (f) Every base module's propsSchema is fast-path eligible
+// ---------------------------------------------------------------------------
+
+describe('validateNodeProps — (f) all base module schemas are fast-path eligible', () => {
+  const baseDefs = registry
+    .list()
+    .filter((d) => d.id.startsWith('base.') && d.propsSchema !== undefined)
+
+  it('registry contains base modules with propsSchemas', () => {
+    expect(baseDefs.length).toBeGreaterThan(5)
+  })
+
+  for (const def of baseDefs) {
+    it(`${def.id}: conforming props take the fast path (same reference back)`, () => {
+      // First call normalizes the module defaults through whatever path they
+      // need; the normalized output is by construction schema-conforming, so
+      // the second call MUST short-circuit and return the same reference.
+      const normalized = validateNodeProps(def, { ...def.defaults })
+      expect(validateNodeProps(def, normalized)).toBe(normalized)
+    })
+  }
 })

--- a/src/__tests__/server/cmsPublish.test.ts
+++ b/src/__tests__/server/cmsPublish.test.ts
@@ -17,14 +17,15 @@ function createPublishFakeDb() {
     site: null as Record<string, unknown> | null,
     dataRows: [] as Record<string, unknown>[],
     dataRowVersions: [] as Record<string, unknown>[],
+    siteSnapshots: [] as Record<string, unknown>[],
     runtimeAssets: [] as Record<string, unknown>[],
   }
 
   const db = createFakeDb(async (rawSql, params): Promise<DbResult> => {
     const sql = rawSql.replace(/\s+/g, ' ').trim().toLowerCase()
 
-    // saveDraftSite — insert or update site row
-    if (sql.startsWith('insert into site')) {
+    // saveDraftSite — insert or update site row (NOT site_snapshots)
+    if (sql.startsWith('insert into site (')) {
       state.site = {
         id: 'default',
         name: params[0],
@@ -104,7 +105,20 @@ function createPublishFakeDb() {
       const nextVersion = Math.max(0, ...rowVersions.map((v) => Number(v.version_number))) + 1
       return { rows: [{ next_version: nextVersion }], rowCount: 1 }
     }
+    // insert into site_snapshots — one per publish, referenced by version rows
+    if (sql.startsWith('insert into site_snapshots')) {
+      state.siteSnapshots.push({
+        id: params[0],
+        site_json: params[1],
+        content_hash: params[2],
+        importmap_body: params[3],
+        importmap_sha256: params[4],
+      })
+      return { rows: [], rowCount: 1 }
+    }
     // insert into data_row_versions
+    // columns: (id, row_id, version_number, cells_json, slug, site_snapshot_id,
+    //           runtime_assets_json, published_by_user_id)
     if (sql.startsWith('insert into data_row_versions')) {
       state.dataRowVersions.push({
         id: params[0],
@@ -112,8 +126,9 @@ function createPublishFakeDb() {
         version_number: params[2],
         cells_json: params[3],
         slug: params[4],
-        snapshot_json: params[5],
-        published_by_user_id: params[6],
+        site_snapshot_id: params[5],
+        runtime_assets_json: params[6],
+        published_by_user_id: params[7],
         published_at: new Date('2026-01-03').toISOString(),
       })
       return { rows: [], rowCount: 1 }
@@ -145,25 +160,39 @@ function createPublishFakeDb() {
       }
       return { rows: [], rowCount: row ? 1 : 0 }
     }
-    // getPublishedPageBySlug — join data_rows + data_row_versions
-    if (sql.includes('select data_row_versions.snapshot_json') && sql.includes('data_rows.slug')) {
+    // getPublishedPageBySlug — join data_rows + data_row_versions + site_snapshots
+    if (sql.includes('site_snapshots.site_json') && sql.includes('data_rows.slug')) {
       const slug = params[0] as string
       const row = state.dataRows.find((r) => r.slug === slug && r.status === 'published')
       const version = row ? state.dataRowVersions.find((v) => v.id === row.active_version_id) : null
+      const snap = version
+        ? state.siteSnapshots.find((s) => s.id === version.site_snapshot_id)
+        : null
       return {
-        rows: version ? [{ snapshot_json: version.snapshot_json }] : [],
-        rowCount: version ? 1 : 0,
+        rows: version && snap
+          ? [{
+              row_id: version.row_id,
+              site_json: snap.site_json,
+              runtime_assets_json: version.runtime_assets_json,
+              importmap_body: snap.importmap_body,
+              importmap_sha256: snap.importmap_sha256,
+            }]
+          : [],
+        rowCount: version && snap ? 1 : 0,
       }
     }
-    // getDraftPublishStatus — published rows join
-    if (sql.includes('from data_rows') && sql.includes('join data_row_versions') && sql.includes('created_at asc')) {
+    // getDraftPublishStatus — published rows join (selects the per-publish content hash)
+    if (sql.includes('site_snapshots.content_hash') && sql.includes('created_at asc')) {
       const rows = state.dataRows
         .filter((r) => r.status === 'published' && r.active_version_id && !r.deleted_at)
         .map((r) => {
           const ver = state.dataRowVersions.find((v) => v.id === r.active_version_id)
-          return ver ? {
+          const snap = ver
+            ? state.siteSnapshots.find((s) => s.id === ver.site_snapshot_id)
+            : null
+          return ver && snap ? {
             row_id: r.id,
-            snapshot_json: ver.snapshot_json,
+            content_hash: snap.content_hash,
             published_at: ver.published_at,
           } : null
         })

--- a/src/__tests__/server/cmsRepositories.test.ts
+++ b/src/__tests__/server/cmsRepositories.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import { createTestDb } from '../helpers/createTestDb'
-import { createSite, getSetupStatus } from '../../../server/repositories/setup'
+import {
+  createSite,
+  getSetupStatus,
+  getSetupStatusCached,
+  resetSetupStatusCacheForTests,
+} from '../../../server/repositories/setup'
 import { createUser, findUserByEmail } from '../../../server/repositories/users'
 import { createCustomRole, listRoles } from '../../../server/repositories/roles'
 import { createSession, findUserBySessionHash, revokeSessionByHash } from '../../../server/auth/sessions'
@@ -35,6 +40,61 @@ describe('CMS repositories', () => {
       })
     } finally {
       await cleanup()
+    }
+  })
+
+  it('getSetupStatusCached re-queries while pending, then memoizes the settled status', async () => {
+    const { db, cleanup } = await createTestDb()
+    try {
+      // Pending: every call queries live so an in-progress setup is observed.
+      expect((await getSetupStatusCached(db)).needsSetup).toBe(true)
+      await createSite(db, 'Example Site', {})
+      expect((await getSetupStatusCached(db)).needsSetup).toBe(true) // owner still missing
+      await createUser(db, {
+        id: 'owner_1',
+        email: 'owner@example.com',
+        displayName: 'Owner',
+        passwordHash: await hashPassword('long-enough-password'),
+        roleId: 'owner',
+        allowOwnerRole: true,
+      })
+      expect((await getSetupStatusCached(db)).needsSetup).toBe(false)
+
+      // Settled: the memo answers without touching the DB. Prove it by
+      // removing the owner out-of-band — the app itself never allows this,
+      // which is exactly why the memo is sound.
+      await db`delete from users`
+      expect((await getSetupStatusCached(db)).needsSetup).toBe(false)
+      expect((await getSetupStatus(db)).needsSetup).toBe(true) // live variant sees raw truth
+
+      // The test-only reset drops the memo and querying resumes.
+      resetSetupStatusCacheForTests()
+      expect((await getSetupStatusCached(db)).needsSetup).toBe(true)
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('getSetupStatusCached keys its memo per DbClient — fresh databases stay isolated', async () => {
+    const settled = await createTestDb()
+    const fresh = await createTestDb()
+    try {
+      await createSite(settled.db, 'Example Site', {})
+      await createUser(settled.db, {
+        id: 'owner_1',
+        email: 'owner@example.com',
+        displayName: 'Owner',
+        passwordHash: await hashPassword('long-enough-password'),
+        roleId: 'owner',
+        allowOwnerRole: true,
+      })
+      expect((await getSetupStatusCached(settled.db)).needsSetup).toBe(false)
+
+      // A different client must not inherit the settled memo.
+      expect((await getSetupStatusCached(fresh.db)).needsSetup).toBe(true)
+    } finally {
+      await settled.cleanup()
+      await fresh.cleanup()
     }
   })
 

--- a/src/__tests__/server/cmsTemplateRoutes.test.ts
+++ b/src/__tests__/server/cmsTemplateRoutes.test.ts
@@ -1,9 +1,10 @@
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { DbResult } from '../../../server/db'
 import { handleServerRequest } from '../../../server/router'
+import { resetForTests } from '../../../server/publish/renderCache'
 import type { PublishedPageSnapshot } from '../../../server/repositories/publish'
 import { makePage, makeSite } from '../publisher/helpers'
 import { createFakeDb } from './dbTestFake'
@@ -31,6 +32,13 @@ function rowDate(value: string) {
 }
 
 describe('CMS dynamic template routes', () => {
+  // Each test serves a different snapshot fixture at the same publish version.
+  // Reset the render cache + version-keyed snapshot memos so one test's
+  // published site can't leak into the next (or in from another test file).
+  beforeEach(() => {
+    resetForTests()
+  })
+
   it('renders a published data row through the highest priority page template', async () => {
     const page = makePage({
       root: { moduleId: 'base.body', props: {}, children: ['title'] },
@@ -72,7 +80,7 @@ describe('CMS dynamic template routes', () => {
         return undefined
       },
       (sql, params) => {
-        if (!sql.startsWith('select data_row_versions.snapshot_json')) return undefined
+        if (!sql.includes('site_snapshots.site_json')) return undefined
 
         // getPublishedPageBySlug — has data_rows.slug parameter; return empty
         // (no published page at 'posts/dynamic-post')
@@ -83,7 +91,16 @@ describe('CMS dynamic template routes', () => {
 
         // getLatestPublishedSiteSnapshot — return the snapshot so the template
         // renderer can find the matching template page
-        return { rows: [{ snapshot_json: snapshot }], rowCount: 1 }
+        return {
+          rows: [{
+            row_id: snapshot.pageRowId,
+            site_json: snapshot.site,
+            runtime_assets_json: null,
+            importmap_body: null,
+            importmap_sha256: null,
+          }],
+          rowCount: 1,
+        }
       },
       (sql, params) => {
         if (!sql.startsWith('select data_row_versions.id')) return undefined
@@ -135,7 +152,7 @@ describe('CMS dynamic template routes', () => {
       // DB that would error if the snapshot path were consulted
       const db = createFakeDb(async (sql: string): Promise<DbResult> => {
         const s = sql.toLowerCase()
-        if (s.includes('snapshot_json')) {
+        if (s.includes('site_snapshots')) {
           throw new Error('Snapshot queried despite disk artefact hit')
         }
         if (s.includes('count(*) as count from site')) return { rows: [{ count: 1 }], rowCount: 1 }
@@ -201,12 +218,21 @@ describe('CMS dynamic template routes', () => {
           }
           return undefined
         },
-        (sql, params) => {
-          if (!sql.startsWith('select data_row_versions.snapshot_json')) return undefined
+        (sql) => {
+          if (!sql.includes('site_snapshots.site_json')) return undefined
           if (sql.includes('data_rows.slug =')) {
             return { rows: [], rowCount: 0 }
           }
-          return { rows: [{ snapshot_json: snapshot }], rowCount: 1 }
+          return {
+            rows: [{
+              row_id: snapshot.pageRowId,
+              site_json: snapshot.site,
+              runtime_assets_json: null,
+              importmap_body: null,
+              importmap_sha256: null,
+            }],
+            rowCount: 1,
+          }
         },
         (sql, params) => {
           if (!sql.startsWith('select data_row_versions.id')) return undefined
@@ -255,7 +281,7 @@ describe('CMS dynamic template routes', () => {
   it('redirects an old published data row slug to the active published slug', async () => {
     const db = makeTemplateRouteFakeDb([
       (sql, params) => {
-        if (!sql.startsWith('select data_row_versions.snapshot_json')) return undefined
+        if (!sql.includes('site_snapshots.site_json')) return undefined
         // getPublishedPageBySlug — return empty (no published page at this slug)
         if (sql.includes('data_rows.slug =')) {
           expect(params).toEqual(['posts/untitled'])

--- a/src/__tests__/server/dataCms.test.ts
+++ b/src/__tests__/server/dataCms.test.ts
@@ -14,6 +14,7 @@ import {
   getDataRowRedirectByRoute,
 } from '../../../server/repositories/data'
 import { handleServerRequest } from '../../../server/router'
+import { resetForTests } from '../../../server/publish/renderCache'
 import { createFakeDb } from './dbTestFake'
 
 type QueryHandler = (sql: string, params: unknown[]) => DbResult | undefined
@@ -418,6 +419,9 @@ describe('data CMS repository', () => {
 
 describe('data CMS public routes', () => {
   it('returns 404 when a postType row has no matching entry template', async () => {
+    // The row route consults the version-keyed published-snapshot memo; reset
+    // publish state so a snapshot cached by another test file can't leak in.
+    resetForTests()
     // Defensive contract: `createDataTable` auto-seeds an entry template
     // for every postType table, and the boot backfill catches any older
     // table that's missing one. So `renderPublishedDataRowTemplate`
@@ -433,8 +437,9 @@ describe('data CMS public routes', () => {
         return undefined
       },
       (sql) => {
-        // getPublishedPageBySlug — no snapshot for this slug.
-        if (sql.startsWith('select data_row_versions.snapshot_json')) {
+        // getPublishedPageBySlug / getLatestPublishedSiteSnapshot — no
+        // published snapshot at all (both run the same site_snapshots join).
+        if (sql.includes('site_snapshots.site_json')) {
           return { rows: [], rowCount: 0 }
         }
         return undefined

--- a/src/__tests__/server/dynamicIslandsPlugin.test.ts
+++ b/src/__tests__/server/dynamicIslandsPlugin.test.ts
@@ -180,10 +180,18 @@ function makeFakeDb(
     ..._values: unknown[]
   ): Promise<DbResult<Row>> => {
     const sql = strings.join(' ').replace(/\s+/g, ' ').trim().toLowerCase()
-    if (sql.includes('select data_row_versions.snapshot_json')) {
+    if (sql.includes('site_snapshots.site_json')) {
       if (counters) counters.snapshotLoads++
       return {
-        rows: snapshot ? [{ snapshot_json: snapshot } as Row] : [],
+        rows: snapshot
+          ? [{
+              row_id: snapshot.pageRowId,
+              site_json: snapshot.site,
+              runtime_assets_json: null,
+              importmap_body: null,
+              importmap_sha256: null,
+            } as unknown as Row]
+          : [],
         rowCount: snapshot ? 1 : 0,
       }
     }

--- a/src/__tests__/server/holeRouteHandler.test.ts
+++ b/src/__tests__/server/holeRouteHandler.test.ts
@@ -91,9 +91,17 @@ function makeFakeDb(snapshot: ReturnType<typeof makeSnapshot> | null): DbClient 
     const sql = strings.reduce<string>((acc, str, i) => (i === 0 ? str : `${acc}$${i}${str}`), '')
     const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase()
 
-    if (normalized.includes('select data_row_versions.snapshot_json')) {
+    if (normalized.includes('site_snapshots.site_json')) {
       return {
-        rows: snapshot ? [{ snapshot_json: snapshot } as Row] : [],
+        rows: snapshot
+          ? [{
+              row_id: snapshot.pageRowId,
+              site_json: snapshot.site,
+              runtime_assets_json: null,
+              importmap_body: null,
+              importmap_sha256: null,
+            } as unknown as Row]
+          : [],
         rowCount: snapshot ? 1 : 0,
       }
     }
@@ -124,10 +132,19 @@ function makeCountingDb(snapshot: ReturnType<typeof makeSnapshot>): {
   ): Promise<DbResult<Row>> => {
     const sql = strings.reduce<string>((acc, str, i) => (i === 0 ? str : `${acc}$${i}${str}`), '')
     const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase()
-    if (normalized.includes('select data_row_versions.snapshot_json')) {
+    if (normalized.includes('site_snapshots.site_json')) {
       loads++
       await Promise.resolve() // let other in-flight callers join before resolving
-      return { rows: [{ snapshot_json: snapshot } as Row], rowCount: 1 }
+      return {
+        rows: [{
+          row_id: snapshot.pageRowId,
+          site_json: snapshot.site,
+          runtime_assets_json: null,
+          importmap_body: null,
+          importmap_sha256: null,
+        } as unknown as Row],
+        rowCount: 1,
+      }
     }
     return { rows: [], rowCount: 0 }
   }

--- a/src/__tests__/server/publicForms.test.ts
+++ b/src/__tests__/server/publicForms.test.ts
@@ -116,8 +116,20 @@ function makeDb(options: {
   const tableRows = options.tableRows ?? { newsletter_submissions: newsletterTableRow }
   const db = createFakeDb(async (rawSql, params): Promise<DbResult> => {
     const sql = rawSql.replace(/\s+/g, ' ').trim().toLowerCase()
-    if (sql.startsWith('select data_row_versions.snapshot_json')) {
-      return { rows: [{ snapshot_json: snapshot }], rowCount: 1 }
+    // getPublishedPageSnapshotById — joins data_row_versions to site_snapshots.
+    // Must be matched before the generic `select data_rows.id` branch below
+    // (the snapshot getter's SELECT also starts with `select data_rows.id`).
+    if (sql.includes('site_snapshots.site_json')) {
+      return {
+        rows: [{
+          row_id: snapshot.pageRowId,
+          site_json: snapshot.site,
+          runtime_assets_json: snapshot.runtimeAssets ?? null,
+          importmap_body: snapshot.runtimePackageImportmap?.body ?? null,
+          importmap_sha256: snapshot.runtimePackageImportmap?.sha256 ?? null,
+        }],
+        rowCount: 1,
+      }
     }
     if (sql.startsWith('select id, name, slug, kind, route_base')) {
       const row = tableRows[String(params[0])]

--- a/src/__tests__/server/publicRendering.test.ts
+++ b/src/__tests__/server/publicRendering.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'bun:test'
+import { beforeEach, describe, expect, it } from 'bun:test'
 import type { DbClient, DbResult } from '../../../server/db'
+import { resetForTests } from '../../../server/publish/renderCache'
 import type { PublishedPageSnapshot } from '../../../server/repositories/publish'
 import {
   renderPublishedSnapshot,
@@ -72,10 +73,19 @@ function makeFakeDb(
       const row = runtimeAssets.find((asset) => asset.public_path === values[0])
       return { rows: row ? [row as Row] : [], rowCount: row ? 1 : 0 }
     }
-    // getPublishedPageBySlug — queries data_row_versions.snapshot_json
-    if (normalized.includes('select data_row_versions.snapshot_json')) {
+    // getPublishedPageBySlug / getLatestPublishedSiteSnapshot — joins
+    // data_row_versions to site_snapshots
+    if (normalized.includes('site_snapshots.site_json')) {
       return {
-        rows: activeSnapshot ? [{ snapshot_json: activeSnapshot } as Row] : [],
+        rows: activeSnapshot
+          ? [{
+              row_id: activeSnapshot.pageRowId,
+              site_json: activeSnapshot.site,
+              runtime_assets_json: activeSnapshot.runtimeAssets ?? null,
+              importmap_body: activeSnapshot.runtimePackageImportmap?.body ?? null,
+              importmap_sha256: activeSnapshot.runtimePackageImportmap?.sha256 ?? null,
+            } as unknown as Row]
+          : [],
         rowCount: activeSnapshot ? 1 : 0,
       }
     }
@@ -96,6 +106,13 @@ function makeFakeDb(
 }
 
 describe('public rendering', () => {
+  // Each test serves a different snapshot/db at the same publish version, and
+  // the public router now peeks the Layer B cache BEFORE resolving the route —
+  // without a reset, one test's cached `/` render would be served to the next.
+  beforeEach(() => {
+    resetForTests()
+  })
+
   it('renders complete HTML from a published snapshot', async () => {
     const snap = snapshot('Visible to public')
     const { html } = await renderPublishedSnapshot(snap, { db: makeFakeDb(snap) })

--- a/src/__tests__/server/publicRouterCache.test.ts
+++ b/src/__tests__/server/publicRouterCache.test.ts
@@ -76,10 +76,18 @@ function makeFakeDb(snapshot: PublishedPageSnapshot | null): DbClient {
     const sql = strings.reduce<string>((acc, str, i) => (i === 0 ? str : `${acc}$${i}${str}`), '')
     const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase()
 
-    // getPublishedPageBySlug — queries data_row_versions.snapshot_json
-    if (normalized.includes('select data_row_versions.snapshot_json')) {
+    // getPublishedPageBySlug — joins data_row_versions to site_snapshots
+    if (normalized.includes('site_snapshots.site_json')) {
       return {
-        rows: snapshot ? [{ snapshot_json: snapshot } as Row] : [],
+        rows: snapshot
+          ? [{
+              row_id: snapshot.pageRowId,
+              site_json: snapshot.site,
+              runtime_assets_json: snapshot.runtimeAssets ?? null,
+              importmap_body: snapshot.runtimePackageImportmap?.body ?? null,
+              importmap_sha256: snapshot.runtimePackageImportmap?.sha256 ?? null,
+            } as unknown as Row]
+          : [],
         rowCount: snapshot ? 1 : 0,
       }
     }
@@ -111,7 +119,7 @@ function makeRedirectDb(): DbClient {
     const normalized = sql.replace(/\s+/g, ' ').trim().toLowerCase()
 
     // getPublishedPageBySlug → not found
-    if (normalized.includes('select data_row_versions.snapshot_json')) {
+    if (normalized.includes('site_snapshots.site_json')) {
       return { rows: [], rowCount: 0 }
     }
     // getDataRowRedirectByRoute → return a redirect

--- a/src/__tests__/server/publishStaticArtefact.test.ts
+++ b/src/__tests__/server/publishStaticArtefact.test.ts
@@ -67,10 +67,38 @@ function buildFakeDb(
   const staticSnapshot = makeSnapshot(staticPage)
   const dynamicSnapshot = makeSnapshot(dynamicPage)
 
+  /** Row shape the snapshot getters' 3-way join returns. */
+  const toSnapshotRow = (snapshot: PublishedPageSnapshot) => ({
+    row_id: snapshot.pageRowId,
+    site_json: snapshot.site,
+    runtime_assets_json: snapshot.runtimeAssets ?? null,
+    importmap_body: snapshot.runtimePackageImportmap?.body ?? null,
+    importmap_sha256: snapshot.runtimePackageImportmap?.sha256 ?? null,
+  })
+
   let insertCallCount = 0
 
   return createFakeDb(async (sql: string, params: unknown[]): Promise<DbResult> => {
     const s = sql.replace(/\s+/g, ' ').trim().toLowerCase()
+
+    // ── snapshot getters (live render fallback / row bake) ────────────────
+    // MUST precede the listDataRows branch below: getLatestPublishedSiteSnapshot
+    // also contains `select data_rows.id` + `order by`.
+    if (s.includes('site_snapshots.site_json')) {
+      // getPublishedPageBySlug — parameterised on data_rows.slug.
+      if (s.includes('data_rows.slug =')) {
+        const slug = typeof params[0] === 'string' ? params[0] : ''
+        if (slug === staticPage.slug || slug === 'index') {
+          return { rows: [toSnapshotRow(staticSnapshot)], rowCount: 1 }
+        }
+        if (slug === dynamicPage.slug) {
+          return { rows: [toSnapshotRow(dynamicSnapshot)], rowCount: 1 }
+        }
+        return { rows: [], rowCount: 0 }
+      }
+      // getLatestPublishedSiteSnapshot
+      return { rows: [toSnapshotRow(staticSnapshot)], rowCount: 1 }
+    }
 
     // ── getDraftSite ───────────────────────────────────────────────────────
     if (s.startsWith('select id, name, version, enabled, lifecycle_status')) {
@@ -195,6 +223,11 @@ function buildFakeDb(
       return { rows: [{ next_version: 1 }], rowCount: 1 }
     }
 
+    // ── insert into site_snapshots (one per publish) ──────────────────────
+    if (s.includes('insert into site_snapshots')) {
+      return { rows: [], rowCount: 1 }
+    }
+
     // ── insert into data_row_versions ─────────────────────────────────────
     if (s.includes('insert into data_row_versions')) {
       insertCallCount++
@@ -212,23 +245,6 @@ function buildFakeDb(
     // ── update data_rows (status=published) ───────────────────────────────
     if (s.includes('update data_rows') && s.includes("status = 'published'")) {
       return { rows: [], rowCount: 1 }
-    }
-
-    // ── getPublishedPageBySlug (live render fallback) ─────────────────────
-    if (s.includes('select data_row_versions.snapshot_json') && s.includes('data_rows.slug =')) {
-      const slug = typeof params[0] === 'string' ? params[0] : ''
-      if (slug === staticPage.slug || slug === 'index') {
-        return { rows: [{ snapshot_json: staticSnapshot }], rowCount: 1 }
-      }
-      if (slug === dynamicPage.slug) {
-        return { rows: [{ snapshot_json: dynamicSnapshot }], rowCount: 1 }
-      }
-      return { rows: [], rowCount: 0 }
-    }
-
-    // ── getLatestPublishedSiteSnapshot ────────────────────────────────────
-    if (s.includes('select data_row_versions.snapshot_json') && !s.includes('slug')) {
-      return { rows: [{ snapshot_json: staticSnapshot }], rowCount: 1 }
     }
 
     // ── collectFrontendInjections: active_media_storage_adapter ──────────
@@ -344,7 +360,7 @@ describe('publishDraftSite — Layer A static artefacts', () => {
     let snapshotLookupCalled = false
     const diskCssDb = createFakeDb(async (sql: string): Promise<DbResult> => {
       const s = sql.toLowerCase()
-      if (s.includes('snapshot_json')) snapshotLookupCalled = true
+      if (s.includes('site_snapshots')) snapshotLookupCalled = true
       return { rows: [], rowCount: 0 }
     })
     const cssRes = await handleServerRequest(
@@ -448,7 +464,7 @@ describe('publicRouter — Layer A disk fast-path', () => {
     let snapshotLookupCalled = false
     const db = createFakeDb(async (sql: string): Promise<DbResult> => {
       const s = sql.toLowerCase()
-      if (s.includes('snapshot_json')) {
+      if (s.includes('site_snapshots')) {
         snapshotLookupCalled = true
       }
       if (s.includes('count(*) as count from site')) {

--- a/src/__tests__/server/rateLimit.test.ts
+++ b/src/__tests__/server/rateLimit.test.ts
@@ -86,4 +86,50 @@ describe('RateLimiter', () => {
     expect(() => new RateLimiter({ limit: 0, windowMs: 1000 })).toThrow()
     expect(() => new RateLimiter({ limit: 1, windowMs: 0 })).toThrow()
   })
+
+  describe('opportunistic pruning via consume()', () => {
+    it('sweeps aged-out buckets after PRUNE_INTERVAL calls', () => {
+      const rl = new RateLimiter({ limit: 5, windowMs: 1000 })
+
+      // 600 distinct keys at t=0 — below both prune triggers, all retained.
+      for (let i = 0; i < 600; i++) rl.consume(`key-${i}`, 0)
+      expect(rl.size()).toBe(600)
+
+      // Advance past the window so every key-N bucket is fully aged out,
+      // then drive the call counter to exactly PRUNE_INTERVAL on one fresh
+      // key (rejected attempts still count as consume() calls).
+      const later = 2000
+      const remaining = RateLimiter.PRUNE_INTERVAL - 600
+      for (let i = 0; i < remaining; i++) rl.consume('probe', later)
+
+      // The sweep dropped all 600 stale buckets; only 'probe' (which holds
+      // in-window attempts) survives.
+      expect(rl.size()).toBe(1)
+    })
+
+    it('sweeps immediately once the map exceeds PRUNE_SIZE_THRESHOLD keys', () => {
+      const rl = new RateLimiter({ limit: 5, windowMs: 1000 })
+
+      const total = RateLimiter.PRUNE_SIZE_THRESHOLD + 1
+      for (let i = 0; i < total; i++) rl.consume(`key-${i}`, 0)
+      // Interval-triggered sweeps ran during the loop, but nothing had aged
+      // out yet — every bucket is still tracked.
+      expect(rl.size()).toBe(total)
+
+      // One consume() past the window: the size trigger fires without
+      // waiting for the call counter, dropping every aged-out bucket.
+      rl.consume('fresh', 2000)
+      expect(rl.size()).toBe(1)
+    })
+
+    it('never changes a limit decision — in-window attempts survive the sweep', () => {
+      const rl = new RateLimiter({ limit: 1, windowMs: 10_000 })
+
+      rl.consume('victim', 0)
+      // Force an interval-triggered sweep mid-window with filler keys.
+      for (let i = 0; i < RateLimiter.PRUNE_INTERVAL; i++) rl.consume(`filler-${i}`, 1)
+      // The victim's accepted attempt is still in window, so it stays blocked.
+      expect(rl.consume('victim', 2).ok).toBe(false)
+    })
+  })
 })

--- a/src/__tests__/server/router.test.ts
+++ b/src/__tests__/server/router.test.ts
@@ -104,7 +104,7 @@ describe('server router — Layer A disk artefact fast-path', () => {
     const trackingDb = Object.assign(
       async (strings: TemplateStringsArray, ...values: unknown[]): Promise<DbResult> => {
         const sql = strings.reduce<string>((acc, s, i) => (i === 0 ? s : `${acc}$${i}${s}`), '')
-        if (sql.toLowerCase().includes('snapshot_json')) snapshotQueried = true
+        if (sql.toLowerCase().includes('site_snapshots')) snapshotQueried = true
         return originalHandle(strings, ...values)
       },
       { transaction: db.transaction, unsafe: db.unsafe },

--- a/src/__tests__/server/siteCssBundleMemo.test.ts
+++ b/src/__tests__/server/siteCssBundleMemo.test.ts
@@ -103,19 +103,37 @@ describe('buildPublishedSiteCssBundle — page-invariant memo', () => {
     expect(after.style).not.toBe(before.style)
   })
 
-  it('recomputes for a different site object at the same publish version', () => {
+  it('memo key is the publish version ALONE — a different site object at the same version reuses it', () => {
+    // Every consumer loads the published snapshot fresh from the DB (a new
+    // JSON-parsed object per query), so a site-identity key would never hit.
+    // Published content is fixed per version (every snapshot writer bumps), so
+    // the version alone is a sound key — and two distinct site objects at the
+    // same version must share one walk.
     const firstSite = makeMultiPageSite()
     const secondSite = makeMultiPageSite()
-    secondSite.pages = [
-      makePage({ id: 'p4', root: { moduleId: 'base.text', props: { text: 'D' } } }),
-    ]
 
-    buildPublishedSiteCssBundle(firstSite, registry, firstSite.pages[0])
+    const first = buildPublishedSiteCssBundle(firstSite, registry, firstSite.pages[0])
     const callsAfterFirstSite = renderCalls
 
-    buildPublishedSiteCssBundle(secondSite, registry, secondSite.pages[0])
+    const second = buildPublishedSiteCssBundle(secondSite, registry, secondSite.pages[0])
 
-    expect(renderCalls).toBeGreaterThan(callsAfterFirstSite)
+    expect(renderCalls).toBe(callsAfterFirstSite)
+    expect(second.framework).toBe(first.framework)
+    expect(second.style).toBe(first.style)
+  })
+
+  it('an explicit publishVersion argument (publish-time bake) gets its own memo slot', () => {
+    // The bake renders the NEXT version's content before bumpPublishVersion()
+    // runs, passing `nextPublishVersion` explicitly — it must not be served the
+    // current version's cached bundles.
+    const site = makeMultiPageSite()
+
+    const current = buildPublishedSiteCssBundle(site, registry, site.pages[0])
+    const callsAfterCurrent = renderCalls
+
+    const next = buildPublishedSiteCssBundle(site, registry, site.pages[0], 1)
+    expect(renderCalls).toBeGreaterThan(callsAfterCurrent)
+    expect(next.framework).not.toBe(current.framework)
   })
 
   it('emits byte-identical CSS to the un-memoised builder', () => {

--- a/src/admin/pages/site/store/slices/site/helpers.ts
+++ b/src/admin/pages/site/store/slices/site/helpers.ts
@@ -13,7 +13,8 @@ import type { StoreApi } from 'zustand'
 import type { FrameworkColorToken } from '@core/framework-schema'
 import type { NodeTree, PageNode, StyleRule, SiteDocument } from '@core/page-tree'
 import { addPage, createNode, reconcileSiteExplorerInPlace, reindexNodeParents } from '@core/page-tree'
-import { syncAllVCRefSlotInstances, allTreeNodeMaps } from '../vcSlotReconcile'
+import type { VisualComponent } from '@core/visualComponents'
+import { syncAllVCRefSlotInstances, allTreeNodeMaps, collectVCSlotOutletNames } from '../vcSlotReconcile'
 import { create } from 'mutative'
 import type { Draft, Patches } from 'mutative'
 import type { ImportFragment } from '@core/htmlImport'
@@ -31,12 +32,18 @@ import { addImportedFonts, addImportedFontTokens, addInstalledFontEntries, overw
 import type { HistoryEntry, SiteMutationResult, SiteSliceHelpers, SiteSliceRecipe, SuperImportHelpers } from './types'
 
 /**
- * Compute a node's depth in the active tree by walking up to root.
+ * Compute a node's depth in a tree by walking the O(1) `parentId` pointer up
+ * to the root — O(depth), no node-map scans. `parentId` is the engine's
+ * denormalised parent cache (see `reindexNodeParents` / `getParent` in
+ * `@core/page-tree`): restamped at every load boundary and maintained by every
+ * tree mutation, so it is reliably consistent for any tree in the store.
+ *
  * Used by `deleteNodes` to delete leaves before parents within a single batch
  * so descendants aren't double-removed (which would throw inside the helper).
  *
- * Returns 0 for the root, +Infinity for orphans (sorts last in DESC order →
- * effectively a no-op when the orphan slot is reached).
+ * Returns 0 for the root, +Infinity for orphans — a `null` (or dangling)
+ * `parentId` on a non-root node (sorts last in DESC order → effectively a
+ * no-op when the orphan slot is reached).
  */
 export function depthInTree(tree: NodeTree<PageNode>, nodeId: string): number {
   if (nodeId === tree.rootNodeId) return 0
@@ -45,13 +52,110 @@ export function depthInTree(tree: NodeTree<PageNode>, nodeId: string): number {
   const visited = new Set<string>()
   while (!visited.has(current)) {
     visited.add(current)
-    const parent = Object.values(tree.nodes).find((n) => n.children.includes(current))
-    if (!parent) return Infinity
+    const parentId = tree.nodes[current]?.parentId
+    if (!parentId || !tree.nodes[parentId]) return Infinity
     depth++
-    if (parent.id === tree.rootNodeId) return depth
-    current = parent.id
+    if (parentId === tree.rootNodeId) return depth
+    current = parentId
   }
   return depth
+}
+
+/**
+ * Resolve the tree the `mutateActiveTree*` helpers route to, from either the
+ * frozen store state or a Mutative draft of it:
+ *   - VC mode (`activeDocument.kind === 'visualComponent'`): the VC's tree,
+ *     returned alongside the owning VisualComponent so callers can propagate
+ *     slot-outlet changes.
+ *   - Page mode (null or `kind === 'page'`): the active Page — Page IS
+ *     NodeTree<PageNode>, so no conversion is needed (`vc` is null).
+ *
+ * This is the single implementation of the `kind === 'visualComponent'` tree
+ * routing (CLAUDE.md §"Mutation API"). `deleteNodes` also calls it against the
+ * frozen pre-mutation state to precompute deletion depths without touching
+ * draft proxies.
+ */
+export function resolveActiveTreeTarget(
+  state: Pick<EditorStore, 'site' | 'activeDocument' | 'activePageId'>,
+): { tree: NodeTree<PageNode>; vc: VisualComponent | null } | null {
+  const { site, activeDocument } = state
+  if (!site) return null
+
+  if (activeDocument?.kind === 'visualComponent') {
+    const vc = site.visualComponents.find((v) => v.id === activeDocument.vcId)
+    if (!vc) return null
+    // VCNode is structurally compatible with PageNode (dynamicBindings is optional).
+    return { tree: vc.tree as NodeTree<PageNode>, vc }
+  }
+
+  const pageId = activeDocument?.kind === 'page' ? activeDocument.pageId : state.activePageId
+  const page = site.pages.find((p) => p.id === pageId)
+  return page ? { tree: page, vc: null } : null
+}
+
+function stringArraysEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/** Serialize a patch path so fold dedup can key on it. */
+function patchPathKey(path: Patches[number]['path']): string {
+  return JSON.stringify(path)
+}
+
+/**
+ * Fold one coalesced keystroke's patch pair into the in-progress burst entry,
+ * deduplicating by patch path: the entry holds AT MOST one inverse and one
+ * forward patch per touched path, instead of accumulating 2K pairs (each
+ * carrying the full prop value at that instant) over a K-keystroke burst.
+ *
+ *  - inverse (undo): the OLDEST patch per path wins — it restores the
+ *    pre-burst value. Patches for newly-touched paths are prepended, keeping
+ *    the previous newest-first replay order for hierarchically-overlapping
+ *    paths.
+ *  - forward (redo): the NEWEST value per path wins, but the stored patch
+ *    keeps the op of the OLDEST forward patch: if the burst CREATED the prop,
+ *    the folded patch stays 'add'-shaped so redo replays from the post-undo
+ *    state where the prop is absent. Mutative's `apply` treats 'add' and
+ *    'replace' identically for plain-object keys (verified against
+ *    mutative@1.3.0 `src/apply.ts`, pinned by `historyCoalescingFold.test.ts`)
+ *    — they differ only for array indices, which coalescing recipes never
+ *    patch — so preserving the op is exactness, not necessity. When a
+ *    'remove' op is involved on either side, the incoming patch replaces the
+ *    stored one wholesale: deleting an absent object key is a no-op, so the
+ *    newest patch already describes the burst's net effect for that path.
+ *
+ * Undo/redo results are bit-identical to the previous concat behavior —
+ * replaying [newest…oldest] inverses leaves the oldest value per path, and
+ * replaying [oldest…newest] forwards leaves the newest.
+ */
+function foldIntoCoalescedEntry(top: Draft<HistoryEntry>, entry: HistoryEntry): void {
+  const knownInverse = new Set<string>()
+  for (const p of top.inverse) knownInverse.add(patchPathKey(p.path))
+  const freshInverse = entry.inverse.filter((p) => !knownInverse.has(patchPathKey(p.path)))
+  if (freshInverse.length > 0) top.inverse = [...freshInverse, ...top.inverse]
+
+  const forward = [...top.forward]
+  const forwardIndexByPath = new Map<string, number>()
+  forward.forEach((p, i) => forwardIndexByPath.set(patchPathKey(p.path), i))
+  for (const incoming of entry.forward) {
+    const key = patchPathKey(incoming.path)
+    const i = forwardIndexByPath.get(key)
+    if (i === undefined) {
+      forwardIndexByPath.set(key, forward.length)
+      forward.push(incoming)
+      continue
+    }
+    const oldest = forward[i]!
+    forward[i] =
+      oldest.op === 'remove' || incoming.op === 'remove'
+        ? incoming
+        : { op: oldest.op, path: incoming.path, value: incoming.value }
+  }
+  top.forward = forward
 }
 
 function applyImportedBodyAttributes(
@@ -87,9 +191,10 @@ function applyImportedBodyAttributes(
  *   - `mutateSiteState`:  the full editor-state draft plus the SiteDocument draft.
  *   - `mutateActiveTree`: the active NodeTree<PageNode>, routed by `activeDocument`.
  *
- * `mutateActiveTree` is the SOLE place that branches on `kind === 'visualComponent'`
- * — every named tree-mutation action delegates to it. Gated by
- * `src/__tests__/architecture/no-vc-mode-branches-in-mutations.test.ts`.
+ * `resolveActiveTreeTarget` (above) is the SOLE implementation of the
+ * `kind === 'visualComponent'` tree routing; `mutateActiveTree` is the only
+ * mutation path through it — every named tree-mutation action delegates there.
+ * Gated by `src/__tests__/architecture/no-vc-mode-branches-in-mutations.test.ts`.
  */
 export function buildSiteHelpers(
   set: (recipe: SiteSliceRecipe) => void,
@@ -103,11 +208,10 @@ export function buildSiteHelpers(
    * Commit one transaction's site-scoped patch pair to undo history.
    *
    * Coalescing: when the incoming key matches the in-progress burst, the entry
-   * folds into the existing top entry instead of pushing a new one — the new
-   * inverse is PREPENDED (so undo reverts newest-change-first back to the
-   * pre-burst state) and the new forward is APPENDED (redo replays in order).
-   * A whole typing burst is therefore one undo step. Patch arrays stay tiny
-   * (one path per keystroke), so the concatenation cost is negligible.
+   * folds into the existing top entry instead of pushing a new one — deduped
+   * by patch path via `foldIntoCoalescedEntry` (oldest inverse wins, newest
+   * forward value wins), so a whole typing burst is one undo step holding at
+   * most one patch pair per touched path.
    */
   function commitHistory(state: Draft<EditorStore>, entry: HistoryEntry): void {
     const coalescing =
@@ -115,9 +219,7 @@ export function buildSiteHelpers(
       entry.coalesceKey === state._historyCoalesceKey &&
       state._historyPast.length > 0
     if (coalescing) {
-      const top = state._historyPast[state._historyPast.length - 1]!
-      top.inverse = [...entry.inverse, ...top.inverse]
-      top.forward = [...top.forward, ...entry.forward]
+      foldIntoCoalescedEntry(state._historyPast[state._historyPast.length - 1]!, entry)
       state._historyFuture = []
       state.canRedo = false
       return
@@ -199,48 +301,63 @@ export function buildSiteHelpers(
   }
 
   /**
+   * Shared recipe core for `mutateActiveTree` / `mutateActiveTreeAndSite`.
+   *
+   * Routes to the active tree via `resolveActiveTreeTarget`, runs `fn`, and —
+   * in VC mode — propagates any change in the VC's slot-outlet set to every
+   * consumer VC ref, across all pages AND every other VC's tree (refs nested
+   * inside other VCs, ISS-026), via `syncAllVCRefSlotInstances`. The sweep
+   * runs INSIDE the recipe so those writes land in the same patch set.
+   *
+   * The sweep is GATED on an actual change of the VC's ordered slot-outlet
+   * name sequence: the pre-mutation sequence is read from the frozen store
+   * state (cheap — no draft proxies), the post-mutation sequence from the
+   * VC-tree-sized draft. That sequence is the ONLY input `syncSlotInstances`
+   * reads from the VC, so an unchanged sequence makes the sweep a guaranteed
+   * no-op — and running it anyway rewrites every consumer ref's `children`
+   * array, turning each per-keystroke VC prop edit into a site-wide sweep.
+   * Gating on the ordered sequence (not the name SET) keeps outlet reorders
+   * propagating, since slot-instance order follows outlet order.
+   */
+  function runActiveTreeRecipe(
+    draft: Draft<EditorStore>,
+    fn: (tree: NodeTree<PageNode>) => SiteMutationResult,
+  ): SiteMutationResult {
+    const target = resolveActiveTreeTarget(draft)
+    if (!target) return false
+    const { tree, vc } = target
+    if (!vc) return fn(tree)
+
+    // `get()` is the frozen pre-mutation state — the VC is guaranteed present
+    // there because the draft (where it was just found) mirrors it.
+    const frozenVc = get().site?.visualComponents.find((v) => v.id === vc.id)
+    const outletNamesBefore = frozenVc ? collectVCSlotOutletNames(frozenVc.tree) : null
+
+    const result = fn(tree)
+    if (result === false) return false
+
+    const outletNamesAfter = collectVCSlotOutletNames(vc.tree)
+    if (outletNamesBefore === null || !stringArraysEqual(outletNamesBefore, outletNamesAfter)) {
+      syncAllVCRefSlotInstances(allTreeNodeMaps(draft.site!), vc.id, vc)
+    }
+    return result
+  }
+
+  /**
    * Mutate the active node tree — auto-records undo history on real changes.
    *
-   * Routes to the correct tree based on `activeDocument`:
+   * Routes based on `activeDocument` (see `resolveActiveTreeTarget`):
    *   - Page mode (null or kind === 'page'): passes the active Page directly —
    *     Page IS NodeTree<PageNode> so no conversion needed.
-   *   - VC mode (kind === 'visualComponent'): passes vc.tree directly —
-   *     VCNode (= BaseNode) is structurally compatible with PageNode (which only
-   *     adds optional `dynamicBindings`), so the cast is safe for all tree
-   *     mutations that operate on BaseNode-level fields.
-   *     After the mutation, propagates any change in the VC's slot-outlet set
-   *     to every consumer VC ref — across all pages AND every other VC's tree
-   *     (refs nested inside other VCs, ISS-026) — via
-   *     `syncAllVCRefSlotInstances`, run INSIDE the recipe so those writes are
-   *     captured in the same patch set.
+   *   - VC mode (kind === 'visualComponent'): passes vc.tree directly, then
+   *     propagates slot-outlet changes to every consumer VC ref when the
+   *     outlet sequence changed (see `runActiveTreeRecipe`).
    */
   function mutateActiveTree(
     fn: (tree: NodeTree<PageNode>) => SiteMutationResult,
     opts?: { coalesceKey?: string },
   ): boolean {
-    return runHistoricMutation((draft) => {
-      const site = draft.site!
-      const { activeDocument } = draft
-
-      if (activeDocument?.kind === 'visualComponent') {
-        const vc = site.visualComponents.find((v) => v.id === activeDocument.vcId)
-        if (!vc) return false
-        // VCNode is structurally compatible with PageNode (dynamicBindings is optional).
-        const result = fn(vc.tree as NodeTree<PageNode>)
-        if (result === false) return false
-        // Propagate slot-outlet changes to every consumer VC ref — in pages AND
-        // nested inside other VC trees. Idempotent when the slot-outlet set is
-        // unchanged.
-        syncAllVCRefSlotInstances(allTreeNodeMaps(site), vc.id, vc)
-        return result
-      }
-
-      // Page mode (activeDocument is null or kind === 'page').
-      const pageId = activeDocument?.kind === 'page' ? activeDocument.pageId : draft.activePageId
-      const page = site.pages.find((p) => p.id === pageId)
-      if (!page) return false
-      return fn(page)
-    }, opts?.coalesceKey ?? null)
+    return runHistoricMutation((draft) => runActiveTreeRecipe(draft, fn), opts?.coalesceKey ?? null)
   }
 
   /** Mutate the site — auto-records undo history on real changes. */
@@ -270,9 +387,10 @@ export function buildSiteHelpers(
 
   /**
    * Mutate the active node tree AND the surrounding site — records undo history
-   * on real changes. Same active-document routing as `mutateActiveTree`, but
-   * also hands the recipe a `SiteDocument` draft so it can read or write
-   * site-level state alongside the tree mutation in one transaction.
+   * on real changes. Same routing and slot-outlet propagation contract as
+   * `mutateActiveTree` (shared via `runActiveTreeRecipe`), but also hands the
+   * recipe a `SiteDocument` draft so it can read or write site-level state
+   * alongside the tree mutation in one transaction.
    *
    * Used by duplicate operations that must clone scoped classes (which live
    * on `site.styleRules`) atomically with the node duplication. Without this
@@ -282,25 +400,10 @@ export function buildSiteHelpers(
   function mutateActiveTreeAndSite(
     fn: (tree: NodeTree<PageNode>, site: SiteDocument) => SiteMutationResult,
   ): boolean {
-    return runHistoricMutation((draft) => {
-      const site = draft.site!
-      const { activeDocument } = draft
-
-      if (activeDocument?.kind === 'visualComponent') {
-        const vc = site.visualComponents.find((v) => v.id === activeDocument.vcId)
-        if (!vc) return false
-        const result = fn(vc.tree as NodeTree<PageNode>, site)
-        if (result === false) return false
-        // Mirror mutateActiveTree's slot-outlet propagation contract.
-        syncAllVCRefSlotInstances(allTreeNodeMaps(site), vc.id, vc)
-        return result
-      }
-
-      const pageId = activeDocument?.kind === 'page' ? activeDocument.pageId : draft.activePageId
-      const page = site.pages.find((p) => p.id === pageId)
-      if (!page) return false
-      return fn(page, site)
-    }, null)
+    return runHistoricMutation(
+      (draft) => runActiveTreeRecipe(draft, (tree) => fn(tree, draft.site!)),
+      null,
+    )
   }
 
   /**

--- a/src/admin/pages/site/store/slices/site/nodeActions.ts
+++ b/src/admin/pages/site/store/slices/site/nodeActions.ts
@@ -33,7 +33,7 @@ import {
 } from '@core/page-tree'
 import type { NodeTree, PageNode, SiteDocument } from '@core/page-tree'
 import { wouldCreateCycle, syncSlotInstances, applySlotSyncResult } from '@core/visualComponents'
-import { depthInTree } from './helpers'
+import { depthInTree, resolveActiveTreeTarget } from './helpers'
 import { pruneCanvasSelectionDraft } from '../selectionSlice'
 import { indexStyleRulesByName, linkImportedClassNames, mergeImportedStyleRules } from './importLinking'
 import type { SiteSlice, SiteSliceHelpers } from './types'
@@ -444,14 +444,22 @@ export function createNodeActions(helpers: SiteSliceHelpers): NodeActions {
 
     deleteNodes: (nodeIds) => {
       if (nodeIds.length === 0) return
+      // Precompute depths ONCE against the FROZEN pre-mutation tree: sorting
+      // inside the recipe would walk ancestor chains through the Mutative
+      // draft (every node access materializes a draft proxy), twice per
+      // comparison. Sorting against pre-draft state is safe because the
+      // recipe re-checks `tree.nodes[id]` before each delete.
+      const target = resolveActiveTreeTarget(get())
+      if (!target) return
+      const depthById = new Map<string, number>()
+      for (const id of nodeIds) depthById.set(id, depthInTree(target.tree, id))
+      // Sort by depth-DESC so leaves go first — descendants of an
+      // already-deleted id are gone, and the "node not found" guard handles
+      // the redundant case cleanly.
+      const ordered = [...nodeIds].sort(
+        (a, b) => depthById.get(b)! - depthById.get(a)!,
+      )
       const deleted = mutateActiveTree((tree) => {
-        // Delete each id; descendants of an already-deleted id are gone, so the
-        // helper's "node not found" branch handles the redundant case cleanly.
-        // We sort by depth-DESC so leaves go first, avoiding noisy throws when
-        // a parent is deleted before its child in the same batch.
-        const ordered = [...nodeIds].sort(
-          (a, b) => depthInTree(tree, b) - depthInTree(tree, a),
-        )
         let changed = false
         for (const id of ordered) {
           if (id === tree.rootNodeId) continue

--- a/src/admin/pages/site/store/slices/vcSlotReconcile.ts
+++ b/src/admin/pages/site/store/slices/vcSlotReconcile.ts
@@ -11,8 +11,52 @@ import type { VisualComponent } from '@core/visualComponents'
 import { syncSlotInstances, applySlotSyncResult } from '@core/visualComponents'
 
 /**
+ * Collect the ordered, deduplicated slot names declared by `base.slot-outlet`
+ * nodes in a VC tree — DFS pre-order, first appearance wins, missing/empty
+ * `slotName` defaults to 'children'.
+ *
+ * Mirrors the (unexported) `extractSlotNamesFromVCTree` inside
+ * `@core/visualComponents`' slotSync. This sequence is the ONLY input
+ * `syncSlotInstances` reads from the VC, so callers can compare pre/post
+ * sequences and skip a guaranteed no-op reconcile sweep when they are equal
+ * (see `runActiveTreeRecipe` in `site/helpers.ts`).
+ */
+export function collectVCSlotOutletNames(tree: {
+  rootNodeId: string
+  nodes: Record<string, BaseNode>
+}): string[] {
+  const result: string[] = []
+  const seen = new Set<string>()
+  const stack: string[] = [tree.rootNodeId]
+
+  while (stack.length > 0) {
+    const id = stack.pop()!
+    const node = tree.nodes[id]
+    if (!node) continue
+
+    if (node.moduleId === 'base.slot-outlet') {
+      const slotName =
+        typeof node.props.slotName === 'string' && node.props.slotName
+          ? node.props.slotName
+          : 'children'
+      if (!seen.has(slotName)) {
+        seen.add(slotName)
+        result.push(slotName)
+      }
+    }
+
+    // DFS pre-order: push children in reverse so leftmost is processed first.
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      stack.push(node.children[i])
+    }
+  }
+
+  return result
+}
+
+/**
  * Re-sync slot-instance children for every `base.visual-component-ref` that
- * references `vcId`, across all supplied node maps. Must run inside an Immer
+ * references `vcId`, across all supplied node maps. Must run inside a Mutative
  * producer — each map is mutated in place via `applySlotSyncResult`.
  */
 export function syncAllVCRefSlotInstances(

--- a/src/core/module-engine/validateNodeProps.ts
+++ b/src/core/module-engine/validateNodeProps.ts
@@ -3,27 +3,181 @@
  *
  * `validateNodeProps` is the single call site that closes the module-props
  * boundary leak: authored props coming from the database can be stale,
- * missing, or lightly malformed. Running them through `Value.Parse`
- * (Default + Convert + Clean + Check) normalises them to the schema's
- * declared shape before they reach the module's pure `render()`.
+ * missing, or lightly malformed. It normalises them to the schema's declared
+ * shape before they reach the module's pure `render()`.
+ *
+ * Two-tier strategy (this runs once per node per render, so it dominates
+ * publish time on large pages):
+ *
+ *   1. FAST PATH — if the schema is structurally "parse-stable" (see
+ *      `fastPathEligible`) and the props already pass the cached compiled
+ *      `Check`, return `rawProps` as-is. For such schema/value pairs the full
+ *      `Value.Parse` pipeline is value-identity: Default and Convert are
+ *      no-ops on a conforming value, Clean only strips unknown keys which the
+ *      slow path's merge would restore anyway, and there are no Transforms to
+ *      decode. Compiled `Check` is ~40-80× faster than interpreted
+ *      `Value.Parse` and the clone is skipped entirely (module `render()`
+ *      functions are pure consumers; `escapeProps` re-copies before any
+ *      publisher-side mutation).
+ *
+ *   2. SLOW PATH — `Value.Parse` (Clone + Clean + Default + Convert + Check)
+ *      exactly as before, for non-conforming values and for schemas where
+ *      Check-pass does not imply Parse-identity.
  *
  * Design constraints:
  *   - SOFT boundary — exceptions from coercion are caught; never bubbles.
- *   - Unknown/injected keys survive — merge is `{ ...rawProps, ...cleaned }`
- *     so publisher-injected fields (`_resolvedMediaByKey`, `_resolvedAutoSizes`)
- *     that arrive on rawProps are never stripped.
+ *   - Unknown/injected keys survive — the fast path returns them untouched on
+ *     `rawProps`; the slow path's merge is `{ ...rawProps, ...cleaned }` so
+ *     publisher-injected fields (`_resolvedMediaByKey`, `_resolvedAutoSizes`)
+ *     are never stripped.
  *   - Pass-through when no schema — modules without `propsSchema` are
  *     unaffected; the function is a no-op for them.
  */
 
+import { Kind, OptionalKind, TransformKind } from '@sinclair/typebox'
+import type { TSchema } from '@sinclair/typebox'
+import { compiledCheck } from '@core/utils/typeboxCompiler'
 import { parseValue } from '@core/utils/typeboxHelpers'
 import type { AnyModuleDefinition } from './types'
+
+/**
+ * Leaf kinds for which a Check-passing value is exactly the Parse output:
+ * none of them accepts `undefined` (so a present-but-undefined value can
+ * never pass Check and then be replaced by a `default`), and Convert is the
+ * identity on any value that already conforms.
+ */
+const ELIGIBLE_LEAF_KINDS = new Set([
+  'String',
+  'Number',
+  'Integer',
+  'Boolean',
+  'Literal',
+  'Null',
+  'TemplateLiteral',
+])
+
+function isSchemaObject(value: unknown): value is TSchema {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Structural walk deciding whether `Check`-pass implies `Value.Parse`
+ * value-identity for this schema. Conservative: anything we cannot reason
+ * about confidently (Ref/This, Intersect, Date/custom kinds, symbol-less
+ * plain-JSON schemas from the plugin boundary, cyclic schema objects) is
+ * ineligible and stays on the slow path.
+ *
+ * The two hard disqualifiers the fast path must catch:
+ *   1. An OPTIONAL property carrying a `default` — the absent key passes
+ *      Check, but Value.Parse would materialize the default.
+ *   2. A Transform anywhere — Value.Parse runs Decode; skipping it would
+ *      hand the module the encoded value.
+ *
+ * `visiting` tracks the current walk path; revisiting an ancestor means the
+ * schema object is literally cyclic, which TypeBox cannot compile — reject.
+ * (Shared, non-cyclic subschemas are simply re-walked.)
+ */
+function walkEligible(schema: TSchema, visiting: Set<TSchema>): boolean {
+  if (visiting.has(schema)) return false
+  visiting.add(schema)
+  try {
+    if (TransformKind in schema) return false
+
+    // TSchema types `[Kind]` as `string`, but schemas that crossed a JSON
+    // boundary (plugin module packs) arrive symbol-less — guard at runtime.
+    const kind: unknown = schema[Kind]
+    if (typeof kind !== 'string') return false
+    if (ELIGIBLE_LEAF_KINDS.has(kind)) return true
+
+    switch (kind) {
+      case 'Object': {
+        // patternProperties is not produced by Type.Object — hand-built
+        // hybrids get the conservative treatment.
+        if ('patternProperties' in schema) return false
+        const properties: unknown = schema.properties
+        if (isSchemaObject(properties)) {
+          for (const prop of Object.values(properties)) {
+            if (!isSchemaObject(prop)) return false
+            // Disqualifier 1: optional-with-default.
+            if (OptionalKind in prop && 'default' in prop) return false
+            if (!walkEligible(prop, visiting)) return false
+          }
+        }
+        const additional: unknown = schema.additionalProperties
+        if (isSchemaObject(additional) && !walkEligible(additional, visiting)) return false
+        return true
+      }
+      case 'Record': {
+        const pattern: unknown = schema.patternProperties
+        if (!isSchemaObject(pattern)) return false
+        for (const valueSchema of Object.values(pattern)) {
+          if (!isSchemaObject(valueSchema)) return false
+          if (!walkEligible(valueSchema, visiting)) return false
+        }
+        const additional: unknown = schema.additionalProperties
+        if (isSchemaObject(additional) && !walkEligible(additional, visiting)) return false
+        return true
+      }
+      case 'Array': {
+        if ('contains' in schema) return false
+        const items: unknown = schema.items
+        return isSchemaObject(items) && walkEligible(items, visiting)
+      }
+      case 'Tuple': {
+        const items: unknown = schema.items
+        if (items === undefined) return true // zero-length tuple has no items
+        if (!Array.isArray(items)) return false
+        for (const item of items) {
+          if (!isSchemaObject(item)) return false
+          if (!walkEligible(item, visiting)) return false
+        }
+        return true
+      }
+      case 'Union': {
+        const anyOf: unknown = schema.anyOf
+        if (!Array.isArray(anyOf)) return false
+        for (const member of anyOf) {
+          if (!isSchemaObject(member)) return false
+          if (!walkEligible(member, visiting)) return false
+        }
+        return true
+      }
+      case 'Unknown':
+      case 'Any':
+        // Clean/Convert/Default are identity for these kinds — UNLESS a
+        // `default` annotation is present: Unknown/Any accept a literal
+        // `undefined` value, which passes Check but which Value.Parse would
+        // replace with the default.
+        return !('default' in schema)
+      default:
+        return false
+    }
+  } finally {
+    visiting.delete(schema)
+  }
+}
+
+// Eligibility is a pure function of the schema object — computed once per
+// schema for the app's lifetime. The allowlisted kinds are all compilable, so
+// `compiledCheck` (which compiles on first use) cannot throw for an eligible
+// schema.
+const eligibilityCache = new WeakMap<TSchema, boolean>()
+
+function fastPathEligible(schema: TSchema): boolean {
+  const cached = eligibilityCache.get(schema)
+  if (cached !== undefined) return cached
+  const result = walkEligible(schema, new Set())
+  eligibilityCache.set(schema, result)
+  return result
+}
 
 /**
  * Coerce and default-fill `rawProps` against `def.propsSchema`.
  *
  * Behaviour:
  *   - No schema → return `rawProps` unchanged.
+ *   - Schema fast-path eligible AND props already conform → return `rawProps`
+ *     unchanged (value-identical to the slow path, minus the clone).
  *   - Schema present, coercion succeeds → `{ ...rawProps, ...cleanedProps }`.
  *     Known props are coerced/defaulted by Value.Parse; unknown keys from
  *     rawProps survive untouched.
@@ -36,10 +190,16 @@ export function validateNodeProps(
 ): Record<string, unknown> {
   if (!def.propsSchema) return rawProps
 
+  // Tier 1: already-conforming props short-circuit through the cached
+  // compiled validator — no clone, no interpreted Value.Parse.
+  if (fastPathEligible(def.propsSchema) && compiledCheck(def.propsSchema, rawProps)) {
+    return rawProps
+  }
+
   try {
-    // parseValue = Value.Parse: Default + Convert + Clean + Check.
-    // Clean strips unknown keys from the result, so `cleaned` contains only
-    // schema-known props. The spread merge below restores everything else.
+    // Tier 2: parseValue = Value.Parse: Clone + Clean + Default + Convert +
+    // Check. Clean strips unknown keys from the result, so `cleaned` contains
+    // only schema-known props. The spread merge below restores everything else.
     const cleaned = parseValue(def.propsSchema, rawProps) as Record<string, unknown>
     return { ...rawProps, ...cleaned }
   } catch (_err) {


### PR DESCRIPTION
## Summary

A multi-agent performance audit of the CMS surfaced 18 confirmed issues (each finding survived two adversarial reviewers: one attacking "is it real and hot", one attacking "is it fixable with byte-identical output"). This PR fixes the critical and high-impact ones across the publish pipeline, the public request path, the render engine, and the editor store — **with zero visual or behavioral change**: same HTML bytes, same API responses, same UI.

## Benchmarks — before / after

Measured with the repo bench harness (`bun run bench`) on the same machine, same bench code (committed separately as the first commit so both runs are identical). Full reports: `.tmp/benchmarks/REPORT-{before,after}.md` from `ec23a586` (before) and `HEAD` (after).

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| Full publish — 40 pages × ~150 nodes | **1.75 s** | **64.3 ms** | **27×** |
| DB growth per publish (40 pages) | **77.7 MB** (1.94 MB/page) | **4.3 MB** (110 KB/page) | **18×** |
| Publish status check (admin poll, 40 pages) | 208.5 ms | 12.6 ms | 17× |
| Warm dynamic-route GET (Layer B hit) | **2.35 ms** | **1.87 µs** | **~1,250×** |
| Published row-route lookup (10k rows) | 671 µs | 9.0 µs | 75× |
| Editor: multi-delete 500 of 10,000 nodes | **56.3 s** | **34.9 ms** | **~1,600×** |
| Editor: per-keystroke in VC mode (20 pages × 500 nodes) | 6.59 ms | 157 µs | 42× |
| Editor: 2,000-keystroke undo burst (retained history / per-op) | 4.38 MB / 3.65 ms | 3.0 KB / 142 µs | 1,500× / 26× |
| publishPage — 100-node page | 265 µs | 199 µs | 1.33× |
| publishPage — 50,000-node page | 138.8 ms | 110.6 ms | 1.26× |
| 404 bot-probe cost | 45.4 µs | 33.1 µs | 1.4× |

Publish was **quadratic** in page count before (10→40 pages: 124 ms→1.75 s wall, 2.6→77.7 MB stored); it is now linear.

## What was wrong, what changed

### Publish pipeline & storage
- **Every page version stored a `structuredClone` of the entire site** (`data_row_versions.snapshot_json`) — publishing N pages cloned, serialized, and stored the whole site N times. Migration 003 is rewritten (pre-release, no compat): a new `site_snapshots` table stores the published `SiteDocument` **once per publish** (with a content hash + the CSP-exact importmap bytes); page versions reference it via `site_snapshot_id` and carry only page-scoped `runtime_assets_json`. The reassembled `PublishedPageSnapshot` shape is unchanged, so all consumers are untouched.
- **The bake rebuilt the whole-site CSS bundle once per page** (~2N full-site render walks per publish): the page-invariant bundle memo was keyed on site-object identity, which never hit (every consumer gets a fresh JSON parse). It is now keyed by publish version alone, with the bake passing `nextPublishVersion` explicitly.
- **Full publish silently stranded every data-row artefact**: the slot wipe + swap rebaked only `pages`-table routes, so every post URL fell off Layer A after each publish (the in-code comment "the next full publish will rebuild" was provably false). New `server/publish/bakeDataRows.ts` bakes every published row route through its entry template into the inactive slot — same render pipeline, same bytes, different serving tier. Each render's actual CSS bundle is collected into the slot too (covers merged-template `userStyles` hashes no raw page produces).
- **`getDraftPublishStatus` canonical-serialized the full site once per published page** (O(N²), synchronous, on every editor mount). It now compares a SHA-256 content hash stamped at publish time — one draft serialization total.

### Public request path
- **Route resolution ran before the Layer B cache lookup**, so even cache hits paid 2–4 DB round-trips plus a full-site JSON parse per request (multi-MB on large sites, blocking the event loop). `renderPublicResolution` now peeks the cache first; warm hits do zero DB work. The correctness hole this exposed is closed: soft-delete, table move, and page reaping now bump the publish version when they retract a published route (new `bumpPublishVersionSerialized()`, never called inside an open transaction — the publish lock can be queued behind the transaction chain). Architecture gate `publish-bumps-cache-version` updated accordingly.
- **Per-version snapshot memos** (`server/publish/publishedSnapshotCache.ts`) now back the public router's row resolution, the hole endpoint (its local memo moved there), and the loop endpoint — which previously re-parsed the full snapshot **and walked every page's render tree on every "Load more" click** (an unauthenticated compute-amplification vector). The loop lookup is now an O(1) map hit.
- **Missing indexes** for the published row-route lookup: `data_row_versions(slug)` + `data_rows(active_version_id)`. Also fixes migration 006's table rebuild silently dropping `data_rows` indexes created in 003 (verified via `EXPLAIN QUERY PLAN`: SCAN → three index SEARCHes).
- **`serveSiteCss` DB fallback rebuilt CSS for every page per request** — O(pages²) render work, no cache, no single-flight, including for crafted stale-hash URLs. Now memoised by `(bundle, hash)` (content-addressed = immutable) with negative caching and single-flight, reset on publish.
- **Every unmatched GET re-queried setup status forever** (two COUNTs per bot probe). Sticky memo — `needsSetup` can only ever flip true→false (last-owner removal is blocked).

### Render engine
- **`validateNodeProps` ran interpreted TypeBox `Value.Parse` per node per render** (~1.7 µs/node vs 0.06 µs compiled). Already-conforming props now take a compiled-`Check` fast path (27× per node), guarded by a structural eligibility walk: schemas with optional-with-default properties or Transforms (possible from plugin module packs) keep the full `Value.Parse` path, cached per schema in a WeakMap.

### Editor store
- **`depthInTree` scanned the entire node map per ancestor level, inside the `deleteNodes` sort comparator** against Mutative draft proxies. It now walks the O(1) `parentId` index; `deleteNodes` precomputes depths once against the frozen pre-mutation tree. (56 s → 35 ms.)
- **Every mutation in VC edit mode swept every node of every page** to re-sync slot instances — including each keystroke. The sweep is now gated on an actual change of the VC's ordered slot-outlet sequence (sequence, not set: outlet *reorders* change consumer slot order).
- **Undo coalescing accumulated O(burst²) patch data** (every keystroke retained a progressively longer full-string snapshot). Bursts now fold per patch path: oldest inverse, newest forward value, oldest forward op preserved (an `add` stays an `add` so redo works from the post-undo state). Bit-identical undo/redo, pinned by new tests.

### Server hygiene
- SQLite adapter uses bun:sqlite's cached `db.query()` instead of recompiling every statement with `db.prepare()`.
- Login rate-limiter actually prunes aged-out buckets (the documented prune had no caller; attacker-controlled `(ip,email)` keys grew unbounded for the process lifetime).
- `contentProjection.ts` extracted from `content.ts` (786 → 661 lines, graduating it off the grandfathered size ledger).

## Verification

- `bun test`: **5,111 pass / 0 fail** · `bun run build` (tsc + vite): clean · `bun run lint`: clean
- All 438 architecture gates pass (migration parity, postgres-isms, boundary validation, size budgets, publish-bump gate — the latter two updated where the rule itself legitimately changed)
- New regression tests: undo-fold bit-identity, deleteNodes ordering pins, VC sweep gating (incl. reorder), TypeBox fast-path eligibility (all 15 base modules eligible; optional-default/Transform schemas excluded), SQLite statement-cache rebind, rate-limiter prune
- Schema change requires dropping local dev DBs (pre-release policy; `bun run db:drop`)

## Explicitly deferred (verified but out of scope)

- **Full-roster autosave** (every save PUTs all pages + full server-side revalidation + N row UPDATEs) — real, but needs a save-protocol redesign; separate PR.
- **Plugin-sandbox findings** (VM payload embedding, sequential boot activation, fetch timeouts, base64 codec) — adversarial verification was cut short by a session limit; needs its own verified pass.
- Refuted by the audit's reviewers (no action): `/admin` shell per-request brotli (measured trivial at 13.7 KB), `createClass` double scan (no bulk path uses it), dynamic-detection VC re-walk (bounded by the seen-set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
