### PR TITLE
fix(media): retina screens download the WebP variants, not the multi-MB original

### DIFF
--- a/docs/features/media.md
+++ b/docs/features/media.md
@@ -279,6 +279,10 @@ media_assets row created, variants_json populated for raster sources
 
 SVG uploads are sanitized and stored as originals only. GIF uploads also stay original-only so animation is preserved; the responsive WebP ladder is generated only for JPEG, PNG, and WebP uploads.
 
+The ladder encodes one WebP per target width (64 / 320 / 640 / 1024 / 1600 / 2048) **below** the source's intrinsic width — never upscaled — plus one rung **at** the intrinsic width. That top rung exists so `srcset` can be built from variants alone: the original file (often a multi-MB PNG) never appears as a srcset candidate, because a high-DPI display asking for more pixels than the largest sub-intrinsic rung would otherwise select it (`sizes="1280px"` on a 2x screen requests 2560 device px). `buildMediaSrcset` (publisher) and `buildVariantSrcset` (admin surfaces) both enforce the variants-only rule at render time, and lazy images emit `sizes="auto, <fallback>"` so Chromium-based browsers select by the actual rendered width.
+
+Ladder edge rules: the intrinsic rung is clamped so neither output dimension exceeds WebP's hard 16383px cap (a 900×17000 screenshot gets a clamped top rung instead of a failed job); images smaller than every target width get **no variants** and publish as plain pixel-exact `src` (small icons are never force-re-encoded to lossy WebP). The Tier-3 delegate path emits **declared widths only** — the host never synthesizes an intrinsic-width URL the delegate's allowlist might reject; the largest declared sub-intrinsic width is that ladder's ceiling.
+
 The image-variant worker pool is sized by `IMAGE_VARIANT_WORKER_POOL_SIZE` (default 2, hard cap 8). Workers are spawned lazily on first use and reused for the life of the process; a crashed worker is dropped from the pool and a replacement spawns on the next submission.
 
 Defense in depth on the static path: `hardenUploadResponse` in `server/static.ts` adds `X-Content-Type-Options: nosniff` and `Content-Disposition: attachment` for non-inert MIME types so a stray non-allowlisted upload can't be top-level navigated and rendered as HTML on the admin origin.

