### PR TITLE
Remove inconsistent panel keyboard shortcuts from the rail

### DIFF
--- a/src/__tests__/architecture/keybindings-registry-single-source.test.ts
+++ b/src/__tests__/architecture/keybindings-registry-single-source.test.ts
@@ -12,7 +12,6 @@
  *   - keybindings.ts           — registry itself (defines match functions)
  *   - HelpKeybindingsList.tsx  — reads from registry, renders <kbd> tags
  *   - SpotlightRow.tsx         — reads from registry, renders <kbd> tags
- *   - PanelRail.tsx            — uses getKeybindingForCommand().match(e)
  *   - CanvasRoot.tsx           — uses getKeybindingForCommand().match(e)
  *   - usePersistence.ts        — uses getKeybindingForCommand().match(e)
  *   - SpotlightRoot.tsx        — uses getKeybindingForCommand().match(e)
@@ -39,7 +38,6 @@ const ALLOWLIST = new Set([
   // ⌘ symbol appears only in a JSDoc comment, not JSX output
   'admin/spotlight/Spotlight.tsx',
   // Handlers that use getKeybindingForCommand().match(e)
-  'admin/pages/site/sidebars/PanelRail/PanelRail.tsx',
   'admin/pages/site/canvas/CanvasRoot.tsx',
   'admin/pages/site/hooks/usePersistence.ts',
   'admin/spotlight/SpotlightRoot.tsx',

--- a/src/__tests__/layout/editorLayoutPersistence.test.tsx
+++ b/src/__tests__/layout/editorLayoutPersistence.test.tsx
@@ -8,7 +8,7 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import React from 'react'
-import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { readFileSync } from 'fs'
 import { join } from 'path'
 import { MemoryRouter } from '@admin/lib/routing'
@@ -398,10 +398,9 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     fireEvent.keyDown(canvas, { key: 'Backspace' })
     expect(Object.keys(useEditorStore.getState().site?.pages[0]?.nodes ?? {})).toEqual(beforeNodeIds)
 
-    // Site Explorer is a navigation panel available to read-only callers, so
-    // the rail keybinding (Ctrl+Shift+E) DOES toggle it open even without
-    // edit capabilities — they can browse the page roster but not edit it.
-    fireEvent.keyDown(document, { key: 'E', ctrlKey: true, shiftKey: true })
+    // Site Explorer is a navigation panel available to read-only callers — they
+    // can open it from the rail to browse the page roster, but not edit it.
+    fireEvent.click(within(rail).getByRole('button', { name: /open site panel/i }))
     expect(useEditorStore.getState().siteExplorerPanelOpen).toBe(true)
   })
 
@@ -650,34 +649,8 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     const sidebar = screen.getByTestId('left-sidebar')
     const rail = within(sidebar).getByRole('navigation', { name: /panel dock/i })
 
+    // Properties lives in the right sidebar, never as a left-rail panel button.
     expect(within(rail).queryByRole('button', { name: /properties panel/i })).toBeNull()
-
-    act(() => {
-      useEditorStore.setState({
-        propertiesPanel: { collapsed: false, x: 0, y: 0, width: 360 },
-        selectedNodeId: 'selected-for-shortcut',
-      } as Parameters<typeof useEditorStore.setState>[0])
-    })
-    fireEvent.keyDown(document, { key: 'R', ctrlKey: true, shiftKey: true })
-
     expect(sidebar.getAttribute('data-active-panel')).toBe('layers')
-    expect(useEditorStore.getState().propertiesPanel.collapsed).toBe(true)
-  })
-
-  it('keeps panel keyboard shortcuts on the permanent rail', () => {
-    renderEditorLayout()
-
-    fireEvent.keyDown(document, { key: 'E', ctrlKey: true, shiftKey: true })
-    expect(useEditorStore.getState().siteExplorerPanelOpen).toBe(true)
-
-    fireEvent.keyDown(document, { key: 'M', ctrlKey: true, shiftKey: true })
-    expect(useEditorStore.getState().mediaExplorerPanelOpen).toBe(true)
-    expect(useEditorStore.getState().siteExplorerPanelOpen).toBe(false)
-
-    fireEvent.keyDown(document, { key: 'R', ctrlKey: true, shiftKey: true })
-    expect(useEditorStore.getState().propertiesPanel.collapsed).toBe(true)
-
-    fireEvent.keyDown(document, { key: 'i', metaKey: true })
-    expect(useEditorStore.getState().isAgentOpen).toBe(true)
   })
 })

--- a/src/admin/pages/site/sidebars/PanelRail/PanelRail.tsx
+++ b/src/admin/pages/site/sidebars/PanelRail/PanelRail.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useSyncExternalStore, type CSSProperties } from 'react'
+import { useSyncExternalStore, type CSSProperties } from 'react'
 import { useEditorStore } from '@site/store/store'
 import type { LeftSidebarPanelId } from '@site/store/slices/uiSlice'
 import type { IconComponent } from 'pixel-art-icons/types'
