### PR TITLE
perf: incremental site saves; hoist runtime builds out of the publish transaction

### DIFF
--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -382,9 +382,14 @@ publishDraftSite (server/repositories/publish.ts)
     │
     ├─→ load draft site shell + all page-table rows + all VC rows
     ├─→ build runtime scripts + runtime package importmap
-    ├─→ write the SiteDocument ONCE into site_snapshots (content hash stamped
-    │     for the publish-status check); each page's data_row_versions row
-    │     references it via site_snapshot_id + carries its runtime_assets_json
+    ├─→ build EVERYTHING expensive first, outside any transaction — dependency
+    │     cache (`bun install`), importmap, per-page esbuild runtime builds.
+    │     The SQLite adapter serializes all transactions through one chain, so
+    │     this work inside the transaction would stall every concurrent write.
+    ├─→ short transaction: write the SiteDocument ONCE into site_snapshots
+    │     (content hash stamped for the publish-status check); each page's
+    │     data_row_versions row references it via site_snapshot_id + carries
+    │     its runtime_assets_json
     ├─→ flip data_rows.status = 'published', set active_version_id
     │
     ├─→ Layer A bake — every page (complete doc, or static shell with <instatic-hole>):

--- a/docs/features/site-shell.md
+++ b/docs/features/site-shell.md
@@ -377,11 +377,19 @@ The shell is saved independently of pages / VCs. Three save paths:
 
 | Endpoint                                    | Saves                                          |
 |---------------------------------------------|------------------------------------------------|
-| `PUT /admin/api/cms/site`                   | The shell — settings, breakpoints, classes, files |
-| `PUT /admin/api/cms/pages`                  | Page roster (batch upsert)                     |
-| `PUT /admin/api/cms/components`             | VC roster (batch upsert)                       |
+| `PUT /admin/api/cms/site`                   | The shell — settings, breakpoints, classes, files (always written) |
+| `PUT /admin/api/cms/pages`                  | `{ changedPages, pageIds, baselinePageIds? }` — only changed pages; full id roster drives reaping |
+| `PUT /admin/api/cms/components`             | `{ changedComponents, componentIds }` — only changed VCs; cross-VC rules run on the merged roster |
 
-The editor's auto-save scheduler (`usePersistence.ts`) batches dirty changes and fires the matching save endpoint. Granular write gates (`SITE_WRITE_CAPABILITIES`) enforce what each role can actually change inside the diff.
+Saves are **incremental**: the editor store derives which pages/VCs changed
+from the same Mutative patches that power undo
+(`src/admin/pages/site/store/slices/site/dirtyTracking.ts`), and
+`usePersistence.ts` ships only those — a one-prop edit uploads one page, not
+the site. The full id rosters always go along, so the server's
+delete-what's-missing reconcile keeps full-replace semantics (including the
+ISS-041 baseline). Anything the tracker can't attribute marks `all` and falls
+back to a full save. Granular write gates (`SITE_WRITE_CAPABILITIES`)
+enforce what each role can actually change inside the diff.
 
 The page and component roster endpoints are fail-closed: because each reconcile soft-deletes stored rows missing from the incoming roster, malformed entries reject the whole save instead of being repaired by dropping entries. Page and VC trees must have a valid root, matching node-map keys, resolvable child IDs, and no reachable child cycles. Component saves also reject duplicate IDs/names, missing VC refs, and dependency cycles. Tolerant repair remains limited to reads of persisted data where dropping bad entries cannot be misread as an intentional delete request.
 

