### PR TITLE
fix(canvas): render base.text tag:none as bare text to match published DOM

### DIFF
--- a/src/__tests__/base-modules.test.ts
+++ b/src/__tests__/base-modules.test.ts
@@ -172,6 +172,62 @@ describe('base.text — unified text module', () => {
     expect(html).toBeCleanHTML()
     expect(html).toContain('&lt;script&gt;')
   })
+
+  // Canvas/publish DOM fidelity: `tag: none` emits NO element on the published
+  // page (render() returns bare text), so the canvas must do the same. A
+  // phantom wrapper (e.g. a `<span>`) would be caught by descendant selectors
+  // like `.parent span`, painting the text in the canvas but not on publish.
+  it('renders tag "none" as bare text with no wrapper element in the canvas', () => {
+    const { container } = renderReact(
+      React.createElement(TextModule.component, {
+        props: { text: '4', tag: 'none', htmlAttributes: {} },
+        nodeId: 'n1',
+        isSelected: false,
+        mcClassName: 'ist-x',
+        nodeWrapperProps: { 'data-node-id': 'n1', 'data-module-id': 'base.text', tabIndex: 0 },
+      } as never),
+    )
+
+    expect(container.textContent).toBe('4')
+    // No wrapping element at all — not a span, and nothing carrying the
+    // canvas identity/class that the publisher's bare text wouldn't have.
+    expect(container.querySelector('span')).toBeNull()
+    expect(container.querySelector('[data-node-id]')).toBeNull()
+    expect(container.querySelector('.ist-x')).toBeNull()
+  })
+
+  it('renders tag "none" multiline as bare text with <br> breaks and no wrapper', () => {
+    const { container } = renderReact(
+      React.createElement(TextModule.component, {
+        props: { text: 'a\nb', tag: 'none', htmlAttributes: {} },
+        nodeId: 'n1',
+        isSelected: false,
+        mcClassName: 'ist-x',
+        nodeWrapperProps: { 'data-node-id': 'n1', 'data-module-id': 'base.text', tabIndex: 0 },
+      } as never),
+    )
+
+    expect(container.querySelector('span')).toBeNull()
+    expect(container.querySelector('br')).not.toBeNull()
+    expect(container.textContent).toBe('ab')
+  })
+
+  it('still wraps a non-none tag in its element carrying the canvas identity', () => {
+    const { container } = renderReact(
+      React.createElement(TextModule.component, {
+        props: { text: '0', tag: 'span', htmlAttributes: {} },
+        nodeId: 'n1',
+        isSelected: false,
+        mcClassName: 'ist-x',
+        nodeWrapperProps: { 'data-node-id': 'n1', 'data-module-id': 'base.text', tabIndex: 0 },
+      } as never),
+    )
+
+    const span = container.querySelector('span')
+    expect(span).not.toBeNull()
+    expect(span?.getAttribute('data-node-id')).toBe('n1')
+    expect(span?.textContent).toBe('0')
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/modules/base/text/TextEditor.tsx
+++ b/src/modules/base/text/TextEditor.tsx
@@ -28,13 +28,16 @@ export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
   inlineEdit,
 }) => {
   const tag = normalizeTag(props.tag)
-  const elementTag = tag === 'none' ? 'span' : tag
-  const Tag = elementTag as React.ElementType
 
   // Editing: the element becomes the contentEditable surface (content seeded
-  // from the frozen initial HTML inside inlineEditableElementProps).
+  // from the frozen initial HTML inside inlineEditableElementProps). `tag: none`
+  // has no published element, but an active edit session still needs a host —
+  // a `<span>` is the minimal one. This branch is effectively unreachable for
+  // tag:none from the canvas: the display branch below renders no element, so
+  // there is nothing to double-click to start a session.
   if (inlineEdit) {
-    return React.createElement(Tag, {
+    const EditTag = (tag === 'none' ? 'span' : tag) as React.ElementType
+    return React.createElement(EditTag, {
       ...nodeWrapperProps,
       ...(tag === 'none' ? {} : htmlAttributesForReact(props.htmlAttributes)),
       className: mcClassName,
@@ -42,12 +45,41 @@ export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
     })
   }
 
+  // Display: `tag: none` emits NO element, exactly like the publisher
+  // (`src/modules/base/text/index.ts` render() returns bare text). Wrapping it
+  // in any element here would let descendant selectors such as `.parent span`
+  // paint the text in the canvas while leaving the published page untouched —
+  // a canvas/publish fidelity break. Bare text keeps the canvas DOM identical
+  // to the published DOM. The cost: a tag:none node owns no element, so it has
+  // no in-canvas selection ring / hover / inline-edit; it is selected and
+  // edited via the Layers + Properties panels instead.
+  if (tag === 'none') {
+    return <>{renderBreakNodes(props.text ?? '')}</>
+  }
+
   // Display: escaped text with newlines as <br>, matching the publisher.
   const html = rawTextToBreakHtml(props.text || 'Text')
+  const Tag = tag as React.ElementType
   return React.createElement(Tag, {
     ...nodeWrapperProps,
-    ...(tag === 'none' ? {} : htmlAttributesForReact(props.htmlAttributes)),
+    ...htmlAttributesForReact(props.htmlAttributes),
     className: mcClassName,
     dangerouslySetInnerHTML: { __html: html },
   })
+}
+
+/**
+ * Render a raw stored value as bare React nodes with `\n` → `<br>` breaks and
+ * no wrapping element. Mirrors the publisher's `textToBreakHtml` output for
+ * `tag: none` (bare text + `<br>`), but as React children so the canvas emits
+ * no host element. React escapes each text segment, matching the publisher's
+ * pre-escaped output.
+ */
+function renderBreakNodes(rawText: string): React.ReactNode {
+  return rawText.split('\n').map((segment, i) => (
+    <React.Fragment key={i}>
+      {i > 0 ? <br /> : null}
+      {segment}
+    </React.Fragment>
+  ))
 }

--- a/src/modules/base/text/TextEditor.tsx
+++ b/src/modules/base/text/TextEditor.tsx
@@ -54,7 +54,7 @@ export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
   // no in-canvas selection ring / hover / inline-edit; it is selected and
   // edited via the Layers + Properties panels instead.
   if (tag === 'none') {
-    return <>{renderBreakNodes(props.text ?? '')}</>
+    return <BareText text={props.text ?? ''} />
   }
 
   // Display: escaped text with newlines as <br>, matching the publisher.
@@ -69,17 +69,18 @@ export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
 }
 
 /**
- * Render a raw stored value as bare React nodes with `\n` → `<br>` breaks and
- * no wrapping element. Mirrors the publisher's `textToBreakHtml` output for
- * `tag: none` (bare text + `<br>`), but as React children so the canvas emits
- * no host element. React escapes each text segment, matching the publisher's
- * pre-escaped output.
+ * Bare text with `\n` → `<br>` breaks and NO wrapping element — a fragment, so
+ * it adds no host element to the canvas DOM. Mirrors the publisher's
+ * `textToBreakHtml` output for `tag: none` (bare text + `<br>`); React escapes
+ * each text segment, matching the publisher's pre-escaped output.
  */
-function renderBreakNodes(rawText: string): React.ReactNode {
-  return rawText.split('\n').map((segment, i) => (
-    <React.Fragment key={i}>
-      {i > 0 ? <br /> : null}
-      {segment}
-    </React.Fragment>
-  ))
-}
+const BareText: React.FC<{ text: string }> = ({ text }) => (
+  <>
+    {text.split('\n').map((segment, i) => (
+      <React.Fragment key={i}>
+        {i > 0 ? <br /> : null}
+        {segment}
+      </React.Fragment>
+    ))}
+  </>
+)


### PR DESCRIPTION
## What

In the visual editor canvas, a `base.text` node with **`tag: none`** was wrapped in a `<span>`. The publisher renders `tag: none` as **bare text with no element** (`src/modules/base/text/index.ts` → `{ html: text }`). That divergence let descendant selectors match the phantom span in the builder while leaving the published page untouched.

Concretely, on the **404 template** the number is one `.ist-404__num` container with three `base.text` children — two `tag: none` `4`s and a `tag: span` `0` — plus an ambient rule `.ist-404__num span { color: var(--ist-accent) }`. In the canvas all three were spans, so the rule painted the `4`s orange; on the published page the `4`s are bare text, so they stayed black. The builder lied about the result.

## Fix

The canvas now renders `tag: none` as bare text + `<br>` breaks (a fragment, no host element), exactly like the publisher — so the canvas DOM equals the published DOM. This is the same canvas-equals-published principle that drove removing the per-node wrapper `<div>`.

- `TextEditor.tsx`: `tag: none` display path renders a `BareText` fragment instead of a `<span>` wrapper. The inline-edit branch still hosts a `<span>` for an active session (unreachable from the canvas for `tag: none` — there is no element to double-click).

### Trade-off (intentional, agreed with author)

A `tag: none` node owns no element, so it has no in-canvas selection ring / hover / inline-edit — it is selected via the **Layers** panel and edited via the **Properties → Text** field. This is the honest reflection of "no element": that text has no box on the published page either. A future, separate PR could add Range-based selection to restore direct manipulation without a phantom element.

## User/developer impact

- **Users:** the builder now shows the same text colors (and any other descendant-selector styling) as the published site for `tag: none` text.
- **Developers:** canvas/publish DOM parity holds for `tag: none`.

## Verification

- `bun run build` ✓
- `bun run lint` ✓
- `bun test` ✓ — 5437 pass, 0 fail (added 3 canvas-render tests in `base-modules.test.ts`)
- **Live in the editor** (isolated dev server against a DB containing the 404 template): the `4`s render black and the `0` orange, matching the front end. `.ist-404__num` DOM is `4<span data-node-id=…>0</span>4` (childNodes `["#text:4","SPAN","#text:4"]`), no console errors.

> Note: the pre-push hook flags a `react-doctor/no-danger` warning on the non-`none` display path's `dangerouslySetInnerHTML` — that is the pre-existing escaped-text + `<br>` pattern already on `main` (only relocated by this diff), not a new regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)