### PR TITLE
fix(export): server-accurate export size estimate (incl. media)

### DIFF
--- a/server/handlers/cms/export.ts
+++ b/server/handlers/cms/export.ts
@@ -3,12 +3,19 @@
  *
  *   GET  /admin/api/cms/export
  *   POST /admin/api/cms/export
+ *   POST /admin/api/cms/export/estimate   → { bytes } (size only, no download)
  *
  * Returns a `SiteBundle` JSON that captures a full or partial site state:
  *   - optionally the lean site shell (breakpoints, settings, classes, files, runtime)
  *   - selected (or all) data tables
  *   - selected (or all) non-deleted data rows
  *   - optionally: non-deleted media assets with bytes embedded as base64
+ *
+ * The `/export/estimate` path runs the IDENTICAL selection logic but reports
+ * only the bundle's byte size — without reading media files off disk or
+ * base64-encoding them. The estimate is therefore exact (it serializes the
+ * real selection and adds each asset's Base64 length analytically), so the
+ * "Estimated size" line in the dialog can never drift from the real download.
  *
  * Filter options (GET → query string, POST → JSON body via ExportRequestSchema):
  *   tables       — comma-separated table ids (GET) or string[] (POST); default all
@@ -39,13 +46,61 @@ import { CMS_API_PREFIX, type CmsHandlerOptions } from './shared'
 import { ExportRequestSchema, type SiteBundle } from '@core/data/bundleSchema'
 import { canSeeAllDataRows } from './data/access'
 
+const EXPORT_PATH = `${CMS_API_PREFIX}/export`
+const EXPORT_ESTIMATE_PATH = `${CMS_API_PREFIX}/export/estimate`
+
+/** A media asset row enriched with its storage path, as loaded for export. */
+type ExportableAsset = Awaited<ReturnType<typeof listMediaAssetsForExport>>[number]
+
+/** Bundle media entry without the heavy `bytesBase64` payload. */
+type MediaEntryMetadata = Omit<NonNullable<SiteBundle['media']>[number], 'bytesBase64'>
+
+/**
+ * The metadata fields of a bundle media entry — everything except the Base64
+ * payload. Shared by the real export (which appends the encoded bytes) and the
+ * estimate (which appends an empty string and sizes the bytes analytically).
+ */
+function mediaEntryMetadata(asset: ExportableAsset): MediaEntryMetadata {
+  return {
+    id: asset.id,
+    filename: asset.filename,
+    mimeType: asset.mimeType,
+    sizeBytes: asset.sizeBytes,
+    altText: asset.altText,
+    caption: asset.caption,
+    title: asset.title,
+    tags: asset.tags,
+    width: asset.width,
+    height: asset.height,
+    durationMs: asset.durationMs,
+    dominantColor: asset.dominantColor,
+    blurHash: asset.blurHash,
+    storagePath: asset.storagePath,
+    posterPath: asset.posterPath,
+  }
+}
+
+/** Exact length of the Base64 encoding (with padding) of `n` raw bytes. */
+function base64Length(n: number): number {
+  return Math.ceil(n / 3) * 4
+}
+
+interface ExportSelection {
+  shell: NonNullable<Awaited<ReturnType<typeof getDraftSite>>>
+  tables: Awaited<ReturnType<typeof listDataTables>>
+  rows: Awaited<ReturnType<typeof listDataRows>>
+  includeMedia: boolean
+  includeSite: boolean
+}
+
 export async function handleExportRoute(
   req: Request,
   db: DbClient,
   options: CmsHandlerOptions = {},
 ): Promise<Response | null> {
   const url = new URL(req.url)
-  if (url.pathname !== `${CMS_API_PREFIX}/export`) return null
+  const isEstimate = url.pathname === EXPORT_ESTIMATE_PATH
+  if (url.pathname !== EXPORT_PATH && !isEstimate) return null
   if (req.method !== 'GET' && req.method !== 'POST') {
     return jsonResponse({ error: 'Method not allowed' }, { status: 405 })
   }
@@ -111,32 +166,58 @@ export async function handleExportRoute(
     tables = tables.filter((t) => referencedTableIds.has(t.id))
   }
 
-  // Optionally embed media bytes
+  const selection: ExportSelection = { shell, tables, rows, includeMedia, includeSite }
+
+  // Media is embedded only when requested AND an uploads dir is configured —
+  // both the estimate and the real export gate on this so they stay in sync.
+  const wantMedia = includeMedia && Boolean(options.uploadsDir)
+  const assets = wantMedia ? await listMediaAssetsForExport(db) : []
+
+  if (isEstimate) {
+    return estimateResponse(selection, wantMedia, assets)
+  }
+
+  return downloadResponse(selection, wantMedia, assets, options.uploadsDir)
+}
+
+/**
+ * Compute the exact bundle byte size without reading media files. Serializes
+ * the real selection with empty `bytesBase64` strings, then adds each asset's
+ * Base64-encoded length — which is precisely what would fill those strings.
+ * (Base64 is ASCII, so its JSON-string length equals its byte length.)
+ */
+function estimateResponse(
+  selection: ExportSelection,
+  wantMedia: boolean,
+  assets: ExportableAsset[],
+): Response {
+  const mediaSkeleton: SiteBundle['media'] = wantMedia
+    ? assets.map((asset) => ({ ...mediaEntryMetadata(asset), bytesBase64: '' }))
+    : undefined
+
+  const skeleton = buildBundle(selection, mediaSkeleton)
+  const structuralBytes = Buffer.byteLength(JSON.stringify(skeleton), 'utf8')
+  const mediaBytes = wantMedia
+    ? assets.reduce((sum, asset) => sum + base64Length(asset.sizeBytes), 0)
+    : 0
+
+  return jsonResponse({ bytes: structuralBytes + mediaBytes })
+}
+
+/** Build the full bundle (reading + base64-encoding media bytes) and stream it as a download. */
+async function downloadResponse(
+  selection: ExportSelection,
+  wantMedia: boolean,
+  assets: ExportableAsset[],
+  uploadsDir: string | undefined,
+): Promise<Response> {
   let media: SiteBundle['media']
-  if (includeMedia && options.uploadsDir) {
-    const assets = await listMediaAssetsForExport(db)
+  if (wantMedia && uploadsDir) {
     const mediaItems = await Promise.all(
       assets.map(async (asset) => {
         try {
-          const bytes = await readFile(join(options.uploadsDir!, asset.storagePath))
-          return {
-            id: asset.id,
-            filename: asset.filename,
-            mimeType: asset.mimeType,
-            sizeBytes: asset.sizeBytes,
-            altText: asset.altText,
-            caption: asset.caption,
-            title: asset.title,
-            tags: asset.tags,
-            width: asset.width,
-            height: asset.height,
-            durationMs: asset.durationMs,
-            dominantColor: asset.dominantColor,
-            blurHash: asset.blurHash,
-            storagePath: asset.storagePath,
-            posterPath: asset.posterPath,
-            bytesBase64: bytes.toString('base64'),
-          }
+          const bytes = await readFile(join(uploadsDir, asset.storagePath))
+          return { ...mediaEntryMetadata(asset), bytesBase64: bytes.toString('base64') }
         } catch {
           // If a file is missing from disk, skip the asset rather than aborting
           // the entire export. The import will recreate metadata rows but without
@@ -148,16 +229,7 @@ export async function handleExportRoute(
     media = mediaItems.filter((item): item is NonNullable<typeof item> => item !== null)
   }
 
-  const bundle: SiteBundle = {
-    schemaVersion: 1,
-    exportedAt: new Date().toISOString(),
-    sourceSiteName: shell.name,
-    ...(includeSite ? { site: shell } : {}),
-    tables,
-    rows,
-    ...(media !== undefined ? { media } : {}),
-  }
-
+  const bundle = buildBundle(selection, media)
   const json = JSON.stringify(bundle)
   const timestamp = new Date().toISOString().slice(0, 19).replace(/[:.]/g, '-')
   return new Response(json, {
@@ -166,4 +238,17 @@ export async function handleExportRoute(
       'content-disposition': `attachment; filename="site-bundle-${timestamp}.json"`,
     },
   })
+}
+
+/** Assemble the `SiteBundle` from a selection plus an already-resolved media array. */
+function buildBundle(selection: ExportSelection, media: SiteBundle['media']): SiteBundle {
+  return {
+    schemaVersion: 1,
+    exportedAt: new Date().toISOString(),
+    sourceSiteName: selection.shell.name,
+    ...(selection.includeSite ? { site: selection.shell } : {}),
+    tables: selection.tables,
+    rows: selection.rows,
+    ...(media !== undefined ? { media } : {}),
+  }
 }

--- a/src/__tests__/admin/data/exportDialog.test.tsx
+++ b/src/__tests__/admin/data/exportDialog.test.tsx
@@ -351,6 +351,38 @@ describe('ExportDialog', () => {
     }
   })
 
+  it('estimate is fetched from the server and grows when media is toggled on', async () => {
+    // The estimate endpoint reports a size that depends on includeMedia, so we
+    // can assert the dialog re-requests and re-renders when the toggle flips.
+    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/admin/api/cms/export/estimate') {
+        const body = JSON.parse((init?.body as string) ?? '{}') as { includeMedia?: boolean }
+        return jsonResponse({ bytes: body.includeMedia ? 5_000_000 : 12_000 })
+      }
+      return jsonResponse({ error: `Unexpected request: ${url}` }, 500)
+    }
+
+    render(
+      <ExportDialog
+        open={true}
+        onClose={() => {}}
+        tables={[POSTS_TABLE]}
+      />,
+    )
+
+    // Initial (media off) estimate resolves to ~12 KB.
+    await waitFor(() => {
+      expect(screen.getByText(/estimated size: ~12 KB/i)).toBeTruthy()
+    })
+
+    // Flip media on → the dialog re-requests and the estimate jumps to MB.
+    fireEvent.click(screen.getByRole('switch', { name: /include media files/i }))
+    await waitFor(() => {
+      expect(screen.getByText(/estimated size: ~4\.8 MB/i)).toBeTruthy()
+    })
+  })
+
   it('Cancel button calls onClose', () => {
     let onCloseCalled = false
     render(

--- a/src/__tests__/architecture/cmsTransferExport.test.ts
+++ b/src/__tests__/architecture/cmsTransferExport.test.ts
@@ -14,12 +14,16 @@
  */
 
 import { describe, test, expect, beforeAll } from 'bun:test'
+import { mkdtemp, writeFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { createSqliteClient } from '../../../server/db/sqlite'
 import { runMigrations } from '../../../server/db/runMigrations'
 import { sqliteMigrations } from '../../../server/db/migrations-sqlite'
 import { saveDraftSite } from '../../../server/repositories/site'
 import { createUser } from '../../../server/repositories/users'
 import { createSession } from '../../../server/auth/sessions'
+import { createMediaAsset } from '../../../server/repositories/media'
 import {
   createSessionToken,
   hashSessionToken,
@@ -388,5 +392,97 @@ describe('handleExportRoute — auth', () => {
     const req = new Request('http://localhost/admin/api/cms/export', { method: 'GET' })
     const res = await handleExportRoute(req, db)
     expect(res!.status).toBe(401)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Estimate endpoint — must equal the real download size exactly, because both
+// run the same selection logic. The estimate just skips reading media bytes
+// and sizes them analytically (Base64 length) instead.
+// ---------------------------------------------------------------------------
+
+async function estimateBytes(path: string, body: unknown, cookieStr: string, opts?: { uploadsDir?: string }): Promise<number> {
+  const res = await handleExportRoute(makePostRequest(path, cookieStr, body), db, opts)
+  expect(res!.status).toBe(200)
+  const parsed = JSON.parse(await res!.text()) as { bytes: number }
+  return parsed.bytes
+}
+
+describe('handleExportRoute — POST /export/estimate', () => {
+  test('estimate equals the real download byte length exactly (no media)', async () => {
+    const dl = await handleExportRoute(makePostRequest('/admin/api/cms/export', cookie, {}), db)
+    const realBytes = Buffer.byteLength(await dl!.text(), 'utf8')
+
+    const bytes = await estimateBytes('/admin/api/cms/export/estimate', {}, cookie)
+    expect(bytes).toBe(realBytes)
+  })
+
+  test('estimate drops the shell cost when includeSite is false, still matching the real download', async () => {
+    const withSite = await estimateBytes('/admin/api/cms/export/estimate', { includeSite: true }, cookie)
+    const withoutSite = await estimateBytes('/admin/api/cms/export/estimate', { includeSite: false }, cookie)
+    expect(withoutSite).toBeLessThan(withSite)
+
+    const realNoSite = await handleExportRoute(
+      makePostRequest('/admin/api/cms/export', cookie, { includeSite: false }),
+      db,
+    )
+    expect(withoutSite).toBe(Buffer.byteLength(await realNoSite!.text(), 'utf8'))
+  })
+
+  test('requires a session (401 without a cookie)', async () => {
+    const req = new Request('http://localhost/admin/api/cms/export/estimate', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}',
+    })
+    const res = await handleExportRoute(req, db)
+    expect(res!.status).toBe(401)
+  })
+})
+
+describe('handleExportRoute — POST /export/estimate with embedded media', () => {
+  test('estimate equals the real download byte length exactly, including Base64 media bytes', async () => {
+    const mediaDb = createSqliteClient(':memory:')
+    await runMigrations(mediaDb, sqliteMigrations)
+    const mediaCookie = await seedAuth(mediaDb)
+
+    const uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-export-estimate-'))
+    try {
+      // Seed one media asset whose bytes live on disk. 5000 raw bytes → a
+      // Base64 payload that isn't a clean multiple of 3 (exercises padding).
+      const fileBytes = Buffer.alloc(5000, 7)
+      await writeFile(join(uploadsDir, 'seed.bin'), fileBytes)
+      await createMediaAsset(mediaDb, {
+        id: 'asset-1',
+        filename: 'seed.bin',
+        mimeType: 'application/octet-stream',
+        sizeBytes: fileBytes.length,
+        storagePath: 'seed.bin',
+        publicPath: '/uploads/seed.bin',
+        uploadedByUserId: null,
+        storageAdapterId: '',
+        externallyHosted: false,
+      })
+
+      const dl = await handleExportRoute(
+        makePostRequest('/admin/api/cms/export', mediaCookie, { includeMedia: true }),
+        mediaDb,
+        { uploadsDir },
+      )
+      const realBytes = Buffer.byteLength(await dl!.text(), 'utf8')
+
+      const estRes = await handleExportRoute(
+        makePostRequest('/admin/api/cms/export/estimate', mediaCookie, { includeMedia: true }),
+        mediaDb,
+        { uploadsDir },
+      )
+      const { bytes } = JSON.parse(await estRes!.text()) as { bytes: number }
+
+      expect(bytes).toBe(realBytes)
+      // Sanity: media actually dominated (the asset's bytes are present).
+      expect(bytes).toBeGreaterThan(5000)
+    } finally {
+      await rm(uploadsDir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/admin/pages/data/components/ExportDialog/ExportDialog.tsx
+++ b/src/admin/pages/data/components/ExportDialog/ExportDialog.tsx
@@ -20,6 +20,7 @@ import { Switch } from '@ui/components/Switch'
 import { pushToast } from '@ui/components/Toast'
 import { exportSiteBundle } from '@core/persistence/cmsTransfer'
 import type { DataTableKind, DataTableListItem } from '@core/data/schemas'
+import type { ExportRequest } from '@core/data/bundleSchema'
 import { useExportEstimate } from './useExportEstimate'
 import styles from './ExportDialog.module.css'
 import { getErrorMessage } from '@core/utils/errorMessage'
@@ -190,20 +191,20 @@ export function ExportDialog({
 
   // ── Estimate ──────────────────────────────────────────────────────────────
 
-  // Derive rowCounts from the tables array (each table carries its live count
-  // from the server list endpoint). Computed inline — no memo needed because
-  // the tables array only changes when the workspace refreshes.
-  const rowCountsByTableId = Object.fromEntries(tables.map((t) => [t.id, t.rowCount]))
+  // Mirror the exact ExportRequest the Download button will send, so the
+  // server sizes the same selection. `null` while the dialog is closed pauses
+  // estimating. Built inline — the React Compiler memoizes; the request only
+  // changes when a toggle/table/scope flips.
+  const estimateRequest: ExportRequest | null = open
+    ? {
+        tables: Array.from(effectiveTableIds),
+        rowIds: scope === 'selected' ? selectedRowIds : undefined,
+        includeMedia,
+        includeSite: siteShell,
+      }
+    : null
 
-  const estimate = useExportEstimate({
-    rowCounts: rowCountsByTableId,
-    selectedTableIds: effectiveTableIds,
-    scope,
-    selectedRowIdCount: selectedRowIds.length,
-    includeSite: siteShell,
-    includeMedia,
-    mediaAssetCount: 0, // caller doesn't provide a cheap count yet
-  })
+  const estimate = useExportEstimate(estimateRequest)
 
   // ── Ids for accessibility ─────────────────────────────────────────────────
 
@@ -354,7 +355,7 @@ export function ExportDialog({
 
         {/* ── Estimated size ───────────────────────────────────────── */}
         <p className={styles.estimate}>
-          Estimated size: {estimate.formatted}
+          Estimated size: {estimate.error ? 'unavailable' : estimate.formatted}
         </p>
 
         {/* ── Inline error ─────────────────────────────────────────── */}

--- a/src/admin/pages/data/components/ExportDialog/useExportEstimate.ts
+++ b/src/admin/pages/data/components/ExportDialog/useExportEstimate.ts
@@ -1,61 +1,32 @@
 /**
- * useExportEstimate — client-side bundle size estimator.
+ * useExportEstimate — live, server-accurate bundle size estimate.
  *
- * Uses simple per-row and per-asset constants to produce a rough estimate of
- * the final bundle size. The result is a display string suitable for the
- * "Estimated size: ~127 KB" line in ExportDialog.
+ * Instead of guessing from per-row/per-asset constants (which ignored media
+ * entirely and ran ~10× low on content), this hook asks the server for the
+ * exact size the bundle WOULD have for the current `ExportRequest`. The server
+ * runs the same selection logic as the real export but skips reading media
+ * bytes off disk, so the number can never drift from the actual download.
  *
- * Constants (deliberately conservative):
- *   - Site shell: 8 KB flat
- *   - Per row:    1.5 KB
- *   - Per media asset: 100 KB (default; configurable via `mediaPerAssetBytes`)
+ * Fetches are debounced (options change as the operator clicks toggles) and
+ * cancellable (a superseded request aborts). The previous value is kept on
+ * screen while a new estimate is in flight to avoid flicker.
  */
 
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
+import { useEffect, useState } from 'react'
+import { estimateSiteBundle } from '@core/persistence/cmsTransfer'
+import { isAbortError } from '@core/http'
+import type { ExportRequest } from '@core/data/bundleSchema'
 
-interface UseExportEstimateOpts {
-  /** rowCounts[tableId] = number of rows in that table. */
-  rowCounts: Record<string, number>
-  /** The subset of table ids currently checked in the dialog. */
-  selectedTableIds: Set<string>
-  /** Export scope. When 'selected', only `selectedRowIdCount` rows are costed. */
-  scope: 'all' | 'selected'
-  /** Number of individually selected row ids (only meaningful when scope='selected'). */
-  selectedRowIdCount: number
-  /** Whether to include the site shell in the estimate. */
-  includeSite: boolean
-  /** Whether to include media bytes in the estimate. */
-  includeMedia: boolean
-  /**
-   * Rough per-asset byte estimate used when `includeMedia` is true.
-   * Defaults to 100_000 (100 KB).
-   */
-  mediaPerAssetBytes?: number
-  /**
-   * Number of media assets in the workspace. Used when `includeMedia` is true.
-   * When not supplied (or 0), media cost is 0.
-   */
-  mediaAssetCount?: number
-}
+const DEBOUNCE_MS = 250
 
 interface UseExportEstimateResult {
-  bytes: number
+  /** Display string, e.g. "~92.3 MB". `'…'` while the first estimate loads. */
   formatted: string
+  /** True while a request is in flight. */
+  loading: boolean
+  /** True when the last request failed (non-abort). */
+  error: boolean
 }
-
-// ---------------------------------------------------------------------------
-// Constants
-// ---------------------------------------------------------------------------
-
-const SITE_SHELL_BYTES = 8 * 1024          // 8 KB
-const BYTES_PER_ROW   = 1.5 * 1024        // 1.5 KB
-const DEFAULT_MEDIA_BYTES_PER_ASSET = 100_000 // 100 KB
-
-// ---------------------------------------------------------------------------
-// Formatter
-// ---------------------------------------------------------------------------
 
 function formatBytes(bytes: number): string {
   if (bytes < 1024) return '< 1 KB'
@@ -63,43 +34,52 @@ function formatBytes(bytes: number): string {
   return `~${(bytes / 1_048_576).toFixed(1)} MB`
 }
 
-// ---------------------------------------------------------------------------
-// Hook
-// ---------------------------------------------------------------------------
+/**
+ * @param request The export request to size, or `null` to pause estimating
+ *                (e.g. while the dialog is closed).
+ */
+export function useExportEstimate(request: ExportRequest | null): UseExportEstimateResult {
+  const [bytes, setBytes] = useState<number | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(false)
 
-export function useExportEstimate({
-  rowCounts,
-  selectedTableIds,
-  scope,
-  selectedRowIdCount,
-  includeSite,
-  includeMedia,
-  mediaPerAssetBytes = DEFAULT_MEDIA_BYTES_PER_ASSET,
-  mediaAssetCount = 0,
-}: UseExportEstimateOpts): UseExportEstimateResult {
-  let bytes = 0
+  // Serialize the request to a stable primitive so the effect re-runs only when
+  // the actual selection changes — not on every render's fresh object identity.
+  const requestKey = request ? JSON.stringify(request) : null
 
-  // Site shell
-  if (includeSite) {
-    bytes += SITE_SHELL_BYTES
-  }
+  useEffect(() => {
+    if (requestKey === null) return
 
-  // Row cost
-  if (scope === 'selected') {
-    bytes += selectedRowIdCount * BYTES_PER_ROW
-  } else {
-    // Sum row counts for all selected tables
-    let totalRows = 0
-    for (const tableId of selectedTableIds) {
-      totalRows += rowCounts[tableId] ?? 0
+    const parsed = JSON.parse(requestKey) as ExportRequest
+    const controller = new AbortController()
+
+    // All state updates happen inside deferred callbacks (the debounce timer
+    // and the promise handlers), never synchronously in the effect body —
+    // synchronous setState-in-effect cascades an extra render and is linted out.
+    const timer = setTimeout(() => {
+      setLoading(true)
+      setError(false)
+      estimateSiteBundle(parsed, controller.signal)
+        .then((result) => {
+          setBytes(result.bytes)
+          setLoading(false)
+        })
+        .catch((err) => {
+          if (isAbortError(err)) return // superseded — a newer request is running
+          setError(true)
+          setLoading(false)
+        })
+    }, DEBOUNCE_MS)
+
+    return () => {
+      clearTimeout(timer)
+      controller.abort()
     }
-    bytes += totalRows * BYTES_PER_ROW
-  }
+  }, [requestKey])
 
-  // Media cost
-  if (includeMedia && mediaAssetCount > 0) {
-    bytes += mediaAssetCount * mediaPerAssetBytes
+  return {
+    formatted: bytes === null ? '…' : formatBytes(bytes),
+    loading,
+    error,
   }
-
-  return { bytes, formatted: formatBytes(bytes) }
 }

--- a/src/core/data/bundleSchema.ts
+++ b/src/core/data/bundleSchema.ts
@@ -117,6 +117,23 @@ export const ExportRequestSchema = Type.Object({
 export type ExportRequest = Static<typeof ExportRequestSchema>
 
 // ---------------------------------------------------------------------------
+// ExportEstimate
+// ---------------------------------------------------------------------------
+
+/**
+ * Response of `POST /admin/api/cms/export/estimate`. Reports the byte size the
+ * export bundle WOULD have for the given `ExportRequest`, computed from the
+ * exact same selection logic the real export uses — without reading media
+ * files off disk or base64-encoding them. `bytes` is the serialized bundle
+ * length plus the Base64-encoded length of every included media asset.
+ */
+export const ExportEstimateSchema = Type.Object({
+  bytes: Type.Number(),
+})
+
+export type ExportEstimate = Static<typeof ExportEstimateSchema>
+
+// ---------------------------------------------------------------------------
 // BundlePreview
 // ---------------------------------------------------------------------------
 

--- a/src/core/persistence/cmsTransfer.ts
+++ b/src/core/persistence/cmsTransfer.ts
@@ -9,10 +9,10 @@
  * return standard JSON envelopes validated with TypeBox via `readEnvelope`.
  */
 
-import type { SiteBundle, BundlePreview, ImportResult, ImportStrategy, ExportRequest } from '@core/data/bundleSchema'
-import { SiteBundleSchema, BundlePreviewSchema, ImportResultSchema } from '@core/data/bundleSchema'
+import type { SiteBundle, BundlePreview, ImportResult, ImportStrategy, ExportRequest, ExportEstimate } from '@core/data/bundleSchema'
+import { SiteBundleSchema, BundlePreviewSchema, ImportResultSchema, ExportEstimateSchema } from '@core/data/bundleSchema'
 import { parseValue, formatValueErrors, compiled } from '@core/utils/typeboxHelpers'
-import { readEnvelope, assertOk } from '@core/http'
+import { apiRequest, readEnvelope, assertOk } from '@core/http'
 
 // ---------------------------------------------------------------------------
 // SiteBundleParseError
@@ -59,6 +59,32 @@ export async function exportSiteBundle(opts: ExportRequest): Promise<Blob> {
   })
   await assertOk(res, 'Failed to export site')
   return res.blob()
+}
+
+// ---------------------------------------------------------------------------
+// estimateSiteBundle
+// ---------------------------------------------------------------------------
+
+/**
+ * POST /admin/api/cms/export/estimate
+ *
+ * Returns the exact byte size the bundle WOULD have for the given request,
+ * computed server-side from the same selection logic as the real export (it
+ * never reads media files off disk). Used to drive the "Estimated size" line
+ * live as the operator toggles options. Pass an `AbortSignal` so superseded
+ * requests cancel cleanly; detect cancellation with `isAbortError`.
+ */
+export async function estimateSiteBundle(
+  opts: ExportRequest,
+  signal?: AbortSignal,
+): Promise<ExportEstimate> {
+  return apiRequest('/admin/api/cms/export/estimate', {
+    method: 'POST',
+    body: opts,
+    schema: ExportEstimateSchema,
+    signal,
+    fallbackMessage: 'Failed to estimate export size',
+  })
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The **Estimated size** line in the Export dialog was a client-side guess that:
1. **Ignored media entirely** — `mediaAssetCount` was hardcoded to `0` (`ExportDialog.tsx:205`, comment: *"caller doesn't provide a cheap count yet"*), so toggling **Media files** never changed the number.
2. **Underestimated content ~10×** — flat constants (8 KB shell + 1.5 KB/row) that don't model real page-trees/styleRules.

This read as *"media isn't being exported"* — but **the export is correct**; only the estimate was wrong. (Verified separately: a real export of a 19-image site embeds all binaries as base64 and round-trips on import. See the analysis in the conversation that produced this PR.)

## Fix — one source of truth

Replace the heuristic with an **exact, server-computed** estimate that reuses the export's own selection logic so the number can never drift from the real download:

- **New `POST /admin/api/cms/export/estimate`** — runs the identical table/row/media selection as the real export, but computes the byte size instead of streaming the bundle. It **never reads media files off disk or base64-encodes them**: it serializes the real selection with empty `bytesBase64` strings and adds each asset's analytic Base64 length (`4·⌈n/3⌉`). Base64 is ASCII, so this equals the real bundle byte length exactly.
- **`export.ts` refactor** — `buildBundle` + the media-metadata mapping are shared between the download and estimate paths, so they can't diverge. Behavior of the existing download path is unchanged.
- **`useExportEstimate`** — now fetches the endpoint (debounced 250 ms, cancellable via `AbortController`) and formats the result; the dialog mirrors the exact `ExportRequest` it will send. The previous value stays on screen while a new estimate is in flight (no flicker); failures show `unavailable`.

## Verification

- `bun run build` ✓ · `bun run lint` ✓ · `bun test` ✓ — **5439 pass, 0 fail**
- New tests assert **estimate === real download byte length** for the no-media, no-shell, and **embedded-media** cases (`cmsTransferExport.test.ts`), plus a dialog test that the estimate re-fetches and grows when Media is toggled (`exportDialog.test.tsx`).
- **Live**, against a real site (19 images, ~69 MB), on the running server:
  - estimate without media = **183,618 B** (~179 KB)
  - estimate with media = **96,769,329 B** → actual download with media = **96,769,329 B** (byte-identical)
  - Dialog screenshot confirmed: Media off → **~179 KB**, Media on → **~92.3 MB**.

> Note: the pre-push hook surfaces 6 `react-doctor` **warnings** on `ExportDialog.tsx` (lines 142/144/165/264/279 — the `useState` cluster, reset-on-open pattern, and `<label>`/`Switch` markup). All are **pre-existing** patterns unrelated to this change; they only appear because the file is in the diff. `bun run lint` (the CI gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)