--- a/scripts/bench/benches/publish.ts
+++ b/scripts/bench/benches/publish.ts
@@ -47,12 +47,12 @@ async function loadServer() {
   const { sqliteMigrations } = await import('../../../server/db/migrations-sqlite')
   const { saveDraftSite } = await import('../../../server/repositories/site')
   const { publishDraftSite, getDraftPublishStatus } = await import('../../../server/repositories/publish')
-  const { createDataRow, listDataRows, saveDataRowDraft } = await import('../../../server/repositories/data')
+  const { createDataRow, listDataRows, listDataRowIdSlugs, updateDataRowDraftCells } = await import('../../../server/repositories/data')
   const { getPublishedDataRowByRoute } = await import('../../../server/repositories/data/publish')
   const { getSetupStatus } = await import('../../../server/repositories/setup')
   const { renderPublicResolution } = await import('../../../server/publish/publicRouter')
   const { pageToCells, pageFromRow } = await import('../../../src/core/data/pageFromRow')
-  const { validatePages } = await import('../../../src/core/persistence/validate')
+  const { validatePagesForPartialSave } = await import('../../../src/core/persistence/validate')
   const { normalizeSiteRuntimeConfig } = await import('../../../src/core/site-runtime')
   return {
     createSqliteClient,
@@ -63,13 +63,14 @@ async function loadServer() {
     getDraftPublishStatus,
     createDataRow,
     listDataRows,
-    saveDataRowDraft,
+    listDataRowIdSlugs,
+    updateDataRowDraftCells,
     getPublishedDataRowByRoute,
     getSetupStatus,
     renderPublicResolution,
     pageToCells,
     pageFromRow,
-    validatePages,
+    validatePagesForPartialSave,
     normalizeSiteRuntimeConfig,
   }
 }
@@ -470,19 +471,25 @@ export const publishBench: BenchModule = {
             pages[iter % pages.length] = edited
 
             // What the editor ships and what the PUT /pages handler then does:
-            // validate the saved roster + reconcile every saved row's cells.
-            payloadBytes = JSON.stringify({ pages }).length
+            // validate the CHANGED pages against the stored (id, slug) roster,
+            // then reconcile only those rows (roster diff drives reaping).
+            const pageIds = pages.map((p) => p.id)
+            payloadBytes = JSON.stringify({ changedPages: [edited], pageIds }).length
             const t0 = performance.now()
-            const validated = api.validatePages(shell, pages, [])
+            const existingIdSlugs = await api.listDataRowIdSlugs(fresh.db, 'pages')
+            const validated = api.validatePagesForPartialSave([edited], [], existingIdSlugs)
             const db = fresh.db
             await db.transaction(async (tx) => {
+              const existingIds = new Set((await api.listDataRowIdSlugs(tx, 'pages')).map((r) => r.id))
               for (const page of validated) {
-                await api.saveDataRowDraft(
-                  tx,
-                  page.id,
-                  { cells: api.pageToCells(page), slug: page.slug },
-                  ADMIN_USER_ID,
-                )
+                if (existingIds.has(page.id)) {
+                  await api.updateDataRowDraftCells(
+                    tx,
+                    page.id,
+                    { cells: api.pageToCells(page), slug: page.slug },
+                    ADMIN_USER_ID,
+                  )
+                }
               }
             })
             samples.push(performance.now() - t0)

--- a/scripts/bench/benches/publish.ts
+++ b/scripts/bench/benches/publish.ts
@@ -47,11 +47,12 @@ async function loadServer() {
   const { sqliteMigrations } = await import('../../../server/db/migrations-sqlite')
   const { saveDraftSite } = await import('../../../server/repositories/site')
   const { publishDraftSite, getDraftPublishStatus } = await import('../../../server/repositories/publish')
-  const { createDataRow } = await import('../../../server/repositories/data')
+  const { createDataRow, listDataRows, saveDataRowDraft } = await import('../../../server/repositories/data')
   const { getPublishedDataRowByRoute } = await import('../../../server/repositories/data/publish')
   const { getSetupStatus } = await import('../../../server/repositories/setup')
   const { renderPublicResolution } = await import('../../../server/publish/publicRouter')
-  const { pageToCells } = await import('../../../src/core/data/pageFromRow')
+  const { pageToCells, pageFromRow } = await import('../../../src/core/data/pageFromRow')
+  const { validatePages } = await import('../../../src/core/persistence/validate')
   const { normalizeSiteRuntimeConfig } = await import('../../../src/core/site-runtime')
   return {
     createSqliteClient,
@@ -61,10 +62,14 @@ async function loadServer() {
     publishDraftSite,
     getDraftPublishStatus,
     createDataRow,
+    listDataRows,
+    saveDataRowDraft,
     getPublishedDataRowByRoute,
     getSetupStatus,
     renderPublicResolution,
     pageToCells,
+    pageFromRow,
+    validatePages,
     normalizeSiteRuntimeConfig,
   }
 }
@@ -417,10 +422,94 @@ export const publishBench: BenchModule = {
         }
       }
 
+      // ---- Site save round-trip (editor autosave cost) ---------------------
+      log.step('Site save round-trip (one-edit autosave)')
+      const saveRows: BenchRow[] = []
+      {
+        const SAVE_PAGES = ctx.quick ? 15 : 60
+        const SAVE_NODES = ctx.quick ? 100 : 300
+        let fresh: { db: Db; path: string } | null = null
+        try {
+          fresh = await freshDb(api, 'save-roundtrip')
+          await fresh.db`
+            insert into users (id, email, email_normalized, display_name, password_hash, role_id)
+            values (${ADMIN_USER_ID}, 'bench@example.com', 'bench@example.com', 'Bench Admin', 'bench-hash', 'owner')
+          `
+          const shell = makeShell(api)
+          await api.saveDraftSite(fresh.db, shell)
+          for (let i = 0; i < SAVE_PAGES; i++) {
+            const page = makeBenchPage(i, SAVE_NODES)
+            await api.createDataRow(
+              fresh.db,
+              { id: page.id, tableId: 'pages', cells: api.pageToCells(page), slug: page.slug },
+              ADMIN_USER_ID,
+            )
+          }
+          const rows = await api.listDataRows(fresh.db, 'pages')
+          const pages = rows.map(api.pageFromRow)
+
+          const iters = ctx.quick ? 3 : 8
+          const samples: number[] = []
+          let payloadBytes = 0
+          for (let iter = 0; iter < iters; iter++) {
+            // One-prop edit on one page — the canonical autosave trigger.
+            const target = pages[iter % pages.length]
+            const textNodeId = Object.keys(target.nodes).find(
+              (id) => target.nodes[id].moduleId === 'base.text',
+            )!
+            const edited: Page = {
+              ...target,
+              nodes: {
+                ...target.nodes,
+                [textNodeId]: {
+                  ...target.nodes[textNodeId],
+                  props: { ...target.nodes[textNodeId].props, text: `edited ${iter}` },
+                },
+              },
+            }
+            pages[iter % pages.length] = edited
+
+            // What the editor ships and what the PUT /pages handler then does:
+            // validate the saved roster + reconcile every saved row's cells.
+            payloadBytes = JSON.stringify({ pages }).length
+            const t0 = performance.now()
+            const validated = api.validatePages(shell, pages, [])
+            const db = fresh.db
+            await db.transaction(async (tx) => {
+              for (const page of validated) {
+                await api.saveDataRowDraft(
+                  tx,
+                  page.id,
+                  { cells: api.pageToCells(page), slug: page.slug },
+                  ADMIN_USER_ID,
+                )
+              }
+            })
+            samples.push(performance.now() - t0)
+          }
+          const s = summarize(samples)
+          saveRows.push({
+            label: `one-prop edit, ${fmtNum(SAVE_PAGES)} pages × ~${fmtNum(SAVE_NODES)} nodes`,
+            inputs: { pages: SAVE_PAGES, nodes_per_page: SAVE_NODES, iters },
+            metrics: {
+              payload: fmtBytes(payloadBytes),
+              mean: fmtMs(s.mean),
+              p95: fmtMs(s.p95),
+            },
+          })
+          log.detail(`    payload=${fmtBytes(payloadBytes)} mean=${fmtMs(s.mean)}`)
+        } catch (err) {
+          saveRows.push(unavailableRow('site save round-trip', err))
+        } finally {
+          if (fresh) cleanupDbFiles(fresh.path)
+        }
+      }
+
       const largestPublishRow = publishRows[publishRows.length - 1]
       const statusRow = statusRows[0]
       const warmRow = warmRows[0]
       const rowRouteRow = rowRouteRows[0]
+      const saveRow = saveRows[0]
 
       return {
         name: this.name,
@@ -430,6 +519,7 @@ export const publishBench: BenchModule = {
           'status check (mean)': statusRow?.metrics.mean ?? '—',
           'warm dynamic GET (mean)': warmRow?.metrics.mean ?? '—',
           'row-route lookup (mean)': rowRouteRow?.metrics.mean ?? '—',
+          'save round-trip (mean)': saveRow?.metrics.mean ?? '—',
         },
         sections: [
           {
@@ -461,6 +551,12 @@ export const publishBench: BenchModule = {
             intro:
               'Cost of `getPublishedDataRowByRoute` (the `/posts/<slug>` public lookup) against a table with thousands of published rows, each with an active version. Sensitive to indexing on the versions join.',
             rows: rowRouteRows,
+          },
+          {
+            title: 'Site save round-trip',
+            intro:
+              'Models the editor autosave after a ONE-PROP edit: the JSON payload the client ships to PUT /pages plus the server-side work the handler performs (validatePages over the saved roster + the reconcile transaction). HTTP/auth overhead excluded. This section mirrors the save protocol of the commit it runs at.',
+            rows: saveRows,
           },
         ],
       }

--- a/server/handlers/cms/components.ts
+++ b/server/handlers/cms/components.ts
@@ -6,19 +6,22 @@
  *                                   adapter converts these to VisualComponent[]
  *                                   via visualComponentFromRow + validateVisualComponents.
  *
- *   PUT /admin/api/cms/components — batch upsert the full component roster. The
- *                                   body carries `{ components: VisualComponent[] }`
- *                                   (the in-memory representation from the editor
- *                                   store). The server validates them, converts to
- *                                   cells via visualComponentToCells, and reconciles
- *                                   create/update/delete in one transaction.
+ *   PUT /admin/api/cms/components — incremental roster save. The body carries
+ *                                   `{ changedComponents, componentIds }`: only
+ *                                   the VCs the editor changed are validated
+ *                                   and written; `componentIds` is the client's
+ *                                   full roster and rows missing from it are
+ *                                   reaped — identical deletion semantics to
+ *                                   the old full-replace protocol. Cross-VC
+ *                                   rules run against the merged post-save
+ *                                   roster (see validateVisualComponentsForPartialWrite).
  *
  *                                   **Gated by `site.structure.edit`** — the
  *                                   reconcile soft-deletes any VC not in the
- *                                   incoming set. The previous `SITE_WRITE_*`
+ *                                   incoming roster. The previous `SITE_WRITE_*`
  *                                   gate let a Client with `site.content.edit`
  *                                   only wipe every Visual Component by sending
- *                                   `{ components: [] }`. (A1 fix.)
+ *                                   an empty roster. (A1 fix.)
  *
  * The GET response returns raw DataRow objects (not VisualComponent objects) so
  * the client adapter can reconstruct VCs via visualComponentFromRow without a
@@ -29,15 +32,17 @@ import type { DbClient } from '../../db/client'
 import { requireCapability } from '../../auth/authz'
 import {
   listDataRows,
+  listDataRowIdSlugs,
   createDataRow,
-  saveDataRowDraft,
+  updateDataRowDraftCells,
   softDeleteDataRow,
 } from '../../repositories/data'
 import {
   visualComponentToCells,
   vcSlugFromName,
+  visualComponentFromRow,
 } from '../../../src/core/data/componentFromRow'
-import { SiteValidationError, validateVisualComponentsForWrite } from '@core/persistence/validate'
+import { SiteValidationError, validateVisualComponentsForPartialWrite } from '@core/persistence/validate'
 import { VisualComponentSchema, type VisualComponent } from '@core/visualComponents'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../http'
 import { Type } from '@core/utils/typeboxHelpers'
@@ -61,15 +66,35 @@ export async function handleComponentsRoutes(req: Request, db: DbClient): Promis
     if (user instanceof Response) return user
 
     const ComponentsBodySchema = Type.Object({
-      components: Type.Array(VisualComponentSchema),
+      // Only the VCs the editor changed since its last save.
+      changedComponents: Type.Array(VisualComponentSchema),
+      // The client's FULL component-id roster; rows missing from it are reaped.
+      componentIds: Type.Array(Type.String()),
     }, { additionalProperties: false })
     const body = await readValidatedBody(req, ComponentsBodySchema)
     if (!body) return badRequest('Invalid request body')
-    const rawComponents = body.components
+
+    const componentIds = new Set(body.componentIds)
+
+    // The cross-VC rules (identity, refs, dependency-graph acyclicity) are
+    // roster-wide — a changed VC can create a cycle THROUGH an unchanged one —
+    // so validation merges the changed batch over the stored roster. This runs
+    // OUTSIDE the transaction (sanitization is CPU work; the SQLite adapter
+    // serializes every transaction through one chain).
+    const existingRows = await listDataRows(db, 'components')
+    const existingVCs = existingRows.flatMap((r) => {
+      const vc = visualComponentFromRow(r)
+      return vc ? [vc] : []
+    })
 
     let components: VisualComponent[]
     try {
-      components = validateVisualComponentsForWrite(rawComponents)
+      components = validateVisualComponentsForPartialWrite(body.changedComponents, existingVCs, componentIds)
+      for (const vc of components) {
+        if (!componentIds.has(vc.id)) {
+          throw new SiteValidationError(`changed component "${vc.id}" missing from componentIds roster`, 'componentIds')
+        }
+      }
     } catch (err) {
       if (err instanceof SiteValidationError) {
         return badRequest(err.message)
@@ -77,25 +102,23 @@ export async function handleComponentsRoutes(req: Request, db: DbClient): Promis
       throw err
     }
 
-    // Batch reconcile: create / update / soft-delete in a transaction
+    // Batch reconcile: create / update / soft-delete in one short transaction.
     await db.transaction(async (tx) => {
-      const existingRows = await listDataRows(tx, 'components')
-      const existingById = new Map(existingRows.map((r) => [r.id, r]))
-      const incomingIds = new Set(components.map((vc) => vc.id))
+      const existingIds = new Set((await listDataRowIdSlugs(tx, 'components')).map((r) => r.id))
 
       for (const vc of components) {
         const cells = visualComponentToCells(vc)
         const slug = vcSlugFromName(vc.name)
-        if (existingById.has(vc.id)) {
-          await saveDataRowDraft(tx, vc.id, { cells, slug }, user.id)
+        if (existingIds.has(vc.id)) {
+          await updateDataRowDraftCells(tx, vc.id, { cells, slug }, user.id)
         } else {
           await createDataRow(tx, { id: vc.id, tableId: 'components', cells, slug }, user.id)
         }
       }
 
-      // Soft-delete rows no longer in the incoming set
-      for (const [rowId] of existingById) {
-        if (!incomingIds.has(rowId)) {
+      // Soft-delete rows no longer in the client's roster
+      for (const rowId of existingIds) {
+        if (!componentIds.has(rowId)) {
           await softDeleteDataRow(tx, rowId, user.id)
         }
       }

--- a/server/handlers/cms/pages.ts
+++ b/server/handlers/cms/pages.ts
@@ -5,19 +5,21 @@
  *                              (gated by `site.read`). The client adapter
  *                              converts these to Page[] via pageFromRow.
  *
- *   PUT /admin/api/cms/pages — batch upsert the full page roster. The body
- *                              carries `{ pages: Page[] }` (the in-memory
- *                              representation from the editor store). The
- *                              server validates them, converts to cells via
- *                              pageToCells, and reconciles create/update/delete
- *                              against the current rows in one transaction.
+ *   PUT /admin/api/cms/pages — incremental roster save. The body carries
+ *                              `{ changedPages, pageIds, baselinePageIds? }`:
+ *                              only the pages the editor changed are
+ *                              validated and written (O(change), not
+ *                              O(site)); `pageIds` is the client's full
+ *                              roster, and rows missing from it are reaped
+ *                              exactly as the old full-replace protocol did
+ *                              (subject to the ISS-041 baseline).
  *
  *                              **Gated by `site.structure.edit`** — the reconcile
- *                              soft-deletes any row not in the incoming set,
+ *                              soft-deletes any row not in the incoming roster,
  *                              so this endpoint can wipe pages wholesale. The
  *                              previous `SITE_WRITE_CAPABILITIES` gate let a
  *                              Client with `site.content.edit` only also send
- *                              `{ pages: [] }` and erase every page. (A1
+ *                              an empty roster and erase every page. (A1
  *                              fix — see capabilities review.)
  *
  *                              Per-node content edits stay on the site-shell
@@ -30,16 +32,16 @@
  */
 import type { DbClient } from '../../db/client'
 import { requireCapability } from '../../auth/authz'
-import { getDraftSite } from '../../repositories/site'
 import {
   listDataRows,
+  listDataRowIdSlugs,
   createDataRow,
-  saveDataRowDraft,
+  updateDataRowDraftCells,
   softDeleteDataRow,
 } from '../../repositories/data'
 import { pageToCells } from '../../../src/core/data/pageFromRow'
 import { visualComponentFromRow } from '../../../src/core/data/componentFromRow'
-import { validatePages, SiteValidationError } from '@core/persistence/validate'
+import { validatePagesForPartialSave, SiteValidationError } from '@core/persistence/validate'
 import type { Page } from '@core/page-tree'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../http'
 import { bumpPublishVersionSerialized } from '../../publish/publishState'
@@ -77,14 +79,21 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
 
   if (req.method === 'PUT') {
     // Structural gate. The reconcile soft-deletes any row missing from
-    // the incoming set — a Client with `site.content.edit` only must
+    // the incoming roster — a Client with `site.content.edit` only must
     // not be able to trigger that. Per-node content edits flow through
     // the site-shell save endpoint, which has its own diff validator.
     const user = await requireCapability(req, db, 'site.structure.edit')
     if (user instanceof Response) return user
 
     const PagesBodySchema = Type.Object({
-      pages: Type.Array(Type.Unknown()),
+      // Only the pages the editor actually changed since its last save. The
+      // server validates and writes these alone — a one-page edit costs
+      // O(change), not O(site).
+      changedPages: Type.Array(Type.Unknown()),
+      // The client's FULL page-id roster. Rows missing from it are reaped
+      // (subject to baselinePageIds), so deletion semantics are identical to
+      // the old full-replace protocol.
+      pageIds: Type.Array(Type.String()),
       // Optimistic-concurrency token: the page ids the client loaded. When
       // present, the reconcile only reaps rows the client knew about, so a
       // sibling session's just-created page is never silently deleted (ISS-041).
@@ -93,40 +102,45 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
     })
     const body = await readValidatedBody(req, PagesBodySchema)
     if (!body) return badRequest('Invalid request body')
-    const rawPages = body.pages
 
-    // Load current shell and VC roster for full validatePages context
-    const [shell, vcRows] = await Promise.all([
-      getDraftSite(db),
-      listDataRows(db, 'components'),
-    ])
-    if (!shell) return jsonResponse({ error: 'draft site not found' }, { status: 404 })
+    const pageIds = new Set(body.pageIds)
 
+    // VC roster for slot-sync / dangling-ref context on the changed pages.
+    const vcRows = await listDataRows(db, 'components')
     const visualComponents = vcRows.flatMap((r) => {
       const vc = visualComponentFromRow(r)
       return vc ? [vc] : []
     })
 
+    // Validate OUTSIDE the transaction — sanitization (DOMPurify) is CPU work
+    // and the SQLite adapter serializes every transaction through one chain.
+    // The (id, slug) projection is all the slug-uniqueness check needs; the
+    // unique index data_rows_table_slug_active_idx backstops the read-then-
+    // write window at the DB level.
+    const existing = await listDataRowIdSlugs(db, 'pages')
     let pages: Page[]
     try {
-      pages = validatePages(shell, rawPages, visualComponents)
+      pages = validatePagesForPartialSave(body.changedPages, visualComponents, existing)
+      for (const page of pages) {
+        if (!pageIds.has(page.id)) {
+          throw new SiteValidationError(`changed page "${page.id}" missing from pageIds roster`, 'pageIds')
+        }
+      }
     } catch (err) {
       if (err instanceof SiteValidationError) return badRequest(err.message)
       throw err
     }
 
-    // Batch reconcile: create / update / soft-delete in a transaction
+    // Batch reconcile: create / update / soft-delete in one short transaction.
     let reapedPublished = false
     await db.transaction(async (tx) => {
-      const existingRows = await listDataRows(tx, 'pages')
-      const existingById = new Map(existingRows.map((r) => [r.id, r]))
-      const incomingIds = new Set(pages.map((p) => p.id))
+      const existingIds = new Set((await listDataRowIdSlugs(tx, 'pages')).map((r) => r.id))
       const baselineIds = body.baselinePageIds ? new Set(body.baselinePageIds) : undefined
 
       for (const page of pages) {
         const cells = pageToCells(page)
-        if (existingById.has(page.id)) {
-          await saveDataRowDraft(tx, page.id, { cells, slug: page.slug }, user.id)
+        if (existingIds.has(page.id)) {
+          await updateDataRowDraftCells(tx, page.id, { cells, slug: page.slug }, user.id)
         } else {
           await createDataRow(tx, { id: page.id, tableId: 'pages', cells, slug: page.slug }, user.id)
         }
@@ -134,7 +148,7 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
 
       // Soft-delete only the rows the client knew about and dropped — never a
       // concurrently-created sibling page (ISS-041).
-      for (const rowId of pagesToReap([...existingById.keys()], incomingIds, baselineIds)) {
+      for (const rowId of pagesToReap([...existingIds], pageIds, baselineIds)) {
         const deleted = await softDeleteDataRow(tx, rowId, user.id)
         if (deleted?.status === 'published') reapedPublished = true
       }

--- a/server/repositories/data/index.ts
+++ b/server/repositories/data/index.ts
@@ -27,6 +27,7 @@ export {
 
 export {
   listDataRows,
+  listDataRowIdSlugs,
   listDataRowsWithFilter,
   searchDataRows,
   getDataRow,
@@ -35,6 +36,7 @@ export {
   createDataRow,
   createDataRowMany,
   saveDataRowDraft,
+  updateDataRowDraftCells,
   saveDataRowDraftMany,
   softDeleteDataRow,
   softDeleteDataRowMany,

--- a/server/repositories/data/rows/index.ts
+++ b/server/repositories/data/rows/index.ts
@@ -15,7 +15,7 @@
  * Domain types (`DataRow`, etc.) are TypeBox schemas in `@core/data/schemas`.
  */
 
-export { listDataRows, getDataRow, getDataRowBySlug, listDataAuthorOptions } from './read'
+export { listDataRows, listDataRowIdSlugs, getDataRow, getDataRowBySlug, listDataAuthorOptions } from './read'
 
 export { searchDataRows } from './search'
 export type { DataRowSearchResult } from './search'
@@ -26,6 +26,7 @@ export type { ListDataRowsFilterOptions, ListDataRowsWithFilterResult } from './
 export {
   createDataRow,
   saveDataRowDraft,
+  updateDataRowDraftCells,
   softDeleteDataRow,
   updateDataRowTable,
   updateDataRowStatus,

--- a/server/repositories/data/rows/mutations.ts
+++ b/server/repositories/data/rows/mutations.ts
@@ -71,6 +71,23 @@ export async function saveDataRowDraft(
   actorUserId: string | null = null,
   pluginActorId: string | null = null,
 ): Promise<DataRow | null> {
+  const updated = await updateDataRowDraftCells(db, rowId, input, actorUserId, pluginActorId)
+  return updated ? getDataRow(db, rowId) : null
+}
+
+/**
+ * The write half of `saveDataRowDraft`, without the hydrated re-read. The
+ * roster reconcilers (PUT /pages, PUT /components) discard the row anyway —
+ * re-reading every saved row through the user-ref joins doubled their query
+ * count per save. Returns whether a (non-deleted) row matched.
+ */
+export async function updateDataRowDraftCells(
+  db: DbClient,
+  rowId: string,
+  input: UpdateDataRowDraftInput,
+  actorUserId: string | null = null,
+  pluginActorId: string | null = null,
+): Promise<boolean> {
   const { rows } = await db<{ id: string }>`
     update data_rows
     set cells_json = ${input.cells},
@@ -82,7 +99,7 @@ export async function saveDataRowDraft(
       and deleted_at is null
     returning id
   `
-  return rows[0] ? getDataRow(db, rows[0].id) : null
+  return rows.length > 0
 }
 
 /**

--- a/server/repositories/data/rows/read.ts
+++ b/server/repositories/data/rows/read.ts
@@ -46,6 +46,29 @@ export async function listDataRows(
   return dataRows
 }
 
+export interface DataRowIdSlug {
+  id: string
+  slug: string
+}
+
+/**
+ * Lightweight (id, slug) projection of a table's non-deleted rows. The roster
+ * reconcilers (PUT /pages, PUT /components) need exactly this — the reap diff
+ * and the cross-row slug-uniqueness check — so they must not pay the hydrated
+ * SELECT's full `cells_json` parse per row per save.
+ */
+export async function listDataRowIdSlugs(
+  db: DbClient,
+  tableId: string,
+): Promise<DataRowIdSlug[]> {
+  const { rows } = await db<DataRowIdSlug>`
+    select id, slug from data_rows
+    where table_id = ${tableId}
+      and deleted_at is null
+  `
+  return rows
+}
+
 export async function getDataRow(
   db: DbClient,
   rowId: string,

--- a/server/repositories/publish.ts
+++ b/server/repositories/publish.ts
@@ -234,50 +234,103 @@ async function publishDraftSiteLocked(
   adminUserId: string,
   uploadsDir?: string,
 ): Promise<PublishResult> {
-  const { publishedPages, snapshots, runtimeAssetFiles } = await db.transaction(async (tx) => {
-    const shell = await getDraftSite(tx)
-    if (!shell) throw new Error('draft site not found')
+  // ── Phase 1: read inputs + run every expensive non-DB build ──────────────
+  // Dependency installs (`bun install` on a cold cache) and per-page esbuild
+  // runs take seconds; the SQLite adapter serializes ALL transactions through
+  // one chain, so doing this inside the transaction stalled every concurrent
+  // write (autosaves, row publishes) behind it. `withPublishLock` already
+  // serializes publishes, and version numbers are only allocated by publish
+  // paths under that same lock, so reading outside the transaction is stable.
+  const shell = await getDraftSite(db)
+  if (!shell) throw new Error('draft site not found')
 
-    const [pageRows, vcRows] = await Promise.all([
-      listDataRows(tx, 'pages'),
-      listDataRows(tx, 'components'),
-    ])
-    const pages = pageRows.map(pageFromRow)
-    const visualComponents = validateVisualComponents(
-      vcRows.flatMap((r) => { const vc = visualComponentFromRow(r); return vc ? [vc] : [] })
-    )
-    const site: SiteDocument = { ...shell, pages, visualComponents }
+  const [pageRows, vcRows] = await Promise.all([
+    listDataRows(db, 'pages'),
+    listDataRows(db, 'components'),
+  ])
+  const pages = pageRows.map(pageFromRow)
+  const visualComponents = validateVisualComponents(
+    vcRows.flatMap((r) => { const vc = visualComponentFromRow(r); return vc ? [vc] : [] })
+  )
+  const site: SiteDocument = { ...shell, pages, visualComponents }
 
-    const runtime = normalizeSiteRuntimeConfig(site.runtime)
-    const dependencyCache = Object.keys(runtime.dependencyLock.packages).length > 0
-      ? await ensureRuntimeDependencyCache(runtime.dependencyLock)
-      : undefined
-    // Build the package importmap once per publish — the JSON is identical
-    // for every page sharing the same lock, so its SHA-256 stays stable
-    // across snapshots. Module plugins use bare imports (`import "three"`)
-    // and the browser resolves them through this map at page load.
-    const packageImportmap = dependencyCache
-      ? await buildRuntimePackageImportmap(runtime.dependencyLock, dependencyCache)
-      : null
-    const serializedImportmap = packageImportmap
-      ? await serializeImportmapForCsp(packageImportmap.importmap)
-      : null
-    const runtimePackageImportmap: PublishedRuntimePackageImportmap | undefined = serializedImportmap
-      ? { body: serializedImportmap.body, sha256: serializedImportmap.sha256 }
-      : undefined
+  const runtime = normalizeSiteRuntimeConfig(site.runtime)
+  const dependencyCache = Object.keys(runtime.dependencyLock.packages).length > 0
+    ? await ensureRuntimeDependencyCache(runtime.dependencyLock)
+    : undefined
+  // Build the package importmap once per publish — the JSON is identical
+  // for every page sharing the same lock, so its SHA-256 stays stable
+  // across snapshots. Module plugins use bare imports (`import "three"`)
+  // and the browser resolves them through this map at page load.
+  const packageImportmap = dependencyCache
+    ? await buildRuntimePackageImportmap(runtime.dependencyLock, dependencyCache)
+    : null
+  const serializedImportmap = packageImportmap
+    ? await serializeImportmapForCsp(packageImportmap.importmap)
+    : null
+  const runtimePackageImportmap: PublishedRuntimePackageImportmap | undefined = serializedImportmap
+    ? { body: serializedImportmap.body, sha256: serializedImportmap.sha256 }
+    : undefined
 
-    const publishedSite: SiteDocument = {
-      ...site,
-      pages: site.pages.map((page) => ({
-        ...page,
-        updatedByUserId: adminUserId,
-      })),
+  const publishedSite: SiteDocument = {
+    ...site,
+    pages: site.pages.map((page) => ({
+      ...page,
+      updatedByUserId: adminUserId,
+    })),
+  }
+
+  const siteSnapshotId = nanoid()
+  const snapshots: PublishedPageSnapshot[] = []
+  // Runtime JS bytes for every page, collected for the Layer A disk write so
+  // published pages serve their scripts straight off disk (not the DB).
+  const runtimeAssetFiles: Array<{ publicPath: string; bytes: Uint8Array }> = []
+  const builtPages: Array<{
+    page: SiteDocument['pages'][number]
+    versionId: string
+    versionNumber: number
+    runtimeAssets: PublishedPageRuntimeAssets | null
+    runtimeFiles: Awaited<ReturnType<typeof buildSiteRuntimeScripts>>['files']
+  }> = []
+  for (const page of publishedSite.pages) {
+    const versionNumber = await nextDataRowVersionNumber(db, page.id)
+    const versionId = nanoid()
+    const runtimeBuild = await buildSiteRuntimeScripts({
+      site: publishedSite,
+      page,
+      target: 'publish',
+      assetBasePath: `/_instatic/assets/${versionId}/`,
+      dependencyCache,
+    })
+    const runtimeErrors = runtimeBuild.diagnostics.filter((d) => d.severity === 'error')
+    if (runtimeErrors.length > 0) {
+      throw new Error(`runtime build failed: ${runtimeErrors.map((d) => d.message).join('; ')}`)
     }
 
+    const snapshot = createSnapshot(
+      publishedSite,
+      page.id,
+      runtimeBuild.runtimeAssets,
+      runtimePackageImportmap,
+    )
+    snapshots.push(snapshot)
+    builtPages.push({
+      page,
+      versionId,
+      versionNumber,
+      runtimeAssets: snapshot.runtimeAssets ?? null,
+      runtimeFiles: runtimeBuild.files,
+    })
+    for (const file of runtimeBuild.files) {
+      runtimeAssetFiles.push({ publicPath: file.publicPath, bytes: file.bytes })
+    }
+  }
+
+  // ── Phase 2: short transaction — DB writes only ───────────────────────────
+  await db.transaction(async (tx) => {
     // The site document is stored ONCE per publish; every page version row
     // references it. The content hash powers the publish-status check without
     // ever re-fetching the document.
-    const siteSnapshotId = nanoid()
     await tx`
       insert into site_snapshots (id, site_json, content_hash, importmap_body, importmap_sha256)
       values (
@@ -289,66 +342,42 @@ async function publishDraftSiteLocked(
       )
     `
 
-    const snapshots: PublishedPageSnapshot[] = []
-    // Runtime JS bytes for every page, collected for the Layer A disk write so
-    // published pages serve their scripts straight off disk (not the DB).
-    const runtimeAssetFiles: Array<{ publicPath: string; bytes: Uint8Array }> = []
-    for (const page of publishedSite.pages) {
-      const version = await nextDataRowVersionNumber(tx, page.id)
-      const versionId = nanoid()
-      const runtimeBuild = await buildSiteRuntimeScripts({
-        site: publishedSite,
-        page,
-        target: 'publish',
-        assetBasePath: `/_instatic/assets/${versionId}/`,
-        dependencyCache,
-      })
-      const runtimeErrors = runtimeBuild.diagnostics.filter((d) => d.severity === 'error')
-      if (runtimeErrors.length > 0) {
-        throw new Error(`runtime build failed: ${runtimeErrors.map((d) => d.message).join('; ')}`)
-      }
-
-      const snapshot = createSnapshot(
-        publishedSite,
-        page.id,
-        runtimeBuild.runtimeAssets,
-        runtimePackageImportmap,
-      )
-      snapshots.push(snapshot)
-
+    for (const built of builtPages) {
       await tx`
         insert into data_row_versions
           (id, row_id, version_number, cells_json, slug, site_snapshot_id, runtime_assets_json, published_by_user_id)
         values (
-          ${versionId},
-          ${page.id},
-          ${version},
-          ${{ title: page.title, slug: page.slug }},
-          ${page.slug},
+          ${built.versionId},
+          ${built.page.id},
+          ${built.versionNumber},
+          ${{ title: built.page.title, slug: built.page.slug }},
+          ${built.page.slug},
           ${siteSnapshotId},
-          ${snapshot.runtimeAssets ?? null},
+          ${built.runtimeAssets},
           ${adminUserId}
         )
       `
-      await savePublishedRuntimeAssets(tx, versionId, runtimeBuild.files)
-      for (const file of runtimeBuild.files) {
-        runtimeAssetFiles.push({ publicPath: file.publicPath, bytes: file.bytes })
-      }
-      await tx`
+      await savePublishedRuntimeAssets(tx, built.versionId, built.runtimeFiles)
+      const { rowCount } = await tx`
         update data_rows
-        set active_version_id = ${versionId},
+        set active_version_id = ${built.versionId},
             status = 'published',
             published_by_user_id = ${adminUserId},
             published_at = current_timestamp,
             updated_by_user_id = ${adminUserId},
             updated_at = current_timestamp
-        where id = ${page.id}
+        where id = ${built.page.id}
           and deleted_at is null
       `
+      // The page was read before the transaction opened; if a concurrent save
+      // reaped it in between, don't leave an orphan version pointing at it.
+      if (rowCount === 0) {
+        await tx`delete from data_row_versions where id = ${built.versionId}`
+      }
     }
-
-    return { publishedPages: publishedSite.pages.length, snapshots, runtimeAssetFiles }
   })
+
+  const publishedPages = publishedSite.pages.length
 
   // Layer A: write static artefacts outside the transaction. Disk artefacts
   // are derived state — a write failure is logged but does not roll back the

--- a/src/__tests__/architecture/module-size-budgets.test.ts
+++ b/src/__tests__/architecture/module-size-budgets.test.ts
@@ -105,7 +105,8 @@ const GRANDFATHERED: Record<string, number> = {
   // inline. The node deep-clone primitive lives in its own module
   // (cloneNode.ts) so the three duplicate/paste/duplicatePage callers share one
   // clone. See docs/reference/page-tree.md (parentId).
-  'src/core/page-tree/mutations.ts': 880,
+  // Ratcheted 880 → 760 when the page-roster mutations moved to pageMutations.ts.
+  'src/core/page-tree/mutations.ts': 760,
   // server/plugins/host/handlers/content.ts graduated (786 → 661) when the
   // DB→wire projection helpers moved to contentProjection.ts.
   'src/core/siteImport/cssToStyleRules.ts': 742,

--- a/src/__tests__/editor-store/dirtyTracking.test.ts
+++ b/src/__tests__/editor-store/dirtyTracking.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Patch-derived save-dirty tracking (slices/site/dirtyTracking.ts).
+ *
+ * Unit half: collectDirtyFromSitePatches resolves site-relative Mutative
+ * patch paths to page / Visual Component ids against the POST-mutation site,
+ * escalating anything unattributable to `all` (over-marking is safe,
+ * under-marking loses edits).
+ *
+ * Store half: the real editor store wires the collector into
+ * runHistoricMutation, undo/redo, the lifecycle resets, and the
+ * `_dirtySave` snapshot/restore actions consumed by autosave.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import type { Patches } from 'mutative'
+import { useEditorStore } from '@site/store/store'
+import {
+  collectDirtyFromSitePatches,
+  emptyDirtyMarks,
+  mergeDirtyMarks,
+  type DirtyMarks,
+} from '@site/store/slices/site/dirtyTracking'
+import { makePage, makeSite, makeVC } from '../fixtures'
+
+// ---------------------------------------------------------------------------
+// Unit: collectDirtyFromSitePatches
+// ---------------------------------------------------------------------------
+
+function twoPageTwoVcSite() {
+  return makeSite({
+    pages: [
+      makePage({ id: 'page-a', slug: 'index', title: 'Home' }),
+      makePage({ id: 'page-b', slug: 'about', title: 'About' }),
+    ],
+    visualComponents: [
+      makeVC({ id: 'vc-one', name: 'One' }),
+      makeVC({ id: 'vc-two', name: 'Two' }),
+    ],
+  })
+}
+
+describe('collectDirtyFromSitePatches', () => {
+  it('attributes a nested page edit to that page id', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [
+      { op: 'replace', path: ['pages', 1, 'nodes', 'root', 'props', 'text'], value: 'x' },
+    ]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(false)
+    expect([...marks.pageIds]).toEqual(['page-b'])
+    expect(marks.componentIds.size).toBe(0)
+  })
+
+  it('attributes a VC tree edit to that component id', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [
+      { op: 'replace', path: ['visualComponents', 0, 'tree', 'nodes', 'vc-root', 'props', 'x'], value: 1 },
+    ]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(false)
+    expect(marks.pageIds.size).toBe(0)
+    expect([...marks.componentIds]).toEqual(['vc-one'])
+  })
+
+  it('marks nothing for a remove at exactly [pages, i] — the roster conveys deletions', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'remove', path: ['pages', 1] }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks).toEqual(emptyDirtyMarks())
+  })
+
+  it('marks nothing for a remove at exactly [visualComponents, i]', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'remove', path: ['visualComponents', 1] }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks).toEqual(emptyDirtyMarks())
+  })
+
+  it('escalates a wholesale [pages] replacement to all', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'replace', path: ['pages'], value: site.pages }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(true)
+  })
+
+  it('marks nothing for [pages, length] array bookkeeping', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'replace', path: ['pages', 'length'], value: 1 }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks).toEqual(emptyDirtyMarks())
+  })
+
+  it('escalates an index that does not resolve in the post-state to all', () => {
+    const site = twoPageTwoVcSite() // 2 pages — index 5 resolves to nothing
+    const patches: Patches = [{ op: 'replace', path: ['pages', 5, 'title'], value: 'ghost' }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(true)
+  })
+
+  it('escalates a non-numeric, non-length second segment to all', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'replace', path: ['pages', 'not-an-index'], value: 1 }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(true)
+  })
+
+  it('marks nothing for shell-field paths — the shell is always saved', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [
+      { op: 'replace', path: ['styleRules', 'x'], value: {} },
+      { op: 'replace', path: ['name'], value: 'Renamed' },
+      { op: 'replace', path: ['updatedAt'], value: 123 },
+    ]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks).toEqual(emptyDirtyMarks())
+  })
+
+  it('attributes an element add at [pages, i] to the added page', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'add', path: ['pages', 1], value: site.pages[1] }]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(false)
+    expect([...marks.pageIds]).toEqual(['page-b'])
+  })
+
+  it('accumulates marks across a mixed patch set', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [
+      { op: 'replace', path: ['pages', 0, 'title'], value: 'New Home' },
+      { op: 'replace', path: ['visualComponents', 1, 'name'], value: 'Two v2' },
+      { op: 'replace', path: ['styleRules', 'r1'], value: {} },
+    ]
+    const marks = collectDirtyFromSitePatches(patches, site)
+    expect(marks.all).toBe(false)
+    expect([...marks.pageIds]).toEqual(['page-a'])
+    expect([...marks.componentIds]).toEqual(['vc-two'])
+  })
+})
+
+describe('mergeDirtyMarks', () => {
+  it('unions ids and propagates the all flag', () => {
+    const target: DirtyMarks = {
+      all: false,
+      pageIds: new Set(['page-a']),
+      componentIds: new Set(['vc-one']),
+    }
+    mergeDirtyMarks(target, {
+      all: false,
+      pageIds: new Set(['page-b']),
+      componentIds: new Set(),
+    })
+    expect(target.all).toBe(false)
+    expect([...target.pageIds].sort()).toEqual(['page-a', 'page-b'])
+    expect([...target.componentIds]).toEqual(['vc-one'])
+
+    mergeDirtyMarks(target, { ...emptyDirtyMarks(), all: true })
+    expect(target.all).toBe(true)
+    // Existing ids survive an all-merge — `all` is a flag, not a reset.
+    expect([...target.pageIds].sort()).toEqual(['page-a', 'page-b'])
+  })
+
+  it('never clears all once set, even when incoming is partial', () => {
+    const target: DirtyMarks = { ...emptyDirtyMarks(), all: true }
+    mergeDirtyMarks(target, { all: false, pageIds: new Set(['page-a']), componentIds: new Set() })
+    expect(target.all).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Store integration: the real editor store
+// ---------------------------------------------------------------------------
+
+function freshStore() {
+  useEditorStore.setState({
+    site: null,
+    activePageId: null,
+    activeDocument: null,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    _historyCoalesceKey: null,
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+    _dirtySave: emptyDirtyMarks(),
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+function dirty(): DirtyMarks {
+  return useEditorStore.getState()._dirtySave
+}
+
+function loadTwoPageSite() {
+  useEditorStore.getState().loadSite(
+    makeSite({
+      pages: [
+        makePage({ id: 'page-a', slug: 'index', title: 'Home' }),
+        makePage({ id: 'page-b', slug: 'about', title: 'About' }),
+      ],
+      visualComponents: [makeVC({ id: 'vc-card', name: 'Card' })],
+    }),
+  )
+}
+
+describe('editor store dirty-save tracking', () => {
+  beforeEach(freshStore)
+
+  it('loadSite starts with empty marks', () => {
+    loadTwoPageSite()
+    expect(dirty()).toEqual(emptyDirtyMarks())
+  })
+
+  it('updateNodeProps on the active page marks exactly that page', () => {
+    loadTwoPageSite()
+    // loadSite activates the home page (slug `index`) — page-a.
+    expect(useEditorStore.getState().activePageId).toBe('page-a')
+
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+
+    const marks = dirty()
+    expect(marks.all).toBe(false)
+    expect([...marks.pageIds]).toEqual(['page-a'])
+    expect(marks.componentIds.size).toBe(0)
+  })
+
+  it('editing a VC tree in VC canvas mode marks exactly that component', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().setActiveDocument({ kind: 'visualComponent', vcId: 'vc-card' })
+
+    useEditorStore.getState().updateNodeProps('vc-root', { padding: '8px' })
+
+    const marks = dirty()
+    expect(marks.all).toBe(false)
+    expect(marks.pageIds.size).toBe(0)
+    expect([...marks.componentIds]).toEqual(['vc-card'])
+  })
+
+  it('takeDirtySaveSnapshot returns the accumulated marks AND resets the accumulator', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+
+    const snapshot = useEditorStore.getState().takeDirtySaveSnapshot()
+
+    expect([...snapshot.pageIds]).toEqual(['page-a'])
+    expect(snapshot.all).toBe(false)
+    expect(dirty()).toEqual(emptyDirtyMarks())
+
+    // The snapshot is an independent copy — mutating it cannot poison the store.
+    snapshot.pageIds.add('page-injected')
+    expect(dirty().pageIds.size).toBe(0)
+  })
+
+  it('undo after a snapshot re-marks the restored page', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+    useEditorStore.getState().takeDirtySaveSnapshot() // simulate a successful save
+    expect(dirty()).toEqual(emptyDirtyMarks())
+
+    useEditorStore.getState().undo()
+
+    // The undone page differs from what storage now holds — it must re-save.
+    expect([...dirty().pageIds]).toEqual(['page-a'])
+    expect(dirty().all).toBe(false)
+  })
+
+  it('redo after a snapshot re-marks the replayed page', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+    useEditorStore.getState().undo()
+    useEditorStore.getState().takeDirtySaveSnapshot()
+
+    useEditorStore.getState().redo()
+
+    expect([...dirty().pageIds]).toEqual(['page-a'])
+  })
+
+  it('restoreDirtySaveSnapshot merges a failed save back into fresh marks', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+    const snapshot = useEditorStore.getState().takeDirtySaveSnapshot()
+
+    // While the (failed) save was in flight, the user edited page-b.
+    useEditorStore.setState({ activePageId: 'page-b' })
+    useEditorStore.getState().updateNodeProps('root', { text: 'other page' })
+    expect([...dirty().pageIds]).toEqual(['page-b'])
+
+    useEditorStore.getState().restoreDirtySaveSnapshot(snapshot)
+
+    expect([...dirty().pageIds].sort()).toEqual(['page-a', 'page-b'])
+    expect(dirty().all).toBe(false)
+  })
+
+  it('markAllDirtyForSave sets the conservative full-save flag', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().markAllDirtyForSave()
+    expect(dirty().all).toBe(true)
+  })
+
+  it('loadSite resets accumulated marks', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+    expect(dirty().pageIds.size).toBe(1)
+
+    loadTwoPageSite()
+    expect(dirty()).toEqual(emptyDirtyMarks())
+  })
+
+  it('createSite resets marks to all=true — a brand-new site needs a full first save', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+
+    useEditorStore.getState().createSite('Fresh Site')
+
+    const marks = dirty()
+    expect(marks.all).toBe(true)
+    expect(marks.pageIds.size).toBe(0)
+    expect(marks.componentIds.size).toBe(0)
+  })
+
+  it('clearSite resets marks to empty', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateNodeProps('root', { text: 'hello' })
+
+    useEditorStore.getState().clearSite()
+
+    expect(dirty()).toEqual(emptyDirtyMarks())
+  })
+
+  it('addPage marks the created page (and only it)', () => {
+    loadTwoPageSite()
+    const newPage = useEditorStore.getState().addPage('Pricing', 'pricing')
+
+    const marks = dirty()
+    expect(marks.all).toBe(false)
+    expect([...marks.pageIds]).toEqual([newPage.id])
+    expect(marks.componentIds.size).toBe(0)
+  })
+
+  it('deletePage shrinks the roster and never marks the deleted page id', () => {
+    loadTwoPageSite()
+    // Delete the LAST page so no surviving element is displaced to a new index.
+    useEditorStore.getState().deletePage('page-b')
+
+    const state = useEditorStore.getState()
+    expect(state.site!.pages.map((p) => p.id)).toEqual(['page-a'])
+    // The deleted page must NOT appear as a changed page — its removal is
+    // conveyed by the shrunken id roster the save always ships.
+    expect(dirty().pageIds.has('page-b')).toBe(false)
+
+    // `deletePage` splices in place, so Mutative emits a `remove` patch at
+    // ['pages', i] — which the collector deliberately ignores (the shrunken
+    // id roster conveys the deletion). No full-save escalation.
+    expect(dirty().all).toBe(false)
+    expect(dirty().pageIds.size).toBe(0)
+  })
+
+  it('a VC delete via splice does not escalate to all', () => {
+    // Contrast with deletePage: the VC slice deletes via splice(idx, 1), so
+    // the patches are index/length bookkeeping the collector can attribute.
+    useEditorStore.getState().loadSite(
+      makeSite({
+        pages: [makePage({ id: 'page-a', slug: 'index' })],
+        visualComponents: [
+          makeVC({ id: 'vc-one', name: 'One' }),
+          makeVC({ id: 'vc-two', name: 'Two' }),
+        ],
+      }),
+    )
+
+    // Delete the LAST component — no displaced survivors.
+    useEditorStore.getState().deleteVisualComponent('vc-two')
+
+    const state = useEditorStore.getState()
+    expect(state.site!.visualComponents.map((vc) => vc.id)).toEqual(['vc-one'])
+    expect(dirty().all).toBe(false)
+    expect(dirty().componentIds.has('vc-two')).toBe(false)
+  })
+
+  it('shell-only mutations (site rename) accumulate no marks', () => {
+    loadTwoPageSite()
+    useEditorStore.getState().updateSiteName('Renamed Site')
+
+    expect(useEditorStore.getState().site!.name).toBe('Renamed Site')
+    expect(useEditorStore.getState().hasUnsavedChanges).toBe(true)
+    expect(dirty()).toEqual(emptyDirtyMarks())
+  })
+})

--- a/src/__tests__/persistence/cmsAdapter.test.ts
+++ b/src/__tests__/persistence/cmsAdapter.test.ts
@@ -1,28 +1,54 @@
 import { describe, expect, it } from 'bun:test'
-import type { SiteDocument } from '@core/page-tree'
+import type { Page, SiteDocument } from '@core/page-tree'
+import type { VisualComponent } from '@core/visualComponents'
 import { CmsAdapter } from '@core/persistence/cms'
+
+function makePage(id: string, slug: string): Page {
+  return {
+    id,
+    title: slug,
+    slug,
+    rootNodeId: 'root',
+    nodes: {
+      root: {
+        id: 'root',
+        moduleId: 'base.body',
+        props: {},
+        breakpointOverrides: {},
+        children: [],
+      },
+    },
+  }
+}
+
+function makeVC(id: string, name: string): VisualComponent {
+  return {
+    id,
+    name,
+    tree: {
+      rootNodeId: 'vc-root',
+      nodes: {
+        'vc-root': {
+          id: 'vc-root',
+          moduleId: 'base.container',
+          props: {},
+          breakpointOverrides: {},
+          children: [],
+          classIds: [],
+        },
+      },
+    },
+    params: [],
+    classIds: [],
+    createdAt: 1000,
+  }
+}
 
 function site(): SiteDocument {
   return {
     id: 'project_1',
     name: 'CMS Site',
-    pages: [
-      {
-        id: 'page_home',
-        title: 'Home',
-        slug: 'index',
-        rootNodeId: 'root',
-        nodes: {
-          root: {
-            id: 'root',
-            moduleId: 'base.body',
-            props: {},
-            breakpointOverrides: {},
-            children: [],
-          },
-        },
-      },
-    ],
+    pages: [makePage('page_home', 'index')],
     files: [],
     visualComponents: [],
     breakpoints: [
@@ -87,5 +113,131 @@ describe('CmsAdapter', () => {
       new Response(JSON.stringify({ error: 'Duplicate page slug "/about"' }), { status: 400 }))
 
     await expect(adapter.saveSite(site())).rejects.toThrow('Duplicate page slug "/about"')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Incremental save wire shapes
+//
+// saveSite PUTs three bodies:
+//   /site       → { site: <shell — no pages, no visualComponents> }
+//   /pages      → { changedPages, pageIds, baselinePageIds? }
+//   /components → { changedComponents, componentIds }
+//
+// Only the pages/components named by opts.dirty ship in changed*; the FULL id
+// rosters always go along so server-side reaping keeps full-replace semantics.
+// ---------------------------------------------------------------------------
+
+describe('CmsAdapter incremental save wire shapes', () => {
+  function multiDocSite(): SiteDocument {
+    return {
+      ...site(),
+      pages: [makePage('page-1', 'index'), makePage('page-2', 'about')],
+      visualComponents: [makeVC('vc-1', 'Card'), makeVC('vc-2', 'Hero')],
+    }
+  }
+
+  interface RecordedCall {
+    input: RequestInfo | URL
+    init?: RequestInit
+  }
+
+  function recordingAdapter() {
+    const calls: RecordedCall[] = []
+    const adapter = new CmsAdapter(async (input, init) => {
+      calls.push({ input, init })
+      return new Response(JSON.stringify({ ok: true }), { status: 200 })
+    })
+    return { adapter, calls }
+  }
+
+  function bodyOf(calls: RecordedCall[], path: string): Record<string, unknown> {
+    const call = calls.find((c) => c.input === path)
+    expect(call).toBeDefined()
+    return JSON.parse(String(call!.init?.body)) as Record<string, unknown>
+  }
+
+  function ids(items: unknown): string[] {
+    return (items as Array<{ id: string }>).map((item) => item.id)
+  }
+
+  it('full save (no opts.dirty) ships ALL pages/components plus the full rosters, no baseline', async () => {
+    const { adapter, calls } = recordingAdapter()
+    await adapter.saveSite(multiDocSite())
+
+    const shellBody = bodyOf(calls, '/admin/api/cms/site')
+    const shell = shellBody.site as Record<string, unknown>
+    expect('pages' in shell).toBe(false)
+    expect('visualComponents' in shell).toBe(false)
+
+    const pagesBody = bodyOf(calls, '/admin/api/cms/pages')
+    expect(ids(pagesBody.changedPages)).toEqual(['page-1', 'page-2'])
+    expect(pagesBody.pageIds).toEqual(['page-1', 'page-2'])
+    expect('baselinePageIds' in pagesBody).toBe(false)
+
+    const componentsBody = bodyOf(calls, '/admin/api/cms/components')
+    expect(ids(componentsBody.changedComponents)).toEqual(['vc-1', 'vc-2'])
+    expect(componentsBody.componentIds).toEqual(['vc-1', 'vc-2'])
+  })
+
+  it('dirty save ships ONLY the named pages but always the FULL pageIds roster', async () => {
+    const { adapter, calls } = recordingAdapter()
+    await adapter.saveSite(multiDocSite(), {
+      dirty: { all: false, pageIds: new Set(['page-2']), componentIds: new Set() },
+    })
+
+    const pagesBody = bodyOf(calls, '/admin/api/cms/pages')
+    expect(ids(pagesBody.changedPages)).toEqual(['page-2'])
+    expect(pagesBody.pageIds).toEqual(['page-1', 'page-2'])
+
+    // Nothing marked on the component side — empty changed batch, full roster.
+    const componentsBody = bodyOf(calls, '/admin/api/cms/components')
+    expect(componentsBody.changedComponents).toEqual([])
+    expect(componentsBody.componentIds).toEqual(['vc-1', 'vc-2'])
+  })
+
+  it('components PUT mirrors the pages contract: named changedComponents, full componentIds roster', async () => {
+    const { adapter, calls } = recordingAdapter()
+    await adapter.saveSite(multiDocSite(), {
+      dirty: { all: false, pageIds: new Set(), componentIds: new Set(['vc-2']) },
+    })
+
+    const componentsBody = bodyOf(calls, '/admin/api/cms/components')
+    expect(ids(componentsBody.changedComponents)).toEqual(['vc-2'])
+    expect(componentsBody.componentIds).toEqual(['vc-1', 'vc-2'])
+
+    const pagesBody = bodyOf(calls, '/admin/api/cms/pages')
+    expect(pagesBody.changedPages).toEqual([])
+    expect(pagesBody.pageIds).toEqual(['page-1', 'page-2'])
+  })
+
+  it('includes baselinePageIds when provided and omits the key otherwise', async () => {
+    const { adapter, calls } = recordingAdapter()
+    await adapter.saveSite(multiDocSite(), {
+      baselinePageIds: ['page-1'],
+      dirty: { all: false, pageIds: new Set(['page-2']), componentIds: new Set() },
+    })
+
+    const pagesBody = bodyOf(calls, '/admin/api/cms/pages')
+    expect(pagesBody.baselinePageIds).toEqual(['page-1'])
+
+    // Components never carry a baseline — pages-only concurrency token (ISS-041).
+    const componentsBody = bodyOf(calls, '/admin/api/cms/components')
+    expect('baselinePageIds' in componentsBody).toBe(false)
+  })
+
+  it('dirty.all = true sends everything despite narrower id sets', async () => {
+    const { adapter, calls } = recordingAdapter()
+    await adapter.saveSite(multiDocSite(), {
+      dirty: { all: true, pageIds: new Set(['page-2']), componentIds: new Set() },
+    })
+
+    const pagesBody = bodyOf(calls, '/admin/api/cms/pages')
+    expect(ids(pagesBody.changedPages)).toEqual(['page-1', 'page-2'])
+    expect(pagesBody.pageIds).toEqual(['page-1', 'page-2'])
+
+    const componentsBody = bodyOf(calls, '/admin/api/cms/components')
+    expect(ids(componentsBody.changedComponents)).toEqual(['vc-1', 'vc-2'])
+    expect(componentsBody.componentIds).toEqual(['vc-1', 'vc-2'])
   })
 })

--- a/src/__tests__/persistence/visualComponentsWriteValidation.test.ts
+++ b/src/__tests__/persistence/visualComponentsWriteValidation.test.ts
@@ -2,9 +2,18 @@ import { describe, expect, it } from 'bun:test'
 import {
   SiteValidationError,
   validateVisualComponents,
-  validateVisualComponentsForWrite,
+  validateVisualComponentsForPartialWrite,
 } from '@core/persistence/validate'
 import type { VisualComponent } from '@core/visualComponents'
+
+/**
+ * Full-roster write = the partial-write validator with an empty stored
+ * roster: every component is "changed", nothing is merged in. The old
+ * dedicated full-write validator was deleted in favour of this shape.
+ */
+function validateVisualComponentsForWrite(rawVCs: unknown[]): VisualComponent[] {
+  return validateVisualComponentsForPartialWrite(rawVCs, [], new Set<string>())
+}
 
 function vc(overrides: Partial<VisualComponent> = {}): VisualComponent {
   return {
@@ -41,7 +50,7 @@ function refNode(id: string, componentId: string) {
   }
 }
 
-describe('validateVisualComponentsForWrite', () => {
+describe('validateVisualComponentsForPartialWrite (full-roster mode)', () => {
   it('preserves valid Visual Components', () => {
     const components = validateVisualComponentsForWrite([vc()])
 

--- a/src/__tests__/server/pagesPartialSave.test.ts
+++ b/src/__tests__/server/pagesPartialSave.test.ts
@@ -1,0 +1,421 @@
+/**
+ * Incremental roster saves: PUT /admin/api/cms/pages and PUT /admin/api/cms/components.
+ *
+ * The bodies carry `{ changedPages, pageIds, baselinePageIds? }` /
+ * `{ changedComponents, componentIds }` — only the changed rows are validated
+ * and written; the full id roster drives reaping with full-replace semantics
+ * (subject to the ISS-041 baseline on the pages side).
+ *
+ * Runs against a real isolated SQLite DB through the established capability
+ * harness (`createCapabilityTestHarness` → `createTestDb`): migrations applied,
+ * owner user + stepped-up session seeded via the real setup/login endpoints,
+ * requests dispatched through `handleCmsRequest`.
+ */
+import { describe, expect, it } from 'bun:test'
+import {
+  createCapabilityTestHarness,
+  readJson,
+  type CapabilityTestHarness,
+} from '../helpers/capabilityHarness'
+
+// ---------------------------------------------------------------------------
+// Payload + DB helpers
+// ---------------------------------------------------------------------------
+
+const BACKDATED = '2000-01-01 00:00:00'
+
+function pagePayload(id: string, slug: string, title = slug): Record<string, unknown> {
+  const rootId = `root-${id}`
+  return {
+    id,
+    slug,
+    title,
+    rootNodeId: rootId,
+    nodes: {
+      [rootId]: {
+        id: rootId,
+        moduleId: 'base.body',
+        props: {},
+        breakpointOverrides: {},
+        children: [],
+      },
+    },
+  }
+}
+
+function vcNode(id: string, moduleId: string, children: string[] = [], props: Record<string, unknown> = {}) {
+  return { id, moduleId, props, breakpointOverrides: {}, children, classIds: [] }
+}
+
+/** A minimal VC; pass `refTo` to embed a base.visual-component-ref child. */
+function vcPayload(id: string, name: string, refTo?: string): Record<string, unknown> {
+  const rootId = `root-${id}`
+  const nodes: Record<string, unknown> = refTo
+    ? {
+        [rootId]: vcNode(rootId, 'base.container', [`ref-${id}`]),
+        [`ref-${id}`]: vcNode(`ref-${id}`, 'base.visual-component-ref', [], { componentId: refTo }),
+      }
+    : { [rootId]: vcNode(rootId, 'base.container') }
+  return {
+    id,
+    name,
+    tree: { rootNodeId: rootId, nodes },
+    params: [],
+    classIds: [],
+    createdAt: 1_700_000_000_000,
+  }
+}
+
+interface StoredRow {
+  id: string
+  slug: string
+  cells_json: { title?: string } & Record<string, unknown>
+  updated_at: string
+  deleted_at: string | null
+}
+
+async function storedRows(harness: CapabilityTestHarness, tableId: string): Promise<Map<string, StoredRow>> {
+  const { rows } = await harness.db<StoredRow>`
+    select id, slug, cells_json, updated_at, deleted_at
+    from data_rows
+    where table_id = ${tableId}
+  `
+  return new Map(rows.map((row) => [row.id, row]))
+}
+
+async function backdateRows(harness: CapabilityTestHarness, tableId: string): Promise<void> {
+  await harness.db`
+    update data_rows set updated_at = ${BACKDATED} where table_id = ${tableId}
+  `
+}
+
+interface Ctx {
+  harness: CapabilityTestHarness
+  cookie: string
+  /** Id of the home page row the setup endpoint seeds (slug `index`). */
+  homeId: string
+}
+
+async function setupHarness(): Promise<Ctx> {
+  const harness = await createCapabilityTestHarness()
+  const cookie = await harness.setupOwner()
+  const pages = await storedRows(harness, 'pages')
+  expect(pages.size).toBe(1)
+  const homeId = [...pages.keys()][0]
+  return { harness, cookie, homeId }
+}
+
+function putPages(ctx: Ctx, body: Record<string, unknown>): Promise<Response> {
+  return ctx.harness.cms('/admin/api/cms/pages', { method: 'PUT', cookie: ctx.cookie, json: body })
+}
+
+function putComponents(ctx: Ctx, body: Record<string, unknown>): Promise<Response> {
+  return ctx.harness.cms('/admin/api/cms/components', { method: 'PUT', cookie: ctx.cookie, json: body })
+}
+
+async function expectOk(res: Response): Promise<void> {
+  expect(res.status).toBe(200)
+  expect(await readJson<{ ok?: boolean }>(res)).toEqual({ ok: true })
+}
+
+// ---------------------------------------------------------------------------
+// PUT /admin/api/cms/pages
+// ---------------------------------------------------------------------------
+
+describe('PUT /admin/api/cms/pages — incremental roster save', () => {
+  it('writes ONLY the changed page among N stored rows', async () => {
+    const ctx = await setupHarness()
+    try {
+      // Store two extra pages so the table holds three rows.
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'about'), pagePayload('page-b', 'contact')],
+        pageIds: [ctx.homeId, 'page-a', 'page-b'],
+      }))
+
+      await backdateRows(ctx.harness, 'pages')
+      const before = await storedRows(ctx.harness, 'pages')
+
+      // Change ONLY page-a.
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'About v2')],
+        pageIds: [ctx.homeId, 'page-a', 'page-b'],
+      }))
+
+      const after = await storedRows(ctx.harness, 'pages')
+
+      // page-a: cells rewritten, updated_at bumped off the backdated value.
+      expect(after.get('page-a')!.cells_json.title).toBe('About v2')
+      expect(after.get('page-a')!.updated_at).not.toBe(BACKDATED)
+
+      // The home page and page-b are untouched — identical cells AND the
+      // backdated updated_at survives, proving no redundant write happened.
+      for (const id of [ctx.homeId, 'page-b']) {
+        expect(after.get(id)!.updated_at).toBe(BACKDATED)
+        expect(after.get(id)!.cells_json).toEqual(before.get(id)!.cells_json)
+      }
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('rejects a changed page whose id is missing from the pageIds roster', async () => {
+    const ctx = await setupHarness()
+    try {
+      const res = await putPages(ctx, {
+        changedPages: [pagePayload('page-orphan', 'orphan')],
+        pageIds: [ctx.homeId], // page-orphan not in the roster
+      })
+      expect(res.status).toBe(400)
+      const body = await readJson<{ error: string }>(res)
+      expect(body.error).toContain('missing from pageIds roster')
+
+      // Nothing was written.
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.has('page-orphan')).toBe(false)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('soft-deletes a row missing from the roster when the baseline contains it (ISS-041)', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'about')],
+        pageIds: [ctx.homeId, 'page-a'],
+      }))
+
+      // Client knew about page-a (baseline) and dropped it from the roster.
+      await expectOk(await putPages(ctx, {
+        changedPages: [],
+        pageIds: [ctx.homeId],
+        baselinePageIds: [ctx.homeId, 'page-a'],
+      }))
+
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.deleted_at).not.toBeNull()
+      expect(rows.get(ctx.homeId)!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('preserves a row missing from the roster when the baseline does NOT contain it (sibling create)', async () => {
+    const ctx = await setupHarness()
+    try {
+      // page-c simulates a sibling session's just-created page.
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-c', 'pricing')],
+        pageIds: [ctx.homeId, 'page-c'],
+      }))
+
+      // This client never loaded page-c: roster omits it, baseline omits it.
+      await expectOk(await putPages(ctx, {
+        changedPages: [],
+        pageIds: [ctx.homeId],
+        baselinePageIds: [ctx.homeId],
+      }))
+
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-c')!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('rejects a slug conflict between a changed page and an UNCHANGED stored page', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'about'), pagePayload('page-b', 'contact')],
+        pageIds: [ctx.homeId, 'page-a', 'page-b'],
+      }))
+
+      // page-a tries to take page-b's slug while page-b stays unchanged.
+      const res = await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'contact')],
+        pageIds: [ctx.homeId, 'page-a', 'page-b'],
+      })
+      expect(res.status).toBe(400)
+      const body = await readJson<{ error: string }>(res)
+      expect(body.error.toLowerCase()).toContain('duplicate')
+      expect(body.error).toContain('slug')
+
+      // page-a keeps its old slug in storage.
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.slug).toBe('about')
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('a changed batch may retake the slug of a row this same batch replaces (id-matched exclusion)', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'about')],
+        pageIds: [ctx.homeId, 'page-a'],
+      }))
+
+      // page-a itself changes title but keeps its own slug — its stored slug
+      // must not count as a conflict against itself.
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'About again')],
+        pageIds: [ctx.homeId, 'page-a'],
+      }))
+
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.cells_json.title).toBe('About again')
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('creates a row for a new page id present in changedPages + pageIds', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putPages(ctx, {
+        changedPages: [pagePayload('page-new', 'team', 'Team')],
+        pageIds: [ctx.homeId, 'page-new'],
+      }))
+
+      const rows = await storedRows(ctx.harness, 'pages')
+      const created = rows.get('page-new')
+      expect(created).toBeDefined()
+      expect(created!.slug).toBe('team')
+      expect(created!.cells_json.title).toBe('Team')
+      expect(created!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// PUT /admin/api/cms/components
+// ---------------------------------------------------------------------------
+
+describe('PUT /admin/api/cms/components — incremental roster save', () => {
+  it('keeps a changed VC valid when it references an UNCHANGED stored VC', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-base', 'Base'), vcPayload('vc-ref', 'RefCard', 'vc-base')],
+        componentIds: ['vc-base', 'vc-ref'],
+      }))
+
+      await backdateRows(ctx.harness, 'components')
+
+      // Only vc-ref changes; its ref target vc-base rides along unchanged in
+      // the merged validation roster.
+      await expectOk(await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-ref', 'RefCard v2', 'vc-base')],
+        componentIds: ['vc-base', 'vc-ref'],
+      }))
+
+      const rows = await storedRows(ctx.harness, 'components')
+      expect(rows.get('vc-ref')!.updated_at).not.toBe(BACKDATED)
+      expect((rows.get('vc-ref')!.cells_json as { name?: string }).name).toBe('RefCard v2')
+      // The unchanged ref target was not rewritten.
+      expect(rows.get('vc-base')!.updated_at).toBe(BACKDATED)
+      expect(rows.get('vc-base')!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('rejects a changed VC referencing an id absent from the componentIds roster', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-base', 'Base')],
+        componentIds: ['vc-base'],
+      }))
+
+      // vc-ref points at vc-base, but the roster drops vc-base — the merged
+      // post-save roster would not contain the ref target.
+      const res = await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-ref', 'RefCard', 'vc-base')],
+        componentIds: ['vc-ref'],
+      })
+      expect(res.status).toBe(400)
+      const body = await readJson<{ error: string }>(res)
+      expect(body.error).toContain('references missing Visual Component')
+
+      // Neither the write nor the reap happened — vc-base survives untouched.
+      const rows = await storedRows(ctx.harness, 'components')
+      expect(rows.get('vc-base')!.deleted_at).toBeNull()
+      expect(rows.has('vc-ref')).toBe(false)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('rejects deleting a VC that an UNCHANGED stored VC still references', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-base', 'Base'), vcPayload('vc-ref', 'RefCard', 'vc-base')],
+        componentIds: ['vc-base', 'vc-ref'],
+      }))
+
+      // Drop vc-base from the roster while the unchanged vc-ref still points
+      // at it. validateVisualComponentsForPartialWrite merges the kept stored
+      // roster (vc-ref) over keptIds and runs validateStrictVCRefs — the
+      // dangling ref through the UNCHANGED component must reject the save.
+      const res = await putComponents(ctx, {
+        changedComponents: [],
+        componentIds: ['vc-ref'],
+      })
+      expect(res.status).toBe(400)
+      const body = await readJson<{ error: string }>(res)
+      expect(body.error).toContain('references missing Visual Component')
+
+      // The reap was rejected wholesale — vc-base is still live.
+      const rows = await storedRows(ctx.harness, 'components')
+      expect(rows.get('vc-base')!.deleted_at).toBeNull()
+      expect(rows.get('vc-ref')!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('soft-deletes an unreferenced VC missing from the componentIds roster', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-base', 'Base'), vcPayload('vc-lone', 'Standalone')],
+        componentIds: ['vc-base', 'vc-lone'],
+      }))
+
+      await expectOk(await putComponents(ctx, {
+        changedComponents: [],
+        componentIds: ['vc-base'],
+      }))
+
+      const rows = await storedRows(ctx.harness, 'components')
+      expect(rows.get('vc-lone')!.deleted_at).not.toBeNull()
+      expect(rows.get('vc-base')!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('rejects a changed component whose id is missing from the componentIds roster', async () => {
+    const ctx = await setupHarness()
+    try {
+      const res = await putComponents(ctx, {
+        changedComponents: [vcPayload('vc-orphan', 'Orphan')],
+        componentIds: [],
+      })
+      expect(res.status).toBe(400)
+      const body = await readJson<{ error: string }>(res)
+      expect(body.error).toContain('missing from componentIds roster')
+
+      const rows = await storedRows(ctx.harness, 'components')
+      expect(rows.has('vc-orphan')).toBe(false)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+})

--- a/src/admin/pages/site/hooks/usePersistence.ts
+++ b/src/admin/pages/site/hooks/usePersistence.ts
@@ -129,18 +129,27 @@ export function usePersistence(
   // Exception #1: referenced in the auto-save and Cmd/Ctrl+S useEffect dep arrays,
   // so exhaustive-deps requires a stable identity here.
   const saveCurrentSite = useCallback(async () => {
-    const { site, setHasUnsavedChanges } = useEditorStore.getState()
+    const { site, setHasUnsavedChanges, takeDirtySaveSnapshot, restoreDirtySaveSnapshot } =
+      useEditorStore.getState()
     if (!site) return
 
     setSaveStatus({ state: 'saving', message: 'Saving draft' })
+    // Snapshot-and-reset the dirty marks BEFORE the await: edits landing while
+    // the save is in flight accumulate fresh marks for the NEXT save, and a
+    // failed save merges this snapshot back so nothing is lost.
+    const dirty = takeDirtySaveSnapshot()
     try {
-      await adapterRef.current.saveSite(site, syncedPageIdsRef.current)
+      await adapterRef.current.saveSite(site, {
+        baselinePageIds: syncedPageIdsRef.current,
+        dirty,
+      })
       // The save just reconciled storage to this client's roster; that set is
       // the new concurrency baseline for the next save.
       syncedPageIdsRef.current = site.pages.map((p) => p.id)
       setHasUnsavedChanges(false)
       setSaveStatus({ state: 'saved', lastSavedAt: Date.now() })
     } catch (err) {
+      restoreDirtySaveSnapshot(dirty)
       setSaveStatus({ state: 'error', message: errorMessage(err, 'Save failed') })
       throw err
     }
@@ -227,7 +236,10 @@ export function usePersistence(
         loadedRef.current = true
         syncedPageIdsRef.current = created.pages.map((p) => p.id)
         try {
-          await adapterRef.current.saveSite(created, syncedPageIdsRef.current)
+          // Full save (no dirty hints): the site doesn't exist in storage yet.
+          await adapterRef.current.saveSite(created, { baselinePageIds: syncedPageIdsRef.current })
+          // Storage now matches the store — drop the createSite all-dirty mark.
+          useEditorStore.getState().takeDirtySaveSnapshot()
           setSaveStatus({ state: 'saved', lastSavedAt: Date.now() })
         } catch (err) {
           setHasUnsavedChanges(true)
@@ -323,12 +335,16 @@ export function usePersistence(
     // The 30s debounce means the last unsaved edit would be dropped without this.
     // Fire-and-forget: beforeunload can't await async work.
     function flushOnUnload() {
-      const { site, hasUnsavedChanges } = useEditorStore.getState()
+      const { site, hasUnsavedChanges, _dirtySave } = useEditorStore.getState()
       if (!site || !loadedRef.current || !hasUnsavedChanges) return
       clearTimeout(timer)
-      void adapterRef.current.saveSite(site, syncedPageIdsRef.current).catch((err) => {
-        console.error('[persistence] beforeunload save failed:', err)
-      })
+      // Read the marks without resetting them: if the unload is cancelled and
+      // this fire-and-forget save failed, the next autosave still has them.
+      void adapterRef.current
+        .saveSite(site, { baselinePageIds: syncedPageIdsRef.current, dirty: _dirtySave })
+        .catch((err) => {
+          console.error('[persistence] beforeunload save failed:', err)
+        })
     }
 
     window.addEventListener('beforeunload', flushOnUnload)

--- a/src/admin/pages/site/store/slices/site/dirtyTracking.ts
+++ b/src/admin/pages/site/store/slices/site/dirtyTracking.ts
@@ -1,0 +1,83 @@
+/**
+ * Patch-derived save-dirty tracking.
+ *
+ * Every undoable mutation already produces site-relative Mutative patches
+ * (for undo history); this module reuses them to answer "which pages and
+ * Visual Components changed since the last successful save", so autosave can
+ * ship `{ changedPages, pageIds }` instead of the whole roster.
+ *
+ * Resolution rules (paths are relative to the SiteDocument):
+ *   - `['pages', i, …]` / `['visualComponents', i, …]` → the POST-mutation
+ *     element at index `i` is dirty. Post-state indexing is correct for every
+ *     op that leaves an element at that index (add, replace, nested edits);
+ *     reorders mark each displaced index — over-marking, which is safe.
+ *   - `remove` at exactly `['pages', i]` marks nothing: deletions are conveyed
+ *     by the id roster the save always ships, not by a page payload.
+ *   - `['pages', 'length']` (array truncation bookkeeping) marks nothing for
+ *     the same reason.
+ *   - `['pages']` / `['visualComponents']` wholesale replacement, an index
+ *     that doesn't resolve in the post-state, or any unrecognised shape →
+ *     `all` (conservative full save).
+ *   - Any other top-level path is a shell field; the shell is always saved,
+ *     so it needs no marks.
+ *
+ * The invariant: OVER-marking costs a few redundant page writes;
+ * UNDER-marking loses edits. Anything ambiguous must resolve to `all`.
+ */
+
+import type { Patches } from 'mutative'
+import type { SiteDocument } from '@core/page-tree'
+
+export interface DirtyMarks {
+  all: boolean
+  pageIds: Set<string>
+  componentIds: Set<string>
+}
+
+export function emptyDirtyMarks(): DirtyMarks {
+  return { all: false, pageIds: new Set(), componentIds: new Set() }
+}
+
+/** Derive dirty marks from one mutation's site-relative patches. */
+export function collectDirtyFromSitePatches(
+  patches: Patches,
+  postSite: SiteDocument,
+): DirtyMarks {
+  const marks = emptyDirtyMarks()
+  for (const patch of patches) {
+    const head = patch.path[0]
+    if (head !== 'pages' && head !== 'visualComponents') continue // shell field — always saved
+
+    if (patch.path.length === 1) {
+      // Wholesale array replacement (e.g. an import recipe) — can't attribute.
+      marks.all = true
+      continue
+    }
+    const index = patch.path[1]
+    if (index === 'length') continue // array bookkeeping; roster conveys removals
+    if (typeof index !== 'number') {
+      marks.all = true
+      continue
+    }
+    if (patch.op === 'remove' && patch.path.length === 2) {
+      continue // element removal; roster conveys it
+    }
+    const element = head === 'pages' ? postSite.pages[index] : postSite.visualComponents[index]
+    if (!element) {
+      // Index doesn't resolve post-mutation (unexpected op ordering) —
+      // attribute conservatively.
+      marks.all = true
+      continue
+    }
+    if (head === 'pages') marks.pageIds.add(element.id)
+    else marks.componentIds.add(element.id)
+  }
+  return marks
+}
+
+/** Merge `incoming` into a draft's accumulated dirty state, in place. */
+export function mergeDirtyMarks(target: DirtyMarks, incoming: DirtyMarks): void {
+  if (incoming.all) target.all = true
+  for (const id of incoming.pageIds) target.pageIds.add(id)
+  for (const id of incoming.componentIds) target.componentIds.add(id)
+}

--- a/src/admin/pages/site/store/slices/site/helpers.ts
+++ b/src/admin/pages/site/store/slices/site/helpers.ts
@@ -24,6 +24,7 @@ import type {
 } from '@core/siteImport'
 import { normalizeFrameworkColorSlug } from '@core/framework'
 import { addImportedScripts, addImportedStylesheets } from './importedSiteFiles'
+import { collectDirtyFromSitePatches, mergeDirtyMarks } from './dirtyTracking'
 import type { EditorStore } from '@site/store/types'
 import { MAX_HISTORY } from './defaults'
 import { reconcileFrameworkClasses } from './framework/reconcile'
@@ -294,6 +295,9 @@ export function buildSiteHelpers(
 
       if (siteForward.length > 0) {
         commitHistory(state, { inverse: siteInverse, forward: siteForward, coalesceKey })
+        // The same patches drive save-dirty attribution: autosave ships only
+        // the pages/VCs these paths name (see dirtyTracking.ts).
+        mergeDirtyMarks(state._dirtySave, collectDirtyFromSitePatches(siteForward, next.site!))
       }
       state.hasUnsavedChanges = true
     })

--- a/src/admin/pages/site/store/slices/site/lifecycleActions.ts
+++ b/src/admin/pages/site/store/slices/site/lifecycleActions.ts
@@ -15,6 +15,7 @@ import {
 } from '@core/site-runtime'
 import { clearCanvasSelectionDraft } from '../selectionSlice'
 import { createDefaultSiteDocument } from './defaults'
+import { emptyDirtyMarks } from './dirtyTracking'
 import { reconcileFrameworkClasses } from './framework/reconcile'
 import type { SiteSlice, SiteSliceHelpers } from './types'
 
@@ -62,6 +63,8 @@ export function createLifecycleActions({
         state.canUndo = false
         state.canRedo = false
         state.hasUnsavedChanges = false
+        // A brand-new site has no stored rows at all — first save is full.
+        state._dirtySave = { ...emptyDirtyMarks(), all: true }
       })
       return site
     },
@@ -91,6 +94,7 @@ export function createLifecycleActions({
         state.canUndo = false
         state.canRedo = false
         state.hasUnsavedChanges = false
+        state._dirtySave = emptyDirtyMarks()
       })
     },
 
@@ -108,6 +112,7 @@ export function createLifecycleActions({
         state._historyCoalesceKey = null
         state.canUndo = false
         state.canRedo = false
+        state._dirtySave = emptyDirtyMarks()
       })
     },
 

--- a/src/admin/pages/site/store/slices/site/undoRedoActions.ts
+++ b/src/admin/pages/site/store/slices/site/undoRedoActions.ts
@@ -12,6 +12,7 @@
 import { apply } from 'mutative'
 import { clonePackageJson } from '@core/site-dependencies/manifest'
 import { cloneSiteRuntimeConfig } from '@core/site-runtime'
+import { collectDirtyFromSitePatches, mergeDirtyMarks } from './dirtyTracking'
 import type { SiteSlice, SiteSliceHelpers } from './types'
 
 export type UndoRedoActions = Pick<SiteSlice, 'undo' | 'redo'>
@@ -25,6 +26,9 @@ export function createUndoRedoActions({ get, set }: SiteSliceHelpers): UndoRedoA
       const restored = apply(site, entry.inverse)
       const packageJson = clonePackageJson(restored.packageJson)
       const siteRuntime = cloneSiteRuntimeConfig(restored.runtime)
+      // Undo changes the same paths the original mutation did — the restored
+      // pages/VCs must be re-saved.
+      const dirty = collectDirtyFromSitePatches(entry.inverse, restored)
       set((state) => {
         state._historyPast.pop()
         state._historyFuture.push(entry)
@@ -37,6 +41,7 @@ export function createUndoRedoActions({ get, set }: SiteSliceHelpers): UndoRedoA
         state.canUndo = state._historyPast.length > 0
         state.canRedo = true
         state.hasUnsavedChanges = true
+        mergeDirtyMarks(state._dirtySave, dirty)
         // Keep activePageId valid
         if (!state.site.pages.find((p) => p.id === state.activePageId)) {
           state.activePageId = state.site.pages[0]?.id ?? null
@@ -51,6 +56,8 @@ export function createUndoRedoActions({ get, set }: SiteSliceHelpers): UndoRedoA
       const restored = apply(site, entry.forward)
       const packageJson = clonePackageJson(restored.packageJson)
       const siteRuntime = cloneSiteRuntimeConfig(restored.runtime)
+      // Redo re-applies the mutation's paths — mark the replayed pages/VCs.
+      const dirty = collectDirtyFromSitePatches(entry.forward, restored)
       set((state) => {
         state._historyFuture.pop()
         state._historyPast.push(entry)
@@ -61,6 +68,7 @@ export function createUndoRedoActions({ get, set }: SiteSliceHelpers): UndoRedoA
         state.canUndo = true
         state.canRedo = state._historyFuture.length > 0
         state.hasUnsavedChanges = true
+        mergeDirtyMarks(state._dirtySave, dirty)
         // Keep activePageId valid
         if (!state.site.pages.find((p) => p.id === state.activePageId)) {
           state.activePageId = state.site.pages[0]?.id ?? null

--- a/src/admin/pages/site/store/slices/uiSlice.ts
+++ b/src/admin/pages/site/store/slices/uiSlice.ts
@@ -1,5 +1,6 @@
 import type { EditorStore, EditorStoreSliceCreator } from '@site/store/types'
 import { clearCanvasSelectionDraft } from './selectionSlice'
+import { emptyDirtyMarks, mergeDirtyMarks, type DirtyMarks } from './site/dirtyTracking'
 
 export type FocusedPanel = 'canvas' | 'domTree' | 'properties' | null
 export type FormPreviewState = 'default' | 'submitting' | 'success' | 'error'
@@ -79,6 +80,20 @@ export interface UiSlice {
 
   // Unsaved changes guard
   hasUnsavedChanges: boolean
+
+  /**
+   * Patch-derived save-dirty accumulator — which pages/VCs changed since the
+   * last successful save (see slices/site/dirtyTracking.ts). Autosave takes a
+   * snapshot (which resets this), ships only the named ids, and merges the
+   * snapshot back on save failure so nothing is lost.
+   */
+  _dirtySave: DirtyMarks
+  /** Conservative full-save mark (imports, fresh sites). */
+  markAllDirtyForSave: () => void
+  /** Return the accumulated marks and reset the accumulator. */
+  takeDirtySaveSnapshot: () => DirtyMarks
+  /** Merge a failed save's snapshot back so the next save retries it. */
+  restoreDirtySaveSnapshot: (marks: DirtyMarks) => void
 
   // Module insert picker
   insertPickerOpen: boolean
@@ -306,6 +321,7 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
   previewOpen: false,
   formPreviewStates: {},
   hasUnsavedChanges: false,
+  _dirtySave: emptyDirtyMarks(),
   insertPickerOpen: false,
   insertPickerParentId: null,
   componentizeEditorRequest: null,
@@ -408,6 +424,29 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
     }),
 
   setHasUnsavedChanges: (value) => set({ hasUnsavedChanges: value }),
+
+  markAllDirtyForSave: () =>
+    set((state) => {
+      state._dirtySave.all = true
+    }),
+
+  takeDirtySaveSnapshot: () => {
+    const current = get()._dirtySave
+    const snapshot: DirtyMarks = {
+      all: current.all,
+      pageIds: new Set(current.pageIds),
+      componentIds: new Set(current.componentIds),
+    }
+    set((state) => {
+      state._dirtySave = emptyDirtyMarks()
+    })
+    return snapshot
+  },
+
+  restoreDirtySaveSnapshot: (marks) =>
+    set((state) => {
+      mergeDirtyMarks(state._dirtySave, marks)
+    }),
 
   openInsertPicker: (parentId) =>
     set({ insertPickerOpen: true, insertPickerParentId: parentId }),

--- a/src/core/page-tree/index.ts
+++ b/src/core/page-tree/index.ts
@@ -135,13 +135,16 @@ export {
   pasteSubtree,
   wrapNode,
   wrapNodes,
+  applyTreeOperation,
+} from './mutations'
+
+export {
   addPage,
   deletePage,
   renamePage,
   reorderPages,
   duplicatePage,
-  applyTreeOperation,
-} from './mutations'
+} from './pageMutations'
 
 export { reindexNodeParents } from './parentIndex'
 

--- a/src/core/page-tree/mutations.ts
+++ b/src/core/page-tree/mutations.ts
@@ -1,13 +1,8 @@
 import { nanoid } from 'nanoid'
-import type { Page } from './page'
 import type { PageNode } from './pageNode'
-import type { SiteDocument } from './siteDocument'
 import type { NodeTree } from './treeSchema'
 import type { TreeOperation } from './operationSchema'
 import { getParent, isAncestor, collectSubtreeIds } from './selectors'
-import { normalizePageSlug, uniquePageSlug } from './slugs'
-import { cloneScopedClassesForNodeMap } from './scopedClassClone'
-import { reindexNodeParents } from './parentIndex'
 import { deleteSubtree } from './subtreeRemoval'
 import { cloneNodeWithRemap } from './cloneNode'
 
@@ -762,119 +757,4 @@ export function applyTreeOperation(
       return { tree, affectedNodeIds: parent ? [parent.id] : [] }
     }
   }
-}
-
-// ---------------------------------------------------------------------------
-// Page-level mutations (called on SiteDocument draft)
-// ---------------------------------------------------------------------------
-
-export function addPage(site: SiteDocument, title: string, slug: string): Page {
-  const rootNode = createNode('base.body')
-  const page: Page = {
-    id: nanoid(),
-    title,
-    // Auto-unique so a repeated create (same title/slug) never collides — a
-    // duplicate slug fails validateSite and bricks every save.
-    slug: uniquePageSlug(slug, site.pages),
-    rootNodeId: rootNode.id,
-    nodes: { [rootNode.id]: rootNode },
-  }
-  site.pages.push(page)
-  return page
-}
-
-export function deletePage(site: SiteDocument, pageId: string): void {
-  if (site.pages.length <= 1) {
-    throw new Error(`[PageTree] Cannot delete the last page in a site.`)
-  }
-  site.pages = site.pages.filter((p) => p.id !== pageId)
-}
-
-export function renamePage(site: SiteDocument, pageId: string, title: string, slug?: string): void {
-  const page = site.pages.find((p) => p.id === pageId)
-  if (!page) throw new Error(`[PageTree] Page "${pageId}" not found`)
-  page.title = title
-  if (slug !== undefined) {
-    const normalized = normalizePageSlug(slug)
-    // 'index' is the homepage intent — set it verbatim (homepage swap is a
-    // separate concern). Any other slug is made unique against sibling pages
-    // (excluding this one) so a rename can't introduce a duplicate slug.
-    page.slug = normalized === 'index'
-      ? 'index'
-      : uniquePageSlug(slug, site.pages, pageId)
-  }
-}
-
-export function reorderPages(site: SiteDocument, fromIndex: number, toIndex: number): void {
-  const pages = site.pages
-  const [moved] = pages.splice(fromIndex, 1)
-  pages.splice(toIndex, 0, moved)
-}
-
-/**
- * Deep-clone a page (every node + its children, props, classIds,
- * breakpointOverrides) under a new title and slug. The cloned nodes get
- * fresh nanoid IDs so they don't collide with the source page. Returns
- * the new Page; caller is responsible for activating it if desired.
- *
- * Per-node "module-style" CSS classes (those with `scope.type === 'node'`)
- * are also cloned with fresh class ids and rewritten `scope.nodeId`s — the
- * publisher emits one CSS rule per class, so without this clone the new page
- * would silently share style entries with the source page (editing one would
- * restyle both). The newly cloned classes are written to `site.styleRules`.
- */
-export function duplicatePage(
-  site: SiteDocument,
-  sourcePageId: string,
-  title: string,
-  slug?: string,
-): Page {
-  const source = site.pages.find((p) => p.id === sourcePageId)
-  if (!source) throw new Error(`[PageTree] Page "${sourcePageId}" not found`)
-
-  // Build a fresh-id map for every node in the source page.
-  const idMap = new Map<string, string>()
-  for (const oldId of Object.keys(source.nodes)) {
-    idMap.set(oldId, nanoid())
-  }
-
-  // Clone every node-scoped class for nodes in the source page so the new
-  // page gets its own scoped classes (with `scope.nodeId` pointing at the
-  // duplicate's node ids). Non-scoped classes are shared and not cloned.
-  const { added: clonedClasses, classIdRemap } = cloneScopedClassesForNodeMap(
-    idMap,
-    site.styleRules,
-  )
-  for (const cls of clonedClasses) {
-    site.styleRules[cls.id] = cls
-  }
-
-  // Clone each node with remapped IDs, remapped child references, and
-  // remapped scoped-class ids. Non-scoped classes (absent from classIdRemap)
-  // are kept as-is — they're shared site-level classes that still exist.
-  const remapClassId = (cid: string) => classIdRemap.get(cid) ?? cid
-  const newNodes: Record<string, PageNode> = {}
-  for (const [oldId, oldNode] of Object.entries(source.nodes)) {
-    const newId = idMap.get(oldId)!
-    newNodes[newId] = cloneNodeWithRemap(oldNode, { newId, idMap, classIdRemap: remapClassId })
-  }
-
-  const newRootId = idMap.get(source.rootNodeId)
-  if (!newRootId) {
-    throw new Error('[PageTree] Source page root node missing from page.nodes')
-  }
-
-  // Derive parentId for the cloned page from its (remapped) children arrays.
-  reindexNodeParents(newNodes)
-
-  const newPage: Page = {
-    id: nanoid(),
-    title,
-    // Auto-unique — a duplicate ("Copy") must not collide with the source slug.
-    slug: uniquePageSlug(slug ?? title, site.pages),
-    rootNodeId: newRootId,
-    nodes: newNodes,
-  }
-  site.pages.push(newPage)
-  return newPage
 }

--- a/src/core/page-tree/pageMutations.ts
+++ b/src/core/page-tree/pageMutations.ts
@@ -1,0 +1,135 @@
+/**
+ * Page-level mutations — called on a `SiteDocument` draft.
+ *
+ * Split from `mutations.ts` (which owns the tree-of-nodes engine): these
+ * operate on the page ROSTER (add/delete/rename/reorder/duplicate), not on a
+ * `NodeTree`. Same Mutative-draft calling convention; `duplicatePage` reuses
+ * the node-clone primitives the tree engine shares.
+ *
+ * `deletePage` splices in place deliberately — a wholesale `pages` array
+ * replacement emits a patch the editor's incremental save cannot attribute
+ * to one page (see store slices/site/dirtyTracking.ts), forcing a full save.
+ */
+import { nanoid } from 'nanoid'
+import type { Page } from './page'
+import type { PageNode } from './pageNode'
+import type { SiteDocument } from './siteDocument'
+import { normalizePageSlug, uniquePageSlug } from './slugs'
+import { cloneScopedClassesForNodeMap } from './scopedClassClone'
+import { reindexNodeParents } from './parentIndex'
+import { cloneNodeWithRemap } from './cloneNode'
+import { createNode } from './mutations'
+
+
+export function addPage(site: SiteDocument, title: string, slug: string): Page {
+  const rootNode = createNode('base.body')
+  const page: Page = {
+    id: nanoid(),
+    title,
+    // Auto-unique so a repeated create (same title/slug) never collides — a
+    // duplicate slug fails validateSite and bricks every save.
+    slug: uniquePageSlug(slug, site.pages),
+    rootNodeId: rootNode.id,
+    nodes: { [rootNode.id]: rootNode },
+  }
+  site.pages.push(page)
+  return page
+}
+
+export function deletePage(site: SiteDocument, pageId: string): void {
+  if (site.pages.length <= 1) {
+    throw new Error(`[PageTree] Cannot delete the last page in a site.`)
+  }
+  // Splice in place — never reassign the array (see module header).
+  const index = site.pages.findIndex((p) => p.id === pageId)
+  if (index !== -1) site.pages.splice(index, 1)
+}
+
+export function renamePage(site: SiteDocument, pageId: string, title: string, slug?: string): void {
+  const page = site.pages.find((p) => p.id === pageId)
+  if (!page) throw new Error(`[PageTree] Page "${pageId}" not found`)
+  page.title = title
+  if (slug !== undefined) {
+    const normalized = normalizePageSlug(slug)
+    // 'index' is the homepage intent — set it verbatim (homepage swap is a
+    // separate concern). Any other slug is made unique against sibling pages
+    // (excluding this one) so a rename can't introduce a duplicate slug.
+    page.slug = normalized === 'index'
+      ? 'index'
+      : uniquePageSlug(slug, site.pages, pageId)
+  }
+}
+
+export function reorderPages(site: SiteDocument, fromIndex: number, toIndex: number): void {
+  const pages = site.pages
+  const [moved] = pages.splice(fromIndex, 1)
+  pages.splice(toIndex, 0, moved)
+}
+
+/**
+ * Deep-clone a page (every node + its children, props, classIds,
+ * breakpointOverrides) under a new title and slug. The cloned nodes get
+ * fresh nanoid IDs so they don't collide with the source page. Returns
+ * the new Page; caller is responsible for activating it if desired.
+ *
+ * Per-node "module-style" CSS classes (those with `scope.type === 'node'`)
+ * are also cloned with fresh class ids and rewritten `scope.nodeId`s — the
+ * publisher emits one CSS rule per class, so without this clone the new page
+ * would silently share style entries with the source page (editing one would
+ * restyle both). The newly cloned classes are written to `site.styleRules`.
+ */
+export function duplicatePage(
+  site: SiteDocument,
+  sourcePageId: string,
+  title: string,
+  slug?: string,
+): Page {
+  const source = site.pages.find((p) => p.id === sourcePageId)
+  if (!source) throw new Error(`[PageTree] Page "${sourcePageId}" not found`)
+
+  // Build a fresh-id map for every node in the source page.
+  const idMap = new Map<string, string>()
+  for (const oldId of Object.keys(source.nodes)) {
+    idMap.set(oldId, nanoid())
+  }
+
+  // Clone every node-scoped class for nodes in the source page so the new
+  // page gets its own scoped classes (with `scope.nodeId` pointing at the
+  // duplicate's node ids). Non-scoped classes are shared and not cloned.
+  const { added: clonedClasses, classIdRemap } = cloneScopedClassesForNodeMap(
+    idMap,
+    site.styleRules,
+  )
+  for (const cls of clonedClasses) {
+    site.styleRules[cls.id] = cls
+  }
+
+  // Clone each node with remapped IDs, remapped child references, and
+  // remapped scoped-class ids. Non-scoped classes (absent from classIdRemap)
+  // are kept as-is — they're shared site-level classes that still exist.
+  const remapClassId = (cid: string) => classIdRemap.get(cid) ?? cid
+  const newNodes: Record<string, PageNode> = {}
+  for (const [oldId, oldNode] of Object.entries(source.nodes)) {
+    const newId = idMap.get(oldId)!
+    newNodes[newId] = cloneNodeWithRemap(oldNode, { newId, idMap, classIdRemap: remapClassId })
+  }
+
+  const newRootId = idMap.get(source.rootNodeId)
+  if (!newRootId) {
+    throw new Error('[PageTree] Source page root node missing from page.nodes')
+  }
+
+  // Derive parentId for the cloned page from its (remapped) children arrays.
+  reindexNodeParents(newNodes)
+
+  const newPage: Page = {
+    id: nanoid(),
+    title,
+    // Auto-unique — a duplicate ("Copy") must not collide with the source slug.
+    slug: uniquePageSlug(slug ?? title, site.pages),
+    rootNodeId: newRootId,
+    nodes: newNodes,
+  }
+  site.pages.push(newPage)
+  return newPage
+}

--- a/src/core/persistence/cms.ts
+++ b/src/core/persistence/cms.ts
@@ -1,5 +1,5 @@
 import { reconcileSiteExplorerOrganization, type SiteDocument, type SiteShell } from '@core/page-tree'
-import type { IPersistenceAdapter } from './types'
+import type { IPersistenceAdapter, SaveSiteOptions } from './types'
 import { parseJsonResponse } from '@core/utils/jsonValidate'
 import { apiRequest, assertOk, type FetchLike } from '@core/http'
 import { CmsSiteEnvelopeSchema, CmsPagesEnvelopeSchema, CmsComponentsEnvelopeSchema } from './responseSchemas'
@@ -23,17 +23,31 @@ export class CmsAdapter implements IPersistenceAdapter {
   }
 
   /**
-   * Save the full site document:
-   *   1. PUT /admin/api/cms/site — the shell (no pages, no VCs)
-   *   2. PUT /admin/api/cms/pages — the pages array
-   *   3. PUT /admin/api/cms/components — the visual components array
+   * Save the site document:
+   *   1. PUT /admin/api/cms/site — the shell (no pages, no VCs); always written
+   *   2. PUT /admin/api/cms/pages — `{ changedPages, pageIds, baselinePageIds? }`
+   *   3. PUT /admin/api/cms/components — `{ changedComponents, componentIds }`
+   *
+   * Only the pages/components named dirty by `opts.dirty` are shipped — the
+   * full id rosters always go along so the server's reaping (delete-what's-
+   * missing) semantics are identical to a full replace. No dirty hints (or
+   * `dirty.all`) ships everything: the conservative path for imports and any
+   * caller without store-level tracking.
    *
    * Shell is written first; pages and components can then be written in
    * parallel since they do not depend on each other.
    */
-  async saveSite(site: SiteDocument, baselinePageIds?: string[]): Promise<void> {
+  async saveSite(site: SiteDocument, opts: SaveSiteOptions = {}): Promise<void> {
     // Extract shell (strip pages and visualComponents from the full SiteDocument)
     const { pages, visualComponents, ...shell } = site
+    const { baselinePageIds, dirty } = opts
+
+    const changedPages = dirty && !dirty.all
+      ? pages.filter((p) => dirty.pageIds.has(p.id))
+      : pages
+    const changedComponents = dirty && !dirty.all
+      ? visualComponents.filter((vc) => dirty.componentIds.has(vc.id))
+      : visualComponents
 
     await apiRequest(`${this.basePath}/site`, {
       method: 'PUT',
@@ -46,13 +60,20 @@ export class CmsAdapter implements IPersistenceAdapter {
     await Promise.all([
       apiRequest(`${this.basePath}/pages`, {
         method: 'PUT',
-        body: baselinePageIds ? { pages, baselinePageIds } : { pages },
+        body: {
+          changedPages,
+          pageIds: pages.map((p) => p.id),
+          ...(baselinePageIds ? { baselinePageIds } : {}),
+        },
         fetchImpl: this.fetchImpl,
         fallbackMessage: 'CMS pages save failed',
       }),
       apiRequest(`${this.basePath}/components`, {
         method: 'PUT',
-        body: { components: visualComponents },
+        body: {
+          changedComponents,
+          componentIds: visualComponents.map((vc) => vc.id),
+        },
         fetchImpl: this.fetchImpl,
         fallbackMessage: 'CMS components save failed',
       }),

--- a/src/core/persistence/types.ts
+++ b/src/core/persistence/types.ts
@@ -1,18 +1,44 @@
 import type { SiteDocument } from '@core/page-tree'
 
 /**
+ * Which parts of the site document actually changed since the last successful
+ * save. Produced by the editor store's patch-derived dirty tracking and
+ * consumed by `saveSite` to ship only the changed pages/components.
+ *
+ * `all: true` is the conservative sentinel — full save (used after imports,
+ * fresh-site marks, or any mutation whose patches could not be attributed to
+ * specific pages/components). Over-marking is always safe; under-marking
+ * would lose edits, so anything ambiguous must mark all.
+ */
+export interface SaveDirtyHints {
+  all: boolean
+  pageIds: ReadonlySet<string>
+  componentIds: ReadonlySet<string>
+}
+
+export interface SaveSiteOptions {
+  /**
+   * Optimistic-concurrency token: the page ids the client loaded. When
+   * supplied, the server only soft-deletes pages the client knew about and
+   * dropped — never a page another session created concurrently (ISS-041).
+   * Omit it for an authoritative full replace (e.g. import).
+   */
+  baselinePageIds?: string[]
+  /** Dirty hints from the editor store. Absent → full save. */
+  dirty?: SaveDirtyHints
+}
+
+/**
  * IPersistenceAdapter — the interface the CMS draft storage backend satisfies.
  */
 export interface IPersistenceAdapter {
   /**
-   * Persist the single site draft document (shell + pages).
-   *
-   * `baselinePageIds` is an optimistic-concurrency token: the page ids the
-   * client loaded. When supplied, the server only soft-deletes pages the client
-   * knew about and dropped — never a page another session created concurrently
-   * (ISS-041). Omit it for an authoritative full replace (e.g. import).
+   * Persist the single site draft document. The shell is always written;
+   * pages and components ship incrementally per `opts.dirty` (the full id
+   * rosters always accompany the changed payloads so server-side reaping
+   * keeps full-replace semantics).
    */
-  saveSite(site: SiteDocument, baselinePageIds?: string[]): Promise<void>
+  saveSite(site: SiteDocument, opts?: SaveSiteOptions): Promise<void>
 
   /**
    * Load the single site draft document (shell + pages assembled).

--- a/src/core/persistence/validate.ts
+++ b/src/core/persistence/validate.ts
@@ -168,6 +168,97 @@ export function validatePages(
 }
 
 /**
+ * Strict-write validation for a PARTIAL page save: only the pages the editor
+ * actually changed are parsed, tree-checked, slot-synced, ref-stripped, and
+ * sanitized — the cross-page slug-uniqueness rule is enforced against
+ * `otherSlugs`, the (id, slug) pairs of every stored page NOT in this batch.
+ * Validation depth per page is identical to `validatePages` strict mode; only
+ * the roster scope shrinks, so a save after a one-page edit costs O(change)
+ * instead of O(site).
+ */
+export function validatePagesForPartialSave(
+  rawChangedPages: unknown[],
+  visualComponents: VisualComponent[],
+  otherSlugs: ReadonlyArray<{ id: string; slug: string }>,
+): Page[] {
+  let pages: Page[] = []
+  for (let i = 0; i < rawChangedPages.length; i++) {
+    try {
+      pages.push(parsePage(rawChangedPages[i], i))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : `page ${i} is invalid`
+      throw new SiteValidationError(message, extractSiteErrorPath(message))
+    }
+  }
+  // Slug rules: each changed page's slug must be valid AND unique across the
+  // changed batch + every other stored page (excluding rows this batch
+  // replaces, matched by id).
+  const changedIds = new Set(pages.map((p) => p.id))
+  const takenSlugs = new Map<string, string>() // slug → owner id
+  for (const other of otherSlugs) {
+    if (!changedIds.has(other.id)) takenSlugs.set(other.slug, other.id)
+  }
+  for (let i = 0; i < pages.length; i++) {
+    const { slug, id } = pages[i]
+    const slugErr = pageSlugError(slug)
+    if (slugErr) throw new SiteValidationError(slugErr, `site.pages[${i}].slug`)
+    const owner = takenSlugs.get(slug)
+    if (owner !== undefined && owner !== id) {
+      throw new SiteValidationError(`duplicate slug: Duplicate page slug "/${slug}".`, `site.pages[${i}].slug`)
+    }
+    takenSlugs.set(slug, id)
+  }
+  pages = validatePageNodeTreesList(pages, false)
+  syncVCSlotInstancesInTrees(pages.map((p) => p.nodes as Record<string, BaseNode>), visualComponents)
+  stripDanglingVCRefsInPages(pages, new Set(visualComponents.map((vc) => vc.id)))
+  sanitizePageNodeRichtextProps(pages)
+  return pages
+}
+
+/**
+ * Strict-write validation for a PARTIAL Visual Component save. The cross-VC
+ * rules (name/id identity, ref targets, dependency-graph acyclicity) are
+ * inherently roster-wide — a changed VC can create a cycle THROUGH an
+ * unchanged one — so they run against the POST-SAVE roster: `existing`
+ * (validated VCs already in storage) with rows missing from `keptIds` removed
+ * and the changed batch merged over it by id. Only the changed VCs pay
+ * parse + tree-invariant + sanitize costs.
+ *
+ * Returns the parsed CHANGED components only (what the caller writes); the
+ * roster checks are validation side-effects.
+ */
+export function validateVisualComponentsForPartialWrite(
+  rawChangedVCs: unknown[],
+  existing: VisualComponent[],
+  keptIds: ReadonlySet<string>,
+): VisualComponent[] {
+  const parsed: VisualComponent[] = []
+  for (let i = 0; i < rawChangedVCs.length; i++) {
+    const vc = parseVisualComponent(rawChangedVCs[i])
+    if (!vc) {
+      throw new SiteValidationError('invalid Visual Component', `site.visualComponents[${i}]`)
+    }
+    try {
+      assertValidNodeTree(vc.tree, `site.visualComponents[${i}].tree`)
+    } catch (err) {
+      throw siteValidationErrorFromTreeInvariant(err, `site.visualComponents[${i}].tree`)
+    }
+    parsed.push({ ...vc, name: vc.name.trim() })
+  }
+
+  const changedById = new Map(parsed.map((vc) => [vc.id, vc]))
+  const merged: VisualComponent[] = [
+    ...existing.filter((vc) => keptIds.has(vc.id) && !changedById.has(vc.id)),
+    ...parsed,
+  ]
+  validateStrictVCIdentity(merged)
+  validateStrictVCRefs(merged)
+  validateStrictVCDependencyGraph(merged)
+  sanitizeVCNodeRichtextProps(parsed)
+  return parsed
+}
+
+/**
  * Parse and validate an array of raw VisualComponent objects (loaded via
  * `visualComponentFromRow` from `data_rows where table_id = 'components'`).
  *
@@ -213,28 +304,6 @@ export function validateVisualComponents(rawVCs: unknown[]): VisualComponent[] {
  * The caller is about to reconcile the complete roster in storage, so a dropped
  * item would be interpreted as an intentional delete.
  */
-export function validateVisualComponentsForWrite(rawVCs: unknown[]): VisualComponent[] {
-  const parsed: VisualComponent[] = []
-
-  for (let i = 0; i < rawVCs.length; i++) {
-    const vc = parseVisualComponent(rawVCs[i])
-    if (!vc) {
-      throw new SiteValidationError('invalid Visual Component', `site.visualComponents[${i}]`)
-    }
-    try {
-      assertValidNodeTree(vc.tree, `site.visualComponents[${i}].tree`)
-    } catch (err) {
-      throw siteValidationErrorFromTreeInvariant(err, `site.visualComponents[${i}].tree`)
-    }
-    parsed.push({ ...vc, name: vc.name.trim() })
-  }
-
-  validateStrictVCIdentity(parsed)
-  validateStrictVCRefs(parsed)
-  validateStrictVCDependencyGraph(parsed)
-  sanitizeVCNodeRichtextProps(parsed)
-  return parsed
-}
 
 function siteValidationErrorFromTreeInvariant(err: unknown, fallbackPath: string): SiteValidationError {
   const message = err instanceof Error ? err.message : 'invalid node tree'


### PR DESCRIPTION
## Summary

Follow-up to #24 (**stacked on `perf/critical-performance-fixes`** — merge that first; this diff is the last two commits). Fixes the two remaining adversarially-verified server-side findings from the performance audit: the full-roster autosave and the publish transaction blocking every concurrent write.

## Benchmarks — before / after

Same bench discipline as #24: the `Site save round-trip` scenario was committed first and run on unmodified code, then re-run after the fix (full-size: 60 pages × ~300 nodes, one-prop edit — the canonical autosave trigger).

| Metric | Before | After | Δ |
| --- | --- | --- | --- |
| Autosave payload (one-prop edit) | **2.81 MB** | **49.1 KB** | **57×** |
| Server validate + reconcile per save | **32.6 ms** | **0.87 ms** | **38×** |

The publish-transaction hoist isn't a wall-time win for the publish itself — it removes a *stall*: with a cold dependency cache, `bun install` (60 s timeout) plus one esbuild run per page all executed inside the publish transaction, and the SQLite adapter serializes every transaction in the process through one chain. Every concurrent write — autosaves, row publishes, plugin records, sessions — queued behind it. Now the transaction contains only the DB writes.

## What changed

**Incremental saves** (every autosave/Cmd+S used to ship and rewrite the full page + component roster; the server re-validated and DOMPurify-sanitized every node of every page):
- The editor store derives which pages/VCs changed from the same Mutative patches that power undo (`slices/site/dirtyTracking.ts`) — wired into historic mutations, undo/redo, and lifecycle resets. Anything unattributable marks `all` (conservative full save); over-marking is safe, under-marking would lose edits. Autosave snapshots the marks before the request and merges them back on failure, so edits landing mid-save are never lost.
- Wire protocol: `PUT /pages` → `{ changedPages, pageIds, baselinePageIds? }`, `PUT /components` → `{ changedComponents, componentIds }`. Full id rosters always ship, so delete-what's-missing reconcile semantics (including the ISS-041 concurrency baseline) are byte-identical.
- Server validates only the changed batch (`validatePagesForPartialSave`; slug uniqueness against a light id+slug projection) — **outside** the transaction. Cross-VC rules (identity, refs, dependency cycles) are inherently roster-wide, so they run against the merged post-save roster (`validateVisualComponentsForPartialWrite`); the old full-write validator is deleted.
- `updateDataRowDraftCells` drops the hydrated per-row re-read both reconcilers always discarded; `listDataRowIdSlugs` replaces full `cells_json` hydration in the reconcile loops (the third of the three wasted full-tree JSON round-trips per page per save).
- `deletePage` now splices in place — the wholesale array replacement it used emitted a patch dirty-tracking couldn't attribute, silently escalating every post-delete save to a full save (found by the new test suite). Page-roster mutations extracted to `page-tree/pageMutations.ts`; `mutations.ts` ratchets 880 → 760 lines.

**Publish transaction hoist** (verified high/high): dependency-cache priming, the importmap build, and all per-page esbuild runs now execute before the transaction opens; the transaction is writes-only, with an orphan-version guard for pages reaped between the read and the write (`withPublishLock` already serializes publishes, so the read is stable against other publishers).

## Verification

- `bun test`: **5,156 pass / 0 fail** (45 new tests: dirty-collector units + store integration, adapter wire-shape pins, 12 handler-level partial-save cases on real SQLite incl. both ISS-041 directions, slug conflicts vs unchanged rows, and merged-roster VC ref rejection)
- `bun run build` + `bun run lint`: clean. Docs updated (`site-shell.md` save flow, `publisher.md` publish flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
