### PR TITLE
Add a "Not found" template target for designed 404 pages

### DIFF
--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -402,6 +402,13 @@ publishDraftSite (server/publish/publishSite.ts)
     │     its runtime_assets_json
     ├─→ flip data_rows.status = 'published', set active_version_id
     │
+    ├─→ Layer A bake — the 404 page (when a notFound template exists):
+    │     renderPublishedNotFound (notFound template wrapped in the everywhere
+    │     chain) → same pipeline → writeArtefact(<inactiveSlot>, '/404')
+    │     (`404.html` — the static-hosting convention, so Netlify/GH Pages
+    │      pick it up in a raw static export; baked first so a literal page
+    │      with slug `404` would overwrite it and stay authoritative)
+    │
     ├─→ Layer A bake — every page (complete doc, or static shell with <instatic-hole>):
     │     ├── renderPublishedSnapshot(snapshot, { db, url, publishVersion }) → HTML
     │     ├── applyPublishedHtmlPipeline(rendered, db) → final HTML
@@ -453,7 +460,11 @@ tryServePublicRoute (server/router.ts)
           │     row resolutions read the site snapshot via the per-version memo
           │     (publishedSnapshotCache.ts) — no per-request full-site parse
           │     redirects → 301 (not cached)
-          │     not-found → null (router falls through to next handler)
+          │     not-found → null (router falls through: trySetupRedirect, then
+          │     tryServeNotFoundPage → renderNotFoundResponse serves the site's
+          │     404 page — baked `404.html` artefact first, else live render
+          │     through the LRU under the reserved `/404` key — with status 404;
+          │     no notFound template → the dispatcher's bare JSON 404)
           │
           └─→ Layer B in-memory LRU (miss path):
                 getOrRender({urlPath, queryString: canonicalQuery}, async () => {

--- a/docs/features/templates.md
+++ b/docs/features/templates.md
@@ -1,15 +1,16 @@
 # Templates
 
-Templates are pages that wrap other content — every page on the site (everywhere layouts) or every entry in a post type. They are the mechanism for shared headers, footers, and layout chrome.
+Templates are pages that wrap other content — every page on the site (everywhere layouts) or every entry in a post type. They are the mechanism for shared headers, footers, and layout chrome. A third target, `notFound`, designates the page served on public 404s (it doesn't wrap anything — it IS the content, wrapped by the everywhere layout like any page).
 
-A template is an ordinary `pages` row carrying a `target` (everywhere or one/more post types) and a `priority`. When the public router resolves a URL, it collects every matching template, orders them broadest→narrowest, and a composer splices each inner tree into the outer template's single `base.outlet`, producing one merged page tree. That tree feeds the existing `publishPage` pipeline unchanged.
+A template is an ordinary `pages` row carrying a `target` (everywhere, one/more post types, or notFound) and a `priority`. When the public router resolves a URL, it collects every matching template, orders them broadest→narrowest, and a composer splices each inner tree into the outer template's single `base.outlet`, producing one merged page tree. That tree feeds the existing `publishPage` pipeline unchanged.
 
 ---
 
 ## TL;DR
 
-- A template declares `target: { kind: 'everywhere' } | { kind: 'postTypes', tableSlugs }` and a `priority`.
+- A template declares `target: { kind: 'everywhere' } | { kind: 'postTypes', tableSlugs } | { kind: 'notFound' }` and a `priority`.
 - **Chain resolver:** `resolveTemplateChain(site, ctx)` in `src/core/templates/templateMatching.ts` → `Page[]` ordered outer → inner. At most one template per breadth level (highest priority wins, document order breaks ties). Two breadth levels today: `everywhere` (outermost) → `postTypes` (innermost).
+- **404 resolver:** `resolveNotFoundTemplate(site)` → the highest-priority `notFound` template or null. A `notFound` template never enters a route chain — the public router renders it directly when a GET falls through every route (see "The Not found (404) template" below).
 - **Chain composer:** `composeTemplateChain(chain, terminal)` in `src/core/templates/templateCompose.ts` → one merged `Page` ready for `publishPage`.
 - **`base.outlet`** is the polymorphic outlet content flows into. A template *should* contain one. Having NO outlet is not blocked (you add it after converting the page to a template — requiring it first would be circular). The editor enforces a one-outlet-per-document invariant at the store's mutation chokepoints (`insertNode`, `duplicateNode(s)`, `pasteNode`), each surfacing a warning toast when blocked; the module pickers additionally render the outlet as a disabled tile with the reason (non-template page, VC mode, or outlet already placed) so authors rarely hit the block at all. The composer remains defensive for data pre-dating the guard: no outlet → template skipped; multiple → first wins.
 - Template pages are never served at their own slug; the live router and the static bake both skip them.
@@ -23,7 +24,7 @@ A template is an ordinary `pages` row carrying a `target` (everywhere or one/mor
 ```text
 src/core/page-tree/pageTemplate.ts     — TemplateTarget, PageTemplateConfig, parsePageTemplate
 src/core/templates/
-├── templateMatching.ts                — resolveTemplateChain, isTemplatePage, templateTargetLabel, RouteResolutionContext
+├── templateMatching.ts                — resolveTemplateChain, resolveNotFoundTemplate, isTemplatePage, templateTargetLabel, RouteResolutionContext
 ├── templateCompose.ts                 — composeTemplateChain, TerminalContent
 ├── contextFrames.ts                   — PageFrame, SiteFrame, RouteFrame + builders
 ├── dynamicBindings.ts                 — TemplateRenderDataContext + resolveDynamicProps
@@ -45,6 +46,7 @@ server/publish/publicRenderer.ts       — chain-aware render paths
 type TemplateTarget =
   | { kind: 'everywhere' }
   | { kind: 'postTypes'; tableSlugs: string[] }   // ≥1 slug
+  | { kind: 'notFound' }                          // the public 404 page
 
 interface PageTemplateConfig {
   enabled: true
@@ -160,7 +162,7 @@ public GET /<routeBase>/<rowSlug>  →  resolvePublicRoute
                     publishPage(merged, …, templateContext: { entryStack: [row] })
 ```
 
-Render paths: `server/publish/publicRenderer.ts` — `renderPublishedSnapshot` (page route), `renderPublishedDataRowTemplate` (entry route).
+Render paths: `server/publish/publicRenderer.ts` — `renderPublishedSnapshot` (page route), `renderPublishedDataRowTemplate` (entry route), `renderPublishedNotFound` (fall-through 404).
 
 ### Chain for each route kind (v1)
 
@@ -168,12 +170,25 @@ Render paths: `server/publish/publicRenderer.ts` — `renderPublishedSnapshot` (
 |-------|--------------------|----|
 | `/about` (page)          | `[everywhere-layout?]`                           | the `/about` page tree |
 | `/posts/hello` (entry)   | `[everywhere-layout?, posts-entry-template]`     | `{ kind: 'entry' }` — outlet renders the row body |
+| any unmatched GET (404)  | `[everywhere-layout?]`                           | the `notFound` template's tree |
 
 If no `everywhere` layout exists, a plain page renders exactly as a page with no templates. If no postTypes template exists for a route, the entry URL 404s.
 
 ### Static re-bake on template edit
 
 A full `publishDraftSite` re-bakes every non-template page through `renderPublishedSnapshot`, which runs the chain each time — so editing an `everywhere` layout and publishing re-bakes all page artefacts automatically. Entry-detail artefacts (`/posts/hello.html`) are written incrementally by `publishDataRow` (chain-aware since v1) and wiped on the next full slot swap.
+
+---
+
+## The Not found (404) template
+
+A page with `target: { kind: 'notFound' }` is the site's designed 404 page. It is not a wrapper — it carries real content (no `base.outlet` needed) and is itself wrapped by the `everywhere` layout, exactly like a regular page.
+
+- **Resolution:** `resolveNotFoundTemplate(site)` (in `templateMatching.ts`) — highest `priority` wins, document order breaks ties. It never appears in `resolveTemplateChain` output; route matching never "matches" a 404.
+- **Serving:** the dispatcher's last route (`tryServeNotFoundPage` in `server/router.ts`) catches every GET no earlier route claimed and calls `renderNotFoundResponse` (`publicRouter.ts`): baked `404.html` artefact first (one disk read, no DB — what bot probes hit), else a live render through the Layer B LRU under the reserved `/404` key. Always **status 404**. Namespaced prefixes (`/admin/api/*`, `/_instatic/*`, `/uploads/*`) emit their own 404s and never reach it. No notFound template → the dispatcher's bare JSON 404, as before.
+- **Bake:** `publishDraftSite` renders the template through `renderPublishedNotFound` and writes `404.html` into the slot — deliberately the static-hosting convention, so a raw static export of the slot keeps a working error page on Netlify / GitHub Pages.
+- **`/404` direct hit:** serves the baked artefact with status 200 (same convention as static hosts). The template's own slug stays non-routable like every template.
+- **Editor:** Template settings → Applies to → "Not found (404)". No preview-source dropdown (there is no entry to preview); the toolbar's **Open live page** button resolves to `/404`.
 
 ---
 
@@ -242,13 +257,13 @@ Grouped menus rely on a small `Select` primitive capability: an `<optgroup label
 
 The preview selection lives in `templatePreviewSelection` (UI slice, `templateId → sourceId`). It is **session-only** — a pure preview convenience that never dirties or persists to the site document. Unset → the first real page / published row is previewed. Both `OutletEditor` (everywhere) and `useTemplatePreviewContext` (postTypes) read it.
 
-`useActiveLivePath` (`src/admin/pages/site/hooks/useActiveLivePath.ts`) also reads `templatePreviewSelection` to determine the target for the toolbar's **Open live page** button. Template pages have no routable slug of their own (the live router and bake loop both skip them), so opening the template slug directly would 404. Instead the hook resolves to the same source the preview dropdown shows: the previewed page's public path for `everywhere` templates, or the previewed row's permalink for `postTypes` templates. The fallback is the first real page / first published row, matching the preview dropdown's own default.
+`useActiveLivePath` (`src/admin/pages/site/hooks/useActiveLivePath.ts`) also reads `templatePreviewSelection` to determine the target for the toolbar's **Open live page** button. Template pages have no routable slug of their own (the live router and bake loop both skip them), so opening the template slug directly would 404. Instead the hook resolves to the same source the preview dropdown shows: the previewed page's public path for `everywhere` templates, or the previewed row's permalink for `postTypes` templates. A `notFound` template resolves to `/404` (its baked artefact's path). The fallback is the first real page / first published row, matching the preview dropdown's own default.
 
 ### Edit-in-context composition
 
 The design canvas renders the active document the way it publishes: **inside its matching template chain**. `CanvasComposedTree` (`src/admin/pages/site/canvas/CanvasComposedTree.tsx`) is the single render entry used by both `BreakpointFrame` and `CanvasLiveSurface`:
 
-- `resolveEditorWrapperTemplates(site, activeDoc)` (`canvasComposition.ts`) returns the templates that WRAP the active document, outermost-first — the editor-side mirror of `resolveTemplateChain`. Editing a page or a `postTypes` template ⇒ wrapped by the `everywhere` layout; editing the `everywhere` layout ⇒ nothing wraps it.
+- `resolveEditorWrapperTemplates(site, activeDoc)` (`canvasComposition.ts`) returns the templates that WRAP the active document, outermost-first — the editor-side mirror of `resolveTemplateChain`. Editing a page, a `postTypes` template, or a `notFound` template ⇒ wrapped by the `everywhere` layout; editing the `everywhere` layout ⇒ nothing wraps it.
 - Wrappers render **read-only** via `ReadOnlyNodeTree` with the editable document spliced into the innermost wrapper's `base.outlet` (the `outletSlot` prop replaces the outlet node, mirroring `spliceIntoOutlet`). Only the active document's nodes keep `data-node-id` + handlers, so selection / hover / DnD stay scoped to it; the chrome is pixel-identical but non-interactive.
 - Body ownership mirrors the publisher: the iframe `<body>` carries the OUTERMOST wrapper body's classes, and the active document renders as its body *children* (its own `base.body` is dropped, just as the composer drops the inner body).
 - `ReadOnlyNodeTree` (`src/modules/base/utils/ReadOnlyNodeTree.tsx`) is the shared non-interactive tree renderer — also used by `VCInlineTree` for inlined Visual Component bodies.
@@ -284,7 +299,7 @@ Right-click a page row → **Use as template** → the **Template settings** dia
 
 | Field | Description |
 |---|---|
-| Applies to | `Everywhere` (outer layout for all pages and entries) or `Post types` (entry template for ≥1 post-type tables) |
+| Applies to | `Everywhere` (outer layout for all pages and entries), `Post types` (entry template for ≥1 post-type tables), or `Not found (404)` (the public 404 page) |
 | Post types | Checkbox list of all post-type tables — visible when "Post types" is selected |
 | Priority | Higher number wins when multiple templates match the same breadth level |
 
@@ -335,6 +350,12 @@ When a postType is created, the system seeds a default entry template automatica
 ### Share a layout across post types
 
 In the Template settings dialog, set **Applies to** to "Post types" and check multiple post-type tables. A single template can list several `tableSlugs`: `{ kind: 'postTypes', tableSlugs: ['posts', 'news'] }`.
+
+### Add a 404 page (notFound template)
+
+1. Create a new page and design the "not found" content — no `base.outlet` needed.
+2. Set it as a template ("Template settings…"), choose target: **Not found (404)**.
+3. Publish. Every URL that matches nothing now serves this page (wrapped in the everywhere layout) with HTTP status 404, straight from the baked `404.html` artefact.
 
 ### Build a template with the AI agent
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -81,6 +81,9 @@ const routes: readonly RouteHandler[] = [
                                    //   resolves to page snapshot OR data row + template,
                                    //   live-renders, runs publish.html pipeline
   trySetupRedirect,                // first-run redirect → /admin/setup
+  tryServeNotFoundPage,            // fall-through GET → site's 404 page (notFound
+                                   //   template; baked 404.html artefact, else live
+                                   //   render) with status 404; null → JSON 404
 ]
 ```
 

--- a/docs/superpowers/specs/2026-06-12-seo-workspace-design.md
+++ b/docs/superpowers/specs/2026-06-12-seo-workspace-design.md
@@ -1,0 +1,466 @@
+# SEO Workspace Design
+
+Design spec for the core SEO workspace, generated robots.txt/sitemap endpoints, and published metadata model.
+
+Instatic needs SEO as a core publishing capability. Plugins can extend reporting and integrations, but the CMS itself must own correct metadata emission, generated crawl files, and a focused admin surface for editing page, content, and template SEO.
+
+---
+
+## TL;DR
+
+- Add a first-party SEO workspace at `/admin/tools/seo`, reached from a new **Tools** navigation dropdown.
+- Tools contains first-party utility screens such as SEO and future Redirects; plugin admin pages move under the same dropdown instead of occupying top-level nav slots.
+- SEO v1 has three tabs in the existing `AdminPageLayout` pattern: **Meta**, **Robots.txt**, and **Sitemap**.
+- Meta is the v1 build focus: a searchable target index on the right, and a sticky editable preview column on the left.
+- The preview editor uses controlled `Input` / `Textarea` primitives styled as platform snippets, not raw `contentEditable`.
+- SEO data is core structured data, not plugin-owned data: `title`, `description`, `canonicalUrl`, `noindex`, Open Graph fields, and X card fields.
+- The publisher resolves fallbacks and emits search, canonical, robots, Open Graph, and X card tags.
+- `GET /robots.txt` must be handled before public page rendering and always return `text/plain`.
+- `GET /sitemap.xml` is generated from published routable pages and content rows.
+- Google Search Console and dashboard widgets are later integrations that consume the core SEO model; they are not part of v1.
+
+## Current State
+
+The admin shell uses route-level workspaces in `src/admin/router.tsx` and renders first-party pages through `src/admin/AuthenticatedAdmin.tsx`. Tabbed admin pages such as AI, Users, and Account use `AdminPageLayout` with small tab buttons passed through the `tabs` slot:
+
+- `src/admin/pages/ai/AiPage.tsx`
+- `src/admin/pages/users/UsersPage.tsx`
+- `src/admin/pages/account/AccountPage.tsx`
+- `src/admin/layouts/AdminPageLayout/AdminPageLayout.tsx`
+
+The toolbar navigation is shared by `src/admin/shared/AdminSectionNavigation/AdminSectionNavigation.tsx`. Plugin admin pages are currently collected from `listCmsPlugins()` and rendered as top-level nav links. Plugin page routes are declared as `/admin/plugins/:pluginId/:pageId` in `src/admin/router.tsx` and rendered by `src/admin/pages/plugins/PluginPage.tsx`.
+
+Published HTML metadata is currently minimal. `src/core/publisher/render.ts` derives `<title>`, meta description, favicon, and `lang` from `site.settings` and the active page. Current site-wide fields live in `src/core/page-tree/siteSettings.ts` as `metaTitle`, `metaDescription`, `faviconUrl`, and `language`.
+
+Content rows already include built-in SEO fields. The built-in field definitions live in `src/core/data/fields.ts`; the field IDs are exported from `src/core/data/schemas.ts` as `seoTitle` and `seoDescription`, and read by `src/core/data/cells.ts`. The Content workspace edits them through `src/admin/pages/content/components/ContentSettingsPanel/ContentSettingsPanel.tsx`.
+
+There is no first-party robots.txt or sitemap endpoint. Public HTML requests flow through `server/router.ts` into `server/publish/publicRouter.ts`. Without a dedicated `GET /robots.txt` handler before public page rendering, `/robots.txt` can fall through to an HTML response in development, which makes Lighthouse parse HTML as robots text.
+
+## Product Decision
+
+SEO belongs in core. It affects the correctness of published output and crawlability, so the base CMS must provide the model, endpoints, publisher tags, and editing UI.
+
+Plugins can add:
+
+- Google Search Console connection.
+- Dashboard widgets and charts.
+- Keyword research, recommendations, redirects importers, and richer audits.
+- Custom metadata transforms through existing publisher/plugin hooks where appropriate.
+
+Plugins must not be required for:
+
+- Basic title and description editing.
+- Open Graph and X card tags.
+- Robots.txt.
+- Sitemap.xml.
+- Canonical URLs and noindex controls.
+
+## Navigation
+
+Add a top-level **Tools** dropdown to the admin toolbar navigation.
+
+First-party entries:
+
+- SEO: `/admin/tools/seo`
+- Redirects: future `/admin/tools/redirects`
+
+Plugin admin pages:
+
+- Move plugin-provided admin pages under Tools.
+- Keep the existing plugin page renderer and route shape unless a route rename is part of implementation.
+- The dropdown label for plugin pages uses `page.navLabel ?? page.title`, grouped by plugin name when there is more than one page per plugin.
+
+Top-level navigation remains focused on primary workspaces:
+
+- Dashboard
+- Site
+- Content
+- Data
+- Media
+- Plugins
+- Users
+- AI
+- Tools
+
+## SEO Workspace
+
+Route: `/admin/tools/seo`
+
+Workspace type: regular `AdminPageLayout`, not canvas layout.
+
+Tabs:
+
+- Meta
+- Robots.txt
+- Sitemap
+
+The page follows the current tab shell used by `src/admin/pages/ai/AiPage.tsx`, `src/admin/pages/users/UsersPage.tsx`, and `src/admin/pages/account/AccountPage.tsx`: the page component owns the active tab and delegates stateful work to tab components.
+
+Suggested folder layout:
+
+```text
+src/admin/pages/seo/
+|-- SeoPage.tsx
+|-- SeoPage.module.css
+|-- tabs/
+|   |-- MetaTab.tsx
+|   |-- RobotsTab.tsx
+|   `-- SitemapTab.tsx
+|-- components/
+|   |-- SeoTargetIndex.tsx
+|   |-- SeoPreviewEditor.tsx
+|   |-- SearchSnippetPreview.tsx
+|   |-- OpenGraphPreview.tsx
+|   `-- XCardPreview.tsx
+`-- hooks/
+    |-- useSeoTargets.ts
+    `-- useSeoDraft.ts
+```
+
+## Meta Tab UX
+
+The Meta tab has two persistent columns.
+
+Left column: sticky preview editor.
+
+- Platform switcher: Search, Open Graph, X.
+- Search preview includes editable title and description, with route/canonical shown read-only.
+- Open Graph preview includes editable OG title, OG description, image picker, image alt, and type.
+- X preview includes editable X title, X description, image picker, image alt, and card type.
+- X fields are hidden behind a "Customize X preview" control until they differ from fallback values.
+- Field quality hints are inline and local: missing title, long title, missing description, missing image alt, invalid canonical, noindex enabled.
+- Save state is quiet and local: unsaved, saving, saved, error.
+
+Right column: target index.
+
+- Search bar at the top.
+- Target filters: All, Pages, Posts, Templates, Issues.
+- Dense rows, not cards.
+- Each row shows display title, target type, route/template target, and compact health indicators for title, description, image, and indexing.
+- Clicking a row activates that target in the sticky preview editor.
+
+The right index is navigation and audit context. The left preview editor is the editing surface.
+
+## Editable Preview Controls
+
+Do not use raw `contentEditable` for v1.
+
+Use controlled `Input` and `Textarea` primitives styled to look like the platform snippets. This gives the direct-manipulation feel while preserving:
+
+- predictable selection behavior;
+- paste handling;
+- undo behavior;
+- validation;
+- accessibility;
+- save timing;
+- architecture gate compliance for admin controls.
+
+The user feels like they are editing the snippet, but the implementation stays inside existing UI primitives from `src/ui/components/`.
+
+## SEO Data Model
+
+Introduce one structured SEO object used by pages, content rows, and template defaults.
+
+```ts
+export const SeoMetadataSchema = Type.Object({
+  title: Type.Optional(Type.String()),
+  description: Type.Optional(Type.String()),
+  canonicalUrl: Type.Optional(Type.String()),
+  noindex: Type.Optional(Type.Boolean()),
+
+  ogTitle: Type.Optional(Type.String()),
+  ogDescription: Type.Optional(Type.String()),
+  ogImage: Type.Optional(Type.String()),
+  ogImageAlt: Type.Optional(Type.String()),
+  ogType: Type.Optional(Type.Union([
+    Type.Literal('website'),
+    Type.Literal('article'),
+  ])),
+
+  xTitle: Type.Optional(Type.String()),
+  xDescription: Type.Optional(Type.String()),
+  xImage: Type.Optional(Type.String()),
+  xImageAlt: Type.Optional(Type.String()),
+  xCard: Type.Optional(Type.Union([
+    Type.Literal('summary'),
+    Type.Literal('summary_large_image'),
+  ])),
+})
+```
+
+Derived type:
+
+```ts
+export type SeoMetadata = Static<typeof SeoMetadataSchema>
+```
+
+The schema lives in a new core module that can be imported by the publisher, admin persistence schemas, and server handlers without pulling in admin code: `src/core/seo/`.
+
+## Storage
+
+Pages and post-type rows currently store SEO as flat built-in fields: `seoTitle` and `seoDescription`. Replace those with one structured `seo` field.
+
+Because the project is pre-release, do not preserve both systems for compatibility. Change the seeded fields, tests, admin readers/writers, and docs together.
+
+Field shape:
+
+- For `page` and `postType` tables, add a built-in field with id `seo` and type `seoMetadata`.
+- Store the object in `cells_json.seo`.
+- Add `SeoMetadataFieldSchema` to the data field union.
+- Validate `cells_json.seo` with `SeoMetadataSchema` at write boundaries.
+- Do not expose `seoMetadata` as a user-created custom field type.
+- The field is built-in and non-deletable for pages/post types. Its editing surface is the SEO workspace, with optional lightweight summaries in Content/Site metadata panels.
+
+Site defaults live under `site.settings.seo`:
+
+```ts
+{
+  titlePattern?: string
+  description?: string
+  defaultOgImage?: string
+  defaultOgImageAlt?: string
+  defaultXCard?: 'summary' | 'summary_large_image'
+}
+```
+
+Template defaults are stored on the template page or entry-template row as `seo` patterns. Patterns can reference tokens such as `{title}`, `{siteName}`, `{slug}`, and `{excerpt}`.
+
+## Target Types
+
+The Meta tab edits these target kinds:
+
+| Kind | Source | Route |
+| --- | --- | --- |
+| Page | `pages` system table row | Page slug route, with `index` mapped to `/` |
+| Post/content row | `postType` table row | `routeBase + slug` |
+| Template default | Entry template page row | Not directly routable; applies to matching content rows |
+| Site default | `site.settings.seo` | Fallback for every target |
+
+V1 includes Pages, Posts/content rows, Templates, and one pinned Site defaults target at the top of the index.
+
+## Publisher Output
+
+The publisher resolves final metadata per public route and emits:
+
+```html
+<title>...</title>
+<meta name="description" content="...">
+<link rel="canonical" href="...">
+<meta name="robots" content="noindex,nofollow">
+
+<meta property="og:title" content="...">
+<meta property="og:description" content="...">
+<meta property="og:image" content="...">
+<meta property="og:image:alt" content="...">
+<meta property="og:type" content="website">
+<meta property="og:url" content="...">
+<meta property="og:site_name" content="...">
+
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="...">
+<meta name="twitter:description" content="...">
+<meta name="twitter:image" content="...">
+<meta name="twitter:image:alt" content="...">
+```
+
+Even though the UI labels the platform as X, the emitted tag names remain `twitter:*` because that is the current card metadata convention.
+
+Fallback chain:
+
+```ts
+title = seo.title ?? template.titlePattern ?? page.title ?? row.title ?? site.name
+description = seo.description ?? template.description ?? site.seo.description
+
+ogTitle = seo.ogTitle ?? title
+ogDescription = seo.ogDescription ?? description
+ogImage = seo.ogImage ?? site.seo.defaultOgImage
+ogImageAlt = seo.ogImageAlt ?? site.seo.defaultOgImageAlt
+ogType = seo.ogType ?? (routeKind === 'row' ? 'article' : 'website')
+
+xTitle = seo.xTitle ?? ogTitle
+xDescription = seo.xDescription ?? ogDescription
+xImage = seo.xImage ?? ogImage
+xImageAlt = seo.xImageAlt ?? ogImageAlt
+xCard = seo.xCard ?? site.seo.defaultXCard ?? (xImage ? 'summary_large_image' : 'summary')
+```
+
+Canonical URL is resolved from the public origin plus the route path unless `seo.canonicalUrl` is set. Validate user-provided canonical values as safe HTTP(S) URLs.
+
+If `seo.noindex` is true, emit:
+
+```html
+<meta name="robots" content="noindex,nofollow">
+```
+
+The publisher changes belong near `src/core/publisher/render.ts`, but metadata resolution is extracted into a focused core helper so previews and published output share the same fallback logic.
+
+## Robots.txt
+
+Add a first-party `GET /robots.txt` handler before `tryServePublicRoute` in `server/router.ts`.
+
+Default output:
+
+```text
+User-agent: *
+Allow: /
+
+Sitemap: <public-origin>/sitemap.xml
+```
+
+Rules:
+
+- Response content type is `text/plain; charset=utf-8`.
+- `robots.txt` never falls through to public page rendering.
+- Sitemap line is included when sitemap generation is enabled.
+- Robots settings live in `site.settings.seo.robots`.
+- Advanced manual rule editing waits until after generated defaults are stable. V1 starts with generated defaults plus enable/disable indexing.
+
+The Robots.txt tab initially previews the generated file and exposes the minimal controls needed to avoid invalid output.
+
+## Sitemap
+
+Add a first-party `GET /sitemap.xml` handler before public page rendering.
+
+Generated sitemap includes:
+
+- published routable pages;
+- published post-type rows with route bases;
+- no rows/pages marked `noindex`;
+- canonical route URLs only, not redirects;
+- last-modified timestamps when available.
+
+Response content type:
+
+```text
+application/xml; charset=utf-8
+```
+
+The Sitemap tab initially previews inclusion counts and exposes enable/disable plus basic exclusion controls. Rich sitemap reporting belongs to the later reporting/dashboard work.
+
+## Persistence API
+
+Use TypeBox schemas for all request and response bodies.
+
+Recommended CMS endpoints:
+
+```text
+GET  /admin/api/cms/seo/targets
+PUT  /admin/api/cms/seo/targets/:kind/:id
+GET  /admin/api/cms/seo/robots
+PUT  /admin/api/cms/seo/robots
+GET  /admin/api/cms/seo/sitemap
+PUT  /admin/api/cms/seo/sitemap
+```
+
+`GET /seo/targets` returns the complete target index plus current metadata values needed by the selected-target editor. If payload size becomes large, paginate later; do not add pagination in v1 until there is a measured need.
+
+Client calls use `apiRequest(path, { schema })` from `@core/http`, matching the boundary-validation rules in `docs/reference/typebox-patterns.md`.
+
+Server request bodies use `readValidatedBody(req, Schema)` from `server/http.ts`.
+
+## Permissions
+
+Add SEO-specific capabilities:
+
+- `seo.read`: open SEO workspace and read SEO metadata.
+- `seo.manage`: edit metadata, robots settings, and sitemap settings.
+
+The SEO endpoints still enforce target-level ownership:
+
+- Reading targets requires the same read permissions as the underlying target plus site read.
+- Editing page SEO requires page metadata/content edit permission.
+- Editing robots/sitemap settings requires site settings edit permission.
+
+Avoid hiding robots/sitemap under plugin permissions. These are core publishing controls.
+
+## Error Handling
+
+UI async handlers catch and surface errors with component state and `role="alert"`.
+
+Console errors use prefixed messages such as:
+
+```ts
+console.error('[seo-page] save failed:', err)
+```
+
+User-visible error messages use `getErrorMessage(err, 'Unknown SEO error')` from `src/core/utils/errorMessage.ts`.
+
+The target editor must never silently discard unsaved changes when switching targets. If a selected target is dirty, row selection either saves first or asks through an in-app confirmation surface, not `confirm()`.
+
+## Testing
+
+Core tests:
+
+- Metadata resolver fallback chains.
+- Published HTML emits search, canonical, robots, OG, and X tags.
+- `noindex` suppresses sitemap inclusion.
+- Sitemap contains published routable pages/content rows only.
+- `robots.txt` is `text/plain` and never returns HTML.
+
+Admin tests:
+
+- SEO page tab switching.
+- Meta target search/filter.
+- Selecting a target updates the preview editor.
+- Editing snippet fields writes the structured SEO object.
+- X override fields fall back to Open Graph/search fields until customized.
+
+Architecture tests:
+
+- Add route/nav tests if Tools changes the expected admin route list.
+- Update field/system-table tests if flat `seoTitle` / `seoDescription` fields are replaced by `seo`.
+- Keep admin controls on shared UI primitives.
+
+## Work Sequence
+
+These are implementation batches, not separately shipped compatibility states. The branch lands after the model, publisher, endpoints, admin UI, tests, and docs all agree on the structured `seo` field.
+
+Batch 1: model and storage.
+
+- Add core SEO schema and metadata resolver.
+- Replace flat `seoTitle` / `seoDescription` fields with structured `seo`.
+- Update content/page admin code, AI content tools, tests, and docs.
+
+Batch 2: public output.
+
+- Add robots.txt handler.
+- Add sitemap.xml handler.
+- Update publisher metadata output.
+
+Batch 3: admin SEO workspace.
+
+- Add `/admin/tools/seo`.
+- Add Tools dropdown.
+- Move plugin admin page links into Tools.
+- Build Meta tab target index and preview editor.
+
+Later integrations:
+
+- Redirects workspace.
+- SEO audit widgets on Dashboard.
+- Google Search Console connection.
+- Rich local audit reports and duplicate metadata detection.
+
+## Fixed Decisions
+
+- Plugin admin pages keep the current `/admin/plugins/:pluginId/:pageId` route shape. Tools changes navigation grouping, not route identity.
+- Structured SEO is represented as a dedicated built-in `seoMetadata` field type, not a generic user-created JSON field.
+- Site defaults appear as a pinned target row in the Meta tab.
+- Robots advanced manual editing waits until after v1 generated output is stable.
+
+## Related
+
+- `src/admin/router.tsx` - admin route table.
+- `src/admin/AuthenticatedAdmin.tsx` - workspace component selection and preload list.
+- `src/admin/shared/AdminSectionNavigation/AdminSectionNavigation.tsx` - current top-level nav and plugin admin page links.
+- `src/admin/layouts/AdminPageLayout/AdminPageLayout.tsx` - page scaffold used by AI, Users, Account, Plugins, and plugin pages.
+- `src/core/page-tree/siteSettings.ts` - current site settings schema.
+- `src/core/data/fields.ts` - built-in content/page field definitions.
+- `src/core/data/schemas.ts` - data field IDs and TypeBox schemas.
+- `src/core/publisher/render.ts` - current published HTML metadata assembly.
+- `server/router.ts` - request dispatch order for robots.txt and sitemap.xml.
+- `server/publish/publicRouter.ts` - public HTML routing and static artifact fallback.
+- `docs/editor.md` - admin shell, toolbar, settings modal, and workspace layout.
+- `docs/features/publisher.md` - published route pipeline and HTML output.
+- `docs/features/content-storage.md` - data_tables/data_rows storage model.
+- `docs/reference/typebox-patterns.md` - request/response validation rules.

--- a/server/ai/tools/site/systemPrompt.ts
+++ b/server/ai/tools/site/systemPrompt.ts
@@ -108,9 +108,9 @@ function buildDynamicSuffix(snap: SiteAgentSnapshot): string {
         .map((p) => {
           const active = p.id === snap.page.id ? ' (active)' : ''
           const tpl = p.template
-            ? ` [template:${p.template.target.kind === 'everywhere'
-                ? 'everywhere'
-                : p.template.target.tableSlugs.join(',')}]`
+            ? ` [template:${p.template.target.kind === 'postTypes'
+                ? p.template.target.tableSlugs.join(',')
+                : p.template.target.kind}]`
             : ''
           return `${p.id}=${p.slug || '(no-slug)'}${active}${tpl}`
         })

--- a/server/ai/tools/site/writeTools.ts
+++ b/server/ai/tools/site/writeTools.ts
@@ -210,7 +210,7 @@ const setPageTemplateTool: AiTool = {
   scope: 'site',
   execution: 'browser',
   description:
-    'Turn a page INTO a template (or update an existing template\'s target/priority). `target` is `{kind:"everywhere"}` for a site-wide layout that wraps every page+entry, or `{kind:"postTypes", tableSlugs:[…]}` to wrap entries of those post types (slugs from list_post_types). `priority` (default 100) breaks ties when several templates match at the same breadth level — higher wins. A template needs exactly one `<instatic-outlet>` (insert it via insertHtml) marking where matched content flows; a template with no outlet simply doesn\'t apply. Pass a real page id from the suffix / list_pages.',
+    'Turn a page INTO a template (or update an existing template\'s target/priority). `target` is `{kind:"everywhere"}` for a site-wide layout that wraps every page+entry, `{kind:"postTypes", tableSlugs:[…]}` to wrap entries of those post types (slugs from list_post_types), or `{kind:"notFound"}` for the page served on public 404s (status 404, wrapped by the everywhere layout; needs no outlet). `priority` (default 100) breaks ties when several templates match at the same breadth level — higher wins. An everywhere/postTypes template needs exactly one `<instatic-outlet>` (insert it via insertHtml) marking where matched content flows; a wrapper template with no outlet simply doesn\'t apply. Pass a real page id from the suffix / list_pages.',
   inputSchema: SetPageTemplateInputSchema,
 }
 

--- a/server/publish/publicRenderer.ts
+++ b/server/publish/publicRenderer.ts
@@ -5,7 +5,7 @@ import { publishPage } from '@core/publisher'
 import { buildRouteFrame } from '@core/templates/contextFrames'
 import { buildPublishedSiteCssBundle } from './siteCssBundle'
 import { buildPublishedSiteModuleJsMap } from './moduleJsBundle'
-import { resolveTemplateChain, composeTemplateChain } from '@core/templates'
+import { resolveTemplateChain, resolveNotFoundTemplate, composeTemplateChain } from '@core/templates'
 import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { prefetchLoopData, publishedDataRowToLoopItem } from './loopPrefetch'
 import { prefetchMediaAssets } from './mediaPrefetch'
@@ -139,6 +139,31 @@ export async function renderPublishedSnapshot(
 
   const rendered = await renderMergedTemplate(merged, snapshot, templateContext, ctx)
   return { ...rendered, pageId: snapshot.pageRowId, slug: page.slug, siteId: snapshot.site.id }
+}
+
+/**
+ * Render the site's `notFound` template — the body of every public 404
+ * response. Composed exactly like a regular page: wrapped by the matching
+ * `everywhere` layout chain so the 404 page carries the site chrome. Returns
+ * `null` when the published site doesn't define a notFound template (callers
+ * fall back to the bare JSON 404).
+ */
+export async function renderPublishedNotFound(
+  snapshot: PublishedPageSnapshot,
+  ctx: RenderPublishedSnapshotContext,
+): Promise<RendererOutput | null> {
+  const page = resolveNotFoundTemplate(snapshot.site)
+  if (!page) return null
+
+  const chain = resolveTemplateChain(snapshot.site, { kind: 'page' })
+  const merged = composeTemplateChain(chain, { kind: 'page', page })
+
+  const templateContext: TemplateRenderDataContext | undefined = ctx.url
+    ? { entryStack: [], route: buildRouteFrame(ctx.url.toString()) }
+    : undefined
+
+  const rendered = await renderMergedTemplate(merged, snapshot, templateContext, ctx)
+  return { ...rendered, pageId: page.id, slug: page.slug, siteId: snapshot.site.id }
 }
 
 export async function renderPublishedDataRowTemplate(

--- a/server/publish/publicRouter.ts
+++ b/server/publish/publicRouter.ts
@@ -61,7 +61,7 @@
 import type { DbClient } from '../db/client'
 import type { PublishedPageSnapshot } from '../repositories/publish'
 import type { PublishedDataRow } from '@core/data/schemas'
-import { isTemplatePage } from '@core/templates'
+import { isTemplatePage, resolveNotFoundTemplate } from '@core/templates'
 import {
   getDataRowRedirectByRoute,
   getPublishedDataRowByRoute,
@@ -70,9 +70,10 @@ import { getPublishedPageBySlug } from '../repositories/publish'
 import { applyPublishedHtmlPipeline } from './publishedHtmlPipeline'
 import {
   renderPublishedDataRowTemplate,
+  renderPublishedNotFound,
   renderPublishedSnapshot,
 } from './publicRenderer'
-import { readArtefact } from './staticArtefact'
+import { NOT_FOUND_ARTEFACT_URL_PATH, readArtefact } from './staticArtefact'
 import { getOrRender, peek } from './renderCache'
 import { getLatestSnapshotForVersion } from './publishedSnapshotCache'
 import { getPublishVersion } from './publishState'
@@ -271,4 +272,65 @@ export async function renderPublicResolution(
   )
   if (!cached) return null
   return new Response(cached.body, { headers: cached.headers, status: cached.status })
+}
+
+// ---------------------------------------------------------------------------
+// 404 page
+// ---------------------------------------------------------------------------
+
+/**
+ * Materialise the site's 404 page for a GET that fell through every route.
+ *
+ * Serving order mirrors `renderPublicResolution`:
+ *
+ *   - Layer A: the `404.html` artefact baked by the full publish — one disk
+ *     read, no DB. This is the path bot probes and crawler noise hit.
+ *   - Layer B fallback (no uploadsDir / bake failed): live render through the
+ *     LRU under the reserved `/404` key, so a burst of misses renders once.
+ *     The entry is stored as a 200 body (the cache only holds 200 renders);
+ *     status 404 is stamped on the Response here. A direct GET of `/404`
+ *     served through `renderPublicResolution` returns the same body with
+ *     status 200 — identical to how static hosts treat `404.html`.
+ *
+ * Returns `null` when the published site has no notFound template (or nothing
+ * is published at all) — the dispatcher then falls back to its bare JSON 404.
+ *
+ * The render is seeded with a synthetic `/404` URL (not the requested one) so
+ * the cached body — like the baked artefact — is identical for every missed
+ * path; request-dependent nodes are holes and hydrate per request anyway.
+ */
+export async function renderNotFoundResponse(
+  db: DbClient,
+  url: URL,
+  uploadsDir?: string,
+): Promise<Response | null> {
+  const htmlHeaders = { 'content-type': 'text/html; charset=utf-8' }
+
+  // ── Layer A: baked 404 artefact ───────────────────────────────────────────
+  if (uploadsDir) {
+    const html = await readArtefact(uploadsDir, NOT_FOUND_ARTEFACT_URL_PATH)
+    if (html !== null) {
+      return new Response(html, { status: 404, headers: htmlHeaders })
+    }
+  }
+
+  // ── Layer B: live render through the LRU under the reserved /404 key ─────
+  const cacheKey = { urlPath: NOT_FOUND_ARTEFACT_URL_PATH, queryString: '' }
+  const warm = peek(cacheKey)
+  if (warm) {
+    return new Response(warm.body, { headers: warm.headers, status: 404 })
+  }
+
+  const snapshot = await getLatestSnapshotForVersion(db, getPublishVersion())
+  if (!snapshot || !resolveNotFoundTemplate(snapshot.site)) return null
+
+  const syntheticUrl = new URL(NOT_FOUND_ARTEFACT_URL_PATH, url.origin)
+  const cached = await getOrRender(cacheKey, async () => {
+    const rendered = await renderPublishedNotFound(snapshot, { db, url: syntheticUrl })
+    if (!rendered) return null
+    const html = await applyPublishedHtmlPipeline(rendered, db)
+    return { body: html, headers: htmlHeaders, status: 200 }
+  })
+  if (!cached) return null
+  return new Response(cached.body, { headers: cached.headers, status: 404 })
 }

--- a/server/publish/publishSite.ts
+++ b/server/publish/publishSite.ts
@@ -22,7 +22,7 @@ import type { PublishedPageRuntimeAssets } from '@core/site-runtime'
 import type { PublishedRuntimePackageImportmap, SiteCssBundle } from '@core/publisher'
 import { normalizeSiteRuntimeConfig } from '@core/site-runtime'
 import { registry } from '@core/module-engine'
-import { isTemplatePage } from '@core/templates'
+import { isTemplatePage, resolveNotFoundTemplate } from '@core/templates'
 import type { DbClient } from '../db/client'
 import { nextDataRowVersionNumber } from '../repositories/data'
 import {
@@ -37,9 +37,15 @@ import {
   buildRuntimePackageImportmap,
   serializeImportmapForCsp,
 } from './runtime/packageImportmap'
-import { renderPublishedSnapshot } from './publicRenderer'
+import { renderPublishedNotFound, renderPublishedSnapshot } from './publicRenderer'
 import { applyPublishedHtmlPipeline } from './publishedHtmlPipeline'
-import { prepareInactiveSlot, writeArtefact, writeStaticAsset, swapSlot } from './staticArtefact'
+import {
+  NOT_FOUND_ARTEFACT_URL_PATH,
+  prepareInactiveSlot,
+  swapSlot,
+  writeArtefact,
+  writeStaticAsset,
+} from './staticArtefact'
 import { buildPublishedSiteCssBundle } from './siteCssBundle'
 import { bakePublishedDataRowArtefacts } from './bakeDataRows'
 import { bumpPublishVersion, getPublishVersion, withPublishLock } from './publishState'
@@ -220,6 +226,31 @@ async function publishDraftSiteLocked(
       }
       for (const asset of runtimeAssetFiles) {
         if (!assetsByPath.has(asset.publicPath)) assetsByPath.set(asset.publicPath, asset.bytes)
+      }
+
+      // The 404 page: bake the notFound template (wrapped in its everywhere
+      // layout chain) to `404.html`. Baked FIRST so a literal page with slug
+      // `404` — if anyone creates one — overwrites it below and stays
+      // authoritative for both `/404` and the static-export error page.
+      const notFoundPage = resolveNotFoundTemplate(publishedSite)
+      const notFoundSnapshot = notFoundPage
+        ? snapshots.find((s) => s.pageRowId === notFoundPage.id)
+        : undefined
+      if (notFoundSnapshot) {
+        try {
+          const rendered = await renderPublishedNotFound(notFoundSnapshot, {
+            db,
+            url: new URL(`http://localhost${NOT_FOUND_ARTEFACT_URL_PATH}`),
+            publishVersion: nextPublishVersion,
+          })
+          if (rendered) {
+            const html = await applyPublishedHtmlPipeline(rendered, db)
+            await writeArtefact(slotDir, NOT_FOUND_ARTEFACT_URL_PATH, html)
+            collectCssFiles(rendered.cssBundle)
+          }
+        } catch (err) {
+          console.error('[publish:site] failed to bake the 404 artefact (falls through to live renderer):', err)
+        }
       }
 
       // HTML artefacts (or hole shells) for every page. A page that fails to

--- a/server/publish/staticArtefact.ts
+++ b/server/publish/staticArtefact.ts
@@ -47,6 +47,16 @@ import {
 
 export type Slot = 'a' | 'b'
 
+/**
+ * Artefact URL path the site's `notFound` template bakes to. Maps to
+ * `404.html` in the slot — deliberately the static-hosting convention
+ * (Netlify / GitHub Pages serve `404.html` for unmatched routes), so a
+ * published slot keeps working as a self-contained static export. The
+ * dispatcher's fall-through 404 handler reads this artefact and serves it
+ * with status 404.
+ */
+export const NOT_FOUND_ARTEFACT_URL_PATH = '/404'
+
 // ---------------------------------------------------------------------------
 // Private path helpers
 // ---------------------------------------------------------------------------

--- a/server/router.ts
+++ b/server/router.ts
@@ -1,7 +1,7 @@
 import { tryHandleAi } from './ai/handlers'
 import { handleCmsRequest } from './handlers/cms'
 import type { DbClient } from './db/client'
-import { renderPublicResolution } from './publish/publicRouter'
+import { renderNotFoundResponse, renderPublicResolution } from './publish/publicRouter'
 import { readStaticAsset } from './publish/staticArtefact'
 import { getLatestSnapshotForVersion } from './publish/publishedSnapshotCache'
 import { getPublishVersion, registerVersionedCacheReset } from './publish/publishState'
@@ -81,6 +81,7 @@ const routes: readonly RouteHandler[] = [
   tryServeAdminApp,
   tryServePublicRoute,
   trySetupRedirect,
+  tryServeNotFoundPage,
 ]
 
 export async function handleServerRequest(
@@ -439,6 +440,18 @@ async function trySetupRedirect(req: Request, runtime: ServerRuntime, _url: URL,
   return setupStatus.needsSetup
     ? new Response(null, { status: 302, headers: { location: '/admin' } })
     : null
+}
+
+/**
+ * Last route before the dispatcher's bare JSON 404: serve the site's designed
+ * 404 page (the `notFound` template) for any GET no other route claimed.
+ * Namespaced prefixes (`/admin/api/*`, `/_instatic/*`, `/uploads/*`) never
+ * reach here — they absorb their namespace and emit their own 404s. Returns
+ * null (→ JSON 404) when the published site has no notFound template.
+ */
+async function tryServeNotFoundPage(req: Request, runtime: ServerRuntime, url: URL, _pathname: string): Promise<Response | null> {
+  if (req.method !== 'GET') return null
+  return await renderNotFoundResponse(runtime.db, url, runtime.uploadsDir)
 }
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/server/notFoundResponse.test.ts
+++ b/src/__tests__/server/notFoundResponse.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Integration tests for `renderNotFoundResponse` in publicRouter.ts — the
+ * dispatcher's fall-through 404 page.
+ *
+ * Verifies the serving order:
+ *   - Layer A: a baked `404.html` artefact in the active slot is served
+ *     directly with status 404 (no DB, no render).
+ *   - Layer B: with no artefact, the notFound template renders live through
+ *     the LRU under the reserved `/404` key — one render per version, every
+ *     missed URL shares it, always status 404.
+ *   - No notFound template in the published site → null (the dispatcher's
+ *     bare JSON 404 takes over), and nothing is cached.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { DbClient, DbResult } from '../../../server/db'
+import type { PublishedPageSnapshot } from '../../../server/repositories/publish'
+import { renderNotFoundResponse } from '../../../server/publish/publicRouter'
+import { getStats, resetForTests } from '../../../server/publish/renderCache'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/** Site snapshot with (optionally) a notFound template page. */
+function makeSnapshot(withNotFound: boolean): PublishedPageSnapshot {
+  const notFoundPage = {
+    id: 'page_nf',
+    title: 'Not found',
+    slug: 'not-found',
+    rootNodeId: 'root',
+    template: { enabled: true, target: { kind: 'notFound' }, priority: 0 },
+    nodes: {
+      root: {
+        id: 'root',
+        moduleId: 'base.body',
+        props: {},
+        breakpointOverrides: {},
+        children: ['msg'],
+      },
+      msg: {
+        id: 'msg',
+        moduleId: 'base.text',
+        props: { text: 'This page is missing', tag: 'h1' },
+        breakpointOverrides: {},
+        children: [],
+      },
+    },
+  }
+  return {
+    cmsSnapshotVersion: 1,
+    pageRowId: withNotFound ? 'page_nf' : 'page_home',
+    site: {
+      id: 'site_1',
+      name: 'Test Site',
+      pages: [
+        {
+          id: 'page_home',
+          title: 'Home',
+          slug: 'index',
+          rootNodeId: 'root',
+          nodes: {
+            root: { id: 'root', moduleId: 'base.body', props: {}, breakpointOverrides: {}, children: [] },
+          },
+        },
+        ...(withNotFound ? [notFoundPage] : []),
+      ],
+      files: [],
+      visualComponents: [],
+      breakpoints: [{ id: 'desktop', label: 'Desktop', width: 1440, icon: 'monitor' }],
+      settings: { metaTitle: 'Test Site', shortcuts: {} },
+      styleRules: {},
+      createdAt: 1000,
+      updatedAt: 2000,
+    },
+  } as unknown as PublishedPageSnapshot
+}
+
+/**
+ * Minimal DbClient for the live-render path: `getLatestPublishedSiteSnapshot`
+ * (distinguished by its `order by data_rows.created_at` clause) returns the
+ * fixture snapshot; everything else is empty.
+ */
+function makeFakeDb(snapshot: PublishedPageSnapshot | null): DbClient {
+  const handle = async <Row extends Record<string, unknown> = Record<string, unknown>>(
+    strings: TemplateStringsArray,
+    ...values: unknown[]
+  ): Promise<DbResult<Row>> => {
+    void values
+    const sql = strings.join(' ').replace(/\s+/g, ' ').trim().toLowerCase()
+    if (sql.includes('site_snapshots.site_json') && sql.includes('order by data_rows.created_at')) {
+      return {
+        rows: snapshot
+          ? [{
+              row_id: snapshot.pageRowId,
+              site_json: snapshot.site,
+              runtime_assets_json: snapshot.runtimeAssets ?? null,
+              importmap_body: null,
+              importmap_sha256: null,
+            } as unknown as Row]
+          : [],
+        rowCount: snapshot ? 1 : 0,
+      }
+    }
+    return { rows: [], rowCount: 0 }
+  }
+  handle.unsafe = async <Row extends Record<string, unknown> = Record<string, unknown>>(
+    _sql: string,
+    _params?: unknown[],
+  ): Promise<DbResult<Row>> => ({ rows: [], rowCount: 0 })
+  handle.transaction = async <T>(cb: (tx: DbClient) => Promise<T>): Promise<T> =>
+    cb(handle as unknown as DbClient)
+  return handle as DbClient
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  resetForTests()
+})
+
+describe('renderNotFoundResponse — Layer B live render', () => {
+  it('renders the notFound template with status 404 and caches it', async () => {
+    const db = makeFakeDb(makeSnapshot(true))
+
+    const res1 = await renderNotFoundResponse(db, new URL('http://localhost/nowhere'))
+    expect(res1?.status).toBe(404)
+    const body = await res1!.text()
+    expect(body).toContain('This page is missing')
+    expect(getStats()).toMatchObject({ hits: 0, misses: 1, size: 1 })
+
+    // A different missed URL shares the same reserved /404 cache entry.
+    const res2 = await renderNotFoundResponse(db, new URL('http://localhost/elsewhere'))
+    expect(res2?.status).toBe(404)
+    expect(await res2!.text()).toBe(body)
+    expect(getStats()).toMatchObject({ hits: 1, misses: 1, size: 1 })
+  })
+
+  it('returns null — and caches nothing — when the site has no notFound template', async () => {
+    const db = makeFakeDb(makeSnapshot(false))
+    expect(await renderNotFoundResponse(db, new URL('http://localhost/nowhere'))).toBeNull()
+    expect(getStats()).toMatchObject({ hits: 0, misses: 0, size: 0 })
+  })
+
+  it('returns null when nothing is published at all', async () => {
+    const db = makeFakeDb(null)
+    expect(await renderNotFoundResponse(db, new URL('http://localhost/nowhere'))).toBeNull()
+  })
+})
+
+describe('renderNotFoundResponse — Layer A baked artefact', () => {
+  let uploadsDir: string
+
+  beforeEach(async () => {
+    uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-404-'))
+    const slotDir = join(uploadsDir, 'published', 'a')
+    await mkdir(slotDir, { recursive: true })
+    await writeFile(join(slotDir, '404.html'), '<!DOCTYPE html><h1>baked 404</h1>', 'utf-8')
+    await symlink('a', join(uploadsDir, 'published', 'current'))
+  })
+
+  afterEach(async () => {
+    await rm(uploadsDir, { recursive: true, force: true })
+  })
+
+  it('serves the baked 404.html with status 404 without touching the DB', async () => {
+    // A DB that throws on ANY query proves the artefact path is DB-free.
+    const explodingDb = (async () => {
+      throw new Error('DB must not be queried on the Layer A path')
+    }) as unknown as DbClient
+
+    const res = await renderNotFoundResponse(explodingDb, new URL('http://localhost/nope'), uploadsDir)
+    expect(res?.status).toBe(404)
+    expect(await res!.text()).toContain('baked 404')
+    expect(res?.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('falls through to the live render when the artefact is missing', async () => {
+    await rm(join(uploadsDir, 'published', 'a', '404.html'))
+    const db = makeFakeDb(makeSnapshot(true))
+    const res = await renderNotFoundResponse(db, new URL('http://localhost/nope'), uploadsDir)
+    expect(res?.status).toBe(404)
+    expect(await res!.text()).toContain('This page is missing')
+  })
+})

--- a/src/__tests__/ui/templateSettingsDialog.test.tsx
+++ b/src/__tests__/ui/templateSettingsDialog.test.tsx
@@ -70,4 +70,31 @@ describe('TemplateSettingsDialog', () => {
     expect(saved).not.toBeNull()
     expect(saved!.template.target).toEqual({ kind: 'postTypes', tableSlugs: ['posts'] })
   })
+
+  it('saves a notFound target (no post-type checkboxes shown)', () => {
+    let saved: TemplateSettingsPayload | null = null
+    render(
+      <TemplateSettingsDialog
+        page={plainPage()}
+        pages={[plainPage()]}
+        onCancel={() => {}}
+        onSave={(p) => { saved = p }}
+      />,
+    )
+    // Switch "Applies to" from Everywhere → Not found via keyboard: open,
+    // move past "Post types" onto "Not found (404)", commit.
+    const combobox = screen.getByRole('combobox', { name: /applies to/i })
+    combobox.focus()
+    fireEvent.keyDown(combobox, { key: 'ArrowDown' })
+    fireEvent.keyDown(combobox, { key: 'ArrowDown' })
+    fireEvent.keyDown(combobox, { key: 'ArrowDown' })
+    fireEvent.keyDown(combobox, { key: 'Enter' })
+
+    // The post-type picker only belongs to the postTypes kind.
+    expect(screen.queryByRole('checkbox')).toBeNull()
+
+    submit()
+    expect(saved).not.toBeNull()
+    expect(saved!.template.target).toEqual({ kind: 'notFound' })
+  })
 })

--- a/src/admin/pages/site/canvas/canvasComposition.ts
+++ b/src/admin/pages/site/canvas/canvasComposition.ts
@@ -9,11 +9,13 @@
  * active document's nodes untouched and editable, rendering only the wrapping
  * templates read-only around it (see `CanvasComposedTree`).
  *
- * Breadth levels (outer → inner): `everywhere` (0) → `postTypes` (1) → a
- * non-template page (2, the innermost terminal). A document is wrapped by every
- * matching template strictly broader than its own level:
+ * Breadth levels (outer → inner): `everywhere` (0) → `postTypes` / `notFound`
+ * (1) → a non-template page (2, the innermost terminal). A document is wrapped
+ * by every matching template strictly broader than its own level:
  *   - editing a page          → wrapped by the `everywhere` layout;
  *   - editing a postTypes tpl  → wrapped by the `everywhere` layout;
+ *   - editing a notFound tpl   → wrapped by the `everywhere` layout (matching
+ *     how the public router composes the 404 render);
  *   - editing the everywhere tpl → nothing wraps it (it is the broadest).
  */
 

--- a/src/admin/pages/site/hooks/useActiveLivePath.ts
+++ b/src/admin/pages/site/hooks/useActiveLivePath.ts
@@ -16,6 +16,7 @@
  *   - postTypes template       → the previewed published row's permalink.
  *     Defaults to the first published row (newest first), again matching the
  *     preview-source dropdown.
+ *   - notFound template        → `/404`, the baked 404 artefact's path.
  *
  * Mounted once from `AdminCanvasEditorBody` (the lazy editor body) so the CMS
  * data fetch needed for the postTypes case stays out of the always-loaded admin
@@ -28,7 +29,7 @@ import { useAdminUi } from '@admin/state/adminUi'
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { selectActivePage, useEditorStore } from '@site/store/store'
 import { isTemplatePage, primaryTemplateTableSlug } from '@core/templates'
-import { pagePublicPath } from '@core/page-tree'
+import { pagePublicPath, type TemplateTarget } from '@core/page-tree'
 import { getCmsDataTableBySlug, previewCmsDataLoopItems } from '@core/persistence/cmsData'
 import type { LoopItem } from '@core/loops/types'
 
@@ -88,7 +89,7 @@ export function useActiveLivePath(): void {
 export interface ResolveArgs {
   activePage: ReturnType<typeof selectActivePage>
   isTemplate: boolean
-  targetKind: 'everywhere' | 'postTypes' | null
+  targetKind: TemplateTarget['kind'] | null
   selection: string | null
   sitePages: ReturnType<typeof selectActivePage>[] | null
   rows: LoopItem[]
@@ -127,6 +128,10 @@ export function resolveLivePath({
     const permalink = previewed?.fields.permalink
     return typeof permalink === 'string' && permalink ? permalink : null
   }
+
+  // notFound template: `/404` serves its baked artefact (the same body every
+  // unmatched URL gets with status 404), so it is the natural live preview.
+  if (targetKind === 'notFound') return '/404'
 
   return null
 }

--- a/src/admin/shared/dialogs/TemplateSettingsDialog/TemplateSettingsDialog.tsx
+++ b/src/admin/shared/dialogs/TemplateSettingsDialog/TemplateSettingsDialog.tsx
@@ -50,6 +50,7 @@ const FORM_ID = 'template-settings-form'
 const TARGET_KIND_OPTIONS = [
   { value: 'everywhere', label: 'Everywhere' },
   { value: 'postTypes', label: 'Post types' },
+  { value: 'notFound', label: 'Not found (404)' },
 ]
 
 export function TemplateSettingsDialog({
@@ -112,9 +113,9 @@ export function TemplateSettingsDialog({
     event.preventDefault()
     if (saveDisabled) return
 
-    const target: TemplateTarget = targetKind === 'everywhere'
-      ? { kind: 'everywhere' }
-      : { kind: 'postTypes', tableSlugs: selectedSlugs }
+    const target: TemplateTarget = targetKind === 'postTypes'
+      ? { kind: 'postTypes', tableSlugs: selectedSlugs }
+      : { kind: targetKind }
 
     onSave({
       title: trimmedTitle,

--- a/src/core/ai/toolSchemas.ts
+++ b/src/core/ai/toolSchemas.ts
@@ -148,6 +148,7 @@ export const TemplateTargetInputSchema = Type.Union([
     kind: Type.Literal('postTypes'),
     tableSlugs: Type.Array(Type.String({ minLength: 1 }), { minItems: 1 }),
   }),
+  Type.Object({ kind: Type.Literal('notFound') }),
 ])
 export type TemplateTargetInput = Static<typeof TemplateTargetInputSchema>
 

--- a/src/core/page-tree/__tests__/pageTemplate.test.ts
+++ b/src/core/page-tree/__tests__/pageTemplate.test.ts
@@ -12,6 +12,11 @@ describe('parsePageTemplate target', () => {
     expect(t).toEqual({ enabled: true, target: { kind: 'postTypes', tableSlugs: ['posts'] }, priority: 0 })
   })
 
+  it('parses a notFound target', () => {
+    const t = parsePageTemplate({ enabled: true, target: { kind: 'notFound' }, priority: 0 })
+    expect(t).toEqual({ enabled: true, target: { kind: 'notFound' }, priority: 0 })
+  })
+
   it('rejects a postTypes target with no usable slugs', () => {
     expect(parsePageTemplate({ enabled: true, target: { kind: 'postTypes', tableSlugs: [''] }, priority: 0 })).toBeNull()
   })

--- a/src/core/page-tree/pageTemplate.ts
+++ b/src/core/page-tree/pageTemplate.ts
@@ -21,6 +21,12 @@ export const TemplateTargetSchema = Type.Union([
     kind: Type.Literal('postTypes'),
     tableSlugs: Type.Array(Type.String({ minLength: 1 }), { minItems: 1 }),
   }),
+  /**
+   * The site's 404 page. Never matched by route resolution — the public
+   * router renders it (wrapped in the `everywhere` layout chain) whenever a
+   * GET falls through every other route. Baked to `404.html` at publish time.
+   */
+  Type.Object({ kind: Type.Literal('notFound') }),
 ])
 export type TemplateTarget = Static<typeof TemplateTargetSchema>
 
@@ -47,6 +53,7 @@ function parseTarget(raw: unknown): TemplateTarget | null {
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return null
   const r = raw as Record<string, unknown>
   if (r.kind === 'everywhere') return { kind: 'everywhere' }
+  if (r.kind === 'notFound') return { kind: 'notFound' }
   if (r.kind === 'postTypes') {
     const slugs = Array.isArray(r.tableSlugs)
       ? r.tableSlugs.filter((s): s is string => typeof s === 'string' && s.length > 0)

--- a/src/core/templates/__tests__/templateMatching.test.ts
+++ b/src/core/templates/__tests__/templateMatching.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test'
-import { resolveTemplateChain, isTemplatePage, primaryTemplateTableSlug } from '../templateMatching'
+import {
+  resolveTemplateChain,
+  resolveNotFoundTemplate,
+  isTemplatePage,
+  primaryTemplateTableSlug,
+  templateTargetLabel,
+} from '../templateMatching'
 import type { Page, SiteDocument } from '@core/page-tree'
 
 const tpl = (id: string, target: Page['template'], priority = 0): Page => ({
@@ -10,6 +16,7 @@ const site = (pages: Page[]): SiteDocument => ({ id: 's', pages } as unknown as 
 
 const everywhere = (id: string, p = 0) => tpl(id, { enabled: true, target: { kind: 'everywhere' } } as never, p)
 const forPosts = (id: string, p = 0) => tpl(id, { enabled: true, target: { kind: 'postTypes', tableSlugs: ['posts'] } } as never, p)
+const notFound = (id: string, p = 0) => tpl(id, { enabled: true, target: { kind: 'notFound' } } as never, p)
 
 describe('resolveTemplateChain', () => {
   it('returns [] for a page route with no everywhere template', () => {
@@ -36,6 +43,12 @@ describe('resolveTemplateChain', () => {
     expect(resolveTemplateChain(s, { kind: 'entry', tableSlug: 'authors' })).toEqual([])
   })
 
+  it('never includes a notFound template in any route chain', () => {
+    const s = site([everywhere('layout'), notFound('nf'), forPosts('entry')])
+    expect(resolveTemplateChain(s, { kind: 'page' }).map((p) => p.id)).toEqual(['layout'])
+    expect(resolveTemplateChain(s, { kind: 'entry', tableSlug: 'posts' }).map((p) => p.id)).toEqual(['layout', 'entry'])
+  })
+
   it('isTemplatePage flags template-configured pages', () => {
     expect(isTemplatePage(everywhere('x'))).toBe(true)
     expect(isTemplatePage(tpl('plain', undefined as never))).toBe(false)
@@ -52,5 +65,30 @@ describe('primaryTemplateTableSlug', () => {
   })
   it('returns null for a non-template page', () => {
     expect(primaryTemplateTableSlug(tpl('plain', undefined as never))).toBeNull()
+  })
+})
+
+describe('resolveNotFoundTemplate', () => {
+  it('returns null when the site has no notFound template', () => {
+    expect(resolveNotFoundTemplate(site([everywhere('layout'), forPosts('entry')]))).toBeNull()
+  })
+
+  it('finds the notFound template among other templates and pages', () => {
+    const s = site([everywhere('layout'), tpl('plain', undefined as never), notFound('nf')])
+    expect(resolveNotFoundTemplate(s)?.id).toBe('nf')
+  })
+
+  it('picks the highest priority, document order breaking ties', () => {
+    expect(resolveNotFoundTemplate(site([notFound('low', 1), notFound('high', 9)]))?.id).toBe('high')
+    expect(resolveNotFoundTemplate(site([notFound('first', 5), notFound('second', 5)]))?.id).toBe('first')
+  })
+})
+
+describe('templateTargetLabel', () => {
+  it('labels each target kind', () => {
+    expect(templateTargetLabel(everywhere('x'))).toBe('Everywhere')
+    expect(templateTargetLabel(notFound('x'))).toBe('Not found')
+    expect(templateTargetLabel(forPosts('x'))).toBe('posts')
+    expect(templateTargetLabel(tpl('plain', undefined as never))).toBe('')
   })
 })

--- a/src/core/templates/index.ts
+++ b/src/core/templates/index.ts
@@ -1,10 +1,12 @@
 /**
  * @core/templates — template resolution, composition, and validation.
  *
- * A template is a page-tree carrying a `target` (everywhere | postTypes) plus a
- * `priority`. The resolver collects every template matching a route, ordered
- * broadest → narrowest; the composer splices each inner tree into the outer
- * template's single `base.outlet`, producing one merged tree for `publishPage`.
+ * A template is a page-tree carrying a `target` (everywhere | postTypes |
+ * notFound) plus a `priority`. The resolver collects every template matching a
+ * route, ordered broadest → narrowest; the composer splices each inner tree
+ * into the outer template's single `base.outlet`, producing one merged tree
+ * for `publishPage`. The `notFound` target sits outside route matching — the
+ * public router renders it directly for fall-through 404s.
  */
 
 export {
@@ -13,6 +15,7 @@ export {
   primaryTemplateTableSlug,
   templateTargetLabel,
   resolveTemplateChain,
+  resolveNotFoundTemplate,
   type RouteResolutionContext,
 } from './templateMatching'
 export { composeTemplateChain, type TerminalContent } from './templateCompose'

--- a/src/core/templates/templateMatching.ts
+++ b/src/core/templates/templateMatching.ts
@@ -34,7 +34,9 @@ export function primaryTemplateTableSlug(page: Page): string | null {
 export function templateTargetLabel(page: Page): string {
   const target = page.template?.target
   if (!target) return ''
-  return target.kind === 'everywhere' ? 'Everywhere' : target.tableSlugs.join(', ')
+  if (target.kind === 'everywhere') return 'Everywhere'
+  if (target.kind === 'notFound') return 'Not found'
+  return target.tableSlugs.join(', ')
 }
 
 /**
@@ -59,6 +61,22 @@ function matchesLevel(
 }
 
 const LEVELS = ['everywhere', 'postTypes'] as const
+
+/**
+ * The page that renders public 404s, or null when the site doesn't define
+ * one. A `notFound` template never participates in `resolveTemplateChain` —
+ * it isn't a breadth level; route resolution never "matches" a 404. The
+ * public router calls this directly when a GET falls through every route,
+ * then composes the winner like a regular page (wrapped by the `everywhere`
+ * layout chain). Highest priority wins, document order breaks ties.
+ */
+export function resolveNotFoundTemplate(site: SiteDocument): Page | null {
+  return site.pages
+    .map((page, index) => ({ page, index }))
+    .filter(({ page }) => isTemplatePage(page) && page.template?.target.kind === 'notFound')
+    .sort((a, b) => ((b.page.template?.priority ?? 0) - (a.page.template?.priority ?? 0)) || a.index - b.index)[0]
+    ?.page ?? null
+}
 
 /**
  * Collect every template matching the route, ordered outer → inner. At most


### PR DESCRIPTION
## What

Adds a third template target kind — **Not found (404)** — so a designed page can be served for every public 404, replacing the bare `{ "error": "Not found" }` JSON response.

## How it works

**Core** (`src/core`)
- `TemplateTargetSchema` gains `{ kind: 'notFound' }` (+ tolerant `parseTarget` branch). No DB migration — template config lives in `cells_json`.
- New `resolveNotFoundTemplate(site)` picks the winner (highest priority, document order breaks ties). A notFound template never enters `resolveTemplateChain` — it isn't a breadth level; route matching never "matches" a 404.

**Publish** (`server/publish`)
- `renderPublishedNotFound` composes the template like a regular page — wrapped by the `everywhere` layout chain, so the 404 page carries the site chrome.
- Full publish bakes it to **`404.html`** in the slot — deliberately the static-hosting convention, so a raw static export keeps a working error page on Netlify / GitHub Pages. Baked first, so a literal page with slug `404` would overwrite it and stay authoritative.

**Serve** (`server/router.ts`, `publicRouter.ts`)
- New last dispatcher route `tryServeNotFoundPage`: any GET no other route claimed serves the baked artefact (one disk read, no DB — the path bot probes hit) with **status 404**; falls back to a live render through the Layer B LRU under the reserved `/404` key (stored once per publish version, shared by every missed URL). No notFound template → today's JSON 404, unchanged.
- Namespaced prefixes (`/admin/api/*`, `/_instatic/*`, `/uploads/*`) keep their own 404s; the fresh-install setup redirect still wins (it runs earlier).

**Editor / AI**
- "Not found (404)" option in Template settings → Applies to; explorer meta shows "Not found".
- Canvas wraps the template in the everywhere layout (mirrors the publish composition); "Open live page" resolves to `/404`.
- `setPageTemplate` AI tool accepts the new kind.

## Known trade-off

A direct GET of `/404` serves the baked artefact with status 200 — the same convention as GitHub Pages. Documented in `docs/features/templates.md`.

## Testing

- `bun test` — 5385 pass (new: `notFoundResponse.test.ts` covering Layer A artefact serving incl. a DB-free proof, live-render fallback + caching, and the no-template null path; matching/parse/label/dialog tests extended).
- `bun run build`, `bun run lint` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)