### PR TITLE
refactor(publisher): single class-CSS emission engine for publish and canvas

### DIFF
--- a/docs/reference/css-class-registry.md
+++ b/docs/reference/css-class-registry.md
@@ -396,11 +396,11 @@ Nodes that reference the rule by id keep working — only the rendered CSS outpu
   - `src/core/page-tree/classUtils.ts` — `isUserVisibleClass`, `isGeneratedClass`, ...
   - `src/core/page-tree/cssPropertyBag.ts` — `CSSPropertyBag` type
   - `src/core/page-tree/scopedClassClone.ts` — `cloneScopedClassesForNodeMap`
-  - `src/core/publisher/classCss.ts` — `bagToCSS`
+  - `src/core/publisher/classCss.ts` — `bagToCSS`, `generateClassCSS`, `createStyleRuleCssEmitter` (the single rule-emission engine shared by publish and canvas)
   - `src/core/publisher/cssCollector.ts` — `collectClassCSS`
   - `src/admin/pages/site/cssStatePseudo.ts` — `SUPPORTED_PSEUDO_STATES`, `selectorStatePseudo`, `stripStatePseudos`, `splitSelectorList`; shared helpers for reasoning about state pseudo-classes in the editor
   - `src/admin/pages/site/panels/PropertiesPanel/selectorPickerModel.ts` — `deriveSelectorPickerModel`, `SelectorMatch`, `SelectorPillItem`, `SelectorSuggestionItem`; pure derivation layer for the unified selector picker including specificity sorting and inactive-pseudo logic
-  - `src/admin/pages/site/canvas/canvasClassCss.ts` — `generateCanvasClassCSS`, `generatePreviewClassCSS`, `generateForcedStateCSS`; canvas CSS generation including forced state preview
+  - `src/admin/pages/site/canvas/canvasClassCss.ts` — `generateCanvasClassCSS`, `generatePreviewClassCSS`, `generateForcedStateCSS`; thin canvas wrappers over the publisher's `generateClassCSS` / `createStyleRuleCssEmitter` (reset + fonts + framework preamble, forced-state selectors, identity memo)
   - `src/admin/pages/site/canvas/ClassStyleInjector.tsx` — manages three `<style>` elements per iframe: `mc-classes`, `mc-classes-preview`, `mc-classes-force-state`
   - `src/core/page-tree/styleRule.ts` — `classifySelectorCreateInput`; the shared classifier for selector creation surfaces
   - `src/admin/pages/site/store/styleRuleRename.ts` — `renameStyleRule`, `isValidCssSelector`; rename logic for both class-kind and ambient rules

--- a/src/__tests__/canvas/classStyleInjector.test.ts
+++ b/src/__tests__/canvas/classStyleInjector.test.ts
@@ -70,6 +70,46 @@ describe('generateCanvasClassCSS', () => {
     expect(css).not.toContain('[data-breakpoint-id="mobile"] .title')
   })
 