--- a/docs/reference/module-engine.md
+++ b/docs/reference/module-engine.md
@@ -330,7 +330,7 @@ interface RenderResolvedMedia {
 }
 ```
 
-`buildMediaSrcset(media)` returns a `srcset` string sorted by ascending width with the original appended, or `null` when no variants exist. `pickMediaVariantUrl(media, targetWidth)` returns the smallest variant ≥ `targetWidth` (safe URL-escaped).
+`buildMediaSrcset(media)` returns a `srcset` string of the variants sorted by ascending width, or `null` when no variants exist. The original file is never included — any srcset candidate is selectable, and the original may be a multi-MB unoptimized source; the ladder's intrinsic-width WebP rung is the full-quality ceiling instead. `pickMediaVariantUrl(media, targetWidth)` returns the smallest variant ≥ `targetWidth` (safe URL-escaped).
 
 ---
 

--- a/server/handlers/cms/imageVariantWorker.ts
+++ b/server/handlers/cms/imageVariantWorker.ts
@@ -5,7 +5,9 @@
  *
  *   1. Probe intrinsic dimensions via `sharp`.
  *   2. Encode a BlurHash placeholder from a downsampled RGBA buffer.
- *   3. (Optional) Generate one WebP per configured target width.
+ *   3. (Optional) Generate one WebP per configured target width below the
+ *      intrinsic width, plus one at the intrinsic width (the srcset's
+ *      full-quality top rung).
  *
  * Everything else — DB lookups, delegate election, storage-adapter
  * dispatch — stays on the main thread. The worker has no DB client and
@@ -19,6 +21,9 @@ import sharp from 'sharp'
 import { encode as encodeBlurHash } from 'blurhash'
 import type { ImageVariantJobRequest, ImageVariantJobResponse, ImageVariantPayload } from './imageVariantProtocol'
 import { toArrayBuffer } from '../../binary'
+
+/** libwebp's hard cap on either output dimension. */
+const MAX_WEBP_DIMENSION = 16383
 
 function send(msg: ImageVariantJobResponse, transfer: ArrayBuffer[] = []): void {
   ;(self as unknown as { postMessage: (m: unknown, transfer?: ArrayBuffer[]) => void }).postMessage(msg, transfer)
@@ -72,8 +77,28 @@ async function handleJob(req: ImageVariantJobRequest): Promise<void> {
     const variants: ImageVariantPayload[] = []
     const transfer: ArrayBuffer[] = []
     if (req.generateLadder) {
-      for (const width of req.targetWidths) {
-        if (width >= originalWidth) continue
+      // Target rungs below the intrinsic width (never upscale), topped by
+      // one rung AT the intrinsic width: the srcset's largest candidate is
+      // then a full-quality WebP, so the renderer never needs the original
+      // (potentially a multi-MB PNG) as a high-DPI fallback.
+      //
+      // The WebP encoder refuses either OUTPUT dimension above 16383px, so
+      // the ladder is clamped to the largest width whose aspect-scaled
+      // height still fits — a 900x17000 screenshot encodes a clamped top
+      // rung instead of throwing (which would kill the whole job and strip
+      // the asset of variants, dimensions, AND BlurHash).
+      //
+      // Images smaller than every target width get NO variants at all: they
+      // publish as plain pixel-exact `src` (a 48px pixel-art icon must not
+      // be force-re-encoded to lossy WebP for zero byte savings).
+      const maxSafeWidth = Math.min(
+        MAX_WEBP_DIMENSION,
+        Math.floor((MAX_WEBP_DIMENSION * originalWidth) / originalHeight),
+      )
+      const intrinsicRung = Math.min(originalWidth, maxSafeWidth)
+      const subRungs = req.targetWidths.filter((w) => w < intrinsicRung)
+      const widths = subRungs.length ? [...subRungs, intrinsicRung] : []
+      for (const width of widths) {
         const v = await sharp(bytes)
           .resize({ width, withoutEnlargement: true })
           .webp({ quality: req.webpQuality })

--- a/server/handlers/cms/mediaVariants.ts
+++ b/server/handlers/cms/mediaVariants.ts
@@ -36,7 +36,10 @@ import { toArrayBuffer } from '../../binary'
  * Target widths for the responsive variant ladder. Chosen to cover the
  * common breakpoints we serve in the editor (mobile 375 / tablet 768 /
  * desktop 1024 / wide 1600+) plus a tiny 64 the admin grid uses for
- * fast-loading thumbnails, plus a 2048 high-DPI variant.
+ * fast-loading thumbnails, plus a 2048 high-DPI variant. The worker also
+ * encodes one rung at the source's INTRINSIC width, so the srcset's top
+ * candidate is always a full-quality WebP and the original never has to
+ * appear in srcset (see buildMediaSrcset).
  *
  * Sorted ascending so the variant array stays small-to-large for callers
  * doing a linear "smallest >= target" pick.
@@ -253,6 +256,13 @@ function buildDelegateVariants(
   const format = delegate.formats[0] ?? 'webp'
   const path = originPathForDelegate(parentStoragePath)
   const out: MediaVariantRecord[] = []
+  // Declared widths below intrinsic ONLY — no host-synthesized intrinsic
+  // rung here, unlike the local worker. The plugin's `widths` array is a
+  // contract ("widths the renderer should emit in srcset", schema-bounded
+  // to 16..8192): minting an undeclared probed width could exceed the
+  // service's allowlist or output cap and put a broken URL at the TOP of
+  // the srcset. The original is excluded from srcset by buildMediaSrcset
+  // regardless, so the largest declared rung is the delegate's ceiling.
   for (const width of delegate.widths) {
     if (width >= originalWidth) continue
     const url = fillDelegateTemplate(delegate.variantUrlTemplate, {

--- a/server/repositories/mediaMigration.ts
+++ b/server/repositories/mediaMigration.ts
@@ -111,7 +111,7 @@ export interface MigrationBacklog {
    * Computed JS-side from `variants_json` because the value is a JSON blob
    * (no per-variant DB row exists). For sites with thousands of assets the
    * JS pass is still fast — variants per asset are bounded by the
-   * `TARGET_WIDTHS` ladder (≤ 6).
+   * `TARGET_WIDTHS` ladder plus the intrinsic rung (≤ 7).
    */
   variants: number
 }

--- a/src/__tests__/module-engine/moduleConsolidation.test.ts
+++ b/src/__tests__/module-engine/moduleConsolidation.test.ts
@@ -63,10 +63,19 @@ function makeMedia(overrides: Partial<RenderResolvedMedia> = {}): RenderResolved
 // ---------------------------------------------------------------------------
 
 describe('F3 buildMediaSrcset / pickMediaVariantUrl', () => {
-  it('builds an ascending srcset and appends the original at full width', () => {
+  it('builds an ascending srcset from the variants ONLY — never the original', () => {
+    // The original is excluded deliberately: it may be a multi-MB PNG, and
+    // any srcset candidate is selectable (a 1280px slot on a 2x display asks
+    // for 2560px — if the original tops the ladder, every retina visitor
+    // downloads it). The ladder's top rung is the intrinsic-width WebP.
     expect(buildMediaSrcset(makeMedia())).toBe(
-      '/uploads/hero-w320.webp 320w, /uploads/hero-w640.webp 640w, /uploads/hero.webp 1200w',
+      '/uploads/hero-w320.webp 320w, /uploads/hero-w640.webp 640w',
     )
+  })
+
+  it('never includes the original even when it is the only large candidate', () => {
+    const srcset = buildMediaSrcset(makeMedia({ publicPath: '/uploads/hero.png', width: 2688 }))
+    expect(srcset).not.toContain('.png')
   })
 
   it('returns null when there are no variants', () => {

--- a/src/__tests__/modules/imageResponsiveAttrs.test.ts
+++ b/src/__tests__/modules/imageResponsiveAttrs.test.ts
@@ -1,0 +1,79 @@
+/**
+ * base.image responsive attributes — `sizes` resolution.
+ *
+ * `sizes='auto'` (the prop default) must emit the standards-based
+ * `auto, <fallback>` form on LAZY images: browsers that implement
+ * `sizes=auto` (Chrome 121+) pick by the image's actual rendered width,
+ * everyone else parses past the unknown keyword and uses the fallback.
+ * The spec only allows `auto` on `loading="lazy"` images, so eager images
+ * emit the fallback alone. Author-supplied `sizes` values are verbatim.
+ */
+import { describe, expect, it } from 'bun:test'
+import type { RenderResolvedMedia } from '@core/publisher'
+import { registry } from '@core/module-engine'
+
+import '@modules/base'
+
+function media(): RenderResolvedMedia {
+  return {
+    publicPath: '/uploads/hero.png',
+    mimeType: 'image/png',
+    width: 2688,
+    height: 1520,
+    altText: '',
+    blurHash: null,
+    posterPath: null,
+    variants: [
+      { width: 640, height: 362, format: 'webp', path: '/uploads/hero-w640.webp', sizeBytes: 100 },
+      { width: 1024, height: 579, format: 'webp', path: '/uploads/hero-w1024.webp', sizeBytes: 200 },
+    ],
+  }
+}
+
+function renderImage(props: Record<string, unknown>): string {
+  const img = registry.getOrThrow('base.image')
+  return img.render(
+    {
+      src: '/uploads/hero.png',
+      fetchPriority: 'auto',
+      decoding: 'async',
+      _resolvedMediaByKey: { src: media() },
+      ...props,
+    },
+    [],
+  ).html
+}
+
+function sizesAttr(html: string): string | null {
+  const m = html.match(/sizes="([^"]*)"/)
+  return m ? m[1] : null
+}
+
+describe('base.image sizes resolution', () => {
+  it("lazy + sizes 'auto' with a publisher-resolved cap emits `auto, <cap>`", () => {
+    const html = renderImage({ loading: 'lazy', sizes: 'auto', _resolvedAutoSizes: '1280px' })
+    expect(sizesAttr(html)).toBe('auto, 1280px')
+  })
+
+  it("lazy + sizes 'auto' without a resolved cap emits `auto, 100vw`", () => {
+    const html = renderImage({ loading: 'lazy', sizes: 'auto' })
+    expect(sizesAttr(html)).toBe('auto, 100vw')
+  })
+
+  it("eager + sizes 'auto' emits the fallback alone (`auto` keyword is lazy-only)", () => {
+    const html = renderImage({ loading: 'eager', sizes: 'auto', _resolvedAutoSizes: '1280px' })
+    expect(sizesAttr(html)).toBe('1280px')
+  })
+
+  it('an author-supplied sizes value is emitted verbatim', () => {
+    const html = renderImage({ loading: 'lazy', sizes: '(min-width: 1024px) 50vw, 100vw' })
+    expect(sizesAttr(html)).toBe('(min-width: 1024px) 50vw, 100vw')
+  })
+
+  it('srcset never contains the original file', () => {
+    const html = renderImage({ loading: 'lazy', sizes: 'auto' })
+    const m = html.match(/srcset="([^"]*)"/)
+    expect(m).not.toBeNull()
+    expect(m![1]).not.toContain('.png')
+  })
+})

--- a/src/__tests__/server/imageVariantWorker.test.ts
+++ b/src/__tests__/server/imageVariantWorker.test.ts
@@ -54,14 +54,76 @@ describe('image-variant worker pool', () => {
     // encoder isn't deterministic across libvips versions for the same
     // input, but length + non-empty is enough to gate the round-trip.
     expect(response.blurHash.length).toBeGreaterThan(10)
-    // 64, 320, 640 are < 800; 1024 is skipped (>= source width). So 3
-    // variants come back, in ascending order.
-    expect(response.variants.map((v) => v.width)).toEqual([64, 320, 640])
+    // 64, 320, 640 are < 800; 1024 is skipped (>= source width); a final
+    // rung is encoded at the source's intrinsic width so the srcset's top
+    // candidate is a full-quality WebP — the renderer never has to fall
+    // back to the (potentially multi-MB) original for high-DPI displays.
+    expect(response.variants.map((v) => v.width)).toEqual([64, 320, 640, 800])
+    const intrinsic = response.variants[response.variants.length - 1]
+    expect(intrinsic.height).toBe(400)
     for (const variant of response.variants) {
       expect(variant.bytes.byteLength).toBeGreaterThan(0)
       // Each variant is a fresh ArrayBuffer the host now owns.
       expect(variant.bytes).toBeInstanceOf(ArrayBuffer)
     }
+  })
+
+  it('emits exactly one rung when the source width equals a target width', async () => {
+    const bytes = await fixturePng(640, 320)
+    const response = await runImageVariantJob({
+      bytes,
+      generateLadder: true,
+      targetWidths: [64, 320, 640, 1024],
+      webpQuality: 80,
+      blurhashConfig: { x: 4, y: 3, sampleWidth: 32, sampleHeight: 32 },
+    })
+
+    expect(isImageVariantOk(response)).toBe(true)
+    if (!isImageVariantOk(response)) return
+    // 640 is skipped as a target (>= source) but comes back once as the
+    // intrinsic rung — never duplicated.
+    expect(response.variants.map((v) => v.width)).toEqual([64, 320, 640])
+  })
+
+  it('clamps the intrinsic rung to the WebP 16383px dimension cap (tall screenshot)', async () => {
+    // A 100x17000 strip: sub-intrinsic rungs encode fine, but a WebP at the
+    // full intrinsic size is impossible (height > 16383). The rung must be
+    // clamped — one impossible rung must never kill the whole job.
+    const bytes = await fixturePng(100, 17000)
+    const response = await runImageVariantJob({
+      bytes,
+      generateLadder: true,
+      targetWidths: [64, 320, 640, 1024],
+      webpQuality: 80,
+      blurhashConfig: { x: 4, y: 3, sampleWidth: 32, sampleHeight: 32 },
+    })
+
+    expect(isImageVariantOk(response)).toBe(true)
+    if (!isImageVariantOk(response)) return
+    expect(response.width).toBe(100)
+    expect(response.height).toBe(17000)
+    expect(response.blurHash.length).toBeGreaterThan(10)
+    // floor(16383 * 100 / 17000) = 96 — the largest width whose scaled
+    // height still fits the encoder.
+    expect(response.variants.map((v) => v.width)).toEqual([64, 96])
+    expect(response.variants[1].height).toBeLessThanOrEqual(16383)
+  })
+
+  it('emits NO variants for an image smaller than every target width', async () => {
+    // A 40px icon publishes as plain pixel-exact `src` — force-re-encoding
+    // it to lossy WebP would smear pixel art for zero byte savings.
+    const bytes = await fixturePng(40, 20)
+    const response = await runImageVariantJob({
+      bytes,
+      generateLadder: true,
+      targetWidths: [64, 320, 640],
+      webpQuality: 80,
+      blurhashConfig: { x: 4, y: 3, sampleWidth: 32, sampleHeight: 32 },
+    })
+
+    expect(isImageVariantOk(response)).toBe(true)
+    if (!isImageVariantOk(response)) return
+    expect(response.variants).toEqual([])
   })
 
   it('skips the ladder when generateLadder is false (delegate path)', async () => {

--- a/src/admin/pages/media/utils/__tests__/variants.test.ts
+++ b/src/admin/pages/media/utils/__tests__/variants.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Admin variant helpers — same selection policy as the publisher's
+ * `buildMediaSrcset` / `pickMediaVariantUrl` (variants only, never the
+ * original): the editor canvas and media viewer must not download a
+ * multi-MB original on high-DPI displays any more than a published page.
+ */
+import { describe, expect, it } from 'bun:test'
+import { buildVariantSrcset, pickVariantUrl } from '../variants'
+
+const asset = {
+  publicPath: '/uploads/hero.png',
+  width: 2688,
+  variants: [
+    { width: 640, height: 362, format: 'webp', path: '/uploads/hero-w640.webp', sizeBytes: 100 },
+    { width: 2688, height: 1520, format: 'webp', path: '/uploads/hero-w2688.webp', sizeBytes: 400 },
+  ],
+}
+
+describe('buildVariantSrcset', () => {
+  it('emits the variants only — never the original', () => {
+    expect(buildVariantSrcset(asset)).toBe(
+      '/uploads/hero-w640.webp 640w, /uploads/hero-w2688.webp 2688w',
+    )
+  })
+
+  it('returns undefined with no variants', () => {
+    expect(buildVariantSrcset({ ...asset, variants: [] })).toBeUndefined()
+  })
+})
+
+describe('pickVariantUrl', () => {
+  it('picks the smallest variant at or above the target', () => {
+    expect(pickVariantUrl(asset, 500)).toBe('/uploads/hero-w640.webp')
+  })
+
+  it('falls back to the LARGEST VARIANT, not the original, when nothing is big enough', () => {
+    // Legacy assets cap at 2048w; a 4K target must get the largest WebP —
+    // marginally lower resolution beats a multi-MB PNG download.
+    expect(pickVariantUrl(asset, 9999)).toBe('/uploads/hero-w2688.webp')
+  })
+
+  it('returns the original only when the asset has no variants at all', () => {
+    expect(pickVariantUrl({ ...asset, variants: [] }, 500)).toBe('/uploads/hero.png')
+  })
+})

--- a/src/admin/pages/media/utils/variants.ts
+++ b/src/admin/pages/media/utils/variants.ts
@@ -4,8 +4,12 @@
  *
  * The single rule for picking a variant: pick the smallest variant whose
  * width is greater-than-or-equal-to the target rendered width, accounting
- * for devicePixelRatio. If no variant is large enough (or the asset has no
- * variants at all), fall back to the original `publicPath`.
+ * for devicePixelRatio. If no variant is large enough, the LARGEST variant
+ * wins — never the original. Same policy as the publisher's
+ * `buildMediaSrcset` (src/modules/base/utils/mediaAttrs.ts): the original
+ * may be a multi-MB PNG, and the ladder's top rung is the intrinsic-width
+ * WebP, so falling back to the original buys nothing but bytes. The
+ * original is used only when the asset has no variants at all.
  */
 import { decode as decodeBlurHash } from 'blurhash'
 import type { CmsMediaAsset, CmsMediaVariant } from '@core/persistence/cmsMedia'
@@ -29,28 +33,29 @@ export function pickVariantUrl(
   for (const v of sorted) {
     if (v.width >= targetPx) return v.path
   }
-  // No variant is large enough → the original is necessarily larger
-  // (variants are only generated for widths strictly less than the
-  // original), so prefer that over the biggest variant.
-  return asset.publicPath
+  // No variant is large enough → the largest variant still beats the
+  // original: new ladders top at the intrinsic-width WebP (same pixels,
+  // fraction of the bytes), and even legacy 2048-capped ladders trade a
+  // marginal resolution shortfall for not downloading a multi-MB PNG.
+  return sorted[sorted.length - 1].path
 }
 
 /**
- * Build the `srcset` attribute string from the variant ladder. Includes
- * the original asset as the largest entry (so it stays selectable when the
- * browser wants the full resolution). Returns `undefined` when there are
- * no variants — callers should omit the attribute entirely in that case.
+ * Build the `srcset` attribute string from the variant ladder — variants
+ * ONLY, never the original (any srcset candidate is selectable, and on a
+ * high-DPI display the original would be the selected one; see
+ * `buildMediaSrcset`). Returns `undefined` when there are no variants —
+ * callers should omit the attribute entirely in that case.
  */
 export function buildVariantSrcset(
-  asset: Pick<CmsMediaAsset, 'publicPath' | 'variants' | 'width'>,
+  asset: Pick<CmsMediaAsset, 'publicPath' | 'variants'>,
 ): string | undefined {
   if (!asset.variants.length) return undefined
-  const entries = asset.variants
+  return asset.variants
     .slice()
     .sort((a, b) => a.width - b.width)
     .map((v) => `${v.path} ${v.width}w`)
-  if (asset.width) entries.push(`${asset.publicPath} ${asset.width}w`)
-  return entries.join(', ')
+    .join(', ')
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/src/modules/base/image/index.ts
+++ b/src/modules/base/image/index.ts
@@ -3,9 +3,11 @@
  *
  * Published HTML uses the full responsive pipeline produced by the
  * `prefetchMediaAssets` publisher pre-pass:
- *   - `srcset` built from `/uploads/<id>-w<width>.webp` variants
- *   - `sizes` hint (`'auto'` resolves to `100vw` for v1; users can supply
- *     a custom string like `(min-width: 1024px) 50vw, 100vw`)
+ *   - `srcset` built from `/uploads/<id>-w<width>.webp` variants only —
+ *     the original never appears in srcset (see buildMediaSrcset)
+ *   - `sizes` hint (`'auto'` emits `auto, <ancestor-cap-or-100vw>` on lazy
+ *     images so Chrome 121+ selects by actual rendered width; users can
+ *     supply a custom string like `(min-width: 1024px) 50vw, 100vw`)
  *   - intrinsic `width` / `height` to prevent CLS
  *   - `loading` / `decoding` / `fetchpriority` perf hints
  *   - BlurHash data URL as a CSS background while the variant streams in
@@ -40,9 +42,11 @@ export const ImagePropsSchema = Type.Object({
   src: Type.String({ default: '' }),
   loading: Type.Union([Type.Literal('lazy'), Type.Literal('eager')], { default: 'lazy' }),
   /**
-   * `sizes` attribute. `'auto'` resolves to `100vw` at publish time —
-   * future work: derive from canvas breakpoints. A custom string is
-   * emitted verbatim.
+   * `sizes` attribute. `'auto'` emits `auto, <fallback>` on lazy images
+   * (Chrome 121+ selects by actual rendered width); the fallback is the
+   * publisher's ancestor max-width resolution, else `100vw`. Eager images
+   * emit the fallback alone (the `auto` keyword is lazy-only per spec).
+   * A custom string is emitted verbatim.
    */
   sizes: Type.String({ default: 'auto' }),
   /**
@@ -92,12 +96,21 @@ type ImageProps = ImageStoredProps & {
  * Resolve the `sizes` attribute the publisher should emit.
  *
  * Rules:
- *   - Empty / 'auto' AND publisher computed a smarter string → use it.
- *   - Empty / 'auto' AND no smart resolution → fall back to `'100vw'`.
+ *   - Empty / 'auto' → `auto, <fallback>` for LAZY images: browsers that
+ *     implement `sizes=auto` (Chrome 121+) select by the image's actual
+ *     rendered width — far tighter than any publish-time estimate for
+ *     images laid out smaller than their container cap (grids, cards).
+ *     Others skip the unknown keyword and use the fallback. The spec only
+ *     allows `auto` on `loading="lazy"`, so eager images emit the fallback
+ *     alone. The fallback is the publisher's resolved ancestor cap, else
+ *     `'100vw'`.
  *   - Anything else → emit the user's verbatim value (already escaped).
  */
-function resolveSizes(prop: string, autoResolved: string | undefined): string {
-  if (!prop || prop === 'auto') return autoResolved ?? '100vw'
+function resolveSizes(prop: string, autoResolved: string | undefined, lazy: boolean): string {
+  if (!prop || prop === 'auto') {
+    const fallback = autoResolved ?? '100vw'
+    return lazy ? `auto, ${fallback}` : fallback
+  }
   return prop
 }
 
@@ -229,7 +242,7 @@ export const ImageModule: ModuleDefinition<ImageProps> = {
     // pure attribute-safe string (numbers + `min-width` keyword + `px`),
     // so no further escape is needed.
     const sizes = srcset
-      ? resolveSizes(String(props.sizes ?? 'auto'), props._resolvedAutoSizes)
+      ? resolveSizes(String(props.sizes ?? 'auto'), props._resolvedAutoSizes, loading === 'lazy')
       : null
     const width = media?.width ?? null
     const height = media?.height ?? null

--- a/src/modules/base/utils/mediaAttrs.ts
+++ b/src/modules/base/utils/mediaAttrs.ts
@@ -14,18 +14,24 @@ import type { RenderResolvedMedia } from '@core/publisher'
 import { safeUrl } from '@modules/base/utils/escape'
 
 /**
- * Build a `srcset` attribute from a variant ladder, plus the original as the
- * largest entry so high-DPI displays can pick the full-size file. Returns
- * `null` when the asset has no variants.
+ * Build a `srcset` attribute from a variant ladder. Returns `null` when the
+ * asset has no variants.
+ *
+ * The ORIGINAL file is deliberately excluded: every srcset candidate is
+ * selectable, and the original may be a multi-MB unoptimized PNG. A 1280px
+ * slot on a 2x display asks for 2560 device px — if the original tops the
+ * ladder, every retina visitor downloads it instead of a WebP ~60x smaller.
+ * The ladder's top rung is the intrinsic-width WebP the variant worker
+ * encodes, so no quality ceiling is lost. The original survives only in
+ * `src`, which width-descriptor srcsets reserve for non-srcset browsers.
  */
 export function buildMediaSrcset(media: RenderResolvedMedia): string | null {
   if (!media.variants.length) return null
-  const entries = media.variants
+  return media.variants
     .slice()
     .sort((a, b) => a.width - b.width)
     .map((v) => `${safeUrl(v.path)} ${v.width}w`)
-  if (media.width) entries.push(`${safeUrl(media.publicPath)} ${media.width}w`)
-  return entries.join(', ')
+    .join(', ')
 }
 
 /**


### PR DESCRIPTION
## The bug (confirmed)

Lighthouse reports huge PNG downloads even though every `<img>` carries a full WebP `srcset`. Reproduced on a live published page; the mechanism:

- `buildMediaSrcset` deliberately appended the **original file** as the largest srcset candidate ("so high-DPI displays can pick the full-size file").
- The WebP ladder caps at **2048w** (the worker correctly never upscales).
- The auto-resolved `sizes="1280px"` (the container's `max-width`) × DPR ≥ 1.7 → the browser needs >2048 device px → the only candidate big enough is the original. On the reported page that's a **7.46 MB PNG** whose 2048w WebP is **122 KB** (~60× smaller). Lighthouse mobile emulates DPR 2.625, so it selected the PNG for every image, every run.

The variants always existed and resolved fine — the selection math made them unreachable on any retina screen.

## The fix

1. **srcset = variants only.** The original never appears as a candidate — in the publisher (`buildMediaSrcset`) *and* the admin twin (`buildVariantSrcset`: editor canvas, media viewer, video poster), whose no-candidate fallthrough now also returns the largest variant instead of the original. `src` keeps the original purely as the non-srcset-browser fallback (excluded from selection by width-descriptor srcsets per spec).
2. **The ladder gains an intrinsic-width WebP top rung**, so dropping the original costs no quality ceiling. Edge rules: clamped to WebP's hard 16383px output cap (a 900×17000 screenshot gets a clamped rung instead of a dead job); images smaller than every target keep **zero variants** (small pixel-art icons publish pixel-exact, never force-re-encoded to lossy WebP); the Tier-3 delegate path emits **declared widths only** — the host never synthesizes URLs outside the plugin's schema-bounded widths contract.
3. **`sizes="auto, <fallback>"` on lazy images** (the `sizes='auto'` default): Chrome 121+ selects by actual rendered width, so grid/card images stop over-fetching against the container cap; other browsers parse past the unknown keyword to the fallback. Spec-correct: `auto` only on `loading="lazy"`; author-supplied values stay verbatim.

## Verification

- TDD throughout — every behavior landed against a failing test first (`imageResponsiveAttrs.test.ts`, `imageVariantWorker.test.ts` incl. the 16383px clamp against real sharp, admin `variants.test.ts`, `moduleConsolidation.test.ts`).
- **Live end-to-end:** uploaded a 2688×1520 PNG, published, loaded at DPR 2 / 1280px viewport → the browser downloaded the **20 KB `-w2688.webp`**; the PNG was never requested. Markup: WebP-only srcset topped by `2688w`, `sizes="auto, 100vw"`.
- Multi-agent adversarial review of the diff: 10 findings raised, 9 confirmed, **all fixed in this PR** (the 16383px job-killer regression, the admin-twin duplicate-descriptor bug, the delegate widths contract violation, the small-icon lossy re-encode, stale docs/comments).
- `bun test` (5357 pass / 0 fail), `bun run build`, `bun run lint` all green.

## Note on existing assets

Assets uploaded before this change have no intrinsic rung in storage; their srcset now tops at the 2048w WebP — still strictly better than the original on every display. Re-uploading an asset regenerates the ladder with the full-resolution top rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)