### PR TITLE
perf(canvas): kill per-node selector storms, per-frame DOM re-measures, and whole-site loop subscriptions

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -408,6 +408,8 @@ Selection rings and hover rings are absolutely-positioned overlay divs portaled 
 
 Ring and toolbar positions are computed on each animation frame via a RAF loop (simpler than wiring ResizeObserver/MutationObserver/IntersectionObserver to every mutation source — scroll, layout shift, zoom, content animation). The loop only starts when `hasOverlayWork` is true — at least one selection ring, hover ring, selector-affinity highlight, or toolbar is visible. When there is no overlay work the effect returns early so idle breakpoint frames incur no RAF cost. **When adding a new visible overlay type to `BreakpointSelectionOverlay`, update `hasOverlayWork`** so the loop arms correctly.
 
+Each tick is split into a read phase and a write phase to keep the loop cheap at 60fps. The read phase resolves tracked elements through a `CanvasNodeElementCache` (`canvasNodeLookup.ts` — cached until the element disconnects or the iframe swaps documents, so no per-frame `querySelector` document scans), snapshots the shared iframe/canvas-root geometry once per tick via `createCanvasOverlayMeasureSession` (`canvasOverlayGeometry.ts`), and measures every rect — the toolbar anchors to the union of the ring rects already measured, never a second query/measure pass. The write phase then applies styles, skipping any write whose rect is already applied. Steady-state frames are therefore a few cached-layout reads with zero writes, and because no write lands between reads, changing rects never force per-ring reflows. **Keep new overlay work inside this read-then-write structure.**
+
 ### CSS injection into the iframe
 
 Each iframe `<head>` receives five `<style>` elements (three from `ClassStyleInjector`, one each from the others), in this order:

--- a/docs/features/loops.md
+++ b/docs/features/loops.md
@@ -274,11 +274,13 @@ In the editor, `useLoopPreviewItems` (`src/admin/pages/site/canvas/useLoopPrevie
 | Source | Canvas path |
 |---|---|
 | `data.rows` | GETs `/data/tables/:id/loop-preview` — same projection as the publisher. Falls back to synthetic items from the table's field definitions when no published rows exist yet. |
-| `site.pages` | Reads pages from the in-memory site document. Applies `filterPagesForLoop` + `pageToLoopItem` imported from `@core/loops` — identical to the publisher path. |
+| `site.pages` | Reads pages from the in-memory site document via `selectSitePagesLoopItems`. Applies `filterPagesForLoop` + `pageToLoopItem` imported from `@core/loops` — identical to the publisher path. |
 | `site.media` | Fetches via `listCmsMediaAssets()`, filters by MIME prefix, sorts + slices client-side. |
 | Plugin sources | Calls `source.preview(ctx)` synchronously. |
 
 The canvas caps preview results at 6 items (`CANVAS_MAX_ITEMS`) regardless of the loop's configured `limit`. Published pages render the full set.
+
+Subscription granularity: the hook never subscribes to the whole `site` document for built-in sources. `site.pages` loops subscribe through `selectSitePagesLoopItems`, which keeps the items array (and each `LoopItem`) referentially stable across site mutations that don't change the loop's actual items — so typing in an unrelated text node doesn't re-render loop body subtrees. Only the plugin-source fallback subscribes to `site` (its `preview()` contractually receives the full document), and only while such a source is selected. Stability is gated by `src/__tests__/loops/loopPreviewItemStability.test.ts`.
 
 ---
 

--- a/scripts/bench/benches/editor-store.ts
+++ b/scripts/bench/benches/editor-store.ts
@@ -479,6 +479,102 @@ export const editorStoreBench: BenchModule = {
       }
     }
 
+    // ---- set() latency with N canvas-like subscribers -----------------------
+    // Zustand re-runs EVERY subscriber's selector on EVERY store set. The
+    // canvas mounts ~6 per-node subscriptions per rendered node per breakpoint
+    // frame (NodeRenderer), so the hottest editor events — hoverNode on every
+    // mouse crossing, updateNodeProps on every keystroke — pay a full selector
+    // sweep. This scenario registers the same selectors NodeRenderer uses and
+    // measures the set() cost they add. Without subscribers (the scenarios
+    // above) this cost is invisible.
+    log.step('set() latency with N canvas-like subscribers')
+    const subscriberSweepRows: BenchRow[] = []
+    {
+      const PAGES = ctx.quick ? 5 : 20
+      const NODES = ctx.quick ? 200 : 500
+      const FRAMES = 3
+      const HOVERS = ctx.quick ? 100 : 300
+      const KEYS = ctx.quick ? 50 : 150
+      try {
+        const { selectActiveCanvasPage } = await import('../../../src/admin/pages/site/store/store')
+        const { getCanvasNodeClassName } = await import('../../../src/admin/pages/site/canvas/canvasNodeClassName')
+        const { resolveEditorFormPreviewState, resolveEditorFormPreviewSuccessMessage } = await import(
+          '../../../src/admin/pages/site/canvas/canvasFormPreview'
+        )
+
+        const pages = Array.from({ length: PAGES }, (_, i) =>
+          buildStorePage(`sw${i}`, i === 0 ? 'index' : `sweep-page-${i}`, NODES),
+        )
+        loadSyntheticSite(useStore, pages)
+        const state = useStore.getState() as {
+          site: { pages: Array<{ id: string; nodes: Record<string, StoreNode> }> }
+          activePageId: string
+          hoverNode: (nodeId: string | null, breakpointId?: string | null) => void
+          updateNodeProps: (nodeId: string, patch: Record<string, unknown>) => void
+        }
+        const activePage = state.site.pages.find((p) => p.id === state.activePageId)
+        if (!activePage) throw new Error('No active page after loadSite — update editor-store bench.')
+        const nodeIds = Object.keys(activePage.nodes)
+
+        type S = Parameters<typeof selectActiveCanvasPage>[0]
+        const noop = () => {}
+        const unsubs: Array<() => void> = []
+        for (let frame = 0; frame < FRAMES; frame++) {
+          for (const nodeId of nodeIds) {
+            unsubs.push(useStore.subscribe((s: S) => selectActiveCanvasPage(s)?.nodes[nodeId] ?? null, noop))
+            unsubs.push(useStore.subscribe((s: S) => s.selectedNodeIds.includes(nodeId), noop))
+            unsubs.push(useStore.subscribe((s: S) => s.hoveredNodeId === nodeId, noop))
+            unsubs.push(useStore.subscribe(
+              (s: S) => (s.previewClassAssignment?.nodeId === nodeId ? s.previewClassAssignment : null),
+              noop,
+            ))
+            unsubs.push(useStore.subscribe((s: S) => resolveEditorFormPreviewState(s, nodeId), noop))
+            unsubs.push(useStore.subscribe((s: S) => resolveEditorFormPreviewSuccessMessage(s, nodeId), noop))
+            unsubs.push(useStore.subscribe((s: S) => {
+              const canvasNode = selectActiveCanvasPage(s)?.nodes[nodeId]
+              const preview = s.previewClassAssignment?.nodeId === nodeId ? s.previewClassAssignment : null
+              return getCanvasNodeClassName(canvasNode?.classIds, preview, nodeId, s.site?.styleRules)
+            }, noop))
+          }
+        }
+
+        try {
+          const hoverSamples: number[] = []
+          for (let i = 0; i < HOVERS; i++) {
+            const target = nodeIds[i % nodeIds.length]
+            const t0 = performance.now()
+            state.hoverNode(target)
+            hoverSamples.push(performance.now() - t0)
+          }
+          const textNodeId = nodeIds.find((id) => activePage.nodes[id].moduleId === 'base.text')
+          if (!textNodeId) throw new Error('Synthetic page has no text node — update editor-store bench.')
+          const keySamples: number[] = []
+          for (let i = 0; i < KEYS; i++) {
+            const t0 = performance.now()
+            state.updateNodeProps(textNodeId, { text: 'x'.repeat(i + 1) })
+            keySamples.push(performance.now() - t0)
+          }
+          const hover = summarize(hoverSamples)
+          const keys = summarize(keySamples)
+          subscriberSweepRows.push({
+            label: `${fmtNum(unsubs.length)} subscribers (${fmtNum(NODES)} nodes × ${FRAMES} frames), ${fmtNum(PAGES)} pages`,
+            inputs: { pages: PAGES, nodes: NODES, frames: FRAMES, subscribers: unsubs.length },
+            metrics: {
+              hover_mean: fmtMs(hover.mean),
+              hover_p95: fmtMs(hover.p95),
+              keystroke_mean: fmtMs(keys.mean),
+              keystroke_p95: fmtMs(keys.p95),
+            },
+          })
+          log.detail(`    hover mean=${fmtMs(hover.mean)} p95=${fmtMs(hover.p95)}  keystroke mean=${fmtMs(keys.mean)} p95=${fmtMs(keys.p95)}`)
+        } finally {
+          for (const unsub of unsubs) unsub()
+        }
+      } catch (err) {
+        subscriberSweepRows.push(unavailableRow(`${fmtNum(NODES)} nodes × ${FRAMES} frames canvas subscriber sweep`, err))
+      }
+    }
+
     // ---- Undo coalescing burst ----------------------------------------------
     log.step('Undo coalescing burst (single-prop typing burst + retained history)')
     const coalesceRows: BenchRow[] = []
@@ -575,6 +671,12 @@ export const editorStoreBench: BenchModule = {
           intro:
             'Per-keystroke `updateNodeProps` on a text node inside a Visual Component while the site holds many pages. Every VC-mode mutation re-syncs slot instances across all consumer trees, so this measures whether typing inside a VC scales with total site size.',
           rows: vcSweepRows,
+        },
+        {
+          title: 'set() latency with canvas-like subscribers',
+          intro:
+            'hoverNode / updateNodeProps latency with NodeRenderer-equivalent per-node Zustand subscriptions registered (nodes × 3 frames × 7 selectors). Measures the selector-sweep cost every canvas-visible store set pays — the cost the zero-subscriber scenarios above cannot see.',
+          rows: subscriberSweepRows,
         },
         {
           title: 'Undo coalescing burst',

--- a/src/__tests__/canvas/canvasFormPreview.test.ts
+++ b/src/__tests__/canvas/canvasFormPreview.test.ts
@@ -1,0 +1,85 @@
+/**
+ * canvasFormPreview — nearest-form resolution + parent-index caching.
+ *
+ * Both form-preview selectors run for every `base.form-message` node on every
+ * store set in every breakpoint frame, so the parent index must be built at
+ * most once per `page.nodes` identity (Mutative structural sharing mints a
+ * new identity exactly when the tree changes).
+ */
+
+import { describe, it, expect } from 'bun:test'
+import type { PageNode } from '@core/page-tree'
+import { nearestFormNode } from '@site/canvas/canvasFormPreview'
+
+function node(id: string, moduleId: string, children: string[] = []): PageNode {
+  return {
+    id,
+    moduleId,
+    props: {},
+    breakpointOverrides: {},
+    children,
+  } as unknown as PageNode
+}
+
+function makeNodes(): Record<string, PageNode> {
+  return {
+    root: node('root', 'base.body', ['form', 'aside']),
+    form: node('form', 'base.form', ['fieldset']),
+    fieldset: node('fieldset', 'base.container', ['message']),
+    message: node('message', 'base.form-message'),
+    aside: node('aside', 'base.container', ['orphanMessage']),
+    orphanMessage: node('orphanMessage', 'base.form-message'),
+  }
+}
+
+/** Wrap a nodes map so `Object.values` walks (ownKeys) are countable. */
+function countingNodes(nodes: Record<string, PageNode>) {
+  let ownKeysCalls = 0
+  const proxied = new Proxy(nodes, {
+    ownKeys(target) {
+      ownKeysCalls++
+      return Reflect.ownKeys(target)
+    },
+  })
+  return { nodes: proxied, ownKeysCalls: () => ownKeysCalls }
+}
+
+describe('nearestFormNode', () => {
+  it('finds the nearest enclosing base.form across intermediate containers', () => {
+    const nodes = makeNodes()
+    expect(nearestFormNode({ nodes }, 'message')?.id).toBe('form')
+  })
+
+  it('returns null when no enclosing form exists', () => {
+    const nodes = makeNodes()
+    expect(nearestFormNode({ nodes }, 'orphanMessage')).toBeNull()
+    expect(nearestFormNode({ nodes }, 'root')).toBeNull()
+  })
+
+  it('builds the parent index once per nodes identity', () => {
+    const counted = countingNodes(makeNodes())
+    const page = { nodes: counted.nodes }
+
+    nearestFormNode(page, 'message')
+    const buildsAfterFirst = counted.ownKeysCalls()
+    expect(buildsAfterFirst).toBeGreaterThan(0)
+
+    // A selector sweep resolves every form-message node repeatedly with the
+    // SAME tree identity — no further full-tree walks allowed.
+    for (let i = 0; i < 50; i++) {
+      nearestFormNode(page, 'message')
+      nearestFormNode(page, 'orphanMessage')
+    }
+    expect(counted.ownKeysCalls()).toBe(buildsAfterFirst)
+  })
+
+  it('rebuilds the parent index when the nodes identity changes', () => {
+    const first = countingNodes(makeNodes())
+    nearestFormNode({ nodes: first.nodes }, 'message')
+    const firstBuilds = first.ownKeysCalls()
+
+    const second = countingNodes(makeNodes())
+    expect(nearestFormNode({ nodes: second.nodes }, 'message')?.id).toBe('form')
+    expect(second.ownKeysCalls()).toBe(firstBuilds)
+  })
+})

--- a/src/__tests__/canvas/canvasOverlayMeasurement.test.ts
+++ b/src/__tests__/canvas/canvasOverlayMeasurement.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Overlay measurement primitives used by the BreakpointSelectionOverlay RAF
+ * tick:
+ *
+ *  - `createCanvasOverlayMeasureSession` must read the shared iframe /
+ *    canvas-root geometry exactly ONCE per tick no matter how many rings it
+ *    measures (the old code re-read them per ring).
+ *  - `CanvasNodeElementCache` must resolve a tracked node's element without
+ *    re-querying the document on every frame (the old code paid an
+ *    O(document) `querySelector` scan per ring per frame).
+ *
+ * Everything is duck-typed DOM, so plain counting fakes keep these tests
+ * deterministic — no happy-dom layout involved.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import {
+  createCanvasOverlayMeasureSession,
+  measureCanvasElementRect,
+  unionCanvasOverlayRects,
+} from '@site/canvas/canvasOverlayGeometry'
+import { CanvasNodeElementCache } from '@site/canvas/canvasNodeLookup'
+
+interface RectInit {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+function domRect({ left, top, width, height }: RectInit): DOMRect {
+  return {
+    x: left,
+    y: top,
+    left,
+    top,
+    width,
+    height,
+    right: left + width,
+    bottom: top + height,
+    toJSON: () => ({}),
+  } as DOMRect
+}
+
+function fakeMeasurable(rect: RectInit) {
+  let calls = 0
+  return {
+    element: {
+      getBoundingClientRect: () => {
+        calls++
+        return domRect(rect)
+      },
+    } as unknown as HTMLElement,
+    calls: () => calls,
+  }
+}
+
+function fakeIframe(rect: RectInit, offsetWidth: number) {
+  const measurable = fakeMeasurable(rect)
+  return {
+    iframe: Object.assign(measurable.element, { offsetWidth }) as unknown as HTMLIFrameElement,
+    calls: measurable.calls,
+  }
+}
+
+describe('createCanvasOverlayMeasureSession', () => {
+  it('reads iframe and canvas-root geometry once per session, not per measured element', () => {
+    const { iframe, calls: iframeCalls } = fakeIframe({ left: 100, top: 50, width: 400, height: 300 }, 400)
+    const root = fakeMeasurable({ left: 10, top: 20, width: 800, height: 600 })
+
+    const session = createCanvasOverlayMeasureSession(iframe, root.element)
+    for (let i = 0; i < 25; i++) {
+      session.measure(fakeMeasurable({ left: i, top: i, width: 10, height: 10 }).element)
+    }
+
+    expect(iframeCalls()).toBe(1)
+    expect(root.calls()).toBe(1)
+  })
+
+  it('translates iframe-internal rects into canvas-root-local coords with zoom recovery', () => {
+    // iframe client width 200 vs offsetWidth 400 → canvas zoom 0.5.
+    const { iframe } = fakeIframe({ left: 100, top: 50, width: 200, height: 150 }, 400)
+    const root = fakeMeasurable({ left: 10, top: 20, width: 800, height: 600 })
+    const session = createCanvasOverlayMeasureSession(iframe, root.element)
+
+    const rect = session.measure(fakeMeasurable({ left: 40, top: 60, width: 80, height: 30 }).element)
+    expect(rect).toEqual({
+      x: 100 + 40 * 0.5 - 10,
+      y: 50 + 60 * 0.5 - 20,
+      width: 80 * 0.5,
+      height: 30 * 0.5,
+    })
+  })
+
+  it('uses viewport (client) coordinates when no canvas root is wired in', () => {
+    const { iframe } = fakeIframe({ left: 100, top: 50, width: 400, height: 300 }, 400)
+    const session = createCanvasOverlayMeasureSession(iframe, null)
+    expect(session.canvasRect).toBeNull()
+
+    const rect = session.measure(fakeMeasurable({ left: 5, top: 6, width: 7, height: 8 }).element)
+    expect(rect).toEqual({ x: 105, y: 56, width: 7, height: 8 })
+  })
+
+  it('returns null for missing, non-measurable, and zero-size targets', () => {
+    const { iframe } = fakeIframe({ left: 0, top: 0, width: 400, height: 300 }, 400)
+    const session = createCanvasOverlayMeasureSession(iframe, null)
+    expect(session.measure(null)).toBeNull()
+    expect(session.measure({} as HTMLElement)).toBeNull()
+    expect(session.measure(fakeMeasurable({ left: 1, top: 1, width: 0, height: 0 }).element)).toBeNull()
+  })
+
+  it('matches the one-shot measureCanvasElementRect output', () => {
+    const target = fakeMeasurable({ left: 40, top: 60, width: 80, height: 30 })
+    const a = createCanvasOverlayMeasureSession(
+      fakeIframe({ left: 100, top: 50, width: 200, height: 150 }, 400).iframe,
+      null,
+    ).measure(target.element)
+    const b = measureCanvasElementRect(
+      target.element,
+      fakeIframe({ left: 100, top: 50, width: 200, height: 150 }, 400).iframe,
+      null,
+    )
+    expect(b).toEqual(a)
+  })
+
+  it('one-shot helper does not touch the iframe when the target is null', () => {
+    const { iframe, calls } = fakeIframe({ left: 0, top: 0, width: 400, height: 300 }, 400)
+    expect(measureCanvasElementRect(null, iframe, null)).toBeNull()
+    expect(calls()).toBe(0)
+  })
+})
+
+describe('unionCanvasOverlayRects', () => {
+  it('returns the second rect when accumulating from null', () => {
+    const b = { x: 1, y: 2, width: 3, height: 4 }
+    expect(unionCanvasOverlayRects(null, b)).toBe(b)
+  })
+
+  it('returns the smallest rect containing both inputs', () => {
+    expect(
+      unionCanvasOverlayRects({ x: 0, y: 0, width: 10, height: 10 }, { x: 5, y: -5, width: 20, height: 10 }),
+    ).toEqual({ x: 0, y: -5, width: 25, height: 15 })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// CanvasNodeElementCache
+// ---------------------------------------------------------------------------
+
+interface FakeNodeElement {
+  isConnected: boolean
+  ownerDocument: unknown
+}
+
+function fakeDocument(elements: Record<string, FakeNodeElement | null>) {
+  let queries = 0
+  const doc = {
+    querySelector(selector: string) {
+      queries++
+      const match = /\[data-node-id="(.*)"\]/.exec(selector)
+      const el = match ? elements[match[1]] : null
+      return el ?? null
+    },
+  } as unknown as Document
+  // Wire ownerDocument so the cache's same-document check passes.
+  for (const el of Object.values(elements)) {
+    if (el) el.ownerDocument = doc
+  }
+  return { doc, queries: () => queries }
+}
+
+describe('CanvasNodeElementCache', () => {
+  it('queries the document once per node while the element stays connected', () => {
+    const el: FakeNodeElement = { isConnected: true, ownerDocument: null }
+    const { doc, queries } = fakeDocument({ a: el })
+    const cache = new CanvasNodeElementCache()
+
+    // 60 ticks of the steady-state RAF loop → exactly one document scan.
+    for (let i = 0; i < 60; i++) {
+      expect(cache.resolve(doc, 'a')).toBe(el as unknown as HTMLElement)
+    }
+    expect(queries()).toBe(1)
+  })
+
+  it('re-queries when the cached element is disconnected (node re-rendered)', () => {
+    const el: FakeNodeElement = { isConnected: true, ownerDocument: null }
+    const { doc, queries } = fakeDocument({ a: el })
+    const cache = new CanvasNodeElementCache()
+
+    cache.resolve(doc, 'a')
+    el.isConnected = false
+    cache.resolve(doc, 'a')
+    expect(queries()).toBe(2)
+  })
+
+  it('re-queries when the iframe swapped documents (stale ownerDocument)', () => {
+    const el: FakeNodeElement = { isConnected: true, ownerDocument: null }
+    const first = fakeDocument({ a: el })
+    const cache = new CanvasNodeElementCache()
+    cache.resolve(first.doc, 'a')
+
+    const replacement: FakeNodeElement = { isConnected: true, ownerDocument: null }
+    const second = fakeDocument({ a: replacement })
+    expect(cache.resolve(second.doc, 'a')).toBe(replacement as unknown as HTMLElement)
+    expect(second.queries()).toBe(1)
+  })
+
+  it('keeps re-querying (and drops the entry) while the node has no rendered element', () => {
+    const { doc, queries } = fakeDocument({ a: null })
+    const cache = new CanvasNodeElementCache()
+    expect(cache.resolve(doc, 'a')).toBeNull()
+    expect(cache.resolve(doc, 'a')).toBeNull()
+    expect(queries()).toBe(2)
+  })
+
+  it('retainOnly drops untracked entries so they re-query on next resolve', () => {
+    const a: FakeNodeElement = { isConnected: true, ownerDocument: null }
+    const b: FakeNodeElement = { isConnected: true, ownerDocument: null }
+    const { doc, queries } = fakeDocument({ a, b })
+    const cache = new CanvasNodeElementCache()
+    cache.resolve(doc, 'a')
+    cache.resolve(doc, 'b')
+
+    cache.retainOnly(new Set(['a']))
+    cache.resolve(doc, 'a') // still cached
+    expect(queries()).toBe(2)
+    cache.resolve(doc, 'b') // pruned → fresh query
+    expect(queries()).toBe(3)
+  })
+})

--- a/src/__tests__/canvas/classStyleInjector.test.ts
+++ b/src/__tests__/canvas/classStyleInjector.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { generateCanvasClassCSS, generateForcedStateCSS } from '@site/canvas/canvasClassCss'
+import {
+  createCanvasClassCssMemo,
+  generateCanvasClassCSS,
+  generateForcedStateCSS,
+} from '@site/canvas/canvasClassCss'
 import { generateFrameworkColorUtilityClasses } from '@core/framework'
 import { classKindSelector, type StyleRule } from '@core/page-tree'
 
@@ -104,6 +108,53 @@ describe('generateCanvasClassCSS', () => {
     expect(css).toContain('--primary: hsla(238, 100%, 62%, 1);')
     expect(css).toContain('.text-primary')
     expect(css).toContain('color: var(--primary);')
+  })
+})
+
+describe('createCanvasClassCssMemo', () => {
+  const classes = { title: makeClass('title', { fontSize: '64px' }) }
+  const breakpoints = [{ id: 'mobile', width: 375, mediaQuery: '(min-width: 375px)' }]
+  const conditions: never[] = []
+
+  function countingMemo() {
+    let calls = 0
+    const memo = createCanvasClassCssMemo((...args) => {
+      calls++
+      return `generated-${calls}-${Object.keys(args[0]).length}`
+    })
+    return { memo, calls: () => calls }
+  }
+
+  it('generates once per identity-equal input set — frames 2..N hit the cache', () => {
+    const { memo, calls } = countingMemo()
+
+    // 3 breakpoint-frame injectors re-running with the SAME store snapshot.
+    const first = memo(classes, breakpoints, conditions, null, null, null, null, null)
+    const second = memo(classes, breakpoints, conditions, null, null, null, null, null)
+    const third = memo(classes, breakpoints, conditions, null, null, null, null, null)
+
+    expect(calls()).toBe(1)
+    expect(second).toBe(first)
+    expect(third).toBe(first)
+  })
+
+  it('regenerates when any input identity changes', () => {
+    const { memo, calls } = countingMemo()
+    memo(classes, breakpoints, conditions, null, null, null, null, null)
+
+    // Same content, new identity — a store commit always mints new refs.
+    memo({ ...classes }, breakpoints, conditions, null, null, null, null, null)
+    expect(calls()).toBe(2)
+
+    memo({ ...classes }, [...breakpoints], conditions, null, null, null, null, null)
+    expect(calls()).toBe(3)
+  })
+
+  it('the exported generator produces identical CSS for cached and fresh inputs', () => {
+    const cached = generateCanvasClassCSS(classes, breakpoints)
+    expect(generateCanvasClassCSS(classes, breakpoints)).toBe(cached)
+    // Fresh identities regenerate, but the output text is byte-identical.
+    expect(generateCanvasClassCSS({ ...classes }, [...breakpoints])).toBe(cached)
   })
 })
 

--- a/src/__tests__/canvas/nodeRendererClassPreview.test.ts
+++ b/src/__tests__/canvas/nodeRendererClassPreview.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test'
-import { getCanvasNodeClassName } from '@site/canvas/canvasNodeClassName'
+import { getCanvasNodeClassIds, getCanvasNodeClassName } from '@site/canvas/canvasNodeClassName'
 import { classKindSelector, type StyleRule } from '@core/page-tree'
 
 function makeClass(id: string, name: string): StyleRule {
@@ -53,5 +53,40 @@ describe('NodeRenderer class hover preview', () => {
         classes,
       ),
     ).toBe('assigned_name preview_name')
+  })
+})
+
+describe('getCanvasNodeClassIds referential stability', () => {
+  // These run in a per-node Zustand selector on every store set — when no
+  // preview applies, the node's own array must pass through untouched so
+  // selector sweeps don't allocate O(nodes) copies per store change.
+  it('returns the same array reference when no preview applies', () => {
+    const ids = ['assigned']
+    expect(getCanvasNodeClassIds(ids, null, 'node-1')).toBe(ids)
+    expect(getCanvasNodeClassIds(ids, { nodeId: 'node-2', classId: 'preview' }, 'node-1')).toBe(ids)
+  })
+
+  it('returns the same reference when the preview class is already assigned', () => {
+    const ids = ['assigned', 'preview']
+    expect(getCanvasNodeClassIds(ids, { nodeId: 'node-1', classId: 'preview' }, 'node-1')).toBe(ids)
+  })
+
+  it('returns undefined for empty or missing class lists', () => {
+    expect(getCanvasNodeClassIds(undefined, null, 'node-1')).toBeUndefined()
+    expect(getCanvasNodeClassIds([], null, 'node-1')).toBeUndefined()
+  })
+
+  it('appends a matching preview without mutating the original array', () => {
+    const ids = ['assigned']
+    const merged = getCanvasNodeClassIds(ids, { nodeId: 'node-1', classId: 'preview' }, 'node-1')
+    expect(merged).toEqual(['assigned', 'preview'])
+    expect(merged).not.toBe(ids)
+    expect(ids).toEqual(['assigned'])
+  })
+
+  it('returns just the preview class when the node has none of its own', () => {
+    expect(
+      getCanvasNodeClassIds(undefined, { nodeId: 'node-1', classId: 'preview' }, 'node-1'),
+    ).toEqual(['preview'])
   })
 })

--- a/src/__tests__/loops/loopPreviewItemStability.test.ts
+++ b/src/__tests__/loops/loopPreviewItemStability.test.ts
@@ -1,0 +1,104 @@
+/**
+ * selectSitePagesLoopItems — identity stability for canvas loop previews.
+ *
+ * Any node edit anywhere replaces the `site.pages` array identity (pages own
+ * nodes under Mutative structural sharing), so a `site.pages`-bound loop's
+ * selector re-runs per keystroke. The contract under test: when the loop's
+ * actual items are unchanged, the selector returns the PREVIOUS array (and
+ * the previous LoopItem objects), so `CanvasTemplateContext` values stay
+ * stable and the loop body subtree does not re-render.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import type { Page, PageNode } from '@core/page-tree'
+import { selectSitePagesLoopItems } from '@site/canvas/useLoopPreviewItems'
+
+function makePage(id: string, title: string, slug: string): Page {
+  return {
+    id,
+    title,
+    slug,
+    nodes: {},
+    rootNodeId: 'root',
+  } as unknown as Page
+}
+
+function makeLoopNode(props: Record<string, unknown> = {}): PageNode {
+  return {
+    id: `loop-${Math.random().toString(36).slice(2)}`,
+    moduleId: 'base.loop',
+    // direction defaults to 'desc' in readLoopProps; pin 'asc' so the
+    // definition-order assertions below read naturally.
+    props: { sourceId: 'site.pages', direction: 'asc', ...props },
+    breakpointOverrides: {},
+    children: ['variant'],
+  } as unknown as PageNode
+}
+
+describe('selectSitePagesLoopItems', () => {
+  it('returns the cached array for the same (node, pages) identities', () => {
+    const node = makeLoopNode()
+    const pages = [makePage('a', 'A', 'a'), makePage('b', 'B', 'b')]
+
+    const first = selectSitePagesLoopItems(node, pages)
+    expect(first.map((i) => i.id)).toEqual(['a', 'b'])
+    // A selector sweep re-runs this on every store set with unchanged state.
+    for (let i = 0; i < 20; i++) {
+      expect(selectSitePagesLoopItems(node, pages)).toBe(first)
+    }
+  })
+
+  it('keeps the array identity when pages identity changes but the items do not', () => {
+    const node = makeLoopNode()
+    const pageA = makePage('a', 'A', 'a')
+    const pageB = makePage('b', 'B', 'b')
+
+    const first = selectSitePagesLoopItems(node, [pageA, pageB])
+    // Unrelated edit: Mutative replaces the array but reuses untouched pages.
+    const second = selectSitePagesLoopItems(node, [pageA, pageB])
+    expect(second).toBe(first)
+  })
+
+  it('keeps untouched item identities when one page actually changes', () => {
+    const node = makeLoopNode()
+    const pageA = makePage('a', 'A', 'a')
+    const pageB = makePage('b', 'B', 'b')
+    const first = selectSitePagesLoopItems(node, [pageA, pageB])
+
+    const editedB = makePage('b', 'B edited', 'b')
+    const second = selectSitePagesLoopItems(node, [pageA, editedB])
+
+    expect(second).not.toBe(first)
+    expect(second[0]).toBe(first[0]) // untouched page → same LoopItem
+    expect(second[1]).not.toBe(first[1])
+    expect(second[1].fields.title).toBe('B edited')
+  })
+
+  it('recomputes when the loop node itself changes (new props → new node identity)', () => {
+    const pages = [makePage('a', 'A', 'a'), makePage('b', 'B', 'b'), makePage('c', 'C', 'c')]
+    const all = selectSitePagesLoopItems(makeLoopNode(), pages)
+    expect(all).toHaveLength(3)
+
+    const limited = selectSitePagesLoopItems(makeLoopNode({ limit: 2 }), pages)
+    expect(limited.map((i) => i.id)).toEqual(['a', 'b'])
+
+    const sorted = selectSitePagesLoopItems(
+      makeLoopNode({ orderBy: 'title', direction: 'desc' }),
+      pages,
+    )
+    expect(sorted.map((i) => i.id)).toEqual(['c', 'b', 'a'])
+  })
+
+  it('returns the shared empty result for a missing pages list', () => {
+    const node = makeLoopNode()
+    expect(selectSitePagesLoopItems(node, null)).toBe(selectSitePagesLoopItems(node, null))
+    expect(selectSitePagesLoopItems(node, null)).toHaveLength(0)
+  })
+
+  it('projects pages through the engine projection (permalink normalization)', () => {
+    const node = makeLoopNode()
+    const items = selectSitePagesLoopItems(node, [makePage('home', 'Home', 'index')])
+    expect(items[0].fields.permalink).toBe('/')
+    expect(items[0].fields.slug).toBe('index')
+  })
+})

--- a/src/__tests__/store/selectActivePage.test.ts
+++ b/src/__tests__/store/selectActivePage.test.ts
@@ -1,0 +1,92 @@
+/**
+ * selectActivePage memo contract.
+ *
+ * Zustand re-runs every subscriber's selector on every store set, and each
+ * canvas NodeRenderer mounts several subscriptions that resolve the active
+ * page. The selector therefore must (a) scan `site.pages` at most ONCE per
+ * (site, activePageId) identity pair, and (b) keep its output referentially
+ * stable so per-node selector outputs don't churn.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { selectActivePage, type EditorStore } from '@site/store/store'
+
+interface CountingPages {
+  pages: unknown[]
+  findCalls: () => number
+}
+
+function makePages(ids: string[]): CountingPages {
+  let findCalls = 0
+  const raw = ids.map((id) => ({ id, title: id, slug: id, nodes: {}, rootNodeId: 'root' }))
+  const pages = new Proxy(raw, {
+    get(target, prop, receiver) {
+      if (prop === 'find') findCalls++
+      return Reflect.get(target, prop, receiver)
+    },
+  })
+  return { pages, findCalls: () => findCalls }
+}
+
+function makeState(pages: unknown[], activePageId: string | null): EditorStore {
+  return { site: { pages }, activePageId } as unknown as EditorStore
+}
+
+describe('selectActivePage', () => {
+  it('scans site.pages once per (site, activePageId) identity, not once per call', () => {
+    const { pages, findCalls } = makePages(['a', 'b', 'c'])
+    const state = makeState(pages, 'b')
+
+    const first = selectActivePage(state)
+    expect((first as { id: string }).id).toBe('b')
+    const callsAfterFirst = findCalls()
+    expect(callsAfterFirst).toBe(1)
+
+    // A selector sweep re-runs the selector for every subscriber with the
+    // SAME state — all subsequent calls must hit the single-slot cache.
+    for (let i = 0; i < 100; i++) {
+      expect(selectActivePage(state)).toBe(first)
+    }
+    expect(findCalls()).toBe(callsAfterFirst)
+  })
+
+  it('re-scans when the site identity changes and returns the new page object', () => {
+    const a = makePages(['p1', 'p2'])
+    const stateA = makeState(a.pages, 'p2')
+    const pageA = selectActivePage(stateA)
+
+    const b = makePages(['p1', 'p2'])
+    const stateB = makeState(b.pages, 'p2')
+    const pageB = selectActivePage(stateB)
+
+    expect(b.findCalls()).toBe(1)
+    expect(pageB).not.toBe(pageA)
+    expect((pageB as { id: string }).id).toBe('p2')
+
+    // Coming back to a previously-seen-but-evicted site re-scans (single slot).
+    selectActivePage(stateA)
+    expect(a.findCalls()).toBe(2)
+  })
+
+  it('re-scans when activePageId changes on the same site', () => {
+    const { pages, findCalls } = makePages(['x', 'y'])
+    expect((selectActivePage(makeState(pages, 'x')) as { id: string }).id).toBe('x')
+    expect((selectActivePage(makeState(pages, 'y')) as { id: string }).id).toBe('y')
+    expect(findCalls()).toBe(2)
+  })
+
+  it('returns null without scanning when site or activePageId is missing', () => {
+    const { pages, findCalls } = makePages(['a'])
+    expect(selectActivePage(makeState(pages, null))).toBeNull()
+    expect(findCalls()).toBe(0)
+    expect(selectActivePage({ site: null, activePageId: 'a' } as unknown as EditorStore)).toBeNull()
+  })
+
+  it('caches a missing-page result (null) without re-scanning', () => {
+    const { pages, findCalls } = makePages(['a'])
+    const state = makeState(pages, 'nope')
+    expect(selectActivePage(state)).toBeNull()
+    expect(selectActivePage(state)).toBeNull()
+    expect(findCalls()).toBe(1)
+  })
+})

--- a/src/admin/pages/site/canvas/BreakpointSelectionOverlay.tsx
+++ b/src/admin/pages/site/canvas/BreakpointSelectionOverlay.tsx
@@ -35,9 +35,21 @@
  *   the old `<div class="nodeWrapper">` design and produced a selection ring
  *   the size of the first child only.
  * - Computes the rect relative to the canvas root on every animation frame
- *   while a ring is visible (cheap; getBoundingClientRect + style write).
- *   Polling via RAF is simpler than wiring ResizeObserver/MutationObserver/
- *   IntersectionObserver to every possible mutation source.
+ *   while a ring is visible. Polling via RAF is simpler than wiring
+ *   ResizeObserver/MutationObserver/IntersectionObserver to every possible
+ *   mutation source (scroll, layout shift, zoom/pan, CSS animation) — but
+ *   each tick must stay cheap, so it is structured as:
+ *     1. READ phase — one `createCanvasOverlayMeasureSession` snapshots the
+ *        iframe + canvas-root geometry shared by every ring, tracked
+ *        elements resolve through a `CanvasNodeElementCache` (no per-frame
+ *        `querySelector` scans), and every rect is measured up front. The
+ *        toolbar anchors to the union of the ring rects already measured —
+ *        nothing is queried or measured twice.
+ *     2. WRITE phase — styles are applied after all reads, and writes are
+ *        skipped when a rect matches what's already applied. Steady-state
+ *        frames therefore do a handful of cached-layout reads and zero
+ *        writes; no read/write interleaving means no forced reflows while
+ *        rects are actually changing.
  * - Clears style positioning when the tracked node disappears or the
  *   selection/hover clears.
  * - Renders the selected-layer toolbar AND the selection / hover rings
@@ -71,10 +83,13 @@ import { HandGrabSolidIcon } from 'pixel-art-icons/icons/hand-grab-solid'
 import { CanvasViewportActionsContext } from './CanvasContexts'
 import { CanvasInsertModuleButton } from './CanvasInsertModuleButton'
 import { useCanvasReorderDrag } from './useCanvasReorderDrag'
-import { measureCanvasNodeClientUnionRect } from './canvasDomGeometry'
 import { useCanvasTreeLadderOverlay } from './CanvasTreeLadderOverlay'
-import { escapeCssAttributeValue } from './canvasNodeLookup'
-import { measureCanvasElementRect } from './canvasOverlayGeometry'
+import { CanvasNodeElementCache } from './canvasNodeLookup'
+import {
+  createCanvasOverlayMeasureSession,
+  unionCanvasOverlayRects,
+  type CanvasOverlayRect,
+} from './canvasOverlayGeometry'
 import type {
   CanvasDropAxis,
   CanvasDropTarget,
@@ -93,10 +108,9 @@ interface BreakpointSelectionOverlayProps {
    */
   breakpointId: string
   /**
-   * Ref to the outer viewport `<div>` (which contains the iframe). Used for
-   * zoom recovery (`offsetWidth` vs `getBoundingClientRect().width`), the
-   * toolbar's canvas-root container, and reorder-drag drop-candidate
-   * measurement against the wrapping layout box.
+   * Ref to the outer viewport `<div>` (which contains the iframe). Used by
+   * the reorder drag for drop-candidate measurement against the wrapping
+   * layout box.
    */
   viewportRef: React.RefObject<HTMLElement | null>
   /**
@@ -170,6 +184,10 @@ export function BreakpointSelectionOverlay({
   // from React state — there's no node-id list to map over.
   const selectorHighlightRef = useRef<HTMLDivElement>(null)
   const toolbarRef = useRef<HTMLDivElement>(null)
+  // nodeId → rendered iframe element, reused across RAF ticks so the
+  // steady-state tick never pays a per-frame `querySelector` document scan.
+  const nodeElementCacheRef = useRef<CanvasNodeElementCache | null>(null)
+  if (nodeElementCacheRef.current === null) nodeElementCacheRef.current = new CanvasNodeElementCache()
   const viewportActions = use(CanvasViewportActionsContext)
 
   // Selection toolbar (drag / duplicate / delete) is purely structural —
@@ -228,36 +246,69 @@ export function BreakpointSelectionOverlay({
   // which specific nodes are tracked.
   //
   // Bridge inputs:
-  //  - `viewport` is the outer `<div>` (parent doc). Used for drop-indicator
-  //    positioning (which stays viewport-local, transform-scaled) and as the
-  //    fallback positioning origin when no canvas root is wired in (tests).
   //  - `iframe` is the breakpoint's iframe element. `[data-node-id]` lookups
-  //    happen inside `iframe.contentDocument`, then `positionRing` /
-  //    `positionToolbar` translate from iframe-document coordinates into
-  //    canvas-root-local (screen-px, NOT scaled) coordinates so the 1px
-  //    border on each ring stays exactly 1px at every zoom level.
+  //    happen inside `iframe.contentDocument`, then the measure session
+  //    translates from iframe-document coordinates into canvas-root-local
+  //    (screen-px, NOT scaled) coordinates so the 1px border on each ring
+  //    stays exactly 1px at every zoom level.
   //  - `canvasRoot` is the editor canvas surface — the rings and toolbar are
   //    portaled into it (see render output below) and positioned in its
-  //    coordinate space, escaping the transform layer's scale.
-  const tickOnce = useEffectEvent((viewport: HTMLElement, iframe: HTMLIFrameElement | null) => {
+  //    coordinate space, escaping the transform layer's scale. Null in the
+  //    fixed/body fallback mode (tests, transient mount race), where overlay
+  //    coords stay in viewport (client) space.
+  //
+  // The tick is split into a READ phase (resolve cached elements, measure
+  // every rect through one shared geometry session) and a WRITE phase
+  // (apply styles, skipping writes whose rect is already applied) — see the
+  // header comment. Reordering measurements/writes here can reintroduce
+  // per-frame forced reflows.
+  const tickOnce = useEffectEvent((iframe: HTMLIFrameElement | null) => {
     const canvasRoot = viewportActions?.canvasRootRef.current ?? null
-    for (const id of selectedNodeIds) {
-      positionRing(ringRefs.current?.get(id) ?? null, id, iframe, canvasRoot)
+    const iframeDoc = iframe?.contentDocument ?? null
+    const elementCache = nodeElementCacheRef.current!
+
+    if (!iframe || !iframeDoc) {
+      // Nothing measurable (iframe not mounted yet / reloading) — hide all
+      // chrome. Pure writes; they no-op once everything is already hidden.
+      for (const id of selectedNodeIds) hideOverlayElement(ringRefs.current?.get(id) ?? null)
+      hideOverlayElement(hoverRef.current)
+      if (selectorHighlightRef.current) hideSurplusRings(selectorHighlightRef.current, 0)
+      hideOverlayElement(toolbarRef.current)
+      return
     }
-    positionRing(hoverRef.current, showHover ? hoverRingNodeId : null, iframe, canvasRoot)
-    syncSelectorHighlightRings(
-      selectorHighlightRef.current,
+
+    // ── READ phase ──────────────────────────────────────────────────────
+    const session = createCanvasOverlayMeasureSession(iframe, canvasRoot)
+    const trackedIds = new Set<string>()
+
+    const ringPlacements: Array<{ ring: HTMLDivElement | null; rect: CanvasOverlayRect | null }> = []
+    let toolbarUnion: CanvasOverlayRect | null = null
+    for (const id of selectedNodeIds) {
+      trackedIds.add(id)
+      const rect = session.measure(elementCache.resolve(iframeDoc, id))
+      ringPlacements.push({ ring: ringRefs.current?.get(id) ?? null, rect })
+      if (showToolbar && rect) toolbarUnion = unionCanvasOverlayRects(toolbarUnion, rect)
+    }
+
+    const hoverId = showHover ? hoverRingNodeId : null
+    let hoverRect: CanvasOverlayRect | null = null
+    if (hoverId) {
+      trackedIds.add(hoverId)
+      hoverRect = session.measure(elementCache.resolve(iframeDoc, hoverId))
+    }
+    elementCache.retainOnly(trackedIds)
+
+    const selectorRects = measureSelectorHighlightRects(
       showSelectorHighlight ? highlightedSelector : null,
-      iframe,
-      canvasRoot,
+      iframeDoc,
+      session,
     )
-    positionToolbar(
-      toolbarRef.current,
-      showToolbar ? selectedNodeIds : [],
-      viewport,
-      iframe,
-      canvasRoot,
-    )
+
+    // ── WRITE phase ─────────────────────────────────────────────────────
+    for (const { ring, rect } of ringPlacements) positionOverlayElement(ring, rect)
+    positionOverlayElement(hoverRef.current, hoverRect)
+    syncSelectorHighlightRings(selectorHighlightRef.current, selectorRects)
+    positionToolbar(toolbarRef.current, showToolbar ? toolbarUnion : null, session.canvasRect)
   })
 
   // The RAF loop exists to re-position overlay chrome as the tracked element
@@ -275,15 +326,13 @@ export function BreakpointSelectionOverlay({
 
   useEffect(() => {
     if (!hasOverlayWork) return
-    const viewport = viewportRef.current
-    if (!viewport) return
 
     let frame = 0
     let cancelled = false
 
     const tick = () => {
       if (cancelled) return
-      tickOnce(viewport, iframeElement)
+      tickOnce(iframeElement)
       frame = requestAnimationFrame(tick)
     }
     frame = requestAnimationFrame(tick)
@@ -292,7 +341,7 @@ export function BreakpointSelectionOverlay({
       cancelled = true
       cancelAnimationFrame(frame)
     }
-  }, [hasOverlayWork, viewportRef, iframeElement])
+  }, [hasOverlayWork, iframeElement])
 
   const toolbar = showToolbar ? (
     <div
@@ -420,67 +469,56 @@ export function BreakpointSelectionOverlay({
 }
 
 // ---------------------------------------------------------------------------
-// Positioning helper
+// Positioning helpers — WRITE phase only. Every rect is measured up front in
+// the tick's READ phase; these apply the results, skipping writes that match
+// what is already on the element so steady-state frames touch no styles.
 // ---------------------------------------------------------------------------
 
 /**
- * Move/resize a ring div to overlay the rendered element of `nodeId`. Hides
- * the ring (display: none) if the element is not currently mounted — happens
- * transiently during page swaps, breakpoint changes, or when the selection
- * points into a hidden subtree.
- *
- * The ring lives in the canvas root's coordinate space (or document.body's
- * when `canvasRoot` is null — tests / transient mount race), NOT inside the
- * transform-scaled layer. So we want POST-transform, screen-px coordinates:
- * the ring's width/height directly mirror the visual size of the selected
- * element on screen, and its 1px box-shadow stays 1px at every zoom.
- *
- * `getBoundingClientRect()` inside the iframe returns un-transformed coords
- * (the iframe document is its own viewport, never transformed). The iframe
- * ELEMENT in the parent doc IS scaled by the canvas transform layer. So we
- * recover the canvas zoom from the iframe element itself (clientRect.width
- * / offsetWidth) and multiply the inner rect by that scale, then add the
- * iframe's outer offset — the result is in editor-document (post-transform)
- * screen-px coords. Subtracting the canvas-root client rect (or zero, in
- * fixed-position fallback mode) gives the ring's own coordinate space.
+ * Last placement applied per overlay element ('hidden' or the exact rect).
+ * Lets the WRITE phase no-op when nothing moved — same-value style writes
+ * are not guaranteed free across engines, and skipping them keeps the
+ * steady-state tick read-only.
  */
-function positionRing(
-  ring: HTMLDivElement | null,
-  nodeId: string | null,
-  iframe: HTMLIFrameElement | null,
-  canvasRoot: HTMLElement | null,
-): void {
-  if (!ring) return
+const appliedOverlayPlacements = new WeakMap<HTMLElement, CanvasOverlayRect | 'hidden'>()
 
-  if (!nodeId) {
-    ring.style.display = 'none'
-    return
-  }
-
-  // `[data-node-id]` elements live inside the iframe's document now. Query
-  // there. Each module spreads `nodeWrapperProps` directly onto its own root
-  // tag (the `<a>` / `<h1>` / grid `<div>` / …), so the matched element IS
-  // the rendered element and its `getBoundingClientRect()` spans the full
-  // visual extent — every column of a grid, every row of a flex container.
-  // Reading the rect off `firstElementChild` was a leftover from when a
-  // wrapping `<div class="nodeWrapper">` sat between `data-node-id` and the
-  // rendered tag; it produced a selection ring the size of the first child.
-  const iframeDoc = iframe?.contentDocument
-  if (!iframeDoc) {
-    ring.style.display = 'none'
-    return
-  }
-  const target = iframeDoc.querySelector<HTMLElement>(
-    `[data-node-id="${escapeCssAttributeValue(nodeId)}"]`,
-  )
-
-  const rect = measureCanvasElementRect(target, iframe, canvasRoot)
+/**
+ * Move/resize an overlay div (selection ring, hover ring, affinity ring) to
+ * `rect`, in canvas-root-local coordinates (or viewport coordinates in the
+ * fixed/body fallback). `rect === null` hides the element — the tracked node
+ * is unmounted (page swap, hidden subtree) or the ring is inactive.
+ */
+function positionOverlayElement(element: HTMLElement | null, rect: CanvasOverlayRect | null): void {
+  if (!element) return
   if (!rect) {
-    ring.style.display = 'none'
+    hideOverlayElement(element)
     return
   }
+  const prev = appliedOverlayPlacements.get(element)
+  if (
+    prev !== undefined &&
+    prev !== 'hidden' &&
+    prev.x === rect.x &&
+    prev.y === rect.y &&
+    prev.width === rect.width &&
+    prev.height === rect.height
+  ) {
+    return
+  }
+  Object.assign(element.style, {
+    display: '',
+    transform: `translate(${rect.x}px, ${rect.y}px)`,
+    width: `${rect.width}px`,
+    height: `${rect.height}px`,
+  })
+  appliedOverlayPlacements.set(element, rect)
+}
 
-  applyOverlayRectStyle(ring, rect)
+function hideOverlayElement(element: HTMLElement | null): void {
+  if (!element) return
+  if (appliedOverlayPlacements.get(element) === 'hidden') return
+  element.style.display = 'none'
+  appliedOverlayPlacements.set(element, 'hidden')
 }
 
 /**
@@ -494,26 +532,16 @@ function positionRing(
 const SELECTOR_HIGHLIGHT_RING_CAP = 300
 
 /**
- * Sync the orange affinity rings to the set of elements matching `selector`
- * inside the breakpoint iframe. Reuses a pool of ring divs under `container`:
- * grows it to match the live match count (capped), positions each over its
- * element, and hides any surplus from a previous, larger match set.
- *
- * Passing `selector === null` (or an absent container/iframe) clears the pool.
+ * READ-phase half of the selector-affinity highlight: measure every element
+ * matching `selector` inside the breakpoint iframe (capped). Returns null
+ * when the highlight is inactive (clears the pool in the write phase).
  */
-function syncSelectorHighlightRings(
-  container: HTMLDivElement | null,
+function measureSelectorHighlightRects(
   selector: string | null,
-  iframe: HTMLIFrameElement | null,
-  canvasRoot: HTMLElement | null,
-): void {
-  if (!container) return
-
-  const iframeDoc = iframe?.contentDocument
-  if (!selector || !iframeDoc) {
-    hideSurplusRings(container, 0)
-    return
-  }
+  iframeDoc: Document,
+  session: ReturnType<typeof createCanvasOverlayMeasureSession>,
+): CanvasOverlayRect[] | null {
+  if (!selector) return null
 
   // Ambient selectors are arbitrary author/CSS-importer strings; a malformed
   // one makes querySelectorAll throw. Treat that as "matches nothing" rather
@@ -522,12 +550,35 @@ function syncSelectorHighlightRings(
   try {
     matches = iframeDoc.querySelectorAll<HTMLElement>(selector)
   } catch {
+    return []
+  }
+
+  const count = Math.min(matches.length, SELECTOR_HIGHLIGHT_RING_CAP)
+  const rects: CanvasOverlayRect[] = []
+  for (let i = 0; i < count; i++) {
+    const rect = session.measure(matches[i])
+    if (rect) rects.push(rect)
+  }
+  return rects
+}
+
+/**
+ * WRITE-phase half: sync the orange affinity ring pool under `container` to
+ * the measured `rects` — grows the pool as needed, positions each ring, and
+ * hides any surplus from a previous, larger match set (rings are reused, not
+ * removed). `rects === null` clears the pool.
+ */
+function syncSelectorHighlightRings(
+  container: HTMLDivElement | null,
+  rects: CanvasOverlayRect[] | null,
+): void {
+  if (!container) return
+  if (!rects) {
     hideSurplusRings(container, 0)
     return
   }
 
-  const count = Math.min(matches.length, SELECTOR_HIGHLIGHT_RING_CAP)
-  for (let i = 0; i < count; i++) {
+  for (let i = 0; i < rects.length; i++) {
     let ring = container.children[i] as HTMLDivElement | undefined
     if (!ring) {
       ring = container.ownerDocument.createElement('div')
@@ -535,106 +586,75 @@ function syncSelectorHighlightRings(
       ring.setAttribute('data-canvas-selector-highlight-ring', 'true')
       container.appendChild(ring)
     }
-    const rect = measureCanvasElementRect(matches[i], iframe!, canvasRoot)
-    if (!rect) {
-      ring.style.display = 'none'
-      continue
-    }
-    applyOverlayRectStyle(ring, rect)
+    positionOverlayElement(ring, rects[i])
   }
-  hideSurplusRings(container, count)
-}
-
-function applyOverlayRectStyle(
-  element: HTMLElement,
-  rect: { x: number; y: number; width: number; height: number },
-): void {
-  Object.assign(element.style, {
-    display: '',
-    transform: `translate(${rect.x}px, ${rect.y}px)`,
-    width: `${rect.width}px`,
-    height: `${rect.height}px`,
-  })
+  hideSurplusRings(container, rects.length)
 }
 
 /** Hide every pooled ring from index `keep` onward (they're reused, not removed). */
 function hideSurplusRings(container: HTMLDivElement, keep: number): void {
   for (let i = keep; i < container.children.length; i++) {
-    ;(container.children[i] as HTMLElement).style.display = 'none'
+    hideOverlayElement(container.children[i] as HTMLElement)
   }
 }
 
+/**
+ * Anchor the selection toolbar to `union` — the union of the selection-ring
+ * rects already measured this tick (no second query/measure pass). Hides the
+ * toolbar when there is no measurable selection or when the selection sits
+ * entirely outside the canvas root's visible area — otherwise the toolbar
+ * would "hang on screen" detached from the element it belongs to. For
+ * partial overlap, the canvas root's overflow:hidden clips it.
+ *
+ * Scoped path: toolbar lives inside the canvas root (position: absolute), so
+ * the CSS variables are in canvas-root-local coordinates — exactly the
+ * coordinate space `union` is measured in. Fixed path (fallback,
+ * `canvasRect === null`): toolbar lives in document.body (position: fixed)
+ * and the same values are viewport (client) coordinates.
+ */
 function positionToolbar(
   toolbar: HTMLDivElement | null,
-  nodeIds: readonly string[],
-  viewport: HTMLElement,
-  iframe: HTMLIFrameElement | null,
-  canvasRoot: HTMLElement | null,
+  union: CanvasOverlayRect | null,
+  canvasRect: DOMRect | null,
 ): void {
-  if (!toolbar || nodeIds.length === 0) {
-    if (toolbar) toolbar.style.display = 'none'
+  if (!toolbar) return
+  if (!union) {
+    hideOverlayElement(toolbar)
     return
   }
 
-  // Pass the iframe through so the helper queries the right document AND
-  // translates each measured rect from iframe-internal coords into editor
-  // coords. Without this the toolbar would anchor to (0,0) of the editor.
-  const rect = measureCanvasNodeClientUnionRect(viewport, nodeIds, iframe)
-  if (!rect) {
-    toolbar.style.display = 'none'
-    return
-  }
-
-  // When the selected element has been panned/zoomed entirely outside the
-  // canvas root's visible area, hide the toolbar rather than leaving it
-  // anchored to an off-canvas position. Otherwise the toolbar appears to
-  // "hang on screen" detached from the element it belongs to. This also
-  // covers the case where overflow:hidden clipping would only partially hide
-  // the toolbar — once the element is gone, hide the chrome cleanly.
-  if (canvasRoot) {
-    const canvasRect = canvasRoot.getBoundingClientRect()
+  if (canvasRect) {
     const elementFullyOutOfBounds =
-      rect.right <= canvasRect.left ||
-      rect.left >= canvasRect.right ||
-      rect.bottom <= canvasRect.top ||
-      rect.top >= canvasRect.bottom
+      union.x + union.width <= 0 ||
+      union.x >= canvasRect.width ||
+      union.y + union.height <= 0 ||
+      union.y >= canvasRect.height
     if (elementFullyOutOfBounds) {
-      toolbar.style.display = 'none'
+      hideOverlayElement(toolbar)
       return
     }
-  }
-
-  toolbar.style.display = ''
-
-  // Scoped path: toolbar lives inside the canvas root (position: absolute),
-  // so the CSS variables are in canvas-root-local coordinates. The canvas
-  // root's overflow:hidden then clips the toolbar when it lands outside the
-  // visible canvas area (e.g. anchored to an element near a frame edge that
-  // the user has panned partly out of view).
-  //
-  // Fixed path (fallback): toolbar lives in document.body (position: fixed),
-  // so the CSS variables remain in viewport (client) coordinates.
-  let originLeft = 0
-  let originTop = 0
-  if (canvasRoot) {
-    const canvasRect = canvasRoot.getBoundingClientRect()
-    originLeft = canvasRect.left
-    originTop = canvasRect.top
   }
 
   // No horizontal clamping: the toolbar anchors to the selected element's
   // left edge. A previous `Math.max(4, x)` clamp kept the toolbar visible at
   // the canvas-left edge when the element panned off-screen left, but that
   // decoupled the toolbar from the element and left it "hanging" far from
-  // the actual selection. The element-out-of-bounds check above already
-  // hides the toolbar when the selection is fully off-canvas; for partial
-  // overlap, overflow:hidden clips the toolbar so it can't bleed into the
-  // sidebars.
-  const x = rect.left - originLeft
-  const y = rect.top - originTop - TOOLBAR_VERTICAL_OFFSET
+  // the actual selection.
+  const placement: CanvasOverlayRect = {
+    x: union.x,
+    y: union.y - TOOLBAR_VERTICAL_OFFSET,
+    width: union.width,
+    height: union.height,
+  }
+  const prev = appliedOverlayPlacements.get(toolbar)
+  if (prev !== undefined && prev !== 'hidden' && prev.x === placement.x && prev.y === placement.y) {
+    return
+  }
 
-  toolbar.style.setProperty('--canvas-toolbar-x', `${x}px`)
-  toolbar.style.setProperty('--canvas-toolbar-y', `${y}px`)
+  toolbar.style.display = ''
+  toolbar.style.setProperty('--canvas-toolbar-x', `${placement.x}px`)
+  toolbar.style.setProperty('--canvas-toolbar-y', `${placement.y}px`)
+  appliedOverlayPlacements.set(toolbar, placement)
 }
 
 function dropIndicatorStyle(target: CanvasDropTarget): CSSProperties {

--- a/src/admin/pages/site/canvas/ClassStyleInjector.tsx
+++ b/src/admin/pages/site/canvas/ClassStyleInjector.tsx
@@ -28,13 +28,19 @@
  * - Only known CSS property names from CSSPropertyBag interface are emitted.
  *
  * Performance:
- * - Subscribes with a shallow-equality selector so re-renders only happen when
- *   classes actually change (not on every site edit).
+ * - Subscribes with granular selectors so re-renders only happen when the
+ *   relevant slices actually change (not on every site edit).
+ * - `generateCanvasClassCSS` is identity-memoized on its 8 inputs (see
+ *   `createCanvasClassCssMemo`). All breakpoint-frame injectors render with
+ *   the same store snapshot in the same commit, so the full registry CSS is
+ *   generated ONCE per change and frames 2..N reuse the cached string. Only
+ *   the per-frame viewport-unit resolution still runs per injector — its
+ *   output genuinely differs per frame width.
  */
 
 import { useEffect } from 'react'
 import { useEditorStore } from '@site/store/store'
-import { styleRuleSelector, type ConditionDef } from '@core/page-tree'
+import { styleRuleSelector, type ConditionDef, type StyleRule } from '@core/page-tree'
 import { selectorStatePseudo } from '@site/cssStatePseudo'
 import { generateCanvasClassCSS, generateForcedStateCSS, generatePreviewClassCSS } from './canvasClassCss'
 import { resolveViewportUnitsForCanvas, type CanvasViewport } from './resolveViewportUnits'
@@ -74,6 +80,13 @@ const EMPTY_BREAKPOINTS: Array<{ id: string; width: number }> = []
 /** Stable empty fallback for the conditions selector (Guideline #239). */
 const EMPTY_CONDITIONS: ConditionDef[] = []
 
+/**
+ * Stable empty registry passed to `generateCanvasClassCSS` when the site has
+ * no style rules. An inline `{}` literal would mint a new identity per effect
+ * run, defeating the generator's input-identity memo across frames.
+ */
+const EMPTY_STYLE_RULES: Record<string, StyleRule> = {}
+
 export function ClassStyleInjector({ targetDocument, viewport }: ClassStyleInjectorProps = {}) {
   // Subscribe to class registry — shallow equality so we only re-run when
   // the classes object reference changes (Immer always creates a new ref on mutation)
@@ -105,7 +118,7 @@ export function ClassStyleInjector({ targetDocument, viewport }: ClassStyleInjec
     const forCanvas = (css: string) => (viewport ? resolveViewportUnitsForCanvas(css, viewport) : css)
 
     const generated = generateCanvasClassCSS(
-      classes && Object.keys(classes).length > 0 ? classes : {},
+      classes ?? EMPTY_STYLE_RULES,
       breakpoints,
       conditions,
       frameworkColors,

--- a/src/admin/pages/site/canvas/ModuleSandboxFrame.tsx
+++ b/src/admin/pages/site/canvas/ModuleSandboxFrame.tsx
@@ -27,10 +27,10 @@ interface ModuleSandboxFrameProps {
   nodeId: string
   isSelected: boolean
   mcClassName?: string
-  classIds?: string[]
+  classIds?: readonly string[]
 }
 
-function getNodeClassCSS(site: SiteDocument | null, classIds: string[] | undefined): string {
+function getNodeClassCSS(site: SiteDocument | null, classIds: readonly string[] | undefined): string {
   if (!site || !classIds?.length) return ''
 
   const classes: SiteDocument['styleRules'] = {}

--- a/src/admin/pages/site/canvas/NodeRenderer.tsx
+++ b/src/admin/pages/site/canvas/NodeRenderer.tsx
@@ -10,6 +10,13 @@
  * - selectedNodeId / hoveredNodeId are NOT in context (Perf fix #495):
  *   Each NodeRenderer subscribes directly to its own boolean — only the 2
  *   affected nodes re-render per selection/hover event (O(2) not O(N)).
+ * - Zustand re-runs EVERY subscriber's selector on EVERY store set, so the
+ *   per-node selectors below must be O(1)-ish per sweep: the active-page
+ *   resolution is single-slot memoized in `selectActivePage`, the
+ *   form-preview helpers cache their parent index per tree identity
+ *   (`canvasFormPreview.ts`), and `getCanvasNodeClassIds` passes the node's
+ *   own array through untouched when no preview applies — selector outputs
+ *   stay referentially stable for unchanged data.
  */
 
 import { memo, use, useSyncExternalStore } from 'react'
@@ -23,6 +30,11 @@ import { WarningDiamondSolidIcon } from 'pixel-art-icons/icons/warning-diamond-s
 import { ErrorBoundary } from '@ui/components/ErrorBoundary'
 import { ModuleSandboxFrame } from './ModuleSandboxFrame'
 import { CanvasBreakpointContext, CanvasSelectionContext, CanvasTemplateContext } from './CanvasContexts'
+import {
+  addEditorFormPreviewProps,
+  resolveEditorFormPreviewState,
+  resolveEditorFormPreviewSuccessMessage,
+} from './canvasFormPreview'
 import { getCanvasNodeClassIds, getCanvasNodeClassName, getCanvasNodeInlineStyle } from './canvasNodeClassName'
 import { findEnclosingComponentRef, type AnnotatedPageNode } from './canvasSelectionUtils'
 import { useLoopPreviewItems } from './useLoopPreviewItems'
@@ -386,7 +398,6 @@ function LoopIterationsPreview({ node, baseTemplateContext }: LoopIterationsPrev
 const CANVAS_EDITOR_CONTROL_SELECTOR = '[data-canvas-interactive="true"]'
 const CANVAS_NODE_SELECTOR = '[data-node-id]'
 const CANVAS_FORM_CONTROL_SELECTOR = 'input, textarea, select, button, option, optgroup'
-const DEFAULT_FORM_SUCCESS_MESSAGE = 'Thanks. Your submission was received.'
 let latestSuppressedPointerTarget: EventTarget | null = null
 
 /**
@@ -462,69 +473,4 @@ function isAuthoredFormControlTarget(
 
 function isFocusableElement(target: EventTarget | null): target is HTMLElement {
   return isElementLike(target) && typeof (target as HTMLElement).blur === 'function'
-}
-
-function addEditorFormPreviewProps(
-  moduleId: string,
-  props: Record<string, unknown>,
-  previewState: FormPreviewState,
-  successMessage: string,
-): Record<string, unknown> {
-  if (previewState === 'default') return props
-  if (moduleId !== 'base.form' && moduleId !== 'base.form-message') return props
-  return {
-    ...props,
-    editorPreviewState: previewState,
-    editorPreviewSuccessMessage: successMessage,
-  }
-}
-
-type FormPreviewState = 'default' | 'submitting' | 'success' | 'error'
-
-function resolveEditorFormPreviewState(state: ReturnType<typeof useEditorStore.getState>, nodeId: string): FormPreviewState {
-  const page = selectActiveCanvasPage(state)
-  const node = page?.nodes[nodeId]
-  if (!page || !node) return 'default'
-  const formNode = node.moduleId === 'base.form'
-    ? node
-    : node.moduleId === 'base.form-message'
-      ? nearestFormNode(page, nodeId)
-      : null
-  if (!formNode) return 'default'
-  return state.formPreviewStates[formNode.id] ?? 'default'
-}
-
-function resolveEditorFormPreviewSuccessMessage(
-  state: ReturnType<typeof useEditorStore.getState>,
-  nodeId: string,
-): string {
-  const page = selectActiveCanvasPage(state)
-  const node = page?.nodes[nodeId]
-  if (!page || !node) return DEFAULT_FORM_SUCCESS_MESSAGE
-  const formNode = node.moduleId === 'base.form'
-    ? node
-    : node.moduleId === 'base.form-message'
-      ? nearestFormNode(page, nodeId)
-      : null
-  return formNode ? stringNodeProp(formNode, 'successMessage', DEFAULT_FORM_SUCCESS_MESSAGE) : DEFAULT_FORM_SUCCESS_MESSAGE
-}
-
-function nearestFormNode(page: { nodes: Record<string, PageNode> }, nodeId: string): PageNode | null {
-  const parentByNodeId = new Map<string, string>()
-  for (const node of Object.values(page.nodes)) {
-    for (const childId of node.children) parentByNodeId.set(childId, node.id)
-  }
-  let currentId = parentByNodeId.get(nodeId)
-  while (currentId) {
-    const current = page.nodes[currentId]
-    if (!current) return null
-    if (current.moduleId === 'base.form') return current
-    currentId = parentByNodeId.get(current.id)
-  }
-  return null
-}
-
-function stringNodeProp(node: PageNode, key: string, fallback: string): string {
-  const value = node.props[key]
-  return typeof value === 'string' && value.trim() ? value : fallback
 }

--- a/src/admin/pages/site/canvas/canvasClassCss.ts
+++ b/src/admin/pages/site/canvas/canvasClassCss.ts
@@ -17,7 +17,7 @@ import type {
   FrameworkTypographySettings,
 } from '@core/framework-schema'
 
-export function generateCanvasClassCSS(
+function buildCanvasClassCSS(
   classes: Record<string, StyleRule>,
   breakpoints: ViewportContext[],
   conditions: ReadonlyArray<ConditionDef> = [],
@@ -111,6 +111,71 @@ export function generateCanvasClassCSS(
 
   return blocks.join('\n\n')
 }
+
+type CanvasClassCssGenerator = typeof buildCanvasClassCSS
+
+/**
+ * Wrap the registry-CSS generator in a single-slot identity memo.
+ *
+ * Every breakpoint-frame `ClassStyleInjector` regenerates this CSS with the
+ * SAME store-snapshot inputs in the same commit — the generation is pure and
+ * all inputs are Mutative-immutable, so comparing the 8 argument identities
+ * is exact: frames 2..N (and any re-run with unchanged inputs) return the
+ * cached string instead of re-sorting and re-emitting the whole registry.
+ *
+ * The factory shape exists so tests can inject a counting generator; runtime
+ * code uses the bound `generateCanvasClassCSS` singleton below.
+ */
+export function createCanvasClassCssMemo(
+  generate: CanvasClassCssGenerator = buildCanvasClassCSS,
+): CanvasClassCssGenerator {
+  let lastInputs: readonly unknown[] | null = null
+  let lastCss = ''
+  return (
+    classes,
+    breakpoints,
+    conditions = [],
+    frameworkColors,
+    frameworkTypography,
+    frameworkSpacing,
+    frameworkPreferences,
+    fonts,
+  ) => {
+    const inputs = [
+      classes,
+      breakpoints,
+      conditions,
+      frameworkColors,
+      frameworkTypography,
+      frameworkSpacing,
+      frameworkPreferences,
+      fonts,
+    ]
+    const prev = lastInputs
+    if (prev && inputs.every((value, i) => Object.is(value, prev[i]))) {
+      return lastCss
+    }
+    lastCss = generate(
+      classes,
+      breakpoints,
+      conditions,
+      frameworkColors,
+      frameworkTypography,
+      frameworkSpacing,
+      frameworkPreferences,
+      fonts,
+    )
+    lastInputs = inputs
+    return lastCss
+  }
+}
+
+/**
+ * Generate the canvas class-registry CSS (publisher reset + fonts +
+ * framework root CSS + every style rule with its breakpoint/condition
+ * overrides). Identity-memoized — see `createCanvasClassCssMemo`.
+ */
+export const generateCanvasClassCSS: CanvasClassCssGenerator = createCanvasClassCssMemo()
 
 /**
  * Generate a higher-specificity preview rule for a single class, used by

--- a/src/admin/pages/site/canvas/canvasDomGeometry.ts
+++ b/src/admin/pages/site/canvas/canvasDomGeometry.ts
@@ -1,6 +1,5 @@
 import type { PageNode } from '@core/page-tree'
 import type { NodeTree } from '@core/page-tree'
-import { escapeCssAttributeValue } from './canvasNodeLookup'
 import type {
   CanvasDropAxis,
   CanvasDropCandidate,
@@ -98,75 +97,6 @@ export function panToCenterBreakpointFrame(
   }
 }
 
-export function measureCanvasNodeClientUnionRect(
-  viewport: HTMLElement,
-  nodeIds: readonly string[],
-  /**
-   * Optional iframe hosting the canvas content. When provided, `[data-node-id]`
-   * lookups happen inside `iframe.contentDocument` and each measured rect is
-   * translated from iframe-internal coordinates into editor-document
-   * coordinates (by adding the iframe's own client rect AND multiplying by
-   * the canvas zoom — inner rects come back unscaled, since the iframe
-   * document is its own viewport).
-   */
-  iframe?: HTMLIFrameElement | null,
-): CanvasRect | null {
-  let union: CanvasRect | null = null
-  const queryScope: ParentNode | null = iframe?.contentDocument ?? viewport
-  const iframeRect = iframe?.getBoundingClientRect() ?? null
-  // See the analogous comment in BreakpointSelectionOverlay.positionRing:
-  // the iframe ELEMENT is scaled by the canvas transform, but
-  // `getBoundingClientRect()` inside the iframe document returns rects in
-  // the iframe's own (un-transformed) viewport. We must multiply each inner
-  // rect by `iframeRect.width / iframe.offsetWidth` before adding the
-  // iframe's outer offset so the result stays in consistent editor-doc px.
-  const iframeScale =
-    iframe && iframe.offsetWidth > 0 && iframeRect ? iframeRect.width / iframe.offsetWidth : 1
-
-  for (const id of nodeIds) {
-    const target = queryCanvasNodeElement(queryScope, id)
-    if (!target) continue
-
-    const rectInsideScope = target.getBoundingClientRect()
-    if (rectInsideScope.width === 0 && rectInsideScope.height === 0) continue
-
-    // Translate iframe-internal coords to editor-document coords by
-    // multiplying by the canvas zoom and adding the iframe's own client
-    // rect. For the legacy in-document path (no iframe), the rect is
-    // already in editor coords so we skip the translation.
-    const rect = iframeRect
-      ? {
-          left: iframeRect.left + rectInsideScope.left * iframeScale,
-          top: iframeRect.top + rectInsideScope.top * iframeScale,
-          right: iframeRect.left + rectInsideScope.right * iframeScale,
-          bottom: iframeRect.top + rectInsideScope.bottom * iframeScale,
-          width: rectInsideScope.width * iframeScale,
-          height: rectInsideScope.height * iframeScale,
-        }
-      : {
-          left: rectInsideScope.left,
-          top: rectInsideScope.top,
-          right: rectInsideScope.right,
-          bottom: rectInsideScope.bottom,
-          width: rectInsideScope.width,
-          height: rectInsideScope.height,
-        }
-
-    union = union
-      ? {
-          left: Math.min(union.left, rect.left),
-          top: Math.min(union.top, rect.top),
-          right: Math.max(union.right, rect.right),
-          bottom: Math.max(union.bottom, rect.bottom),
-          width: Math.max(union.right, rect.right) - Math.min(union.left, rect.left),
-          height: Math.max(union.bottom, rect.bottom) - Math.min(union.top, rect.top),
-        }
-      : rect
-  }
-
-  return union
-}
-
 export function measureCanvasDropCandidates(
   viewport: HTMLElement,
   tree: NodeTree<PageNode>,
@@ -184,8 +114,8 @@ export function measureCanvasDropCandidates(
   const iframeRect = iframe?.getBoundingClientRect() ?? null
   // Inner rects come back unscaled (iframe document is its own viewport);
   // multiply by the canvas zoom recovered from the iframe element before
-  // adding the iframe's outer offset. See the matching comment in
-  // `measureCanvasNodeClientUnionRect`.
+  // adding the iframe's outer offset. See the matching explanation in
+  // `canvasOverlayGeometry.ts`.
   const iframeScale =
     iframe && iframe.offsetWidth > 0 && iframeRect ? iframeRect.width / iframe.offsetWidth : 1
   const candidates: CanvasDropCandidate[] = []
@@ -224,23 +154,6 @@ export function measureCanvasDropCandidates(
   }
 
   return candidates
-}
-
-/**
- * Look up the rendered DOM element for a page-tree node. Each module spreads
- * `nodeWrapperProps` (which carries `data-node-id`) directly onto its own root
- * tag — there is no wrapping `<div class="nodeWrapper">` anymore — so the
- * `[data-node-id]` match IS the rendered element. Returning it directly is
- * what every caller wants: for a grid container with multiple columns, the
- * rect spans the whole grid; for a single text node, the rect is the text.
- */
-function queryCanvasNodeElement(
-  scope: ParentNode,
-  nodeId: string,
-): HTMLElement | null {
-  return scope.querySelector<HTMLElement>(
-    `[data-node-id="${escapeCssAttributeValue(nodeId)}"]`,
-  )
 }
 
 /**

--- a/src/admin/pages/site/canvas/canvasFormPreview.ts
+++ b/src/admin/pages/site/canvas/canvasFormPreview.ts
@@ -1,0 +1,107 @@
+/**
+ * canvasFormPreview — editor-only preview state for `base.form` /
+ * `base.form-message` nodes.
+ *
+ * The Properties panel lets authors preview a form's `submitting` / `success`
+ * / `error` states without submitting anything. The preview state is stored
+ * per FORM node (`formPreviewStates[formNodeId]`), so a `base.form-message`
+ * node must resolve its nearest enclosing form to find its state.
+ *
+ * Both resolvers run inside per-node Zustand selectors (NodeRenderer mounts
+ * one of each per canvas node), and Zustand re-runs every subscriber's
+ * selector on every store set — so everything here must be cheap on the
+ * cache-hit path and must return referentially stable values for unchanged
+ * data (strings / nulls / nodes from the store).
+ */
+
+import type { PageNode } from '@core/page-tree'
+import { selectActiveCanvasPage, type EditorStore } from '@site/store/store'
+
+export type FormPreviewState = 'default' | 'submitting' | 'success' | 'error'
+
+const DEFAULT_FORM_SUCCESS_MESSAGE = 'Thanks. Your submission was received.'
+
+/**
+ * Resolve the editor form-preview state for `nodeId` — `default` unless the
+ * node is a form (or a form-message inside one) with an active preview.
+ */
+export function resolveEditorFormPreviewState(state: EditorStore, nodeId: string): FormPreviewState {
+  const formNode = previewedFormNode(state, nodeId)
+  if (!formNode) return 'default'
+  return state.formPreviewStates[formNode.id] ?? 'default'
+}
+
+/** Resolve the success message the form preview should display for `nodeId`. */
+export function resolveEditorFormPreviewSuccessMessage(state: EditorStore, nodeId: string): string {
+  const formNode = previewedFormNode(state, nodeId)
+  return formNode
+    ? stringNodeProp(formNode, 'successMessage', DEFAULT_FORM_SUCCESS_MESSAGE)
+    : DEFAULT_FORM_SUCCESS_MESSAGE
+}
+
+/**
+ * Merge the editor preview state into a form module's props. No-op (same
+ * props reference) for non-form modules or when no preview is active.
+ */
+export function addEditorFormPreviewProps(
+  moduleId: string,
+  props: Record<string, unknown>,
+  previewState: FormPreviewState,
+  successMessage: string,
+): Record<string, unknown> {
+  if (previewState === 'default') return props
+  if (moduleId !== 'base.form' && moduleId !== 'base.form-message') return props
+  return {
+    ...props,
+    editorPreviewState: previewState,
+    editorPreviewSuccessMessage: successMessage,
+  }
+}
+
+function previewedFormNode(state: EditorStore, nodeId: string): PageNode | null {
+  const page = selectActiveCanvasPage(state)
+  const node = page?.nodes[nodeId]
+  if (!page || !node) return null
+  if (node.moduleId === 'base.form') return node
+  if (node.moduleId === 'base.form-message') return nearestFormNode(page, nodeId)
+  return null
+}
+
+// Parent-id index per nodes-map identity. Without the cache every
+// form-message node rebuilds the index — an O(page) walk + allocation — in
+// BOTH form-preview selectors on every store set in every breakpoint frame.
+// The WeakMap keys on `page.nodes`: Mutative structural sharing mints a new
+// map identity exactly when the tree changes, so invalidation is automatic.
+const parentIndexCache = new WeakMap<Record<string, PageNode>, Map<string, string>>()
+
+function parentIndexFor(nodes: Record<string, PageNode>): Map<string, string> {
+  const cached = parentIndexCache.get(nodes)
+  if (cached) return cached
+  const parentByNodeId = new Map<string, string>()
+  for (const node of Object.values(nodes)) {
+    for (const childId of node.children) parentByNodeId.set(childId, node.id)
+  }
+  parentIndexCache.set(nodes, parentByNodeId)
+  return parentByNodeId
+}
+
+/** Walk up from `nodeId` to the nearest enclosing `base.form` node, if any. */
+export function nearestFormNode(
+  page: { nodes: Record<string, PageNode> },
+  nodeId: string,
+): PageNode | null {
+  const parentByNodeId = parentIndexFor(page.nodes)
+  let currentId = parentByNodeId.get(nodeId)
+  while (currentId) {
+    const current = page.nodes[currentId]
+    if (!current) return null
+    if (current.moduleId === 'base.form') return current
+    currentId = parentByNodeId.get(current.id)
+  }
+  return null
+}
+
+function stringNodeProp(node: PageNode, key: string, fallback: string): string {
+  const value = node.props[key]
+  return typeof value === 'string' && value.trim() ? value : fallback
+}

--- a/src/admin/pages/site/canvas/canvasNodeClassName.ts
+++ b/src/admin/pages/site/canvas/canvasNodeClassName.ts
@@ -6,17 +6,21 @@ export function getCanvasNodeClassIds(
   classIds: readonly string[] | undefined,
   previewClassAssignment: ClassPreviewAssignment | null,
   nodeId: string,
-): string[] | undefined {
-  const ids = classIds ? [...classIds] : []
-
-  if (
+): readonly string[] | undefined {
+  const previewClassId =
     previewClassAssignment?.nodeId === nodeId &&
-    !ids.includes(previewClassAssignment.classId)
-  ) {
-    ids.push(previewClassAssignment.classId)
+    !classIds?.includes(previewClassAssignment.classId)
+      ? previewClassAssignment.classId
+      : null
+
+  if (previewClassId === null) {
+    // No preview to merge — pass the node's own (store-immutable) list
+    // through. This runs in a per-node selector on every store set, so
+    // copying here would allocate O(nodes) arrays per store change.
+    return classIds && classIds.length > 0 ? classIds : undefined
   }
 
-  return ids.length > 0 ? ids : undefined
+  return classIds ? [...classIds, previewClassId] : [previewClassId]
 }
 
 export function getCanvasNodeClassName(

--- a/src/admin/pages/site/canvas/canvasNodeLookup.ts
+++ b/src/admin/pages/site/canvas/canvasNodeLookup.ts
@@ -22,6 +22,43 @@ export function escapeCssAttributeValue(value: string): string {
   return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
 }
 
+/**
+ * Per-overlay cache of nodeId → rendered element inside one breakpoint
+ * iframe.
+ *
+ * The selection overlay's RAF tick used to `querySelector` every tracked
+ * node on every frame — an O(document) attribute scan per ring at 60fps.
+ * Caching the resolved element makes the steady-state tick O(1) per ring;
+ * a cached entry is re-queried only when it has been unmounted
+ * (`!isConnected` — e.g. the node re-rendered) or when the iframe swapped
+ * documents (a srcDoc reload leaves stale elements connected to the OLD
+ * document, so `ownerDocument` must match the live one).
+ *
+ * Call `retainOnly` with the ids tracked this tick so entries for
+ * deselected nodes don't pin detached DOM subtrees in memory.
+ */
+export class CanvasNodeElementCache {
+  private elements = new Map<string, HTMLElement>()
+
+  resolve(doc: Document, nodeId: string): HTMLElement | null {
+    const cached = this.elements.get(nodeId)
+    if (cached && cached.isConnected && cached.ownerDocument === doc) return cached
+
+    const element = doc.querySelector<HTMLElement>(
+      `[data-node-id="${escapeCssAttributeValue(nodeId)}"]`,
+    )
+    if (element) this.elements.set(nodeId, element)
+    else this.elements.delete(nodeId)
+    return element
+  }
+
+  retainOnly(nodeIds: ReadonlySet<string>): void {
+    for (const id of this.elements.keys()) {
+      if (!nodeIds.has(id)) this.elements.delete(id)
+    }
+  }
+}
+
 export function findRenderedCanvasNodeElement(
   nodeId: string,
   root: Document = document,

--- a/src/admin/pages/site/canvas/canvasOverlayGeometry.ts
+++ b/src/admin/pages/site/canvas/canvasOverlayGeometry.ts
@@ -1,42 +1,100 @@
 /**
- * Translate an element measured inside the breakpoint iframe into the canvas
- * overlay coordinate space.
+ * Geometry helpers that translate elements measured inside a breakpoint
+ * iframe into the canvas overlay coordinate space (canvas-root-local,
+ * post-transform screen px).
+ *
+ * `getBoundingClientRect()` inside the iframe returns un-transformed coords
+ * (the iframe document is its own viewport, never transformed). The iframe
+ * ELEMENT in the parent doc IS scaled by the canvas transform layer, so we
+ * recover the canvas zoom from the iframe element itself
+ * (`clientRect.width / offsetWidth`), multiply the inner rect by that scale,
+ * add the iframe's outer offset, and subtract the canvas-root origin (zero
+ * in the fixed-position fallback mode).
+ */
+
+export interface CanvasOverlayRect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface CanvasOverlayMeasureSession {
+  /** Canvas-root client rect, or null in the fixed/body fallback mode. */
+  canvasRect: DOMRect | null
+  /** Measure one iframe element into overlay (canvas-root-local) coords. */
+  measure(target: HTMLElement | null): CanvasOverlayRect | null
+}
+
+/**
+ * Snapshot the geometry shared by every overlay measurement in one animation
+ * frame — the iframe rect/scale and the canvas-root origin — so a tick that
+ * positions K rings reads them ONCE instead of K times. Reading them in the
+ * parent document before any overlay style write also keeps the tick's
+ * read phase free of forced reflows (the writes happen afterwards).
+ */
+export function createCanvasOverlayMeasureSession(
+  iframe: HTMLIFrameElement,
+  canvasRoot: HTMLElement | null,
+): CanvasOverlayMeasureSession {
+  const iframeRect = iframe.getBoundingClientRect()
+  const iframeScale = iframe.offsetWidth > 0 ? iframeRect.width / iframe.offsetWidth : 1
+  const canvasRect = canvasRoot ? canvasRoot.getBoundingClientRect() : null
+  const originLeft = canvasRect?.left ?? 0
+  const originTop = canvasRect?.top ?? 0
+
+  return {
+    canvasRect,
+    measure(target) {
+      // Duck-type check (`getBoundingClientRect` is callable) rather than
+      // `instanceof Element` because iframe nodes have their own Element class.
+      if (
+        !target ||
+        typeof (target as { getBoundingClientRect?: unknown }).getBoundingClientRect !== 'function'
+      ) {
+        return null
+      }
+
+      const elementRectInIframe = target.getBoundingClientRect()
+      if (elementRectInIframe.width === 0 && elementRectInIframe.height === 0) {
+        return null
+      }
+      return {
+        x: iframeRect.left + elementRectInIframe.left * iframeScale - originLeft,
+        y: iframeRect.top + elementRectInIframe.top * iframeScale - originTop,
+        width: elementRectInIframe.width * iframeScale,
+        height: elementRectInIframe.height * iframeScale,
+      }
+    },
+  }
+}
+
+/**
+ * One-shot convenience over `createCanvasOverlayMeasureSession` for callers
+ * that measure a single element (plugin canvas hooks, tree-ladder rows).
+ * Hot per-frame loops should create a session instead.
  */
 export function measureCanvasElementRect(
   target: HTMLElement | null,
   iframe: HTMLIFrameElement,
   canvasRoot: HTMLElement | null,
-): { x: number; y: number; width: number; height: number } | null {
-  // Use a duck-type check (`getBoundingClientRect` is callable) rather than
-  // `instanceof Element` because iframe nodes have their own Element class.
-  if (!target || typeof (target as { getBoundingClientRect?: unknown }).getBoundingClientRect !== 'function') {
-    return null
-  }
+): CanvasOverlayRect | null {
+  if (!target) return null
+  return createCanvasOverlayMeasureSession(iframe, canvasRoot).measure(target)
+}
 
-  const elementRectInIframe = target.getBoundingClientRect()
-  if (elementRectInIframe.width === 0 && elementRectInIframe.height === 0) {
-    return null
-  }
-  const iframeRect = iframe.getBoundingClientRect()
-  const iframeScale = iframe.offsetWidth > 0 ? iframeRect.width / iframe.offsetWidth : 1
-  const editorDocRect = {
-    left: iframeRect.left + elementRectInIframe.left * iframeScale,
-    top: iframeRect.top + elementRectInIframe.top * iframeScale,
-    width: elementRectInIframe.width * iframeScale,
-    height: elementRectInIframe.height * iframeScale,
-  }
-
-  let originLeft = 0
-  let originTop = 0
-  if (canvasRoot) {
-    const canvasRect = canvasRoot.getBoundingClientRect()
-    originLeft = canvasRect.left
-    originTop = canvasRect.top
-  }
+/** Smallest rect containing both `a` (may be null) and `b`. */
+export function unionCanvasOverlayRects(
+  a: CanvasOverlayRect | null,
+  b: CanvasOverlayRect,
+): CanvasOverlayRect {
+  if (!a) return b
+  const x = Math.min(a.x, b.x)
+  const y = Math.min(a.y, b.y)
   return {
-    x: editorDocRect.left - originLeft,
-    y: editorDocRect.top - originTop,
-    width: editorDocRect.width,
-    height: editorDocRect.height,
+    x,
+    y,
+    width: Math.max(a.x + a.width, b.x + b.width) - x,
+    height: Math.max(a.y + a.height, b.y + b.height) - y,
   }
 }

--- a/src/admin/pages/site/canvas/useLoopPreviewItems.ts
+++ b/src/admin/pages/site/canvas/useLoopPreviewItems.ts
@@ -22,6 +22,16 @@
  *   - any other source — falls back to the source's synchronous
  *     `preview()` method (plugin sources can ship synthetic data;
  *     follow-up work will let plugins declare a server fetch endpoint).
+ *
+ * Subscription granularity: the hook never subscribes to the whole `site`
+ * document for built-in sources. `site.pages` loops subscribe through
+ * `selectSitePagesLoopItems`, whose output keeps a stable identity (per-page
+ * WeakMap projection cache + previous-array reuse) when an unrelated edit
+ * replaces the `pages` array without changing the loop's actual items — so
+ * typing in an unrelated text node no longer re-renders every loop body
+ * subtree in every breakpoint frame. Only the plugin-source fallback (whose
+ * `preview()` contractually receives the full document) subscribes to
+ * `site`, and only when such a source is selected.
  */
 
 import { useEffect, useState } from 'react'
@@ -141,8 +151,79 @@ function mediaAssetToLoopItem(asset: CmsMediaAsset): LoopItem {
 // than re-deriving it — keeping editor previews and published output in sync.
 
 // ---------------------------------------------------------------------------
+// site.pages selection — identity-stable across unrelated site mutations
+// ---------------------------------------------------------------------------
+
+/** Stable empty result shared by every inactive branch of the selectors. */
+const EMPTY_ITEMS: LoopItem[] = []
+
+// page → LoopItem projection cache. Mutative structural sharing keeps
+// untouched page objects identical across site mutations, so the projected
+// item keeps its identity too — which is what lets the items-array reuse
+// below actually hit.
+const pageLoopItemCache = new WeakMap<Page, LoopItem>()
+
+function cachedPageToLoopItem(page: Page): LoopItem {
+  let item = pageLoopItemCache.get(page)
+  if (!item) {
+    item = pageToLoopItem(page)
+    pageLoopItemCache.set(page, item)
+  }
+  return item
+}
+
+interface SitePagesItemsCacheEntry {
+  pages: readonly Page[]
+  items: LoopItem[]
+}
+
+// Per-loop-node result cache, keyed on the node object. The node keeps its
+// identity until ITS OWN props change (structural sharing again), so the
+// entry self-invalidates on filter/order/limit edits; the `pages` field
+// detects site mutations. Shared across the 3 breakpoint frames rendering
+// the same node — frames 2..N hit the first frame's entry.
+const sitePagesItemsCache = new WeakMap<PageNode, SitePagesItemsCacheEntry>()
+
+function sameItems(a: readonly LoopItem[], b: readonly LoopItem[]): boolean {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false
+  }
+  return true
+}
+
+/**
+ * Project `pages` into the loop items for a `site.pages`-bound loop node,
+ * keeping the result referentially stable:
+ *
+ *  - same (node, pages) identities → cached array, no recompute;
+ *  - new `pages` identity whose relevant pages are untouched → recomputes,
+ *    then returns the PREVIOUS array because every member is identical.
+ *
+ * Runs inside a Zustand selector on every store set, so the steady-state
+ * path is two identity checks; the recompute path is O(pages log pages).
+ */
+export function selectSitePagesLoopItems(node: PageNode, pages: readonly Page[] | null): LoopItem[] {
+  if (!pages) return EMPTY_ITEMS
+
+  const cached = sitePagesItemsCache.get(node)
+  if (cached && cached.pages === pages) return cached.items
+
+  const { filters, orderBy, direction, offset, limit } = readLoopProps(node)
+  const filtered = filterPagesForLoop(pages, filters)
+  const sorted = sortPages(filtered, orderBy || 'definition', direction)
+  let items = sorted.slice(offset, offset + limit).map(cachedPageToLoopItem)
+  if (cached && sameItems(cached.items, items)) items = cached.items
+
+  sitePagesItemsCache.set(node, { pages, items })
+  return items
+}
+
+// ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
+
+const BUILT_IN_SOURCE_IDS = new Set(['data.rows', 'site.media', 'site.pages'])
 
 export function useLoopPreviewItems(node: PageNode): LoopItem[] {
   // `readLoopProps()` reuses the shared `EMPTY_FILTERS` sentinel when the
@@ -154,10 +235,17 @@ export function useLoopPreviewItems(node: PageNode): LoopItem[] {
   const { sourceId, filters, orderBy, direction, offset, limit } = readLoopProps(node)
   const tableId = typeof filters.tableId === 'string' ? filters.tableId : ''
   const mimePrefix = typeof filters.mimePrefix === 'string' ? filters.mimePrefix : ''
+  const isPluginSource = sourceId !== '' && !BUILT_IN_SOURCE_IDS.has(sourceId)
 
-  // Subscribe reactively so site.pages updates trigger re-renders.
-  const site = useEditorStore((s) => s.site)
-  const sitePages = useEditorStore((s) => s.site?.pages ?? null)
+  // Narrow, identity-stable subscriptions (see module header). Inactive
+  // branches resolve to stable constants so the subscription never fires
+  // for them.
+  const sitePagesItems = useEditorStore((s) =>
+    sourceId === 'site.pages' ? selectSitePagesLoopItems(node, s.site?.pages ?? null) : EMPTY_ITEMS,
+  )
+  // Plugin `preview()` contractually receives the whole site document, so
+  // this is the one branch that genuinely depends on it.
+  const pluginSite = useEditorStore((s) => (isPluginSource ? s.site : null))
 
   // Raw fetched data for async sources — sort/offset/limit applied below.
   const [asyncDataTable, setAsyncDataTable] = useState<DataTable | null>(null)
@@ -223,7 +311,7 @@ export function useLoopPreviewItems(node: PageNode): LoopItem[] {
   }, [sourceId])
 
   // ── Sort + offset + limit pipeline ──────────────────────────────────
-  if (!sourceId) return []
+  if (!sourceId) return EMPTY_ITEMS
 
   if (sourceId === 'data.rows') {
     // Prefer real published rows (server already applied orderBy /
@@ -233,13 +321,13 @@ export function useLoopPreviewItems(node: PageNode): LoopItem[] {
     // items from the table's field definitions so the loop body stays
     // visible in the canvas. The author can lay out the template; once
     // rows are published the preview switches over automatically.
-    if (!asyncDataTable) return []
+    if (!asyncDataTable) return EMPTY_ITEMS
     const previewItem = dataTablePreviewToLoopItem(asyncDataTable)
     return Array.from({ length: Math.min(limit, 3) }, () => previewItem)
   }
 
   if (sourceId === 'site.media') {
-    if (asyncMedia.length === 0) return []
+    if (asyncMedia.length === 0) return EMPTY_ITEMS
     const filtered = mimePrefix
       ? asyncMedia.filter((a) => a.mimeType.startsWith(mimePrefix))
       : asyncMedia
@@ -247,21 +335,16 @@ export function useLoopPreviewItems(node: PageNode): LoopItem[] {
     return sorted.slice(offset, offset + limit).map(mediaAssetToLoopItem)
   }
 
-  if (sourceId === 'site.pages') {
-    if (!sitePages) return []
-    const filtered = filterPagesForLoop(sitePages, filters)
-    const sorted = sortPages(filtered, orderBy || 'definition', direction)
-    return sorted.slice(offset, offset + limit).map(pageToLoopItem)
-  }
+  if (sourceId === 'site.pages') return sitePagesItems
 
   // Plugin source fallback — synchronous preview() with no client-side
   // sort. Plugins that need ordering should apply it inside their own
   // preview() implementation.
   const source = loopSourceRegistry.get(sourceId)
-  if (!source || !site) return []
+  if (!source || !pluginSite) return EMPTY_ITEMS
   try {
-    return source.preview({ site, filters, limit }).slice(offset, offset + limit)
+    return source.preview({ site: pluginSite, filters, limit }).slice(offset, offset + limit)
   } catch {
-    return []
+    return EMPTY_ITEMS
   }
 }

--- a/src/admin/pages/site/store/store.ts
+++ b/src/admin/pages/site/store/store.ts
@@ -152,9 +152,33 @@ bindPluginRuntimeStoreApi(useEditorStore)
 // to keep component subscriptions granular and avoid unnecessary re-renders.
 // ---------------------------------------------------------------------------
 
-/** Select the active page from the site */
-export const selectActivePage = (s: EditorStore) =>
-  s.site?.pages.find((p) => p.id === s.activePageId) ?? null
+// Single-slot memo for the active-page lookup. Zustand re-runs EVERY
+// subscriber's selector on every store set, and each canvas NodeRenderer
+// mounts several subscriptions that resolve the active page — so an
+// unmemoized `pages.find` here costs O(nodes × pages) per store change.
+// Keying on (site, activePageId) identity makes the first selector after a
+// set pay the O(pages) scan once; every other subscriber in the same sweep
+// hits the cache. Mutative copy-on-write replaces `site` exactly when
+// anything inside it changes, so invalidation is automatic — and the cached
+// page is the same object `find` would return, so subscriber outputs keep
+// their referential stability.
+let _activePageCache: { site: object; activePageId: string; page: Page | null } | null = null
+
+/** Select the active page from the site (one `pages` scan per store update). */
+export const selectActivePage = (s: EditorStore): Page | null => {
+  const { site, activePageId } = s
+  if (!site || !activePageId) return null
+  if (
+    _activePageCache &&
+    _activePageCache.site === site &&
+    _activePageCache.activePageId === activePageId
+  ) {
+    return _activePageCache.page
+  }
+  const page = site.pages.find((p) => p.id === activePageId) ?? null
+  _activePageCache = { site, activePageId, page }
+  return page
+}
 
 /** Select whether the docked right sidebar is currently taking layout space. */
 export const selectRightSidebarExpanded = (s: EditorStore) =>


### PR DESCRIPTION
## Summary

Editor-canvas performance cluster from the audit behind #24 (**stacked on `perf/critical-performance-fixes`** — merge that first). Four adversarially-verified findings, all fixed without any visual or behavioral change — the levers are zustand subscription granularity, referential stability, and read/write phasing, not manual memoization (React Compiler stays in charge).

## What changed

1. **Per-node store selectors were O(pages) ×4 per node on every store change** (`NodeRenderer.tsx` — high/high). `selectActivePage` is now a single-slot memo keyed on `(site, activePageId)` identity, so each store update does ONE pages scan instead of one per selector per node. Form-preview resolvers moved to `canvasFormPreview.ts` with a WeakMap parent-index per `page.nodes` identity; `getCanvasNodeClassIds` stops copying per node per sweep.
   **Measured** (20 pages × 500 nodes, 7,500 canvas-like subscribers): pages scans per hover **3,000 → 0**; per keystroke **3,001 → 2**; hover set latency 0.223 ms → 0.163 ms. At 200 pages × 1,000 nodes: **6,000 → 0** scans.

2. **Selection-overlay RAF loop re-queried the iframe DOM and re-measured from scratch every frame** (`BreakpointSelectionOverlay.tsx`). The loop remains (it's what tracks pan/zoom/CSS animation) but each tick is now read-phase-then-write-phase: shared geometry measured once per tick instead of twice per ring, elements resolved through a disconnect-aware cache instead of `querySelector` per node per frame, the toolbar anchored to already-measured rects, and style writes skipped when unchanged — steady-state ticks are read-only with zero document scans and no interleaved write→read reflows.
   **Counted**: 1 shared-geometry read per tick for 25 rings (was 50); 1 `querySelector` per tracked node across 60 ticks (was 60).

3. **Class-registry CSS regenerated once per breakpoint iframe** (`ClassStyleInjector.tsx`). Generation is now a single-slot identity memo shared by all frames (≈6.6 ms saved per commit at 1k classes, ≈71 ms at 10k, per the verifier's measurements). The per-frame viewport-unit rewrite intentionally stays per-frame — its output genuinely differs by frame width.

4. **Loop previews subscribed to the entire site object** (`useLoopPreviewItems.ts`), re-rendering every loop body on any keystroke. Built-in `site.pages` loops now subscribe through a WeakMap-projected, identity-stable items selector; the whole-site subscription survives only for plugin preview sources (their API receives the full document) and only while selected.

## Verification

- Full `bun test` on this branch: **5,147 pass / 0 fail**; `tsc -b` and eslint clean.
- 35 new tests across 6 files pin the memo/identity/measure-count behavior; a new editor-store bench scenario ("set() latency with N canvas-like subscribers") makes the subscriber-storm cost a tracked number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