@@ -14,7 +14,6 @@ import { RulerDimensionSolidIcon } from 'pixel-art-icons/icons/ruler-dimension-s
 import { Button } from '@ui/components/Button'
 import { assignRailAccents, railTintVar, type RailAccent } from '@ui/railAccent'
 import { pluginRuntime } from '@core/plugins/runtime'
-import { getKeybindingForCommand, formatShortcut } from '@admin/spotlight/keybindings'
 import { resolvePluginPanelIcon } from './pluginPanelIcons'
 import styles from './PanelRail.module.css'
 
@@ -23,12 +22,6 @@ interface PrimaryRailItem {
   label: string
   icon: IconComponent
   iconName: string
-  /**
-   * commandId links this panel button to a keybinding in the registry.
-   * The ariaKeyshortcuts and shortcutLabel tooltip are derived from it
-   * at runtime — do NOT hardcode shortcut strings here.
-   */
-  commandId?: string
 }
 
 interface RailItem {
@@ -41,7 +34,7 @@ interface RailItem {
   disabled?: boolean
   onToggle: () => void
   disabledTitle?: string
-  ariaKeyshortcuts?: string
+  /** Plugin-supplied shortcut hint shown in the button tooltip. */
   shortcutLabel?: string
 }
 
@@ -51,14 +44,12 @@ const PRIMARY_RAIL_ITEMS: PrimaryRailItem[] = [
     label: 'Layers',
     icon: DatabaseSolidIcon,
     iconName: 'database-solid',
-    // No keyboard shortcut registered for the Layers panel.
   },
   {
     id: 'site',
     label: 'Site',
     icon: FilesStack2SolidIcon,
     iconName: 'files-stack-2',
-    commandId: 'panels.toggleSiteExplorer',
   },
   {
     id: 'selectors',
@@ -89,7 +80,6 @@ const PRIMARY_RAIL_ITEMS: PrimaryRailItem[] = [
     label: 'Media',
     icon: ImagesSolidIcon,
     iconName: 'images',
-    commandId: 'panels.toggleMedia',
   },
   {
     id: 'dependencies',
@@ -105,7 +95,6 @@ const GLOBAL_RAIL_ITEMS: PrimaryRailItem[] = [
     label: 'AI assistant',
     icon: AiSettingsSolidIcon,
     iconName: 'ai-settings-solid',
-    commandId: 'panels.toggleAgent',
   },
 ]
 
@@ -144,52 +133,6 @@ export function PanelRail({ workspace = 'site', editable = true }: PanelRailProp
     () => SERVER_PLUGIN_PANELS_SNAPSHOT,
   )
 
-  useEffect(() => {
-    // Keyboard shortcuts for switching panels are wired up for every caller.
-    // Read-only viewers should still be able to press the shortcut to flip
-    // to Layers / Site Explorer / Media. The toggle handler in the store is
-    // a no-op when nothing is actually written, so this is safe; the gating
-    // of *content* (and the AI assistant) happens in the panels themselves.
-    // Agent shortcut is opt-in below — only registered for editors since the
-    // agent panel itself is editor-only.
-
-    // All match predicates come from the keybindings registry — single source of truth.
-    const kbSiteExplorer = getKeybindingForCommand('panels.toggleSiteExplorer')
-    const kbMedia        = getKeybindingForCommand('panels.toggleMedia')
-    const kbProperties   = getKeybindingForCommand('panels.toggleProperties')
-    const kbAgent        = editable ? getKeybindingForCommand('panels.toggleAgent') : null
-
-    function isTypingTarget(target: EventTarget | null) {
-      const element = target as HTMLElement | null
-      return Boolean(element && (
-        element.tagName === 'INPUT' ||
-        element.tagName === 'TEXTAREA' ||
-        element.isContentEditable
-      ))
-    }
-
-    function onKeyDown(e: KeyboardEvent) {
-      if (isTypingTarget(e.target)) return
-
-      if (kbSiteExplorer?.match(e)) {
-        e.preventDefault()
-        useEditorStore.getState().toggleLeftSidebarPanel('site')
-      } else if (kbMedia?.match(e)) {
-        e.preventDefault()
-        useEditorStore.getState().toggleLeftSidebarPanel('media')
-      } else if (kbProperties?.match(e)) {
-        e.preventDefault()
-        useEditorStore.getState().togglePropertiesPanel()
-      } else if (kbAgent?.match(e)) {
-        e.preventDefault()
-        useEditorStore.getState().toggleLeftSidebarPanel('agent')
-      }
-    }
-
-    document.addEventListener('keydown', onKeyDown)
-    return () => document.removeEventListener('keydown', onKeyDown)
-  }, [editable])
-
   const panelOpenById = {
     layers: domOpen,
     agent: agentOpen,
@@ -220,18 +163,11 @@ export function PanelRail({ workspace = 'site', editable = true }: PanelRailProp
   }
 
   function toRailItem(item: PrimaryRailItem, accent: RailAccent): RailItem {
-    const label = railLabel(item)
-    // Shortcut labels and ARIA keyshortcuts come from the keybindings registry.
-    const kb = item.commandId ? getKeybindingForCommand(item.commandId) : undefined
-    const shortcutLabel = kb ? formatShortcut(kb.shortcut) : undefined
-    const ariaKeyshortcuts = kb?.ariaKeyshortcuts
     return {
       ...item,
-      label,
+      label: railLabel(item),
       open: panelOpenById[item.id],
       onToggle: () => toggleLeftSidebarPanel(item.id),
-      shortcutLabel,
-      ariaKeyshortcuts,
       accent,
     }
   }
@@ -319,7 +255,6 @@ function RailButton({ item }: { item: RailItem }) {
       iconOnly
       pressed={item.open}
       aria-label={`${action} ${item.label} panel`}
-      aria-keyshortcuts={item.ariaKeyshortcuts}
       disabled={item.disabled}
       tooltip={title}
       data-testid={`panel-rail-${item.id}`}

--- a/src/admin/spotlight/keybindings.ts
+++ b/src/admin/spotlight/keybindings.ts
@@ -161,43 +161,7 @@ export const KEYBINDINGS: ReadonlyArray<KeybindingDefinition> = [
     ignoreInEditableField: true,
   },
 
-  // ── Panels (sidebar panel toggles) ─────────────────────────────────────────
-
-  {
-    commandId: 'panels.toggleSiteExplorer',
-    shortcut: { mac: 'Ctrl+⇧E', win: 'Ctrl+Shift+E' },
-    ariaKeyshortcuts: 'Control+Shift+E',
-    match: (e) => e.ctrlKey && e.shiftKey && e.key === 'E',
-    scope: 'panels',
-    ignoreInEditableField: true,
-  },
-
-  {
-    commandId: 'panels.toggleMedia',
-    shortcut: { mac: 'Ctrl+⇧M', win: 'Ctrl+Shift+M' },
-    ariaKeyshortcuts: 'Control+Shift+M',
-    match: (e) => e.ctrlKey && e.shiftKey && e.key === 'M',
-    scope: 'panels',
-    ignoreInEditableField: true,
-  },
-
-  {
-    commandId: 'panels.toggleProperties',
-    shortcut: { mac: 'Ctrl+⇧R', win: 'Ctrl+Shift+R' },
-    ariaKeyshortcuts: 'Control+Shift+R',
-    match: (e) => e.ctrlKey && e.shiftKey && e.key === 'R',
-    scope: 'panels',
-    ignoreInEditableField: true,
-  },
-
-  {
-    commandId: 'panels.toggleAgent',
-    shortcut: { mac: '⌘I', win: 'Ctrl+I' },
-    ariaKeyshortcuts: isPlatformMac() ? 'Meta+I' : 'Control+I',
-    match: (e) => (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'i',
-    scope: 'panels',
-    ignoreInEditableField: true,
-  },
+  // ── Panels (sidebar focus cycling) ──────────────────────────────────────────
 
   {
     commandId: 'panels.cycleFocus',


### PR DESCRIPTION
## What

The left-rail panel buttons advertised keyboard shortcuts in their tooltips:

| Panel | Tooltip shortcut |
|-------|------------------|
| Site | `Ctrl+⇧E` |
| Media | `Ctrl+⇧M` |
| Properties | `Ctrl+⇧R` |
| AI assistant | `⌘I` |

But only **4 of ~10** rail panels had a shortcut — the other panels (Layers, Selectors, Colors, Typography, Spacing, Dependencies) had none. The affordance was inconsistent and not fully wired across the rail, so this PR removes all four panel-toggle shortcuts.

## Changes

- **`keybindings.ts`** — remove the four `panels.toggle*` registry entries (keeping `panels.cycleFocus`/F6).
- **`PanelRail.tsx`** — drop the `keydown` handler and the `commandId → shortcut/aria` derivation. Rail buttons no longer render a shortcut hint in their tooltip or `aria-keyshortcuts`. Plugin-supplied `shortcutLabel` is unaffected.
- **`keybindings-registry-single-source.test.ts`** — drop `PanelRail.tsx` from the allowlist; it no longer routes through the registry.
- **`editorLayoutPersistence.test.tsx`** — update the three tests that fired the removed shortcuts (now exercise the rail buttons / panel placement directly).

## Not changed

Panels stay toggleable from the **command palette** — the `panels.toggle*` spotlight commands are untouched. Every panel already has a palette toggle command and none carry a keyboard shortcut, so this leaves the palette fully consistent.

## Verification

- `bun run build` ✅
- `bun run lint` ✅
- `bun test` for the touched layout + architecture + spotlight suites ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)