### PR TITLE
refactor(explorer): one structural-row enumeration + shared dnd pointer math

### DIFF
--- a/src/admin/lib/dndPointer.ts
+++ b/src/admin/lib/dndPointer.ts
@@ -1,0 +1,47 @@
+/**
+ * Pointer math shared by the editor's dnd-kit hooks (DOM panel, site
+ * explorer). dnd-kit events expose the activator event + a delta, not the
+ * live pointer position — these helpers reconstruct it.
+ */
+
+import type { DragEndEvent, DragMoveEvent } from '@dnd-kit/core'
+
+export interface DragPointerPoint {
+  x: number
+  y: number
+}
+
+/**
+ * The live pointer position for a drag event: the cached drag-start point
+ * (or the activator event's position on the first call) plus the event's
+ * accumulated delta. Returns `null` when the activator event carries no
+ * usable coordinates (e.g. keyboard-initiated drags).
+ */
+export function getDragPoint(
+  event: DragMoveEvent | DragEndEvent,
+  startPoint: DragPointerPoint | null,
+): DragPointerPoint | null {
+  const start = startPoint ?? getEventPoint(event.activatorEvent)
+  if (!start) return null
+  return {
+    x: start.x + event.delta.x,
+    y: start.y + event.delta.y,
+  }
+}
+
+/**
+ * The pointer position carried by a raw activator event (mouse, pointer, or
+ * first touch). `null` for events with no usable coordinates (keyboard).
+ */
+export function getEventPoint(event: Event): DragPointerPoint | null {
+  if ('clientX' in event && 'clientY' in event) {
+    const maybePointer = event as MouseEvent | PointerEvent
+    return { x: maybePointer.clientX, y: maybePointer.clientY }
+  }
+  if ('touches' in event) {
+    const touchEvent = event as TouchEvent
+    const touch = touchEvent.touches[0] ?? touchEvent.changedTouches[0]
+    return touch ? { x: touch.clientX, y: touch.clientY } : null
+  }
+  return null
+}

--- a/src/admin/pages/site/panels/DomPanel/useDomPanelDnd.ts
+++ b/src/admin/pages/site/panels/DomPanel/useDomPanelDnd.ts
@@ -12,6 +12,7 @@ import {
   type DomDropTarget,
 } from './domPanelDnd'
 import type { DomPanelDndContextValue } from './DomPanelDndContext'
