### PR TITLE
test: stub user-preference fetches in global setup to stop a cross-test ECONNREFUSED leak

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -116,6 +116,48 @@ for (const key of GLOBALS_TO_COPY) {
 }
 
 // ---------------------------------------------------------------------------
+// Default user-preference fetches to the "never set" envelope.
+//
+// Admin surfaces load user preferences on mount (e.g. the module-inserter
+// favourites via `useModuleInserterPreference` → `getUserPreference`), which
+// fires a real `fetch` to `/admin/api/cms/me/preferences/<key>`. In tests that
+// hits `http://localhost` and rejects with ECONNREFUSED. Because the
+// preference store is a module-level singleton whose load promise can outlive
+// the component that triggered it, that rejection surfaces during a LATER
+// test's `cleanup()` as an `AggregateError` — a cross-test flake that depends
+// on render timing (it was masked while canvas frames mounted slowly, and
+// reappeared once they mount synchronously).
+//
+// Returning the server's "never set" signal (`{ value: null }`) makes every
+// such load resolve cleanly to the caller's own default, with no network call.
+// Tests that need specific preference data still override `globalThis.fetch`
+// in their own setup; `getUserPreference` callers that inject a `fetchImpl`
+// bypass this entirely.
+{
+  const realFetch = globalThis.fetch
+  const PREFERENCES_PATH = '/admin/api/cms/me/preferences/'
+  ;(globalThis as Record<string, unknown>).fetch = (async (
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ): Promise<Response> => {
+    const url =
+      typeof input === 'string'
+        ? input
+        : input instanceof URL
+          ? input.href
+          : (input as Request).url
+    const method = (init?.method ?? (input as Request).method ?? 'GET').toUpperCase()
+    if (method === 'GET' && url.includes(PREFERENCES_PATH)) {
+      return new Response(JSON.stringify({ value: null }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    }
+    return realFetch(input, init)
+  }) as typeof globalThis.fetch
+}
+
+// ---------------------------------------------------------------------------
 // Tame DOM serialization in failure output.
 //
 // A happy-dom node is deeply circular (`ownerDocument` → every element →


### PR DESCRIPTION
Follow-up to #58/#59. Final root cause of the canvas-test flake that was failing the release Verify step.

## Root cause

Admin surfaces load user preferences on mount — e.g. module-inserter favourites via `useModuleInserterPreference` → `getUserPreference` → a real `fetch` to `/admin/api/cms/me/preferences/<key>`. In tests that hits `localhost` and rejects with **ECONNREFUSED**.

The preference store is a **module-level singleton** whose load promise can outlive the component that triggered it. So the rejection isn't caught by the originating test — it surfaces during a **later** test's `cleanup()` (when React unmounts the leftover tree inside `act`), bundled as an `AggregateError`. That's why the failure landed on `canvasFrameMounting`'s first test even though that test doesn't fetch anything.

It was **masked** while canvas frames mounted slowly (the breakpoint tests timed out before the preference fetch settled) and **reappeared** once #58 made frames mount synchronously — a pure render-timing change exposing a pre-existing leak.

## Fix

One global stub in the test preload (`src/__tests__/setup.ts`): return the server's "never set" envelope (`{ value: null }`) for preference **GET**s, so the load resolves cleanly to each caller's own default with no network call. Suite-wide, there's no rejection left to leak.

- Tests that need specific preference data still override `globalThis.fetch` in their own setup (verified: the dedicated module-inserter preference tests pass).
- `getUserPreference` callers that inject a `fetchImpl` bypass this entirely.

## Verification

- Proven the stub intercepts: an unmocked preference GET now returns `200 {value:null}` and `getUserPreference('module-inserter')` resolves to `null`.
- Dedicated preference + canvas tests pass.
- Full suite: `bun test` 5432 pass / 0 fail; `bun run build` + `bun run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)