### PR TITLE
Remove AI credential authentication selector

### DIFF
--- a/docs/features/agent.md
+++ b/docs/features/agent.md
@@ -31,7 +31,7 @@ server/ai/
 │   ├── chat.ts             — POST /admin/api/ai/chat/:scope  (NDJSON stream)
 │   ├── toolResult.ts       — POST /admin/api/ai/tool-result  (bridge POST)
 │   ├── conversations.ts    — CRUD for ai_conversations rows
-│   ├── credentials.ts      — CRUD for ai_credentials rows (encrypted API keys); auto-seeds defaults on create
+│   ├── credentials.ts      — CRUD for ai_credentials rows (encrypted secrets + endpoint credentials); auto-seeds defaults on create
 │   ├── defaults.ts         — GET /admin/api/ai/defaults (per-scope defaults)
 │   ├── models.ts           — list available models per provider; enriches Anthropic/OpenAI with catalogue prices + context windows
 │   └── audit.ts            — GET /admin/api/ai/audit (usage rollups for the Audit tab; gated by ai.audit.read)
@@ -105,7 +105,7 @@ src/admin/pages/ai/
 ├── AiPage.tsx              — /admin/ai workspace; three tabs gated by ai.providers.manage + ai.audit.read
 ├── AiPage.module.css
 └── tabs/
-    ├── ProvidersTab.tsx    — CRUD for ai_credentials rows (encrypted API keys)
+    ├── ProvidersTab.tsx    — CRUD for ai_credentials rows (provider-derived API key or endpoint credential shape)
     ├── DefaultsTab.tsx     — per-scope model defaults editor
     ├── AuditTab.tsx        — usage audit view: totals strip, by-model/user/scope tables, daily bar chart
     ├── UsageTablePanel.tsx — shared table scaffolding (title + hint header, numeric-aligned columns, empty row)

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -120,7 +120,7 @@ Was a single `ai.use`. Split so a Client persona can have chat assistance withou
 |------------------------|---------------------------------------------------------------------|---------------|
 | `ai.chat`              | Open AI conversations; use read-only tools (snapshot, search). The chat handler registers ONLY non-mutating tools with the driver for callers without `ai.tools.write`. | Owner, Admin |
 | `ai.tools.write`       | Enable canvas write tools (`setNodeProps`, `insertNode`, `deleteNode`, etc.) in registered AI conversations. Without this, the model has no write tools at all. | Owner, Admin |
-| `ai.providers.manage`  | Create / update / delete API-key credentials + per-scope defaults   | Owner, Admin |
+| `ai.providers.manage`  | Create / update / delete AI provider credentials + per-scope defaults | Owner, Admin |
 | `ai.audit.read`        | Read site-wide AI usage, cost, and error events across all users    | Owner, Admin |
 
 ---

--- a/server/ai/credentials/store.ts
+++ b/server/ai/credentials/store.ts
@@ -227,8 +227,9 @@ export async function resolveCredentialForDriver(
 // ---------------------------------------------------------------------------
 
 /**
- * Insert a new credential row. Encrypts the API key with the live master
- * key + stores the key fingerprint so the UI can later detect rotation.
+ * Insert a new credential row. Encrypts any recoverable secret material with
+ * the live master key + stores the key fingerprint so the UI can later detect
+ * rotation.
  *
  * Throws CredentialError on:
  *   - duplicate (user_id, provider_id, display_label) — surfaced as 409

--- a/server/ai/drivers/types.ts
+++ b/server/ai/drivers/types.ts
@@ -152,11 +152,13 @@ export interface AiProvider {
   readonly id: AiProviderId
   readonly label: string
   /**
-   * Which auth modes this provider supports. The credential UI uses this
-   * to gate the auth-mode picker per provider.
+   * Which credential shapes this provider accepts. Current providers expose
+   * exactly one shape, so the admin UI derives it from the provider instead
+   * of showing a separate auth-mode picker.
    *
    *   anthropic → ['apiKey']
    *   openai    → ['apiKey']
+   *   openrouter → ['apiKey']
    *   ollama    → ['baseUrl']
    */
   readonly supportedAuthModes: readonly AiAuthMode[]

--- a/src/__tests__/ai/providersTab.test.tsx
+++ b/src/__tests__/ai/providersTab.test.tsx
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { ProvidersTab } from '@admin/pages/ai/tabs/ProvidersTab'
+
+const originalFetch = globalThis.fetch
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function mockEmptyCredentials() {
+  globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString()
+    if (url.endsWith('/admin/api/ai/credentials')) return json({ credentials: [] })
+    throw new Error(`Unexpected fetch: ${url}`)
+  }) as typeof fetch
+}
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
+  cleanup()
+})
+
+describe('ProvidersTab', () => {
+  it('derives credential authentication from the selected provider', async () => {
+    mockEmptyCredentials()
+
+    render(<ProvidersTab />)
+    await waitFor(() => expect(screen.getByText('No credentials yet. Add one to start using AI features.')).toBeDefined())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add credential' }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Add AI credential' })
+    expect(within(dialog).getByRole('combobox', { name: 'Provider' })).toBeDefined()
+    expect(within(dialog).queryByLabelText('Authentication')).toBeNull()
+    expect(within(dialog).getByLabelText('API key')).toBeDefined()
+  })
+
+  it('keeps Ollama on the endpoint credential shape without an auth-mode choice', async () => {
+    mockEmptyCredentials()
+
+    render(<ProvidersTab />)
+    await waitFor(() => expect(screen.getByText('No credentials yet. Add one to start using AI features.')).toBeDefined())
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add credential' }))
+
+    const dialog = screen.getByRole('dialog', { name: 'Add AI credential' })
+    const provider = within(dialog).getByRole('combobox', { name: 'Provider' })
+    fireEvent.click(provider.nextElementSibling as HTMLElement)
+    fireEvent.click(screen.getByRole('option', { name: 'Ollama (local)' }))
+
+    expect(within(dialog).queryByLabelText('Authentication')).toBeNull()
+    expect(within(dialog).getByLabelText('Base URL')).toBeDefined()
+    expect(within(dialog).getByLabelText('Bearer token (optional)')).toBeDefined()
+    expect(within(dialog).queryByLabelText('API key')).toBeNull()
+  })
+})