+import { getDragPoint, getEventPoint } from '@admin/lib/dndPointer'
 
 interface Point {
   x: number
@@ -311,28 +312,6 @@ export function useDomPanelDnd({
     handleDragEnd,
     handleDragCancel,
   }
-}
-
-function getDragPoint(event: DragMoveEvent, startPoint: Point | null): Point | null {
-  const start = startPoint ?? getEventPoint(event.activatorEvent)
-  if (!start) return null
-  return {
-    x: start.x + event.delta.x,
-    y: start.y + event.delta.y,
-  }
-}
-
-function getEventPoint(event: Event): Point | null {
-  if ('clientX' in event && 'clientY' in event) {
-    const maybePointer = event as MouseEvent | PointerEvent
-    return { x: maybePointer.clientX, y: maybePointer.clientY }
-  }
-  if ('touches' in event) {
-    const touchEvent = event as TouchEvent
-    const touch = touchEvent.touches[0] ?? touchEvent.changedTouches[0]
-    return touch ? { x: touch.clientX, y: touch.clientY } : null
-  }
-  return null
 }
 
 function getRowCenter(element: HTMLElement | undefined): Point | null {

--- a/src/admin/pages/site/panels/SiteExplorerPanel/useSiteExplorerDnd.ts
+++ b/src/admin/pages/site/panels/SiteExplorerPanel/useSiteExplorerDnd.ts
@@ -15,8 +15,13 @@ import {
   type SiteExplorerSectionId,
   type SiteDocument,
   type StructuralSiteExplorerSectionId,
+  parentPathForPath,
+  sameStructuralParent,
+  compareStructuralRows,
+  structuralRowsForSection,
 } from '@core/page-tree'
 import { useEditorStore } from '@site/store/store'
+import { getDragPoint, getEventPoint } from '@admin/lib/dndPointer'
 
 interface Point {
   x: number
@@ -78,14 +83,6 @@ export interface SiteExplorerDropTarget {
 interface UseSiteExplorerDndOptions {
   enabled: boolean
   onStructuralPathPlan: (plan: ExplorerPathChangePlan) => void
-}
-
-interface StructuralDndRow {
-  kind: 'folder' | 'item'
-  id: string
-  parentPath?: string
-  order: number
-  naturalOrder: number
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -319,7 +316,7 @@ function handleStructuralItemDrop(
   const state = useEditorStore.getState()
   const nextParentPath = structuralNextParentPath(over, target.position)
   const currentParentPath = structuralItemParentPath(state.site, sectionId, active.itemId)
-  if (!samePath(currentParentPath, nextParentPath)) {
+  if (!sameStructuralParent(currentParentPath, nextParentPath)) {
     onStructuralPathPlan(state.previewMoveExplorerItem(sectionId, active.itemId, nextParentPath))
     return
   }
@@ -379,7 +376,7 @@ function handleStructuralFolderDrop(
   const state = useEditorStore.getState()
   const currentParentPath = parentPathForPath(active.folderId)
   const nextParentPath = structuralNextParentPath(over, target.position)
-  if (!samePath(currentParentPath, nextParentPath)) {
+  if (!sameStructuralParent(currentParentPath, nextParentPath)) {
     onStructuralPathPlan(state.previewMoveExplorerFolder(sectionId, active.folderId, nextParentPath))
     return
   }
@@ -455,78 +452,10 @@ function structuralRowIndexInParent(
   row: { kind: 'folder' | 'item'; id: string; parentPath?: string },
 ): number {
   if (!site) return -1
-  return structuralRowsForDnd(site, sectionId)
-    .filter((entry) => samePath(entry.parentPath, row.parentPath))
+  return structuralRowsForSection(site, sectionId)
+    .filter((entry) => sameStructuralParent(entry.parentPath, row.parentPath))
     .sort(compareStructuralRows)
     .findIndex((entry) => entry.kind === row.kind && entry.id === row.id)
-}
-
-function structuralRowsForDnd(
-  site: SiteDocument,
-  sectionId: StructuralSiteExplorerSectionId,
-): StructuralDndRow[] {
-  const rows: Array<Omit<StructuralDndRow, 'order' | 'naturalOrder'>> = []
-  const folders = new Set(site.explorer[sectionId].emptyFolders)
-
-  if (sectionId === 'pages') {
-    for (const page of site.pages) {
-      if (page.template || isHomePage(page)) continue
-      rows.push({ kind: 'item', id: page.id, ...optionalParentPath(parentPathForPath(page.slug)) })
-      addFolderPrefixes(folders, page.slug)
-    }
-  } else {
-    const type = sectionId === 'styles' ? 'style' : 'script'
-    for (const file of site.files) {
-      if (file.type !== type || (file.generated && !file.ejected)) continue
-      rows.push({ kind: 'item', id: file.id, ...optionalParentPath(parentPathForPath(file.path)) })
-      addFolderPrefixes(folders, file.path)
-    }
-  }
-
-  for (const folderPath of folders) {
-    rows.push({ kind: 'folder', id: folderPath, ...optionalParentPath(parentPathForPath(folderPath)) })
-  }
-
-  const orderByKey = new Map(
-    site.explorer[sectionId].rowOrder.map((entry) => [structuralRowKey(entry), entry.order]),
-  )
-  return rows.map((row, naturalOrder) => ({
-    ...row,
-    order: orderByKey.get(structuralRowKey(row)) ?? Number.POSITIVE_INFINITY,
-    naturalOrder,
-  }))
-}
-
-function addFolderPrefixes(folders: Set<string>, path: string): void {
-  const segments = path.split('/').filter(Boolean)
-  let current = ''
-  for (let index = 0; index < segments.length - 1; index += 1) {
-    current = current ? `${current}/${segments[index]}` : segments[index]
-    folders.add(current)
-  }
-}
-
-function optionalParentPath(parentPath: string | undefined): { parentPath?: string } {
-  return parentPath ? { parentPath } : {}
-}
-
-function parentPathForPath(path: string): string | undefined {
-  const index = path.lastIndexOf('/')
-  return index === -1 ? undefined : path.slice(0, index)
-}
-
-function structuralRowKey(row: { kind: 'folder' | 'item'; id: string; parentPath?: string }): string {
-  return `${row.kind}:${row.parentPath ?? ''}:${row.id}`
-}
-
-function samePath(left: string | undefined, right: string | undefined): boolean {
-  return (left ?? '') === (right ?? '')
-}
-
-function compareStructuralRows(left: StructuralDndRow, right: StructuralDndRow): number {
-  return left.order - right.order
-    || left.naturalOrder - right.naturalOrder
-    || left.id.localeCompare(right.id)
 }
 
 function positionForRect(rect: DropRect, point: Point | null): 'before' | 'after' {
@@ -579,28 +508,6 @@ function resolveDropTarget(
   if (drag.kind === 'siteExplorerItem' && drop.itemId === drag.itemId) return null
   if (drop.sectionId === 'pages' && isPinnedHomepage(drop.itemId)) return null
   return { drag, drop, position: positionForRect(event.over.rect, point) }
-}
-
-function getDragPoint(event: DragMoveEvent | DragEndEvent, startPoint: Point | null): Point | null {
-  const start = startPoint ?? getEventPoint(event.activatorEvent)
-  if (!start) return null
-  return {
-    x: start.x + event.delta.x,
-    y: start.y + event.delta.y,
-  }
-}
-
-function getEventPoint(event: Event): Point | null {
-  if ('clientX' in event && 'clientY' in event) {
-    const maybePointer = event as MouseEvent | PointerEvent
-    return { x: maybePointer.clientX, y: maybePointer.clientY }
-  }
-  if ('touches' in event) {
-    const touchEvent = event as TouchEvent
-    const touch = touchEvent.touches[0] ?? touchEvent.changedTouches[0]
-    return touch ? { x: touch.clientX, y: touch.clientY } : null
-  }
-  return null
 }
 
 export function useSiteExplorerDnd({ enabled, onStructuralPathPlan }: UseSiteExplorerDndOptions) {

--- a/src/admin/pages/site/store/slices/site/explorerActions.ts
+++ b/src/admin/pages/site/store/slices/site/explorerActions.ts
@@ -15,11 +15,13 @@ import {
   renameExplorerFolder as renameExplorerFolderInOrganization,
   renamePage as renamePageInSite,
   wrapExplorerItemsInFolder as wrapExplorerItemsInFolderInOrganization,
+  sameStructuralParent,
+  compareStructuralRows,
+  structuralRowsForSection,
 } from '@core/page-tree'
 import type {
   SiteDocument,
   SiteExplorerSectionId,
-  StructuralExplorerRowOrder,
   StructuralSiteExplorerSectionId,
 } from '@core/page-tree'
 import type { SiteSlice, SiteSliceHelpers } from './types'
@@ -42,13 +44,6 @@ export type ExplorerActions = Pick<
   | 'moveStructuralExplorerRow'
   | 'setPageAsHomepage'
 >
-
-type StructuralRowTarget = Omit<StructuralExplorerRowOrder, 'order'>
-
-interface StructuralExplorerRowModel extends StructuralRowTarget {
-  order: number
-  naturalOrder: number
-}
 
 export function createExplorerActions({
   get,
@@ -191,7 +186,7 @@ export function createExplorerActions({
       mutateSite((site) => {
         reconcileSiteExplorerInPlace(site)
         const siblings = structuralRowsForSection(site, sectionId)
-          .filter((entry) => sameParent(entry.parentPath, row.parentPath))
+          .filter((entry) => sameStructuralParent(entry.parentPath, row.parentPath))
           .sort(compareStructuralRows)
         const currentIndex = siblings.findIndex((entry) => entry.kind === row.kind && entry.id === row.id)
         if (currentIndex === -1) return false
@@ -200,7 +195,7 @@ export function createExplorerActions({
         siblings.splice(clampIndex(nextIndex, siblings.length), 0, target)
         const parentPath = row.parentPath
         site.explorer[sectionId].rowOrder = [
-          ...site.explorer[sectionId].rowOrder.filter((entry) => !sameParent(entry.parentPath, parentPath)),
+          ...site.explorer[sectionId].rowOrder.filter((entry) => !sameStructuralParent(entry.parentPath, parentPath)),
           ...siblings.map((entry, order) => ({
             kind: entry.kind,
             id: entry.id,
@@ -299,73 +294,6 @@ function structuralPathInUse(
     && (!file.generated || file.ejected)
     && (file.path === path || file.path.startsWith(`${path}/`))
   )
-}
-
-function structuralRowsForSection(
-  site: SiteDocument,
-  sectionId: StructuralSiteExplorerSectionId,
-): StructuralExplorerRowModel[] {
-  const rows: StructuralRowTarget[] = []
-  const folderPaths = new Set(site.explorer[sectionId].emptyFolders)
-  if (sectionId === 'pages') {
-    for (const page of site.pages) {
-      if (page.template || page.slug === 'index') continue
-      rows.push({ kind: 'item', id: page.id, ...optionalParentPath(parentPathForPath(page.slug)) })
-      addFolderPrefixes(folderPaths, page.slug)
-    }
-  } else {
-    const type = sectionId === 'styles' ? 'style' : 'script'
-    for (const file of site.files) {
-      if (file.type !== type || (file.generated && !file.ejected)) continue
-      rows.push({ kind: 'item', id: file.id, ...optionalParentPath(parentPathForPath(file.path)) })
-      addFolderPrefixes(folderPaths, file.path)
-    }
-  }
-
-  for (const folderPath of folderPaths) {
-    rows.push({ kind: 'folder', id: folderPath, ...optionalParentPath(parentPathForPath(folderPath)) })
-  }
-
-  const orderByKey = new Map(
-    site.explorer[sectionId].rowOrder.map((entry) => [structuralRowKey(entry), entry.order]),
-  )
-  return rows.map((row, naturalOrder) => ({
-    ...row,
-    order: orderByKey.get(structuralRowKey(row)) ?? Number.POSITIVE_INFINITY,
-    naturalOrder,
-  }))
-}
-
-function addFolderPrefixes(folders: Set<string>, path: string): void {
-  const segments = path.split('/').filter(Boolean)
-  let current = ''
-  for (let index = 0; index < segments.length - 1; index += 1) {
-    current = current ? `${current}/${segments[index]}` : segments[index]
-    folders.add(current)
-  }
-}
-
-function parentPathForPath(path: string): string | undefined {
-  const index = path.lastIndexOf('/')
-  return index === -1 ? undefined : path.slice(0, index)
-}
-
-function optionalParentPath(parentPath: string | undefined): { parentPath?: string } {
-  return parentPath ? { parentPath } : {}
-}
-
-function structuralRowKey(row: StructuralRowTarget): string {
-  return `${row.kind}:${row.parentPath ?? ''}:${row.id}`
-}
-
-function sameParent(left: string | undefined, right: string | undefined): boolean {
-  return (left ?? '') === (right ?? '')
-}
-
-function compareStructuralRows(left: StructuralExplorerRowModel, right: StructuralExplorerRowModel): number {
-  return left.order - right.order
-    || left.naturalOrder - right.naturalOrder
-    || left.id.localeCompare(right.id)
 }
 
 function clampIndex(index: number, max: number): number {

--- a/src/core/page-tree/explorerPaths.ts
+++ b/src/core/page-tree/explorerPaths.ts
@@ -1,0 +1,25 @@
+/**
+ * Path helpers for the site-explorer organization model. FileMap-style
+ * slash-separated paths; shared by the section reconciler (siteExplorer.ts)
+ * and the structural row enumeration (structuralRows.ts).
+ */
+
+/** The folder path containing `path`, or `undefined` for root-level paths. */
+export function parentPathForPath(path: string): string | undefined {
+  const index = path.lastIndexOf('/')
+  return index === -1 ? undefined : path.slice(0, index)
+}
+
+/** Add every ancestor folder prefix of `path` (excluding the leaf) to `folders`. */
+export function addFolderPrefixes(folders: Set<string>, path: string): void {
+  const segments = path.split('/').filter(Boolean)
+  let current = ''
+  for (let index = 0; index < segments.length - 1; index += 1) {
+    current = current ? `${current}/${segments[index]}` : segments[index]
+    folders.add(current)
+  }
+}
+
+export function optionalParentPath(parentPath: string | undefined): { parentPath?: string } {
+  return parentPath ? { parentPath } : {}
+}

--- a/src/core/page-tree/index.ts
+++ b/src/core/page-tree/index.ts
@@ -189,3 +189,12 @@ export type { PageTreeDropPosition, PageTreeDropTarget } from './dnd'
 export {
   selectVisualComponentById,
 } from './siteSelectors'
+
+export {
+  compareStructuralRows,
+  sameStructuralParent,
+  structuralRowKey,
+  structuralRowsForSection,
+} from './structuralRows'
+export type { StructuralExplorerRow } from './structuralRows'
+export { parentPathForPath } from './explorerPaths'

--- a/src/core/page-tree/siteExplorer.ts
+++ b/src/core/page-tree/siteExplorer.ts
@@ -6,6 +6,7 @@ import type { Page } from './page'
 import type { SiteDocument } from './siteDocument'
 import type { VisualComponent } from '@core/visualComponents'
 import { isHomePage } from './slugs'
+import { addFolderPrefixes, parentPathForPath } from './explorerPaths'
 
 export const STRUCTURAL_SITE_EXPLORER_SECTION_IDS = [
   'pages',
@@ -274,15 +275,6 @@ function structuralRowsForFiles(files: readonly SiteFile[], type: 'style' | 'scr
   return { folders, items, itemPaths }
 }
 
-function addFolderPrefixes(folders: Set<string>, path: string): void {
-  const segments = path.split('/').filter(Boolean)
-  let current = ''
-  for (let index = 0; index < segments.length - 1; index += 1) {
-    current = current ? `${current}/${segments[index]}` : segments[index]
-    folders.add(current)
-  }
-}
-
 function reconcileStructuralSection(
   section: StructuralExplorerSection,
   rows: StructuralRows,
@@ -304,11 +296,6 @@ function reconcileStructuralSection(
       return rows.items.has(entry.id) && rows.items.get(entry.id) === entry.parentPath
     }),
   }
-}
-
-function parentPathForPath(path: string): string | undefined {
-  const index = path.lastIndexOf('/')
-  return index === -1 ? undefined : path.slice(0, index)
 }
 
 function reconcileSection(section: DecorativeExplorerSection, sourceIds: readonly string[]): DecorativeExplorerSection {

--- a/src/core/page-tree/structuralRows.ts
+++ b/src/core/page-tree/structuralRows.ts
@@ -1,0 +1,84 @@
+/**
+ * Structural row enumeration — the ONE answer to "which rows does a
+ * structural explorer section contain, and how are they ordered?". Shared by
+ * the explorer panel's DnD hook (current-index lookup) and the store's
+ * reorder action (target-index math) so the two can never disagree.
+ */
+
+import type { SiteDocument } from './siteDocument'
+import type { StructuralSiteExplorerSectionId } from './siteExplorer'
+import { isHomePage } from './slugs'
+import { addFolderPrefixes, optionalParentPath, parentPathForPath } from './explorerPaths'
+
+// explorer panel's DnD hook (current-index lookup) and the store's
+// reorder action (target-index math) so the two can never disagree.
+// ---------------------------------------------------------------------------
+
+export interface StructuralExplorerRow {
+  kind: 'folder' | 'item'
+  id: string
+  parentPath?: string
+  /** Persisted order from the section rowOrder; +Infinity when unordered. */
+  order: number
+  /** Position in the section's natural enumeration — the stable tie-break. */
+  naturalOrder: number
+}
+
+/**
+ * Enumerate every row of a structural section: items (non-template,
+ * non-home pages, or non-generated files of the section's type) plus every
+ * folder implied by their paths and the persisted empty folders, each
+ * stamped with its persisted `order` and natural position.
+ */
+export function structuralRowsForSection(
+  site: SiteDocument,
+  sectionId: StructuralSiteExplorerSectionId,
+): StructuralExplorerRow[] {
+  const rows: Array<Omit<StructuralExplorerRow, 'order' | 'naturalOrder'>> = []
+  const folders = new Set(site.explorer[sectionId].emptyFolders)
+
+  if (sectionId === 'pages') {
+    for (const page of site.pages) {
+      if (page.template || isHomePage(page)) continue
+      rows.push({ kind: 'item', id: page.id, ...optionalParentPath(parentPathForPath(page.slug)) })
+      addFolderPrefixes(folders, page.slug)
+    }
+  } else {
+    const type = sectionId === 'styles' ? 'style' : 'script'
+    for (const file of site.files) {
+      if (file.type !== type || (file.generated && !file.ejected)) continue
+      rows.push({ kind: 'item', id: file.id, ...optionalParentPath(parentPathForPath(file.path)) })
+      addFolderPrefixes(folders, file.path)
+    }
+  }
+
+  for (const folderPath of folders) {
+    rows.push({ kind: 'folder', id: folderPath, ...optionalParentPath(parentPathForPath(folderPath)) })
+  }
+
+  const orderByKey = new Map(
+    site.explorer[sectionId].rowOrder.map((entry) => [structuralRowKey(entry), entry.order]),
+  )
+  return rows.map((row, naturalOrder) => ({
+    ...row,
+    order: orderByKey.get(structuralRowKey(row)) ?? Number.POSITIVE_INFINITY,
+    naturalOrder,
+  }))
+}
+
+/** Identity of a row within its section: kind + parent + id. */
+export function structuralRowKey(row: { kind: 'folder' | 'item'; id: string; parentPath?: string }): string {
+  return `${row.kind}:${row.parentPath ?? ''}:${row.id}`
+}
+
+/** Parent-path equality where `undefined` and `''` both mean the root. */
+export function sameStructuralParent(left: string | undefined, right: string | undefined): boolean {
+  return (left ?? '') === (right ?? '')
+}
+
+/** Persisted order first, natural enumeration second, id as final tie-break. */
+export function compareStructuralRows(left: StructuralExplorerRow, right: StructuralExplorerRow): number {
+  return left.order - right.order
+    || left.naturalOrder - right.naturalOrder
+    || left.id.localeCompare(right.id)
+}


### PR DESCRIPTION
Health-check item 6. The explorer/DOM drag-and-drop logic carried three verbatim clone clusters; one pair had already drifted.

## What changed

- **`@core/page-tree/structuralRows.ts`** — the one answer to "which rows does a structural section contain, and how are they ordered?". Previously `useSiteExplorerDnd.ts` (current-index lookup) and `explorerActions.ts` (reorder target math) each had their own copy of the enumeration plus its helper set (`addFolderPrefixes`, `parentPathForPath`, `structuralRowKey`, `sameParent`, `compareStructuralRows`). If those drifted, the panel would compute a drop index against a different row list than the store reorders — exactly the bug class this kills. The canonical filter uses `isHomePage` (one copy hand-rolled `page.slug === 'index'`).
- **`@core/page-tree/explorerPaths.ts`** — path helpers shared by the new enumeration and the existing `siteExplorer.ts` reconciler (whose private copies are deleted). This also keeps `siteExplorer.ts` under the repo's 700-line module ceiling — the size-budget gate flagged the first attempt at appending in place, and the split is the better shape anyway.
- **`src/admin/lib/dndPointer.ts`** — `getDragPoint`/`getEventPoint` shared by `useDomPanelDnd` and `useSiteExplorerDnd`. These copies had **already drifted** (one accepted `DragMoveEvent | DragEndEvent`, the other only `DragMoveEvent`); the shared version carries the wider, correct union.

Net: −113 lines of duplicated logic, `useSiteExplorerDnd.ts` shrinks ~150 lines.

## Verification

Behavior preserved — `bun test` 5,359 pass / 0 fail (including the 1,070-LOC `siteExplorerPanel.test.tsx` drag-drop-reorder integration suite and `dom-panel-dnd/target-resolution.test.ts`); `bun run build` + `bun run lint` green.

Independent of the other open refactor PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)