### PR TITLE
chore(release): prepare v0.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## Unreleased
 
+## 0.0.4 - 2026-06-13
+
+### Editor & canvas
+
+- Inline text editing on the canvas — double-click any text node to edit it in place, byte-identical to the published element.
+- User-saved layouts: save any subtree and re-insert it exactly elsewhere.
+- Double-click a row in the explorer / DOM panels to rename it.
+- Design mode now opens at 50% zoom; live mode is pinned to 100%.
+- Live mode shows the shared frame skeleton while hydrating, and the template read-only hint/open action is scoped to template chrome rather than page content.
+- Removed inconsistent panel keyboard shortcuts from the rail.
+- Fixed template-preview fidelity: composed read-only content (template chrome, outlet previews, inlined Visual Components) now carries each node's inline styles, matching the published page.
+
+### Publisher & media
+
+- `<img sizes>` is now derived automatically from the layout — the manual Sizes field is gone, and lazy images use the standards-based `sizes=auto` with a layout-resolved fallback.
+- Responsive images never serve multi-MB originals to retina screens: `srcset` is built from variants only.
+- Single class-CSS emission engine shared by publish and canvas, and one-way publisher layering (repositories never import the publish layer).
+- Per-module published-JS channel; the form runtime now rides it.
+
+### Templates & content
+
+- Added a "Not found" template target for designing 404 pages.
+- Content Outlet availability fixes and toast layering; closed outlet invariant holes.
+- Roster saves now survive slug handoffs (homepage swap, swaps, revivals).
+
+### Site import
+
+- Refactored the Super Import pipeline into one adapter contract with a phase-decomposed plan/commit flow and deduped helpers; conflict resolution split into named concerns.
+- Improved import fidelity: rgba color tokens, import-from-anywhere, and engine-proof `var()` / `env()` declarations at the import boundary.
+
+### AI & plugins
+
+- AI tools now inherit the caller's capabilities — `ai.chat` no longer acts as a blanket read grant, and write tools require `ai.tools.write`.
+- AI credential auth is derived from the provider.
+- Plugin performance: handle-based VM dispatch, native base64, and indexed content-API lookups; fixed `useCanvasNodeRect` to measure real canvas nodes.
+
+### Admin & performance
+
+- Unknown admin URLs (typos, stale deep links, `/admin/login`) now redirect to the dashboard — showing the login form when signed out — instead of rendering a blank page. Public-site 404s keep their own handling.
+- Incremental site saves with runtime builds hoisted out of the publish transaction, plus hot-path fixes across the publish pipeline, public serving, and the editor store.
+- Dead-code cleanup across the codebase (knip reports zero unused surface).
+
+### Infrastructure
+
+- Standardized container images on GHCR and dropped the Docker Hub mirror.
+
 ## 0.0.3 - 2026-06-10
 
 - Hardened the plugin QuickJS sandbox against hangs: interrupt deadlines on plugin-source and timer execution, a host-side worker RPC timeout, and preserved VM stack traces in server logs.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.3 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.4 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.3
+docker pull ghcr.io/corebunch/instatic:0.0.4
 ```
 
-The v0.0.3 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.4 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.3
+ghcr.io/corebunch/instatic:0.0.4
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.3` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.4` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.3
+Image=ghcr.io/corebunch/instatic:0.0.4
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.3
+ghcr.io/corebunch/instatic:0.0.4
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.3` |
+| Image | `ghcr.io/corebunch/instatic:0.0.4` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.3` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.4` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },


### PR DESCRIPTION
Prepares the 0.0.4 release.

- Bumps `package.json` to `0.0.4`.
- Adds the `0.0.4` CHANGELOG section summarizing everything merged since 0.0.3 (inline text editing, user-saved layouts, layout-derived `<img sizes>`, variants-only srcset, site-import refactor, AI tool capability gating, admin route catch-all, template-preview inline-style fidelity, perf + dead-code cleanup).
- Updates the pinned image tag in the deployment docs to `0.0.4`.

After merge, pushing the `v0.0.4` tag triggers `.github/workflows/release.yml` (verify → GHCR image → release bundle + GitHub release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)