### PR TITLE
Clean up Style-rules review pane + fix icons:sync for in-house icons

### DIFF
--- a/scripts/sync-icons.ts
+++ b/scripts/sync-icons.ts
@@ -56,6 +56,18 @@ const UPSTREAM = resolve(
 const UPSTREAM_ICONS_DIR = join(UPSTREAM, 'icons')
 const UPSTREAM_TYPES_FILE = join(UPSTREAM, 'types.ts')
 
+/**
+ * Icons authored in-house, NOT sourced from the upstream catalog.
+ *
+ * The upstream pixel-art set ships an `underline` glyph but no strikethrough,
+ * so `strike` is hand-drawn and committed directly to `vendor/`. In-house
+ * icons are never copied from (nor reported as missing in) upstream — but they
+ * must still exist as a vendored `.tsx` source, get built into `dist/` like any
+ * other icon, and stay imported (an unused in-house icon is an orphan, same as
+ * any other). The sync therefore leaves these vendored sources untouched.
+ */
+const IN_HOUSE_ICONS = new Set(['strike'])
+
 const SCANNED_EXTS = new Set(['.ts', '.tsx', '.js', '.jsx', '.mts', '.mjs'])
 const IMPORT_RE = /from\s+["']pixel-art-icons\/icons\/([a-z0-9-]+)["']/g
 const ICON_NAME_RE = /^[a-z0-9][a-z0-9-]*$/
@@ -133,6 +145,18 @@ function copyFromUpstream(names: Set<string>, options: SyncOptions): void {
 
   const missing: string[] = []
   for (const name of names) {
+    // In-house icons have no upstream source; keep the vendored .tsx as-is.
+    if (IN_HOUSE_ICONS.has(name)) {
+      const vendoredFile = join(VENDOR_ICONS_DIR, `${name}.tsx`)
+      if (!existsSync(vendoredFile)) {
+        throw new Error(
+          `[sync-icons] In-house icon "${name}" is listed in IN_HOUSE_ICONS but ` +
+            `vendor/pixel-art-icons/icons/${name}.tsx does not exist. Restore the ` +
+            `hand-authored source, or remove the import and the IN_HOUSE_ICONS entry.`,
+        )
+      }
+      continue
+    }
     const upstreamFile = join(UPSTREAM_ICONS_DIR, `${name}.tsx`)
     if (!existsSync(upstreamFile)) {
       missing.push(name)
@@ -147,7 +171,8 @@ function copyFromUpstream(names: Set<string>, options: SyncOptions): void {
     throw new Error(
       `[sync-icons] ${missing.length} icon(s) imported by src/ are missing in upstream:\n` +
         missing.map((n) => `  - ${n}`).join('\n') +
-        `\n\nEither add them to the upstream pixel-art-icons repo, or remove the imports.`,
+        `\n\nAdd them to the upstream pixel-art-icons repo, remove the imports, or — ` +
+        `if hand-authored — list them in IN_HOUSE_ICONS.`,
     )
   }
 }

--- a/src/admin/modals/SiteImport/steps/AnalyzeStep.module.css
+++ b/src/admin/modals/SiteImport/steps/AnalyzeStep.module.css
@@ -247,6 +247,14 @@
   flex-direction: column;
   gap: 2px;
 }
+
+/* Per-stylesheet mode pickers sit above the search; keep them clear of it. */
+.modeRows {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin-bottom: 14px;
+}
 .info {
   display: flex;
   flex-direction: column;
@@ -337,7 +345,7 @@
 }
 .ruleRow {
   display: grid;
-  grid-template-columns: 16px 1fr auto;
+  grid-template-columns: 16px 1fr;
   align-items: center;
   gap: 9px;
   padding: 4px 10px 4px 0;
@@ -367,6 +375,15 @@
   font-size: 10px;
   font-weight: 600;
   white-space: nowrap;
+}
+
+/* CSS-file marker on a converted stylesheet mode row (sits in the checkbox column). */
+.fileBadge {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  color: var(--editor-text-muted);
 }
 
 /* ── Media + colour grids ────────────────────────────────────────────────── */

--- a/src/admin/modals/SiteImport/steps/AnalyzeStep.tsx
+++ b/src/admin/modals/SiteImport/steps/AnalyzeStep.tsx
@@ -399,7 +399,6 @@ export function AnalyzeStep({
                 {isOpen && (
                   <div className={styles.groupRules}>
                     {visible.map((i) => {
-                      const rule = plan.styleRules[i]
                       const on = selection.styleRulesIncluded.has(i)
                       return (
                         <div key={styleRuleKey(plan, i)} className={styles.ruleRow}>
@@ -412,7 +411,6 @@ export function AnalyzeStep({
                           <span className={styles.ruleName} data-off={on ? undefined : 'true'}>
                             {ruleText(plan, i)}
                           </span>
-                          <span className={styles.chip}>{rule.kind}</span>
                         </div>
                       )
                     })}

--- a/src/admin/modals/SiteImport/steps/StylesheetModeRows.tsx
+++ b/src/admin/modals/SiteImport/steps/StylesheetModeRows.tsx
@@ -8,6 +8,7 @@
 
 import { Checkbox } from '@ui/components/Checkbox'
 import { Select } from '@ui/components/Select'
+import { FileTextSolidIcon } from 'pixel-art-icons/icons/file-text-solid'
 import type { ImportPlan, StylesheetImportMode } from '@core/siteImport'
 import styles from './AnalyzeStep.module.css'
 
@@ -30,7 +31,7 @@ export function StylesheetModeRows({
   if (plan.linkedStylesheets.length === 0) return null
 
   return (
-    <div className={styles.rows}>
+    <div className={styles.modeRows}>
       {plan.linkedStylesheets.map((sheet) => {
         const kept = sheet.mode === 'file'
         const keptEntry = kept ? plan.stylesheets.find((s) => s.path === sheet.path) : undefined
@@ -46,7 +47,9 @@ export function StylesheetModeRows({
                 aria-label={`Include stylesheet ${sheet.path}`}
               />
             ) : (
-              <span className={styles.chip}>css</span>
+              <span className={styles.fileBadge} aria-hidden="true">
+                <FileTextSolidIcon size={14} />
+              </span>
             )}
             <div className={styles.info}>
               <span className={styles.title}>{sheet.path}</span>


### PR DESCRIPTION
## What

Tidies up the **Review import → Style rules** pane (the "Super Import" wizard) and fixes a latent break in `bun run icons:sync`.

### Style-rules pane (`AnalyzeStep`, `StylesheetModeRows`)
- **Dropped the `ambient`/`class` badges** on every selector row — a distinction users don't act on. `.ruleRow` collapses from 3 columns to 2 so the selector name uses the full width. The underlying `rule.kind` still drives import behavior; only the UI noise is gone.
- **Fixed the broken-looking `css` chip** on converted-stylesheet rows. It was a text chip crammed into the 16px checkbox column, overflowing its box. Replaced with a properly sized `FileTextSolidIcon` (`.fileBadge`).
- **Added spacing** between the per-stylesheet mode rows and the "Search selectors…" bar, which previously sat flush together (`.modeRows` wrapper with bottom margin).

### `scripts/sync-icons.ts`
`bun run icons:sync` threw on any imported icon with no upstream source. The culprit is the hand-authored `strike` glyph in `BodyBubbleMenu` (upstream pixel-art-icons ships `underline` but no strikethrough, so it was drawn in-house and committed to `vendor/`). The sync blindly tried to copy it from upstream and aborted.

Added an `IN_HOUSE_ICONS` allowlist that the upstream-copy step skips — while still asserting the vendored `.tsx` source exists, so a deleted/renamed in-house icon still fails loudly. `bun run icons:sync` and `bun run icons:check` now both pass (134 icons).

## Verification
- `bun run icons:sync` ✓ (134 icons) · `bun run icons:check` ✓ (fresh)
- `bunx eslint` clean on all four touched files
- `bun run build` passed (run before the unrelated parallel work landed in the tree)

## Notes
- React Doctor flags `no-giant-component` on `AnalyzeStep` (556 lines) — **pre-existing**; this PR removes lines rather than adding them. Splitting that component is out of scope.
- The working tree currently contains an unrelated in-progress "layouts" feature from a parallel session; none of it is included in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)