### PR TITLE
feat(editor): double-click rows to rename in explorer panels

### DIFF
--- a/src/__tests__/panels/domPanel.test.tsx
+++ b/src/__tests__/panels/domPanel.test.tsx
@@ -601,6 +601,18 @@ describe('DomPanel — tree keyboard navigation', () => {
     expect(screen.getByRole('treeitem', { name: /hero group/i })).toBeDefined()
   })
 
+  it('opens inline tree rename from a double-clicked layer row', () => {
+    loadContainerSite()
+    render(<DomPanel />)
+
+    const containerItem = screen.getByRole('treeitem', { name: /container/i })
+    fireEvent.doubleClick(containerItem)
+
+    expect(screen.getByRole('textbox', {
+      name: /rename (base\.container|container)/i,
+    })).toBeDefined()
+  })
+
   it('keeps hidden nodes in the tree and marks them with a hidden badge', () => {
     loadContainerSite()
     act(() => {

--- a/src/__tests__/site-explorer/siteExplorerPanel.test.tsx
+++ b/src/__tests__/site-explorer/siteExplorerPanel.test.tsx
@@ -920,6 +920,15 @@ describe('SiteExplorerPanel', () => {
     expect(renamed).toBeUndefined()
   })
 
+  it('opens inline page rename from a double-clicked site row', () => {
+    loadSite()
+    render(<SiteExplorerPanel variant="docked" />)
+
+    fireEvent.doubleClick(screen.getByRole('button', { name: /open page pricing/i }))
+
+    expect(screen.getByRole('textbox', { name: 'Rename Pricing' })).toBeDefined()
+  })
+
   it('renames and deletes components from the site row context menu', () => {
     loadSite()
     render(<SiteExplorerPanel variant="docked" />)

--- a/src/admin/pages/site/panels/DomPanel/TreeNode.tsx
+++ b/src/admin/pages/site/panels/DomPanel/TreeNode.tsx
@@ -289,6 +289,11 @@ export const TreeNode = memo(function TreeNode({ nodeId, depth, editable = true 
           selectNode(nodeId)
           if (hasChildren && !isRoot) store.toggle(nodeId)
         }}
+        onDoubleClick={(e) => {
+          e.preventDefault()
+          e.stopPropagation()
+          openRename()
+        }}
         onKeyDown={handleKeyDown}
         onContextMenu={(e) => {
           e.preventDefault(); e.stopPropagation()

--- a/src/admin/pages/site/panels/SiteExplorerPanel/SiteExplorerTreeRows.tsx
+++ b/src/admin/pages/site/panels/SiteExplorerPanel/SiteExplorerTreeRows.tsx
@@ -119,6 +119,11 @@ export function ExplorerFolderRow({
           aria-label={folder.name}
           onClick={onToggle}
           onContextMenu={(event) => onContextMenu(folder, event)}
+          onDoubleClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onRename(folder)
+          }}
           onKeyDown={(event) => {
             if (event.key === 'F2') {
               event.preventDefault()
@@ -248,6 +253,11 @@ export function ExplorerItemRow<TTarget>({
           aria-current={item.active ? 'page' : undefined}
           onClick={(event) => onOpen(item, event)}
           onContextMenu={(event) => onContextMenu(item, event)}
+          onDoubleClick={(event) => {
+            event.preventDefault()
+            event.stopPropagation()
+            onRename(item)
+          }}
           onKeyDown={(event) => {
             if (event.key === 'F2') {
               event.preventDefault()


### PR DESCRIPTION
## Summary

Adds double-click rename shortcuts to the Site Explorer and Layers/DOM panel rows, using the same inline rename flows already used by F2 and context-menu Rename.

## Changes

- Site Explorer folders and items now open inline rename on double-click.
- DOM panel layer rows now open inline rename on double-click.
- Added regression coverage for both row-level shortcuts.

## Validation

- `bun run build`
- `bun test`
- `bun run lint`
- `npx react-doctor@latest --verbose --diff`
- `npx react-doctor@latest --verbose --diff --fail-on warning`