--- a/src/admin/pages/ai/tabs/ProvidersTab.tsx
+++ b/src/admin/pages/ai/tabs/ProvidersTab.tsx
@@ -30,13 +30,13 @@ import { getErrorMessage } from '@core/utils/errorMessage'
 type ProviderId = 'anthropic' | 'openai' | 'ollama' | 'openrouter'
 type AuthMode = 'apiKey' | 'baseUrl'
 
-// Anthropic + OpenAI + OpenRouter require an API key. Ollama uses a local
-// endpoint URL with an optional bearer token for proxied installs.
-const PROVIDERS: Array<{ id: ProviderId; label: string; modes: AuthMode[] }> = [
-  { id: 'anthropic', label: 'Anthropic (Claude)', modes: ['apiKey'] },
-  { id: 'openai', label: 'OpenAI', modes: ['apiKey'] },
-  { id: 'openrouter', label: 'OpenRouter', modes: ['apiKey'] },
-  { id: 'ollama', label: 'Ollama (local)', modes: ['baseUrl'] },
+// Each provider has exactly one credential shape; the UI derives it instead
+// of asking the user to choose an auth mode that cannot vary.
+const PROVIDERS: Array<{ id: ProviderId; label: string; authMode: AuthMode }> = [
+  { id: 'anthropic', label: 'Anthropic (Claude)', authMode: 'apiKey' },
+  { id: 'openai', label: 'OpenAI', authMode: 'apiKey' },
+  { id: 'openrouter', label: 'OpenRouter', authMode: 'apiKey' },
+  { id: 'ollama', label: 'Ollama (local)', authMode: 'baseUrl' },
 ]
 
 const AUTH_MODE_LABEL: Record<AuthMode, string> = {
@@ -131,7 +131,7 @@ export function ProvidersTab() {
       <div className={styles.sectionHeader}>
         <div>
           <h2>Credentials</h2>
-          <p>API keys for each AI provider. Plaintext is encrypted at rest.</p>
+          <p>Provider credentials for AI features. Secrets are encrypted at rest.</p>
         </div>
         <Button type="button" variant="primary" size="sm" onClick={() => setShowDialog(true)}>
           <PlusIcon size={14} aria-hidden="true" />
@@ -270,14 +270,12 @@ function AddCredentialDialog({
   onCreated: () => void
 }) {
   const providerInputId = useId()
-  const authModeInputId = useId()
   const labelInputId = useId()
   const apiKeyInputId = useId()
   const baseUrlInputId = useId()
   const formId = useId()
 
   const [providerId, setProviderId] = useState<ProviderId>('anthropic')
-  const [authMode, setAuthMode] = useState<AuthMode>('apiKey')
   const [displayLabel, setDisplayLabel] = useState('')
   const [apiKey, setApiKey] = useState('')
   const [baseUrl, setBaseUrl] = useState('http://localhost:11434')
@@ -285,10 +283,7 @@ function AddCredentialDialog({
   const [error, setError] = useState<string | null>(null)
 
   const providerSpec = PROVIDERS.find((p) => p.id === providerId)!
-  const availableModes = providerSpec.modes
-
-  // Coerce auth mode when provider changes if it's no longer supported.
-  const effectiveAuthMode = availableModes.includes(authMode) ? authMode : availableModes[0]!
+  const effectiveAuthMode = providerSpec.authMode
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
@@ -321,16 +316,6 @@ function AddCredentialDialog({
             value={providerId}
             onChange={(e) => setProviderId(e.currentTarget.value as ProviderId)}
             options={PROVIDERS.map((p) => ({ value: p.id, label: p.label }))}
-          />
-        </div>
-
-        <div className={styles.dialogField}>
-          <label htmlFor={authModeInputId} className={styles.dialogFieldLabel}>Authentication</label>
-          <Select
-            id={authModeInputId}
-            value={effectiveAuthMode}
-            onChange={(e) => setAuthMode(e.currentTarget.value as AuthMode)}
-            options={availableModes.map((m) => ({ value: m, label: AUTH_MODE_LABEL[m] }))}
           />
         </div>
 


### PR DESCRIPTION
## Summary
- Removes the Add AI credential dialog's separate Authentication selector and derives the credential shape from the selected provider.
- Keeps API-key providers on the API key field and Ollama on the base URL plus optional bearer-token fields.
- Updates AI credential docs/comments and adds a ProvidersTab regression test for both shapes.

## Validation
- `bun run build`
- `bun test`
- `bun run lint`
- `bunx react-doctor@latest --verbose --diff`