### PR TITLE
refactor(vc): split vcTreeOps out of visualComponentsSlice

### DIFF
--- a/src/__tests__/architecture/module-size-budgets.test.ts
+++ b/src/__tests__/architecture/module-size-budgets.test.ts
@@ -94,7 +94,7 @@ const GRANDFATHERED: Record<string, number> = {
   // Grew past the ceiling via parallel work — grandfathered pending a future
   // split (extract responsibilities into sub-modules), not blessed forever.
   'src/admin/pages/site/agent/executor.ts': 730,
-  'src/admin/pages/site/store/slices/visualComponentsSlice.ts': 924,
+  'src/admin/pages/site/store/slices/visualComponentsSlice.ts': 715,
   // server/repositories/media.ts graduated: the row ↔ asset mapping unit was
   // extracted into server/repositories/mediaAssetMapping.ts, dropping media.ts
   // to 583 lines — under CEILING, so it's now held by the normal ceiling rule.

--- a/src/__tests__/core/convertNodeToComponent.test.ts
+++ b/src/__tests__/core/convertNodeToComponent.test.ts
@@ -23,7 +23,7 @@ import { useEditorStore } from '@site/store/store'
 import { create } from 'mutative'
 import type { SiteDocument, PageNode, StyleRule } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
-import { VisualComponentNameError } from '@site/store/slices/visualComponentsSlice'
+import { VisualComponentNameError } from '@site/store/slices/vcTreeOps'
 // Side-effect import: registers base modules in the registry so
 // `registry.get('base.text')`, `'base.container'`, etc. resolve at runtime.
 // Required for the auto-wrap behavior in convertNodeToComponent (which checks

--- a/src/admin/pages/site/panels/PropertiesPanel/ConvertToComponentButton.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/ConvertToComponentButton.tsx
@@ -14,7 +14,7 @@
 
 import { useEffect, useRef, useState } from 'react'
 import { useEditorStore } from '@site/store/store'
-import { VisualComponentNameError } from '@site/store/slices/visualComponentsSlice'
+import { VisualComponentNameError } from '@site/store/slices/vcTreeOps'
 import { Button } from '@ui/components/Button'
 import { Input } from '@ui/components/Input'
 import styles from './ConvertToComponentButton.module.css'

--- a/src/admin/pages/site/store/slices/vcTreeOps.ts
+++ b/src/admin/pages/site/store/slices/vcTreeOps.ts
@@ -1,0 +1,211 @@
+/**
+ * vcTreeOps — pure helpers and typed domain errors for the Visual Components
+ * data layer. Split out of `visualComponentsSlice.ts` (which owns the store
+ * actions) so the page-tree surgery — VC-ref collection, cascade removal,
+ * subtree cloning for componentization — lives in one focused module, the
+ * same pattern as `vcSlotReconcile.ts`.
+ */
+
+import { nanoid } from 'nanoid'
+import type { VCNode } from '@core/visualComponents'
+import type { BaseNode, PageNode, StyleRule } from '@core/page-tree'
+import { removeNodeSubtrees } from '@core/page-tree'
+
+// ---------------------------------------------------------------------------
+// Custom error types (exported so UI + tests can catch by class)
+// ---------------------------------------------------------------------------
+
+export class VisualComponentNameError extends Error {
+  readonly code: string
+  constructor(message: string, code: string) {
+    super(`[visualComponentsSlice] ${message}`)
+    this.name = 'VisualComponentNameError'
+    this.code = code
+  }
+}
+
+export class VisualComponentParamNameError extends Error {
+  readonly code: string
+  constructor(message: string, code: string) {
+    super(`[visualComponentsSlice] ${message}`)
+    this.name = 'VisualComponentParamNameError'
+    this.code = code
+  }
+}
+
+export class VisualComponentRecursionError extends Error {
+  constructor(message: string) {
+    super(`[visualComponentsSlice] ${message}`)
+    this.name = 'VisualComponentRecursionError'
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Collect all VC componentIds referenced by base.visual-component-ref nodes
+ * in the page's flat-map subtree rooted at rootNodeId.
+ */
+export function collectVCRefsFromPageSubtree(
+  pageNodes: Record<string, PageNode>,
+  rootNodeId: string,
+): Set<string> {
+  const refs = new Set<string>()
+  const stack: string[] = [rootNodeId]
+  while (stack.length > 0) {
+    const id = stack.pop()!
+    const node = pageNodes[id]
+    if (!node) continue
+    if (node.moduleId === 'base.visual-component-ref') {
+      const componentId = node.props.componentId
+      if (typeof componentId === 'string' && componentId.length > 0) {
+        refs.add(componentId)
+      }
+    }
+    stack.push(...node.children)
+  }
+  return refs
+}
+
+/**
+ * Collect all node IDs in the page flat-map subtree rooted at rootNodeId (DFS).
+ */
+export function collectSubtreeNodeIds(
+  pageNodes: Record<string, PageNode>,
+  rootNodeId: string,
+): string[] {
+  const ids: string[] = []
+  const stack: string[] = [rootNodeId]
+  while (stack.length > 0) {
+    const id = stack.pop()!
+    const node = pageNodes[id]
+    if (!node) continue
+    ids.push(id)
+    stack.push(...node.children)
+  }
+  return ids
+}
+
+/**
+ * Remove all `base.visual-component-ref` nodes referencing `vcId` from the
+ * given flat-map node tree, along with their entire subtrees (slot-instances,
+ * user content, etc.). Operates inside an Immer producer — mutates in place.
+ *
+ * Used by `deleteVisualComponent` to cascade ref removal across every page and
+ * every remaining VC tree in one atomic `mutateSite` call.
+ */
+export function cascadeRemoveVCRefs(
+  nodes: Record<string, BaseNode>,
+  vcId: string,
+): void {
+  // Collect all top-level ref IDs that point at vcId
+  const refNodeIds: string[] = []
+  for (const [nodeId, node] of Object.entries(nodes)) {
+    if (
+      node.moduleId === 'base.visual-component-ref' &&
+      node.props.componentId === vcId
+    ) {
+      refNodeIds.push(nodeId)
+    }
+  }
+
+  // Cascade-remove each ref node and its entire subtree (slot-instances, user
+  // content, etc.) — same tree surgery the loader uses for dangling refs.
+  removeNodeSubtrees(nodes, refNodeIds)
+}
+
+/**
+ * Clone a page's flat-map subtree into a flat VCNode map.
+ *
+ * - Allocates a fresh nanoid() for every cloned node.
+ * - Populates idMap (oldId → newId) for each visited node so that
+ *   parent `children` string arrays reference the correct new IDs.
+ * - For node-scoped classes (scope.type === 'node' && scope.nodeId === oldId):
+ *   rewrites scope.nodeId to the new ID in-place (must run inside an Immer
+ *   producer) and records the classId in hoistedClassIds so the caller can
+ *   attach it to the new VC's top-level classIds array.
+ * - dynamicBindings is intentionally NOT copied — VCNode has no dynamicBindings.
+ *
+ * Returns { nodes, rootNodeId } — a flat NodeTree for VisualComponent.tree.
+ */
+export function clonePageSubtreeToFlatNodes(
+  pageNodes: Record<string, PageNode>,
+  rootNodeId: string,
+  siteClasses: Record<string, StyleRule>,
+  idMap: Map<string, string>,
+  hoistedClassIds: Set<string>,
+): { nodes: Record<string, VCNode>; rootNodeId: string } {
+  const nodes: Record<string, VCNode> = {}
+
+  // Step 1: allocate new IDs for every node in the subtree (DFS)
+  function allocateIds(nodeId: string): void {
+    if (idMap.has(nodeId)) return // already allocated (cycle guard)
+    idMap.set(nodeId, nanoid())
+    const pageNode = pageNodes[nodeId]
+    if (!pageNode) return
+    for (const childId of pageNode.children) allocateIds(childId)
+  }
+  allocateIds(rootNodeId)
+
+  // Step 2: clone each node using the id map
+  const visited = new Set<string>()
+  function cloneNode(oldNodeId: string): void {
+    if (visited.has(oldNodeId)) return
+    visited.add(oldNodeId)
+
+    const pageNode = pageNodes[oldNodeId]
+    if (!pageNode) {
+      throw new Error(`convertNodeToComponent: page node "${oldNodeId}" not found during clone`)
+    }
+
+    const newId = idMap.get(oldNodeId)!
+
+    // Process classIds: rewrite node-scoped ones to the new ID and hoist to VC level
+    const clonedClassIds: string[] = []
+    for (const classId of pageNode.classIds) {
+      const cls = siteClasses[classId]
+      if (cls && cls.scope?.type === 'node' && cls.scope.nodeId === oldNodeId) {
+        // Rewrite scope in-place (Immer draft mutation)
+        cls.scope.nodeId = newId
+        hoistedClassIds.add(classId)
+      }
+      clonedClassIds.push(classId)
+    }
+
+    const vcNode: VCNode = {
+      id: newId,
+      moduleId: pageNode.moduleId,
+      props: { ...pageNode.props },
+      breakpointOverrides: Object.fromEntries(
+        Object.entries(pageNode.breakpointOverrides).map(([k, v]) => [k, { ...v }]),
+      ),
+      // children[] references the NEW ids of direct children
+      children: pageNode.children.map((childId) => idMap.get(childId)!),
+      classIds: clonedClassIds,
+    }
+
+    // Carry optional fields (dynamicBindings excluded — VCNode has no dynamicBindings field)
+    if (pageNode.label !== undefined) vcNode.label = pageNode.label
+    if (pageNode.locked !== undefined) vcNode.locked = pageNode.locked
+    if (pageNode.hidden !== undefined) vcNode.hidden = pageNode.hidden
+    if (pageNode.propBindings !== undefined) {
+      vcNode.propBindings = Object.fromEntries(
+        Object.entries(pageNode.propBindings).map(([k, v]) => [k, { ...v }]),
+      )
+    }
+
+    nodes[newId] = vcNode
+
+    // Recurse into children
+    for (const childId of pageNode.children) cloneNode(childId)
+  }
+  cloneNode(rootNodeId)
+
+  return { nodes, rootNodeId: idMap.get(rootNodeId)! }
+}
+
+// ---------------------------------------------------------------------------
+// Slice interface
+// ---------------------------------------------------------------------------

--- a/src/admin/pages/site/store/slices/visualComponentsSlice.ts
+++ b/src/admin/pages/site/store/slices/visualComponentsSlice.ts
@@ -18,8 +18,8 @@
 import { nanoid } from 'nanoid'
 import type { EditorStoreSliceCreator } from '@site/store/types'
 import type { VisualComponent, VCParam, VCNode } from '@core/visualComponents'
-import type { BaseNode, PageNode, StyleRule } from '@core/page-tree'
-import { reindexNodeParents, removeNodeSubtrees } from '@core/page-tree'
+import type { BaseNode, PageNode } from '@core/page-tree'
+import { reindexNodeParents } from '@core/page-tree'
 import {
   validateComponentName,
   validateParamName,
@@ -27,205 +27,15 @@ import {
 } from '@core/visualComponents'
 import { buildSiteHelpers } from './site/helpers'
 import { syncAllVCRefSlotInstances, allTreeNodeMaps } from './vcSlotReconcile'
-
-// ---------------------------------------------------------------------------
-// Custom error types (exported so UI + tests can catch by class)
-// ---------------------------------------------------------------------------
-
-export class VisualComponentNameError extends Error {
-  readonly code: string
-  constructor(message: string, code: string) {
-    super(`[visualComponentsSlice] ${message}`)
-    this.name = 'VisualComponentNameError'
-    this.code = code
-  }
-}
-
-class VisualComponentParamNameError extends Error {
-  readonly code: string
-  constructor(message: string, code: string) {
-    super(`[visualComponentsSlice] ${message}`)
-    this.name = 'VisualComponentParamNameError'
-    this.code = code
-  }
-}
-
-class VisualComponentRecursionError extends Error {
-  constructor(message: string) {
-    super(`[visualComponentsSlice] ${message}`)
-    this.name = 'VisualComponentRecursionError'
-  }
-}
-
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Collect all VC componentIds referenced by base.visual-component-ref nodes
- * in the page's flat-map subtree rooted at rootNodeId.
- */
-function collectVCRefsFromPageSubtree(
-  pageNodes: Record<string, PageNode>,
-  rootNodeId: string,
-): Set<string> {
-  const refs = new Set<string>()
-  const stack: string[] = [rootNodeId]
-  while (stack.length > 0) {
-    const id = stack.pop()!
-    const node = pageNodes[id]
-    if (!node) continue
-    if (node.moduleId === 'base.visual-component-ref') {
-      const componentId = node.props.componentId
-      if (typeof componentId === 'string' && componentId.length > 0) {
-        refs.add(componentId)
-      }
-    }
-    stack.push(...node.children)
-  }
-  return refs
-}
-
-/**
- * Collect all node IDs in the page flat-map subtree rooted at rootNodeId (DFS).
- */
-function collectSubtreeNodeIds(
-  pageNodes: Record<string, PageNode>,
-  rootNodeId: string,
-): string[] {
-  const ids: string[] = []
-  const stack: string[] = [rootNodeId]
-  while (stack.length > 0) {
-    const id = stack.pop()!
-    const node = pageNodes[id]
-    if (!node) continue
-    ids.push(id)
-    stack.push(...node.children)
-  }
-  return ids
-}
-
-/**
- * Remove all `base.visual-component-ref` nodes referencing `vcId` from the
- * given flat-map node tree, along with their entire subtrees (slot-instances,
- * user content, etc.). Operates inside an Immer producer — mutates in place.
- *
- * Used by `deleteVisualComponent` to cascade ref removal across every page and
- * every remaining VC tree in one atomic `mutateSite` call.
- */
-function cascadeRemoveVCRefs(
-  nodes: Record<string, BaseNode>,
-  vcId: string,
-): void {
-  // Collect all top-level ref IDs that point at vcId
-  const refNodeIds: string[] = []
-  for (const [nodeId, node] of Object.entries(nodes)) {
-    if (
-      node.moduleId === 'base.visual-component-ref' &&
-      node.props.componentId === vcId
-    ) {
-      refNodeIds.push(nodeId)
-    }
-  }
-
-  // Cascade-remove each ref node and its entire subtree (slot-instances, user
-  // content, etc.) — same tree surgery the loader uses for dangling refs.
-  removeNodeSubtrees(nodes, refNodeIds)
-}
-
-/**
- * Clone a page's flat-map subtree into a flat VCNode map.
- *
- * - Allocates a fresh nanoid() for every cloned node.
- * - Populates idMap (oldId → newId) for each visited node so that
- *   parent `children` string arrays reference the correct new IDs.
- * - For node-scoped classes (scope.type === 'node' && scope.nodeId === oldId):
- *   rewrites scope.nodeId to the new ID in-place (must run inside an Immer
- *   producer) and records the classId in hoistedClassIds so the caller can
- *   attach it to the new VC's top-level classIds array.
- * - dynamicBindings is intentionally NOT copied — VCNode has no dynamicBindings.
- *
- * Returns { nodes, rootNodeId } — a flat NodeTree for VisualComponent.tree.
- */
-function clonePageSubtreeToFlatNodes(
-  pageNodes: Record<string, PageNode>,
-  rootNodeId: string,
-  siteClasses: Record<string, StyleRule>,
-  idMap: Map<string, string>,
-  hoistedClassIds: Set<string>,
-): { nodes: Record<string, VCNode>; rootNodeId: string } {
-  const nodes: Record<string, VCNode> = {}
-
-  // Step 1: allocate new IDs for every node in the subtree (DFS)
-  function allocateIds(nodeId: string): void {
-    if (idMap.has(nodeId)) return // already allocated (cycle guard)
-    idMap.set(nodeId, nanoid())
-    const pageNode = pageNodes[nodeId]
-    if (!pageNode) return
-    for (const childId of pageNode.children) allocateIds(childId)
-  }
-  allocateIds(rootNodeId)
-
-  // Step 2: clone each node using the id map
-  const visited = new Set<string>()
-  function cloneNode(oldNodeId: string): void {
-    if (visited.has(oldNodeId)) return
-    visited.add(oldNodeId)
-
-    const pageNode = pageNodes[oldNodeId]
-    if (!pageNode) {
-      throw new Error(`convertNodeToComponent: page node "${oldNodeId}" not found during clone`)
-    }
-
-    const newId = idMap.get(oldNodeId)!
-
-    // Process classIds: rewrite node-scoped ones to the new ID and hoist to VC level
-    const clonedClassIds: string[] = []
-    for (const classId of pageNode.classIds) {
-      const cls = siteClasses[classId]
-      if (cls && cls.scope?.type === 'node' && cls.scope.nodeId === oldNodeId) {
-        // Rewrite scope in-place (Immer draft mutation)
-        cls.scope.nodeId = newId
-        hoistedClassIds.add(classId)
-      }
-      clonedClassIds.push(classId)
-    }
-
-    const vcNode: VCNode = {
-      id: newId,
-      moduleId: pageNode.moduleId,
-      props: { ...pageNode.props },
-      breakpointOverrides: Object.fromEntries(
-        Object.entries(pageNode.breakpointOverrides).map(([k, v]) => [k, { ...v }]),
-      ),
-      // children[] references the NEW ids of direct children
-      children: pageNode.children.map((childId) => idMap.get(childId)!),
-      classIds: clonedClassIds,
-    }
-
-    // Carry optional fields (dynamicBindings excluded — VCNode has no dynamicBindings field)
-    if (pageNode.label !== undefined) vcNode.label = pageNode.label
-    if (pageNode.locked !== undefined) vcNode.locked = pageNode.locked
-    if (pageNode.hidden !== undefined) vcNode.hidden = pageNode.hidden
-    if (pageNode.propBindings !== undefined) {
-      vcNode.propBindings = Object.fromEntries(
-        Object.entries(pageNode.propBindings).map(([k, v]) => [k, { ...v }]),
-      )
-    }
-
-    nodes[newId] = vcNode
-
-    // Recurse into children
-    for (const childId of pageNode.children) cloneNode(childId)
-  }
-  cloneNode(rootNodeId)
-
-  return { nodes, rootNodeId: idMap.get(rootNodeId)! }
-}
-
-// ---------------------------------------------------------------------------
-// Slice interface
-// ---------------------------------------------------------------------------
+import {
+  VisualComponentNameError,
+  VisualComponentParamNameError,
+  VisualComponentRecursionError,
+  cascadeRemoveVCRefs,
+  clonePageSubtreeToFlatNodes,
+  collectSubtreeNodeIds,
+  collectVCRefsFromPageSubtree,
+} from './vcTreeOps'
 
 export interface VisualComponentsSlice {
   /**


### PR DESCRIPTION
Health-check item 5. `visualComponentsSlice.ts` was the largest store slice (906 LOC, highest total cognitive complexity of any production file).

- **`vcTreeOps.ts`** (new sibling, same pattern as the existing `vcSlotReconcile.ts` split) now owns the typed domain errors (`VisualComponentNameError` / `VisualComponentParamNameError` / `VisualComponentRecursionError`) and the pure page-tree surgery: VC-ref collection from a subtree, cascade removal of refs to a deleted VC, and flat-node subtree cloning for componentization.
- The slice keeps only the store actions (906 → 715 LOC); error-class consumers import from `vcTreeOps`; the module-size ratchet is lowered 924 → 715 to lock the win.

Behavior preserved — `bun test` 5,359 pass / 0 fail (incl. the VC data-layer, componentization, and slot-sync suites); build + lint green. Independent of the other open refactor PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)