### PR TITLE
fix(publisher): render current entry body in any content outlet

### DIFF
--- a/server/publish/__tests__/templateSeeding.test.ts
+++ b/server/publish/__tests__/templateSeeding.test.ts
@@ -18,7 +18,10 @@ describe('buildDefaultTemplateCells', () => {
     const all = Object.values(nodes)
     const outlet = all.find((n) => n.moduleId === 'base.outlet')
     expect(outlet).toBeTruthy()
-    expect(outlet?.dynamicBindings?.html).toEqual({ source: 'currentEntry', field: 'body', format: 'html' })
+    // The outlet carries NO persisted binding — the publisher fills every
+    // outlet's body implicitly (see `effectiveNodeBindings`), so a seeded
+    // outlet is identical to one a user drags in by hand.
+    expect(outlet?.dynamicBindings).toBeUndefined()
     expect(all.some((n) => n.moduleId === 'base.content')).toBe(false)
   })
 })

--- a/server/publish/templateSeeding.ts
+++ b/server/publish/templateSeeding.ts
@@ -25,10 +25,9 @@
  *   - `base.body` root
  *     - `base.text` <h1> bound to `{currentEntry.title}` via static-token
  *       interpolation (cheap; no DynamicPropBinding overlay required).
- *     - `base.outlet` bound to `{currentEntry.body}` with `format: 'html'`
- *       so the publisher converts the post's markdown body to HTML before
- *       rendering. Markdown rendering is the host's responsibility for the
- *       post-type built-in `body` field.
+ *     - `base.outlet` — the publisher fills every outlet's `html` with the
+ *       current entry's body (markdown → HTML) implicitly, so the seed just
+ *       needs the bare outlet node; no per-node binding overlay is required.
  *
  * Site owners are expected to customise the template in the editor; the
  * seed exists so the public URL works the moment a row is published, and
@@ -113,20 +112,13 @@ export function buildDefaultTemplateCells(table: DataTable, slug: string): Recor
         [bodyId]: {
           id: bodyId,
           moduleId: 'base.outlet',
-          // For HTML output (markdown rendering) we need the dynamic
-          // binding overlay — token interpolation only handles strings,
-          // and we need the binding system's `format: 'html'` branch to
-          // run `renderMarkdownToHtml`.
+          // The outlet needs no binding overlay: the publisher fills every
+          // outlet's `html` with the current entry's body (markdown → HTML)
+          // implicitly (see `effectiveNodeBindings`), so the seed — like a
+          // hand-dropped outlet — just needs the bare node.
           props: { html: '' },
           breakpointOverrides: {},
           children: [],
-          dynamicBindings: {
-            html: {
-              source: 'currentEntry',
-              field: 'body',
-              format: 'html',
-            },
-          },
         },
       },
     },

