### PR TITLE
refactor(vc): one slot-outlet collector — export it from @core/visualComponents

### DIFF
--- a/src/admin/pages/site/store/slices/site/helpers.ts
+++ b/src/admin/pages/site/store/slices/site/helpers.ts
@@ -14,7 +14,8 @@ import type { FrameworkColorToken } from '@core/framework-schema'
 import type { NodeTree, PageNode, StyleRule, SiteDocument } from '@core/page-tree'
 import { addPage, createNode, reconcileSiteExplorerInPlace, reindexNodeParents } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
-import { syncAllVCRefSlotInstances, allTreeNodeMaps, collectVCSlotOutletNames } from '../vcSlotReconcile'
+import { syncAllVCRefSlotInstances, allTreeNodeMaps } from '../vcSlotReconcile'
+import { collectSlotOutletNames } from '@core/visualComponents'
 import { create } from 'mutative'
 import type { Draft, Patches } from 'mutative'
 import type { ImportFragment } from '@core/htmlImport'
@@ -335,12 +336,12 @@ export function buildSiteHelpers(
     // `get()` is the frozen pre-mutation state — the VC is guaranteed present
     // there because the draft (where it was just found) mirrors it.
     const frozenVc = get().site?.visualComponents.find((v) => v.id === vc.id)
-    const outletNamesBefore = frozenVc ? collectVCSlotOutletNames(frozenVc.tree) : null
+    const outletNamesBefore = frozenVc ? collectSlotOutletNames(frozenVc.tree) : null
 
     const result = fn(tree)
     if (result === false) return false
 
-    const outletNamesAfter = collectVCSlotOutletNames(vc.tree)
+    const outletNamesAfter = collectSlotOutletNames(vc.tree)
     if (outletNamesBefore === null || !stringArraysEqual(outletNamesBefore, outletNamesAfter)) {
       syncAllVCRefSlotInstances(allTreeNodeMaps(draft.site!), vc.id, vc)
     }

--- a/src/admin/pages/site/store/slices/vcSlotReconcile.ts
+++ b/src/admin/pages/site/store/slices/vcSlotReconcile.ts
@@ -11,50 +11,6 @@ import type { VisualComponent } from '@core/visualComponents'
 import { syncSlotInstances, applySlotSyncResult } from '@core/visualComponents'
 
 /**
- * Collect the ordered, deduplicated slot names declared by `base.slot-outlet`
- * nodes in a VC tree — DFS pre-order, first appearance wins, missing/empty
- * `slotName` defaults to 'children'.
- *
- * Mirrors the (unexported) `extractSlotNamesFromVCTree` inside
- * `@core/visualComponents`' slotSync. This sequence is the ONLY input
- * `syncSlotInstances` reads from the VC, so callers can compare pre/post
- * sequences and skip a guaranteed no-op reconcile sweep when they are equal
- * (see `runActiveTreeRecipe` in `site/helpers.ts`).
- */
-export function collectVCSlotOutletNames(tree: {
-  rootNodeId: string
-  nodes: Record<string, BaseNode>
-}): string[] {
-  const result: string[] = []
-  const seen = new Set<string>()
-  const stack: string[] = [tree.rootNodeId]
-
-  while (stack.length > 0) {
-    const id = stack.pop()!
-    const node = tree.nodes[id]
-    if (!node) continue
-
-    if (node.moduleId === 'base.slot-outlet') {
-      const slotName =
-        typeof node.props.slotName === 'string' && node.props.slotName
-          ? node.props.slotName
-          : 'children'
-      if (!seen.has(slotName)) {
-        seen.add(slotName)
-        result.push(slotName)
-      }
-    }
-
-    // DFS pre-order: push children in reverse so leftmost is processed first.
-    for (let i = node.children.length - 1; i >= 0; i--) {
-      stack.push(node.children[i])
-    }
-  }
-
-  return result
-}
-
-/**
  * Re-sync slot-instance children for every `base.visual-component-ref` that
  * references `vcId`, across all supplied node maps. Must run inside a Mutative
  * producer — each map is mutated in place via `applySlotSyncResult`.

--- a/src/core/visualComponents/index.ts
+++ b/src/core/visualComponents/index.ts
@@ -22,7 +22,7 @@ export { getReferencedComponentIds, wouldCreateCycle } from './recursionGuard'
 export { forEachVCRef, collectVCRefs } from './vcRefs'
 export type { VCRef } from './vcRefs'
 
-export { syncSlotInstances, applySlotSyncResult } from './slotSync'
+export { collectSlotOutletNames, syncSlotInstances, applySlotSyncResult } from './slotSync'
 
 export { previewVCDeletion } from './deletionImpact'
 export type { VCDeletionImpact, VCRefUsage } from './deletionImpact'

--- a/src/core/visualComponents/slotSync.ts
+++ b/src/core/visualComponents/slotSync.ts
@@ -20,7 +20,7 @@ import { deleteSubtree, type BaseNode } from '@core/page-tree'
 import type { VisualComponent } from './schemas'
 
 // ---------------------------------------------------------------------------
-// extractSlotNamesFromVCTree — pure helper
+// collectSlotOutletNames — pure helper
 // ---------------------------------------------------------------------------
 
 /**
@@ -36,14 +36,17 @@ import type { VisualComponent } from './schemas'
  *
  * Returns an empty array when the VC has no slot-outlets.
  */
-function extractSlotNamesFromVCTree(vc: VisualComponent): string[] {
+export function collectSlotOutletNames(tree: {
+  rootNodeId: string
+  nodes: Record<string, BaseNode>
+}): string[] {
   const result: string[] = []
   const seen = new Set<string>()
-  const stack: string[] = [vc.tree.rootNodeId]
+  const stack: string[] = [tree.rootNodeId]
 
   while (stack.length > 0) {
     const id = stack.pop()!
-    const node = vc.tree.nodes[id]
+    const node = tree.nodes[id]
     if (!node) continue
 
     if (node.moduleId === 'base.slot-outlet') {
@@ -163,7 +166,7 @@ export function syncSlotInstances(
   // Slot names sourced directly from `base.slot-outlet` nodes in the VC tree
   // (the slot-outlet IS the slot — no separate vc.params slot entry required).
   // This is the single source of truth for "what slots does this VC declare?".
-  const slotNames = extractSlotNamesFromVCTree(vc)
+  const slotNames = collectSlotOutletNames(vc.tree)
   const targetNames = new Set(slotNames)
 
   // Classify existing children of the VC ref.


### PR DESCRIPTION
Health-check item 4. `vcSlotReconcile.ts` carried a verbatim copy of `slotSync.ts`'s unexported slot-outlet DFS collector — its own doc comment admitted it ("Mirrors the (unexported) extractSlotNamesFromVCTree"). Slot pairing is core VC semantics; the editor's skip-reconcile check must read exactly what `syncSlotInstances` reads.

- Canonical collector: `collectSlotOutletNames(tree)` in `@core/visualComponents` (generalized to the tree shape both callers want; `syncSlotInstances` passes `vc.tree`).
- The slice copy is deleted; `site/helpers.ts` imports the core one.

`bun test` 5,359 pass / 0 fail; build + lint pass. Independent of the other open refactor PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)