### PR TITLE
fix(test): make canvas breakpoint-frame tests wait on readiness instead of fixed sleeps

### DIFF
--- a/src/__tests__/canvas/breakpointActivation.test.tsx
+++ b/src/__tests__/canvas/breakpointActivation.test.tsx
@@ -1,10 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { DndContext } from '@dnd-kit/core'
 import { CanvasRoot } from '@site/canvas/CanvasRoot'
 import { useEditorStore } from '@site/store/store'
 import { makeNode, makePage, makeSite } from '../fixtures'
-import { getCanvasFrameDocument, queryCanvasNodeInFrame } from './iframeCanvasQuery'
+import {
+  queryCanvasNodeInFrame,
+  waitForCanvasFrameDocument,
+  waitForCanvasNodeInFrame,
+} from './iframeCanvasQuery'
 import '@modules/base'
 
 afterEach(cleanup)
@@ -32,7 +36,7 @@ beforeEach(() => {
 describe('canvas breakpoint activation', () => {
   it('activates an inactive breakpoint without changing the selected layer on first node click', async () => {
     renderCanvas()
-    await waitForCanvasNode('mobile', 'other')
+    await waitForCanvasNodeInFrame('mobile', 'other')
     const otherNode = queryCanvasNodeInFrame('mobile', 'other')
     expect(otherNode).toBeTruthy()
 
@@ -48,7 +52,7 @@ describe('canvas breakpoint activation', () => {
 
   it('shows a cursor-following activation tooltip over inactive breakpoint frames', async () => {
     renderCanvas()
-    const mobileDoc = await waitForFrameDocument('mobile')
+    const mobileDoc = await waitForCanvasFrameDocument('mobile')
 
     act(() => {
       fireEvent.mouseMove(mobileDoc.body, { clientX: 24, clientY: 32 })
@@ -59,7 +63,7 @@ describe('canvas breakpoint activation', () => {
 
   it('does not show the activation tooltip when no layer properties context is active', async () => {
     renderCanvas({ selectedNodeId: null, selectedNodeIds: [] })
-    const mobileDoc = await waitForFrameDocument('mobile')
+    const mobileDoc = await waitForCanvasFrameDocument('mobile')
 
     act(() => {
       fireEvent.mouseMove(mobileDoc.body, { clientX: 24, clientY: 32 })
@@ -74,7 +78,7 @@ describe('canvas breakpoint activation', () => {
       selectedNodeIds: ['selected'],
       propertiesPanel: { collapsed: true, x: 0, y: 0, width: 360 },
     })
-    await waitForCanvasNode('mobile', 'other')
+    await waitForCanvasNodeInFrame('mobile', 'other')
     const otherNode = queryCanvasNodeInFrame('mobile', 'other')
     expect(otherNode).toBeTruthy()
 
@@ -129,17 +133,3 @@ function renderCanvas(
   )
 }
 
-async function waitForCanvasNode(breakpointId: string, nodeId: string): Promise<void> {
-  await waitFor(() => {
-    expect(queryCanvasNodeInFrame(breakpointId, nodeId)).toBeTruthy()
-  })
-}
-
-async function waitForFrameDocument(breakpointId: string): Promise<Document> {
-  let doc: Document | null = null
-  await waitFor(() => {
-    doc = getCanvasFrameDocument(breakpointId)
-    expect(doc?.body).toBeTruthy()
-  })
-  return doc!
-}

--- a/src/__tests__/canvas/breakpointProps.test.tsx
+++ b/src/__tests__/canvas/breakpointProps.test.tsx
@@ -5,17 +5,16 @@ import { readFileSync } from 'fs'
 import { useEditorStore } from '@site/store/store'
 import { BreakpointFrame } from '@site/canvas/BreakpointFrame'
 import { CanvasRoot } from '@site/canvas/CanvasRoot'
-import { getCanvasFrameDocument, queryCanvasNodeInFrame } from './iframeCanvasQuery'
+import {
+  getCanvasFrameDocument,
+  queryCanvasNodeInFrame,
+  waitForCanvasFrameDocument,
+  waitForCanvasNodeInFrame,
+} from './iframeCanvasQuery'
 import '@modules/base'
 
 function renderCanvas() {
   return render(<CanvasRoot />)
-}
-
-async function flushProgressiveCanvasFrames() {
-  await act(async () => {
-    await new Promise<void>((resolve) => setTimeout(resolve, 90))
-  })
 }
 
 const BREAKPOINT_FRAME_CSS = new URL(
@@ -91,13 +90,10 @@ describe('canvas breakpoint rendering', () => {
     useEditorStore.getState().setActiveBreakpoint('desktop')
 
     renderCanvas()
-    await flushProgressiveCanvasFrames()
-
-    const mobileNode = queryCanvasNodeInFrame('mobile', textId)
-    expect(mobileNode).toBeTruthy()
+    const mobileNode = await waitForCanvasNodeInFrame('mobile', textId)
 
     act(() => {
-      fireEvent.click(mobileNode!)
+      fireEvent.click(mobileNode)
     })
 
     const state = useEditorStore.getState()
@@ -115,27 +111,23 @@ describe('canvas breakpoint rendering', () => {
     }, page.rootNodeId)
 
     renderCanvas()
-    await flushProgressiveCanvasFrames()
-
-    const mobileNode = queryCanvasNodeInFrame('mobile', textId)
-    const desktopNode = queryCanvasNodeInFrame('desktop', textId)
-    expect(mobileNode).toBeTruthy()
-    expect(desktopNode).toBeTruthy()
+    const mobileNode = await waitForCanvasNodeInFrame('mobile', textId)
+    const desktopNode = await waitForCanvasNodeInFrame('desktop', textId)
 
     act(() => {
-      fireEvent.mouseEnter(mobileNode!)
+      fireEvent.mouseEnter(mobileNode)
     })
 
-    expect(mobileNode!.getAttribute('data-hovered')).toBe('true')
-    expect(desktopNode!.hasAttribute('data-hovered')).toBe(false)
+    expect(mobileNode.getAttribute('data-hovered')).toBe('true')
+    expect(desktopNode.hasAttribute('data-hovered')).toBe(false)
 
     act(() => {
-      fireEvent.mouseLeave(mobileNode!)
-      fireEvent.mouseEnter(desktopNode!)
+      fireEvent.mouseLeave(mobileNode)
+      fireEvent.mouseEnter(desktopNode)
     })
 
-    expect(mobileNode!.hasAttribute('data-hovered')).toBe(false)
-    expect(desktopNode!.getAttribute('data-hovered')).toBe('true')
+    expect(mobileNode.hasAttribute('data-hovered')).toBe(false)
+    expect(desktopNode.getAttribute('data-hovered')).toBe('true')
   })
 
   it('dims inactive breakpoint frames only while editing a selected node in the open properties panel', () => {

--- a/src/__tests__/canvas/canvasFormControls.test.tsx
+++ b/src/__tests__/canvas/canvasFormControls.test.tsx
@@ -4,17 +4,11 @@ import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import { DndContext } from '@dnd-kit/core'
 import { useEditorStore } from '@site/store/store'
 import { CanvasRoot } from '@site/canvas/CanvasRoot'
-import { queryCanvasNodeInFrame } from './iframeCanvasQuery'
+import { waitForCanvasNodeInFrame } from './iframeCanvasQuery'
 import '@modules/base'
 
 function renderCanvas() {
   return render(<DndContext><CanvasRoot /></DndContext>)
-}
-
-async function flushProgressiveCanvasFrames() {
-  await act(async () => {
-    await new Promise<void>((resolve) => setTimeout(resolve, 90))
-  })
 }
 
 beforeEach(() => {
@@ -58,23 +52,20 @@ describe('canvas form controls', () => {
     }, formId)
 
     renderCanvas()
-    await flushProgressiveCanvasFrames()
 
-    const input = queryCanvasNodeInFrame<HTMLInputElement>('desktop', inputId)
-    const select = queryCanvasNodeInFrame<HTMLSelectElement>('desktop', selectId)
-    expect(input).toBeTruthy()
-    expect(select).toBeTruthy()
+    const input = await waitForCanvasNodeInFrame<HTMLInputElement>('desktop', inputId)
+    const select = await waitForCanvasNodeInFrame<HTMLSelectElement>('desktop', selectId)
 
     let inputMouseDown = true
     await act(async () => {
-      inputMouseDown = fireEvent.mouseDown(input!)
+      inputMouseDown = fireEvent.mouseDown(input)
     })
     expect(inputMouseDown).toBe(false)
     expect(useEditorStore.getState().selectedNodeId).toBe(inputId)
 
     let selectMouseDown = true
     await act(async () => {
-      selectMouseDown = fireEvent.pointerDown(select!)
+      selectMouseDown = fireEvent.pointerDown(select)
     })
     expect(selectMouseDown).toBe(false)
     expect(useEditorStore.getState().selectedNodeId).toBe(selectId)

--- a/src/__tests__/canvas/iframeCanvasQuery.ts
+++ b/src/__tests__/canvas/iframeCanvasQuery.ts
@@ -8,7 +8,33 @@
  * detail by walking every canvas iframe in the test DOM and returning the
  * first match. Callers can therefore stay agnostic about whether the
  * canvas renders directly or via iframes.
+ *
+ * Readiness is asynchronous. The canvas reveals breakpoint frames
+ * progressively (`useProgressiveCanvasFrameLoading`: the active frame after a
+ * `requestAnimationFrame`, each inactive frame behind a chained
+ * `setTimeout` → `requestIdleCallback`), and only then mounts each frame's
+ * iframe and portals the page tree into it. So a queried frame — especially a
+ * NON-active one — can take a few hundred milliseconds to appear, and longer
+ * on a loaded CI runner where those timers drift. Tests MUST therefore wait on
+ * the actual condition (the frame document / node being present) rather than
+ * sleeping a fixed duration: a hardcoded sleep that happens to be enough on a
+ * fast laptop is exactly what makes these tests flaky in CI. Use
+ * `waitForCanvasFrameDocument` / `waitForCanvasNodeInFrame` below.
  */
+
+import { waitFor } from '@testing-library/react'
+import { expect } from 'bun:test'
+
+/**
+ * CI-tolerant ceiling for canvas-frame readiness. `waitFor` returns the instant
+ * the condition holds, so this adds no time on a fast machine — it only widens
+ * the headroom so a slow/contended CI runner's timer drift doesn't trip the
+ * default 1000 ms `waitFor` budget. The progressive reveal is bounded
+ * (rAF + setTimeout + a 160 ms idle-callback timeout per inactive frame), so a
+ * healthy canvas always settles well within this; an unhealthy one fails loudly
+ * here instead of hanging.
+ */
+export const CANVAS_FRAME_READY_TIMEOUT_MS = 5000
 
 /**
  * Find the first element matching `selector` inside any canvas iframe (or
@@ -85,4 +111,63 @@ function allCanvasIframes(): HTMLIFrameElement[] {
   return Array.from(document.querySelectorAll<HTMLIFrameElement>('iframe')).filter(
     (i) => i.title.startsWith('Canvas frame for '),
   )
+}
+
+/**
+ * Wait until a breakpoint frame's iframe document is mounted and ready, then
+ * return it. Replaces fixed-duration "flush progressive frames" sleeps — polls
+ * the real readiness condition so it is robust to the progressive reveal's
+ * timing on any machine. Throws (via `waitFor`) if the frame never appears.
+ */
+export async function waitForCanvasFrameDocument(breakpointId: string): Promise<Document> {
+  let doc: Document | null = null
+  await waitFor(
+    () => {
+      doc = getCanvasFrameDocument(breakpointId)
+      expect(doc?.body).toBeTruthy()
+    },
+    { timeout: CANVAS_FRAME_READY_TIMEOUT_MS },
+  )
+  return doc!
+}
+
+/**
+ * Wait until `nodeId` is rendered inside the `breakpointId` frame's iframe,
+ * then return the element. The node-level companion to
+ * `waitForCanvasFrameDocument` for tests that immediately interact with a
+ * specific canvas node.
+ */
+export async function waitForCanvasNodeInFrame<E extends Element = HTMLElement>(
+  breakpointId: string,
+  nodeId: string,
+): Promise<E> {
+  let el: E | null = null
+  await waitFor(
+    () => {
+      el = queryCanvasNodeInFrame<E>(breakpointId, nodeId)
+      expect(el).toBeTruthy()
+    },
+    { timeout: CANVAS_FRAME_READY_TIMEOUT_MS },
+  )
+  return el!
+}
+
+/**
+ * Wait until `selector` matches in any canvas iframe (or the parent document),
+ * then return the first match. The frame-agnostic companion to
+ * `waitForCanvasNodeInFrame` for tests that don't care which breakpoint frame
+ * the element lands in.
+ */
+export async function waitForCanvasElement<E extends Element = HTMLElement>(
+  selector: string,
+): Promise<E> {
+  let el: E | null = null
+  await waitFor(
+    () => {
+      el = queryCanvasElement<E>(selector)
+      expect(el).toBeTruthy()
+    },
+    { timeout: CANVAS_FRAME_READY_TIMEOUT_MS },
+  )
+  return el!
 }

--- a/src/__tests__/canvas/nodeRendererLockdown.test.tsx
+++ b/src/__tests__/canvas/nodeRendererLockdown.test.tsx
@@ -16,10 +16,10 @@
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import React from 'react'
-import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
 import { DndContext } from '@dnd-kit/core'
 import { useEditorStore } from '@site/store/store'
-import { queryCanvasElement } from './iframeCanvasQuery'
+import { queryCanvasElement, waitForCanvasElement } from './iframeCanvasQuery'
 import { CanvasRoot } from '@site/canvas/CanvasRoot'
 import { makeNode, makePage, makeSite } from '../fixtures'
 import type { PageNode } from '@core/page-tree'
@@ -56,11 +56,6 @@ function renderCanvas() {
   return render(<DndContext><CanvasRoot /></DndContext>)
 }
 
-async function flushProgressiveCanvasFrames() {
-  await act(async () => {
-    await new Promise<void>((resolve) => setTimeout(resolve, 90))
-  })
-}
 
 /**
  * Sets up a page with annotated nodes and loads it into the editor store.
@@ -150,12 +145,10 @@ describe('B3 — NodeRenderer lock-down: click routing for inlined VC body nodes
   it('clicking a VC body node (isInsideSlotContent=false) selects the enclosing ref', async () => {
     setupAnnotatedPage()
     renderCanvas()
-    await flushProgressiveCanvasFrames()
 
-    const vcBodyEl = queryCanvasElement('[data-node-id="vc-body"]')
-    expect(vcBodyEl).toBeTruthy()
+    const vcBodyEl = await waitForCanvasElement('[data-node-id="vc-body"]')
 
-    fireEvent.click(vcBodyEl!)
+    fireEvent.click(vcBodyEl)
 
     const state = useEditorStore.getState()
     // Lock-down redirected the click to ref1, not vc-body.
@@ -165,12 +158,10 @@ describe('B3 — NodeRenderer lock-down: click routing for inlined VC body nodes
   it('clicking a slot-content node (isInsideSlotContent=true) selects that node directly', async () => {
     setupAnnotatedPage()
     renderCanvas()
-    await flushProgressiveCanvasFrames()
 
-    const slotChildEl = queryCanvasElement('[data-node-id="slot-child"]')
-    expect(slotChildEl).toBeTruthy()
+    const slotChildEl = await waitForCanvasElement('[data-node-id="slot-child"]')
 
-    fireEvent.click(slotChildEl!)
+    fireEvent.click(slotChildEl)
 
     const state = useEditorStore.getState()
     // Slot content is user-editable — behaves normally (no redirect).
@@ -180,12 +171,10 @@ describe('B3 — NodeRenderer lock-down: click routing for inlined VC body nodes
   it('clicking a plain page node (no _owningRefId) selects that node directly', async () => {
     setupAnnotatedPage()
     renderCanvas()
-    await flushProgressiveCanvasFrames()
 
-    const ref1El = queryCanvasElement('[data-node-id="ref1"]')
-    expect(ref1El).toBeTruthy()
+    const ref1El = await waitForCanvasElement('[data-node-id="ref1"]')
 
-    fireEvent.click(ref1El!)
+    fireEvent.click(ref1El)
 
     const state = useEditorStore.getState()
     // Plain page node — no redirect.
@@ -195,34 +184,30 @@ describe('B3 — NodeRenderer lock-down: click routing for inlined VC body nodes
   it('hovering a VC body node clamps the hover ring to the enclosing ref', async () => {
     setupAnnotatedPage()
     renderCanvas()
-    await flushProgressiveCanvasFrames()
 
-    const vcBodyEl = queryCanvasElement('[data-node-id="vc-body"]')
+    const vcBodyEl = await waitForCanvasElement('[data-node-id="vc-body"]')
     const ref1El = queryCanvasElement('[data-node-id="ref1"]')
-    expect(vcBodyEl).toBeTruthy()
     expect(ref1El).toBeTruthy()
 
-    fireEvent.mouseEnter(vcBodyEl!)
+    fireEvent.mouseEnter(vcBodyEl)
 
     // Lock-down routed hover to ref1 → ref1 gets data-hovered, vc-body does not.
     expect(ref1El!.getAttribute('data-hovered')).toBe('true')
-    expect(vcBodyEl!.hasAttribute('data-hovered')).toBe(false)
+    expect(vcBodyEl.hasAttribute('data-hovered')).toBe(false)
   })
 
   it('hovering a slot-content node hovers that node directly (no redirect)', async () => {
     setupAnnotatedPage()
     renderCanvas()
-    await flushProgressiveCanvasFrames()
 
-    const slotChildEl = queryCanvasElement('[data-node-id="slot-child"]')
+    const slotChildEl = await waitForCanvasElement('[data-node-id="slot-child"]')
     const ref1El = queryCanvasElement('[data-node-id="ref1"]')
-    expect(slotChildEl).toBeTruthy()
     expect(ref1El).toBeTruthy()
 
-    fireEvent.mouseEnter(slotChildEl!)
+    fireEvent.mouseEnter(slotChildEl)
 
     // Slot content behaves normally — slot-child gets data-hovered.
-    expect(slotChildEl!.getAttribute('data-hovered')).toBe('true')
+    expect(slotChildEl.getAttribute('data-hovered')).toBe('true')
     expect(ref1El!.hasAttribute('data-hovered')).toBe(false)
   })
 })


### PR DESCRIPTION
## Problem

The canvas-breakpoint tests flaked in CI — specifically the **Verify** step of the release workflow (this blocked the v0.0.4 release). They failed **reliably on the CI runner** but passed locally, which is the tell-tale sign of a timing assumption rather than a logic bug.

Failing tests (all in `src/__tests__/canvas/`):
- `canvas breakpoint activation` — 4 tests, timing out at ~1010–1048ms
- `canvas breakpoint rendering` — 3 tests, failing fast at ~16–144ms

## Root cause (a real, specific issue)

The canvas reveals breakpoint frames **progressively** (`useProgressiveCanvasFrameLoading`): the active frame after a `requestAnimationFrame`, then each **inactive** frame behind a chained `setTimeout(32ms)` → `requestIdleCallback({timeout:160ms})`, and only then mounts each frame's iframe and portals the page tree into it.

Every failing test queries the **`mobile`** frame. With `desktop` active (the default), `mobile` is the **first _inactive_ frame**, so it only appears after that whole async chain. But the tests waited with **fixed budgets**:
- a hardcoded `setTimeout(90ms)` "flush" helper (copy-pasted across 4 test files), and
- the default `1000ms` `waitFor` timeout.

Both are tuned for a fast laptop. Under CI event-loop saturation (this run was ~1.8× slower overall) those timers drift past the budgets, so the iframe content isn't mounted when the assertion runs.

### Proven, not guessed

I reproduced the **exact** CI signature locally by inflating the inactive-frame reveal delay (`32ms` → `1500ms`): the activation tests timed out at ~1010–1048ms and the rendering tests failed at ~110ms — matching CI. With this change applied, the same slow-runner simulation passes **17/17** (taking ~6.6s, i.e. the waiters correctly absorb the delay instead of giving up).

## Fix

Replace every arbitrary sleep with **condition-based waiting**:
- New shared helpers in `iframeCanvasQuery.ts` — `waitForCanvasFrameDocument`, `waitForCanvasNodeInFrame`, `waitForCanvasElement` — poll the real readiness condition with a CI-tolerant **5s** ceiling. `waitFor` returns the instant the condition holds, so there's **zero added cost on a fast machine**; it only widens headroom for a slow one. The progressive reveal is bounded, so a healthy canvas always settles well within 5s and an unhealthy one fails loudly rather than hanging.
- Removes the `flushProgressiveCanvasFrames` 90ms-sleep helper that was duplicated across `breakpointProps`, `canvasFormControls`, and `nodeRendererLockdown`.

**No product code changes** — the progressive loader is correct behaviour (it avoids mounting three heavy iframes at once); only the tests were making brittle timing assumptions. `progressiveCanvasLoading.test.tsx` is intentionally left as-is: there the staggered timing *is* the behaviour under test.

## Verification

- Affected canvas tests: 17/17 pass normally, and 17/17 under the `1500ms` slow-runner simulation that previously failed.
- Full suite: `bun test` 5431 pass / 0 fail; `bun run build` and `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)