--- a/src/__tests__/publisher/outletEntryBody.test.ts
+++ b/src/__tests__/publisher/outletEntryBody.test.ts
@@ -1,0 +1,69 @@
+/**
+ * The content outlet is, by definition, the hole the current entry's body
+ * flows into. That must hold for ANY `base.outlet` on an entry-route template —
+ * including one a user drags onto a custom template by hand, which carries no
+ * persisted `dynamicBindings` overlay. The publisher applies the entry-body
+ * binding implicitly (see `effectiveNodeBindings`), so the body renders without
+ * the node needing to remember a binding it never had a UI to set.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { makeModule, makePage, makeRegistry, makeSite } from './helpers'
+import { publishPage } from '@core/publisher'
+import type { LoopItem } from '@core/loops/types'
+
+const bodyModule = makeModule('base.body', {
+  canHaveChildren: true,
+  render: (_props, children) => ({ html: `<main>${children.join('')}</main>` }),
+})
+
+// Mirrors the real base.outlet render: a hidden richtext `html` prop (so
+// `escapeProps` sanitises rather than HTML-escapes it) emitted inside the
+// content-region marker.
+const outletModule = makeModule('base.outlet', {
+  schema: { html: { type: 'richtext', label: 'Content', hidden: true } },
+  render: (props) => ({
+    html: `<section data-instatic-content-region>${String((props as { html?: string }).html ?? '')}</section>`,
+  }),
+})
+
+const registry = makeRegistry({ 'base.body': bodyModule, 'base.outlet': outletModule })
+
+function entry(body: string): LoopItem {
+  return { id: 'p1', fields: { id: 'p1', title: 'Untitled', body } }
+}
+
+describe('entry outlet body binding', () => {
+  it('renders the current entry body into an outlet that carries no persisted binding', () => {
+    // A hand-dropped outlet: NO dynamicBindings on the node.
+    const page = makePage({
+      root: { moduleId: 'base.body', children: ['outlet'] },
+      outlet: { moduleId: 'base.outlet' },
+    })
+
+    const { html } = publishPage(page, makeSite(), registry, {
+      templateContext: { entryStack: [entry('## Heading\n\nHello world')] },
+    })
+
+    expect(html).toContain('data-instatic-content-region')
+    expect(html).toContain('<h2>Heading</h2>')
+    expect(html).toContain('Hello world')
+  })
+
+  it('leaves the outlet empty on a non-entry render (no current entry in scope)', () => {
+    const page = makePage({
+      root: { moduleId: 'base.body', children: ['outlet'] },
+      outlet: { moduleId: 'base.outlet' },
+    })
+
+    // No entryStack → currentEntry.body resolves to nothing; the outlet renders
+    // its marker but no body (an `everywhere` layout previewing a page relies on
+    // this so the implicit binding stays inert outside entry routes).
+    const { html } = publishPage(page, makeSite(), registry, {
+      templateContext: { entryStack: [] },
+    })
+
+    expect(html).toContain('data-instatic-content-region')
+    expect(html).not.toContain('Hello world')
+  })
+})

--- a/src/admin/pages/site/canvas/NodeRenderer.tsx
+++ b/src/admin/pages/site/canvas/NodeRenderer.tsx
@@ -26,7 +26,7 @@ import { useEditorStore, selectActiveCanvasPage } from '@site/store/store'
 import { resolveProps } from '@core/page-tree'
 import { registry } from '@core/module-engine'
 import type { NodeWrapperProps as NodeWrapperPropsType } from '@core/module-engine'
-import { resolveDynamicProps, type TemplateRenderDataContext } from '@core/templates/dynamicBindings'
+import { resolveDynamicProps, effectiveNodeBindings, type TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import type { PageNode } from '@core/page-tree'
 import { WarningDiamondSolidIcon } from 'pixel-art-icons/icons/warning-diamond-solid'
 import { ErrorBoundary } from '@ui/components/ErrorBoundary'
@@ -233,7 +233,7 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
     node.moduleId,
     resolveDynamicProps(
     resolveProps(node, breakpointId, definition.schema),
-    node.dynamicBindings,
+    effectiveNodeBindings(node),
     templateContext,
     ),
     editorFormPreviewState,

--- a/src/core/publisher/renderNode.ts
+++ b/src/core/publisher/renderNode.ts
@@ -26,7 +26,7 @@ import { isPageRef, resolvePageRef } from '@core/page-tree'
 import type { AnyModuleDefinition } from '@core/module-engine'
 import { validateNodeProps } from '@core/module-engine'
 import { resolveProps } from '@core/page-tree'
-import { resolveDynamicProps } from '@core/templates/dynamicBindings'
+import { resolveDynamicProps, effectiveNodeBindings } from '@core/templates/dynamicBindings'
 import { sanitizeModuleCSS } from './cssCollector'
 import { escapeHtml } from './utils'
 import { escapeProps } from './escapeProps'
@@ -142,7 +142,7 @@ function renderStandardNode(
   const effectiveProps = resolveProps(node, config.breakpointId, def.schema)
   const dynamicProps = resolveDynamicProps(
     effectiveProps,
-    node.dynamicBindings,
+    effectiveNodeBindings(node),
     config.templateContext,
   )
 

--- a/src/core/templates/dynamicBindings.ts
+++ b/src/core/templates/dynamicBindings.ts
@@ -116,6 +116,39 @@ function resolveBindingValue(
   return value
 }
 
+/**
+ * The implicit binding every `base.outlet` carries: its `html` prop is filled
+ * with the current entry's markdown body, rendered to HTML. An outlet is, by
+ * definition, the hole the current entry's body flows into — there is no UI to
+ * set this and it is never persisted on the node. Resolving it here means ANY
+ * outlet renders the body, including one a user drags onto a custom template by
+ * hand (which carries no `dynamicBindings` overlay). Outside an entry route the
+ * entry stack is empty, so `currentEntry.body` resolves to nothing and the
+ * outlet stays empty — an `everywhere` layout's outlet then hosts a whole page
+ * instead.
+ */
+const OUTLET_BODY_BINDING: DynamicPropBinding = {
+  source: 'currentEntry',
+  field: 'body',
+  format: 'html',
+}
+
+/**
+ * The bindings that actually apply to a node at render time: its persisted
+ * `dynamicBindings` overlay plus the implicit outlet body binding for
+ * `base.outlet`. Both the publisher (`renderNode`) and the editor canvas
+ * (`NodeRenderer`) resolve through this so the two surfaces render identically.
+ */
+export function effectiveNodeBindings(node: {
+  moduleId: string
+  dynamicBindings?: Record<string, DynamicPropBinding>
+}): Record<string, DynamicPropBinding> | undefined {
+  if (node.moduleId === 'base.outlet') {
+    return { ...node.dynamicBindings, html: OUTLET_BODY_BINDING }
+  }
+  return node.dynamicBindings
+}
+
 export function resolveDynamicProps(
   staticProps: Record<string, unknown>,
   bindings: Record<string, DynamicPropBinding> | undefined,


### PR DESCRIPTION
## What changed

A `base.outlet` only rendered the current entry's body when the node carried a **persisted** `dynamicBindings.html` overlay — which was set in exactly one place: the auto-seeded default entry template (`buildDefaultTemplateCells`).

When a site owner builds their own post template and **drags a Content Outlet in by hand**, that outlet has `props.html: ''` and **no binding**, so the publisher filled it with nothing and it rendered as an empty `<main data-instatic-content-region></main>`.

The body resolution (`resolveDynamicProps`) is shared by all three render surfaces, so the gap broke the **published page**, the **content preview API**, and the **Live Canvas editor** alike.

## Why

An outlet is, by definition, the hole the current entry's body flows into — there is no UI to bind it and the binding is always the same (`currentEntry.body`, rendered markdown → HTML). Relying on a persisted overlay that only the seeder set was fragile: any hand-authored outlet was silently broken.

## The fix

- **`dynamicBindings.ts`** — new `effectiveNodeBindings(node)` helper applies the `currentEntry.body → html` binding **implicitly** to every `base.outlet`, merged on top of any persisted overlay.
- **`renderNode.ts`** (publisher) and **`NodeRenderer.tsx`** (editor canvas) now resolve through `effectiveNodeBindings(node)` so all surfaces behave identically.
- **`templateSeeding.ts`** — dropped the now-redundant persisted binding from the seed; a seeded outlet is now identical to a hand-dropped one (single source of truth).

Outside an entry route the entry stack is empty, so the binding resolves to nothing and the outlet stays empty — an `everywhere` layout's outlet still hosts a whole page.

## User / developer impact

Dragging a Content Outlet into a custom post template now renders each post's body in it — on the canvas, in the live editor, and on the published page. No migration needed; existing seeded templates keep working (the implicit binding resolves to the same value).

## Verification

- New `src/__tests__/publisher/outletEntryBody.test.ts` reproduces the bug (outlet with no persisted binding) and confirms the body renders, plus the inert-outside-entry-routes case.
- `bun test src/__tests__/publisher/ src/core/templates/ server/publish/` → 405 pass.
- `bun run build` and `bun run lint` → clean.
- `react-doctor --scope changed --base main` → no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)