+  it('emits sanitized raw @keyframes rules, matching the published output', () => {
+    // Regression: the canvas used to skip `rawCss` rules entirely, so
+    // imported keyframe animations published fine but never played in the
+    // editor preview. The canvas now routes through the publisher's
+    // `generateClassCSS`, which emits them through the same safety gate.
+    const pulse: StyleRule = {
+      id: 'pulse',
+      name: '@keyframes pulse',
+      kind: 'ambient',
+      selector: '@keyframes pulse',
+      order: 0,
+      styles: {},
+      contextStyles: {},
+      rawCss: '@keyframes pulse {\n  0% {\n    opacity: 0;\n  }\n  100% {\n    opacity: 1;\n  }\n}',
+      createdAt: 0,
+      updatedAt: 0,
+    }
+
+    const css = generateCanvasClassCSS({ pulse }, [])
+    expect(css).toContain('@keyframes pulse')
+    expect(css).toContain('opacity: 0')
+  })
+
+  it('drops unsupported raw CSS, matching the published output', () => {
+    const bad: StyleRule = {
+      id: 'bad',
+      name: 'bad',
+      kind: 'ambient',
+      selector: '.bad',
+      order: 0,
+      styles: {},
+      contextStyles: {},
+      rawCss: '@media screen { .bad { color: red; } }',
+      createdAt: 0,
+      updatedAt: 0,
+    }
+
+    expect(generateCanvasClassCSS({ bad }, [])).not.toContain('.bad')
+  })
+
   it('includes framework color variables for editor preview', () => {
     const colors = {
       tokens: [

--- a/src/admin/pages/site/canvas/canvasClassCss.ts
+++ b/src/admin/pages/site/canvas/canvasClassCss.ts
@@ -1,14 +1,14 @@
 import {
   bagToCSS,
-  compareViewportContextCascade,
-  conditionPrelude,
+  createStyleRuleCssEmitter,
+  generateClassCSS,
   PUBLISHER_RESET_CSS,
   type ViewportContext,
 } from '@core/publisher'
 import { generateFrameworkRootCss } from '@core/framework'
 import { generateFontsCss } from '@core/fonts'
-import { breakpointMediaQuery, styleRuleSelector } from '@core/page-tree'
-import type { StyleRule, Condition, ConditionDef } from '@core/page-tree'
+import { styleRuleSelector } from '@core/page-tree'
+import type { StyleRule, ConditionDef } from '@core/page-tree'
 import type { SiteFontsSettings } from '@core/fonts'
 import type {
   FrameworkColorSettings,
@@ -52,62 +52,12 @@ function buildCanvasClassCSS(
   })
   if (frameworkCss) blocks.push(frameworkCss)
 
-  // Cascade order matches the publisher: rules sorted by `order` ascending so
-  // a later, more-specific override appears later in source and wins on equal
-  // specificity. See generateClassCSS for the matching publisher invariant.
-  const orderedClasses = Object.values(classes).slice().sort((a, b) => {
-    const ao = typeof a.order === 'number' ? a.order : 0
-    const bo = typeof b.order === 'number' ? b.order : 0
-    return ao - bo
-  })
-
-  const breakpointById = new Map<string, { breakpoint: ViewportContext; index: number }>(
-    breakpoints.map((bp, index) => [bp.id, { breakpoint: bp, index }]),
-  )
-  // Condition id → (condition, registry index) for stable ordering.
-  const conditionById = new Map<string, { condition: Condition; index: number }>(
-    conditions.map((c, index) => [c.id, { condition: c.condition, index }]),
-  )
-
-  for (const cls of orderedClasses) {
-    const baseDecls = bagToCSS(cls.styles)
-    if (baseDecls) {
-      blocks.push(`${styleRuleSelector(cls)} {\n${baseDecls}\n}`)
-    }
-
-    // Unified contextStyles: a key is either a viewport context or a custom
-    // condition. Both emit real @-rule wrappers here so each iframe evaluates
-    // the same conditions as the published page.
-    const conditionEntries: Array<{ bag: Record<string, unknown>; condition: Condition; index: number }> = []
-    const bpEntries: Array<{ bag: Record<string, unknown>; breakpoint: ViewportContext; index: number }> = []
-    for (const [contextId, bag] of Object.entries(cls.contextStyles ?? {})) {
-      const cond = conditionById.get(contextId)
-      if (cond) {
-        conditionEntries.push({ bag, condition: cond.condition, index: cond.index })
-        continue
-      }
-      const breakpointEntry = breakpointById.get(contextId)
-      if (breakpointEntry) bpEntries.push({ bag, ...breakpointEntry })
-    }
-
-    conditionEntries.sort((a, b) => a.index - b.index)
-    for (const { bag, condition } of conditionEntries) {
-      const decls = bagToCSS(bag)
-      if (!decls) continue
-      const prelude = conditionPrelude(condition)
-      if (!prelude) continue
-      blocks.push(`${prelude} {\n  ${styleRuleSelector(cls)} {\n${decls}\n  }\n}`)
-    }
-
-    bpEntries.sort(compareViewportContextCascade)
-    for (const { bag, breakpoint } of bpEntries) {
-      const decls = bagToCSS(bag)
-      if (!decls) continue
-      const prelude = conditionPrelude({ kind: 'media', query: breakpointMediaQuery(breakpoint) })
-      if (!prelude) continue
-      blocks.push(`${prelude} {\n  ${styleRuleSelector(cls)} {\n${decls}\n  }\n}`)
-    }
-  }
+  // The registry CSS is the publisher's own generator — the canvas ships the
+  // exact bytes a publish would (rule order, condition/viewport cascade, and
+  // sanitized raw @keyframes rules included), so the preview cannot drift
+  // from the published output.
+  const classCss = generateClassCSS(classes, breakpoints, conditions)
+  if (classCss) blocks.push(classCss)
 
   return blocks.join('\n\n')
 }
@@ -172,8 +122,8 @@ export function createCanvasClassCssMemo(
 
 /**
  * Generate the canvas class-registry CSS (publisher reset + fonts +
- * framework root CSS + every style rule with its breakpoint/condition
- * overrides). Identity-memoized — see `createCanvasClassCssMemo`.
+ * framework root CSS + the publisher's `generateClassCSS` output).
+ * Identity-memoized — see `createCanvasClassCssMemo`.
  */
 export const generateCanvasClassCSS: CanvasClassCssGenerator = createCanvasClassCssMemo()
 
@@ -219,7 +169,7 @@ export interface ForcedStateInflight {
  * state wins over the element's base class rules while leaving unspecified
  * properties to fall through.
  *
- * Crucially this mirrors `generateCanvasClassCSS`'s per-rule emission: the base
+ * The emission itself is the publisher's `createStyleRuleCssEmitter`: the base
  * styles AND every `contextStyles` override are emitted under their real
  * `@media`/`@container`/`@supports` preludes. Because each canvas frame is an
  * iframe at a fixed width, those queries evaluate per-frame exactly as on the
@@ -235,20 +185,10 @@ export function generateForcedStateCSS(
 ): string {
   const rawSelector = `[data-node-id="${escapeCssAttribute(nodeId)}"]`
   const selector = `${rawSelector}${rawSelector}`
-  const blocks: string[] = []
 
   const baseStyles = inflight && inflight.contextId === null
     ? { ...rule.styles, ...inflight.styles }
     : rule.styles
-  const baseDecls = bagToCSS(baseStyles)
-  if (baseDecls) blocks.push(`${selector} {\n${baseDecls}\n}`)
-
-  const breakpointById = new Map<string, { breakpoint: ViewportContext; index: number }>(
-    breakpoints.map((bp, index) => [bp.id, { breakpoint: bp, index }]),
-  )
-  const conditionById = new Map<string, { condition: Condition; index: number }>(
-    conditions.map((c, index) => [c.id, { condition: c.condition, index }]),
-  )
 
   // Merge any in-flight edit into the context it targets so a brand-new
   // context override previews live too.
@@ -257,37 +197,8 @@ export function generateForcedStateCSS(
     contextStyles[inflight.contextId] = { ...(contextStyles[inflight.contextId] ?? {}), ...inflight.styles }
   }
 
-  const conditionEntries: Array<{ bag: Record<string, unknown>; condition: Condition; index: number }> = []
-  const bpEntries: Array<{ bag: Record<string, unknown>; breakpoint: ViewportContext; index: number }> = []
-  for (const [contextId, bag] of Object.entries(contextStyles)) {
-    const cond = conditionById.get(contextId)
-    if (cond) {
-      conditionEntries.push({ bag, condition: cond.condition, index: cond.index })
-      continue
-    }
-    const breakpointEntry = breakpointById.get(contextId)
-    if (breakpointEntry) bpEntries.push({ bag, ...breakpointEntry })
-  }
-
-  conditionEntries.sort((a, b) => a.index - b.index)
-  for (const { bag, condition } of conditionEntries) {
-    const decls = bagToCSS(bag)
-    if (!decls) continue
-    const prelude = conditionPrelude(condition)
-    if (!prelude) continue
-    blocks.push(`${prelude} {\n  ${selector} {\n${decls}\n  }\n}`)
-  }
-
-  bpEntries.sort(compareViewportContextCascade)
-  for (const { bag, breakpoint } of bpEntries) {
-    const decls = bagToCSS(bag)
-    if (!decls) continue
-    const prelude = conditionPrelude({ kind: 'media', query: breakpointMediaQuery(breakpoint) })
-    if (!prelude) continue
-    blocks.push(`${prelude} {\n  ${selector} {\n${decls}\n  }\n}`)
-  }
-
-  return blocks.join('\n\n')
+  const emitRule = createStyleRuleCssEmitter(breakpoints, conditions)
+  return emitRule(selector, baseStyles, contextStyles).join('\n\n')
 }
 
 function escapeCssAttribute(value: string): string {

--- a/src/core/publisher/classCss.ts
+++ b/src/core/publisher/classCss.ts
@@ -241,12 +241,30 @@ export function compareViewportContextCascade(
   return a.index - b.index
 }
 
-export function generateClassCSS(
-  classes: Record<string, StyleRule>,
+/**
+ * Emit the CSS blocks for ONE style rule under an arbitrary selector: the base
+ * declaration block plus every `contextStyles` override wrapped in its real
+ * `@media`/`@container`/`@supports` prelude.
+ *
+ * This is the single emission engine behind every surface that renders style
+ * rules — the published page (`generateClassCSS`) and the editor canvas
+ * (registry CSS and forced-state previews) — so the cascade can never drift
+ * between what the editor shows and what a publish ships.
+ *
+ * Cascade order (precedence Q-A): base → custom conditions (registry order) →
+ * viewport @media contexts (see `compareViewportContextCascade`). Context keys
+ * matching neither registry are skipped (orphaned overrides).
+ */
+export type StyleRuleCssEmitter = (
+  selector: string,
+  styles: Record<string, unknown>,
+  contextStyles?: Record<string, Record<string, unknown>>,
+) => string[]
+
+export function createStyleRuleCssEmitter(
   breakpoints: ViewportContext[],
   conditions: ReadonlyArray<ConditionDef> = [],
-): string {
-  const blocks: string[] = []
+): StyleRuleCssEmitter {
   const breakpointById = new Map<string, { breakpoint: ViewportContext; index: number }>(
     breakpoints.map((bp, index) => [bp.id, { breakpoint: bp, index }]),
   )
@@ -256,25 +274,10 @@ export function generateClassCSS(
     conditions.map((c, index) => [c.id, { condition: c.condition, index }]),
   )
 
-  // Cascade order: rules with a smaller `order` are emitted first so a later,
-  // more-specific override appears later in source and wins on equal
-  // specificity. Imported rules carry the source stylesheet's position;
-  // user-created rules append at the end (see classSlice.nextRuleOrder).
-  const orderedClasses = Object.values(classes).slice().sort((a, b) => {
-    const ao = typeof a.order === 'number' ? a.order : 0
-    const bo = typeof b.order === 'number' ? b.order : 0
-    return ao - bo
-  })
+  return (selector, styles, contextStyles) => {
+    const blocks: string[] = []
 
-  for (const cls of orderedClasses) {
-    if (typeof cls.rawCss === 'string') {
-      const rawCss = sanitizeRawKeyframesCss(cls.rawCss)
-      if (rawCss) blocks.push(rawCss)
-      continue
-    }
-
-    const selector = styleRuleSelector(cls)
-    const baseDecls = bagToCSS(cls.styles)
+    const baseDecls = bagToCSS(styles)
     if (baseDecls) {
       blocks.push(`${selector} {\n${baseDecls}\n}`)
     }
@@ -283,7 +286,7 @@ export function generateClassCSS(
     // entries. Keys matching neither registry are skipped (orphaned overrides).
     const conditionEntries: Array<{ bag: Record<string, unknown>; condition: Condition; index: number }> = []
     const bpEntries: Array<{ bag: Record<string, unknown>; breakpoint: ViewportContext; index: number }> = []
-    for (const [contextId, bag] of Object.entries(cls.contextStyles ?? {})) {
+    for (const [contextId, bag] of Object.entries(contextStyles ?? {})) {
       const cond = conditionById.get(contextId)
       if (cond) {
         conditionEntries.push({ bag, condition: cond.condition, index: cond.index })
@@ -312,6 +315,37 @@ export function generateClassCSS(
       if (!prelude) continue
       blocks.push(`${prelude} {\n  ${selector} {\n${decls}\n  }\n}`)
     }
+
+    return blocks
+  }
+}
+
+export function generateClassCSS(
+  classes: Record<string, StyleRule>,
+  breakpoints: ViewportContext[],
+  conditions: ReadonlyArray<ConditionDef> = [],
+): string {
+  const blocks: string[] = []
+  const emitRule = createStyleRuleCssEmitter(breakpoints, conditions)
+
+  // Cascade order: rules with a smaller `order` are emitted first so a later,
+  // more-specific override appears later in source and wins on equal
+  // specificity. Imported rules carry the source stylesheet's position;
+  // user-created rules append at the end (see classSlice.nextRuleOrder).
+  const orderedClasses = Object.values(classes).slice().sort((a, b) => {
+    const ao = typeof a.order === 'number' ? a.order : 0
+    const bo = typeof b.order === 'number' ? b.order : 0
+    return ao - bo
+  })
+
+  for (const cls of orderedClasses) {
+    if (typeof cls.rawCss === 'string') {
+      const rawCss = sanitizeRawKeyframesCss(cls.rawCss)
+      if (rawCss) blocks.push(rawCss)
+      continue
+    }
+
+    blocks.push(...emitRule(styleRuleSelector(cls), cls.styles, cls.contextStyles))
   }
 
   return blocks.join('\n\n')
@@ -354,9 +388,9 @@ function isSafeConditionText(text: string): boolean {
  * Build the `@<kind> <query>` prelude for a custom condition. Returns null when
  * the query / container name fails the structural safety check (the override is
  * then dropped, not emitted). Viewport contexts also call this helper after
- * resolving their configured media query in `generateClassCSS`.
+ * resolving their configured media query in `createStyleRuleCssEmitter`.
  */
-export function conditionPrelude(condition: Condition): string | null {
+function conditionPrelude(condition: Condition): string | null {
   switch (condition.kind) {
     case 'media':
       return isSafeConditionText(condition.query) ? `@media ${condition.query}` : null

--- a/src/core/publisher/index.ts
+++ b/src/core/publisher/index.ts
@@ -37,12 +37,11 @@ export { escapeHtml, isSafeUrl, safeUrl, sanitiseCssValue } from './utils'
 
 export {
   bagToCSS,
-  compareViewportContextCascade,
-  conditionPrelude,
+  createStyleRuleCssEmitter,
   generateClassCSS,
   isEmittableProperty,
 } from './classCss'
-export type { ViewportContext } from './classCss'
+export type { StyleRuleCssEmitter, ViewportContext } from './classCss'
 
 export { collectClassCSS, CssCollector, sanitizeModuleCSS } from './cssCollector'
 


### PR DESCRIPTION
## Why

Item 2 of the pre-1.0 health check. `src/admin/pages/site/canvas/canvasClassCss.ts` re-implemented the publisher's `generateClassCSS` loop — rule ordering, `contextStyles` partitioning, the condition/viewport cascade, prelude emission — and `generateForcedStateCSS` repeated the same partition/sort/emit a **third** time (fallow flagged 5 clone groups across the two files). Two implementations of "what CSS does this class produce" means the editor preview can silently disagree with published output.

It already had: the canvas copy **skipped sanitized raw `@keyframes` rules**, so imported keyframe animations published fine but never played in the editor preview.

## What changed

- **`src/core/publisher/classCss.ts`** — extracted `createStyleRuleCssEmitter`, the single engine that emits one rule's base block plus every `contextStyles` override under its real `@media`/`@container`/`@supports` prelude, in publisher cascade order (custom conditions in registry order → viewport contexts in `compareViewportContextCascade` order). `generateClassCSS` is now just rule ordering + the `rawCss` safety gate + that emitter.
- **`src/admin/pages/site/canvas/canvasClassCss.ts`** — the canvas registry CSS is now literally the publisher's `generateClassCSS` output behind the canvas preamble (reset + fonts + framework root CSS). The duplicated loop is gone, and the `@keyframes` drift is fixed as a side effect. `generateForcedStateCSS` delegates to the shared emitter, keeping only its genuinely canvas-specific parts (doubled `[data-node-id]` selector, in-flight edit merge). The identity memo and `generatePreviewClassCSS` are unchanged.
- **`@core/publisher` barrel** — exports `createStyleRuleCssEmitter` / `StyleRuleCssEmitter`; drops `compareViewportContextCascade` and `conditionPrelude` (their only external consumer was the deleted duplicate; `conditionPrelude` is module-private again).
- **Tests** — two new canvas regression tests pin emission parity for raw CSS: supported `@keyframes` now appear on canvas; unsupported raw CSS is dropped on canvas exactly as at publish.
- **Docs** — `docs/reference/css-class-registry.md` source-of-truth entries updated.

## Behavior notes

- Non-raw rules: canvas output is byte-identical to before (the deleted loop was a verbatim copy).
- One intentional fix: classes carrying sanitized raw `@keyframes` now render in the canvas preview, matching the published page.

## Verification

- `bun test` — 5,345 pass / 0 fail (2 new tests)
- `bun run build`, `bun run lint` — pass
- `fallow dupes` — 0 clone groups touching the two files (was 5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)