### PR TITLE
test: register global afterEach(cleanup) so RTL trees don't leak across files under bun

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -280,3 +280,29 @@ if (typeof (globalThis as { EventSource?: unknown }).EventSource === 'undefined'
   }
   ;(globalThis as { EventSource?: unknown }).EventSource = StubEventSource as unknown
 }
+
+// ---------------------------------------------------------------------------
+// Global React Testing Library cleanup after every test.
+//
+// @testing-library/react auto-registers an `afterEach(cleanup)` ONLY when
+// `afterEach` is a global (the Jest/Vitest convention). Under `bun test`
+// `afterEach` is import-only, so auto-cleanup never installs: any test that
+// renders a component and doesn't manually `cleanup()` leaves it mounted, and
+// it lingers into the NEXT test file. When a later file's own `cleanup()`
+// finally unmounts that stale tree, an effect or in-flight request that
+// resolved after the originating test surfaces inside that unrelated test's
+// `act()` as an `AggregateError` — a cross-file flake whose victim depends on
+// file ordering. Registering cleanup here (from the preload, so it applies to
+// every file) restores the intended per-test isolation. `cleanup()` is a no-op
+// when nothing is mounted, so non-React tests are unaffected.
+//
+// Imported dynamically so it runs AFTER the happy-dom globals above are
+// installed — a static top-level import would be hoisted and pull in React
+// before `document` exists.
+{
+  const { afterEach } = await import('bun:test')
+  const { cleanup } = await import('@testing-library/react')
+  afterEach(() => {
+    cleanup()
+  })
+}


### PR DESCRIPTION
The actual root cause of the canvas-test flake that kept failing the release Verify step.

## Root cause

`@testing-library/react` auto-installs `afterEach(cleanup)` **only when `afterEach` is a global** (the Jest/Vitest convention). Under `bun test`, `afterEach` is import-only — so RTL auto-cleanup **never ran**. Any test that rendered a component without a manual `cleanup()` left it mounted into the **next test file**. When a later file's own `cleanup()` finally unmounted that stale tree, an effect or in-flight fetch that resolved *after* the originating test surfaced inside the unrelated test's `act()` as an `AggregateError` — a cross-file flake whose victim depends purely on file ordering.

That's exactly what happened: renaming `progressiveCanvasLoading` → `canvasFrameMounting` (#58) moved that file's alphabetical position, so its `beforeEach cleanup()` began flushing a leaky leftover from a *different* prior file, whose `/admin/api/...` fetch (ECONNREFUSED in tests) aggregated into its first test. #60 (preference stub) removed one such fetch; this removes the whole class.

## Fix

Register `afterEach(cleanup)` once in the preload (`src/__tests__/setup.ts`) so it applies to every file, restoring the per-test isolation RTL intends. `cleanup()` is a no-op when nothing is mounted, so non-React tests are unaffected.

## Verification

- Full suite **5432 pass / 0 fail** — including the 54 files that already call `cleanup()` manually (double-cleanup is harmless; no hook-ordering breakage).
- `bun run build` + `bun run lint` clean.

This is a pure test-infrastructure fix; no product code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)