### PR TITLE
docs(readme): rewrite the GitHub front page in a human voice with deeper feature detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@
 
 **Own your site. Love building it.**
 
-The self-hosted visual CMS with a canvas editor that feels like a design tool,
-a real content engine underneath, and published pages so clean you'll want to view source.
+A self-hosted CMS where the visual editor, content engine, and publisher all live in one Bun server — and the pages it ships are clean enough to read in view-source.
 
 [![Release](https://img.shields.io/github/v/release/corebunch/instatic?color=black&labelColor=black)](https://github.com/corebunch/instatic/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-black?labelColor=black&color=blue)](LICENSE)
 [![Runtime: Bun](https://img.shields.io/badge/runtime-Bun-black?labelColor=black&color=f9f1e1)](https://bun.sh)
 [![TypeScript](https://img.shields.io/badge/TypeScript-everywhere-black?labelColor=black&color=3178c6)](https://www.typescriptlang.org/)
 
-[One-Click Deploy](#deploy-in-one-click) · [Quick Start](#quick-start) · [Docs](docs/README.md) · [Plugins](docs/features/plugin-system.md) · [Roadmap](#this-is-the-inception)
+[One-Click Deploy](#deploy-in-one-click) · [Quick Start](#quick-start) · [Docs](docs/README.md) · [Plugins](docs/features/plugin-system.md) · [Roadmap](#early-on-purpose)
 
 <br>
 
@@ -22,24 +21,17 @@ a real content engine underneath, and published pages so clean you'll want to vi
 
 <br>
 
-> WordPress gives you ownership wrapped in 2003.
-> Webflow and Framer give you 2026 — as long as you keep paying rent.
->
-> **Instatic is what happens when you refuse to choose.**
+A modern website usually means assembling a stack: a headless CMS, a framework, a host, a form service, an analytics vendor, an image CDN — each with its own bill, dashboard, and 2 a.m. outage. Instatic is the opposite bet. One Bun server holds the whole thing — the canvas editor, the content engine, media, auth, forms, plugins, and the publisher — and you run it wherever you like, backed by SQLite or Postgres.
 
-For twenty years the deal has been the same. Want to own your site? Enjoy plugin roulette, theme archaeology, and page builders that publish markup soup. Want a modern visual editor? Hand your site to someone else's cloud, behind someone else's subscription, exporting someone else's idea of your content — forever.
+What comes out the other end is the part most builders quietly compromise on: plain semantic HTML and compact CSS, with none of the editor's machinery left behind in the page. No framework runtime, no builder attributes, no div soup. The site loads like a static file because, most of the time, it is one.
 
-We think that deal is expired.
-
-Instatic is a canvas editor that feels like Figma, a content engine that works like a real CMS, and a publisher that ships plain, semantic HTML with hand-clean CSS — the kind of output a senior developer would write by hand. No framework runtime injected into your pages. No builder watermark in your markup. All of it on one Bun server, on hardware you choose, under a license that never asks for your credit card.
-
-**MIT licensed. Self-hosted. Yours.**
+**MIT. Self-hosted. Yours.**
 
 <br>
 
 ## Deploy in one click
 
-The fastest way to a running Instatic is Railway. One click, ~2 minutes, no terminal — secret keys generated, volumes attached, health checks configured. Truly one click, not "one click and then forty minutes of environment variables."
+Railway is the fastest way to get Instatic live. Pick a template, hit the button, wait about two minutes. That's it. It generates the secret keys, attaches the storage volume, and sets up the health checks on its own. You never open a terminal.
 
 <div align="center">
 
@@ -47,74 +39,82 @@ The fastest way to a running Instatic is Railway. One click, ~2 minutes, no term
 
 *One minute to live. Unedited.*
 
-<br><br>
-
-[![Deploy on Railway — SQLite](https://railway.com/button.svg)](https://railway.com/deploy/instatic-cms-sqlite?referralCode=Zm9bVJ&utm_medium=integration&utm_source=template&utm_campaign=generic)
-
-**SQLite** — one service, one volume. The right default for a single site, a blog, a portfolio, a small business.
-
-[![Deploy on Railway — Postgres](https://railway.com/button.svg)](https://railway.com/deploy/instatic-cms-postgres?referralCode=Zm9bVJ&utm_medium=integration&utm_source=template&utm_campaign=generic)
-
-**Postgres** — for multi-author editorial teams, managed database backups, and room to scale out.
-
 </div>
 
-Prefer your own metal? Instatic ships as a single Docker image:
+<br>
+
+| Provider | Database | Best for | Deploy |
+|---|---|---|---|
+| **Railway** · *Recommended* | SQLite | A single site — blog, portfolio, small business | [Deploy →](https://railway.com/deploy/instatic-cms-sqlite?referralCode=Zm9bVJ&utm_medium=integration&utm_source=template&utm_campaign=generic) |
+| **Railway** | Postgres | Multiple authors, managed backups, room to grow | [Deploy →](https://railway.com/deploy/instatic-cms-postgres?referralCode=Zm9bVJ&utm_medium=integration&utm_source=template&utm_campaign=generic) |
+| **Render** | — | — | *Coming soon* |
+| **Fly.io** | — | — | *Coming soon* |
+| **DigitalOcean** | — | — | *Coming soon* |
+
+SQLite is the right default for most sites. Reach for Postgres when you've got a team of authors or want managed database backups.
+
+Prefer your own hardware? Instatic is a single Docker image:
 
 ```sh
 INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
-Full guides — VPS, Postgres, HTTPS via Caddy, Render, backups: [docs/deployment](docs/deployment/README.md).
+Full guides for VPS, Postgres, HTTPS with Caddy, Render, and backups are in [docs/deployment](docs/deployment/README.md).
 
 <br>
 
-## One tool, the whole cycle
+## One tool, the whole life of a site
 
-Most tools pick one verb and outsource the rest. Instatic was built to carry a website through its entire life — **design it, build it, manage it, understand it, extend it** — without ever leaving the tool or losing ownership.
+Most tools do one job and hand you off for the rest. You design in one place, build in another, keep content somewhere else, then bolt analytics on from a fourth. Instatic does all of it. Here's what's actually in the box.
 
 ### 🎨 Design
 
 <img src="docs/assets/readme/design-framework.webp" alt="Core Framework scales inside Instatic — a fluid spacing scale with mathematical ratios, edited live next to the canvas" width="100%">
 
-The editor is a real canvas, not a form pretending to be a website builder. Multiple breakpoint frames sit side by side — edit the desktop, watch the mobile react. Or flip to live mode and edit a single real-size page in place.
+The editor is a real canvas, not a form with a preview pane stapled to it. You put several breakpoint frames side by side and edit them together. Change the desktop and the mobile frame reacts in the same view. When you'd rather work on the real thing, flip to live mode and edit a single full-size page in place.
 
-And here's the part the incumbents can't copy: **[Core Framework](https://coreframework.com) is built in natively.** The design-token engine trusted by thousands of WordPress professionals lives inside Instatic — not as a plugin, as a core system:
+The part nobody else has: **[Core Framework](https://coreframework.com) is built in.** It's the design-token engine thousands of WordPress pros already use every day, and here it's a core system, not a plugin you install and pray over.
 
-- **Color tokens with generated shades** — define a brand color, get a full tuned shade scale.
-- **Typography scales** — fluid, mathematical type ramps instead of forty hand-picked font sizes.
-- **Spacing scales** — consistent rhythm across every page, every breakpoint.
-- **Utility class generators** — locked, generated classes emitted into one compact `framework.css`.
+- **Color tokens that generate their own shade scale.** Define one brand color, get the full set of tuned tints and shades automatically.
+- **Type scales that are fluid and mathematical.** One ramp that scales with the viewport, instead of forty hand-picked font sizes you have to keep in sync.
+- **Spacing scales** so every page and every breakpoint keeps the same rhythm.
+- **A utility-class generator** that emits locked, generated classes into one small `framework.css`. No bloat, no duplicate rules, nothing you didn't ask for.
 
-Your design system is data, not vibes.
+Your whole design system lives as data. Change one token and every page that uses it updates.
 
 ### 🧱 Build
 
 <img src="docs/assets/readme/build-components.webp" alt="Editing a Visual Component — a typed text param with a default value, bound to a node in the component's own tree" width="100%">
 
-- **Modules** — containers, text, images, buttons, video, lists, and more, composed by drag and drop.
-- **Visual Components** — reusable components with **typed parameters and slots**. Change the definition, every instance updates.
-- **Templates and loops** — shared headers and footers, post-type layouts, loops bound to content entries, media, or plugin data sources.
-- **CMS-native forms** — build forms visually from semantic primitives, submissions land in your own data tables. No third-party form SaaS.
-- **An AI agent in the editor** — describe what you want, it builds it on the canvas as real, editable nodes. Bring your own model: Claude, OpenAI, OpenRouter, or local Ollama.
-- **Imports that actually work** — paste raw HTML and get editable nodes. Drop an entire static site (HTML, CSS, images, fonts) and Super Import converts it into pages, style rules, and media — conflicts reviewed before commit.
+- **Modules** are the building blocks: containers, text, images, buttons, video, lists, links, SVG, forms. Drag them onto the canvas and nest them however you want.
+- **Visual Components** are reusable pieces with typed parameters and named slots. A parameter can be a string, number, boolean, color, image, URL, rich text, an enum, or a whole slot of content. Edit the component once and every instance on the site updates. Components that would reference themselves are blocked before they happen, so nothing eats its own tail.
+- **Templates** handle the shared chrome. One layout for the whole site, separate layouts per post type, and a real 404 page you design yourself. Content flows into an outlet, so a header and footer get written once and wrap everything.
+- **Loops** repeat a layout over a collection: your posts, your pages, your media, or anything a plugin exposes as a source. Give a loop a couple of variants and it alternates between them as it goes. Good for post lists, product grids, galleries.
+- **Forms that belong to your CMS.** Build a form out of semantic fields and the submissions land in your own data tables. Instatic can read the fields you placed and create the matching table for you. No third-party form service, no embed, no monthly fee for a contact form.
+- **An AI agent that actually edits the page.** Describe what you want and it builds it on the canvas as real, editable nodes, not a screenshot or a wall of code. It writes semantic HTML for structure and CSS for style, through the same import pipeline you use when you paste markup. 28 tools under the hood. Bring your own model: Claude, OpenAI, OpenRouter, or local Ollama. Your key, your model, your bill.
+- **Imports that hold up.** Paste raw HTML and get editable nodes. Or drop a whole static site — HTML, CSS, images, fonts — and Super Import turns it into pages, style rules, design tokens, and media. Every conflict is shown to you before anything is written, and the entire import is a single undo.
 
 ### 🗂 Manage
 
 <img src="docs/assets/readme/manage-media.webp" alt="The Media workspace — an OS-style file manager for every asset on the site" width="100%">
 
-- **Content workspace** — a focused writing surface for posts and collections, plus live mode so authors edit inside the real design of the site.
-- **Data workspace** — pages, posts, components, custom collections, and arbitrary structured tables all share **one universal content model**. Schemas, raw rows, imports, exports, form submissions.
-- **Media workspace** — an OS-style file manager: folders, smart folders, bulk operations, usage tracking, replacement workflows, pluggable storage adapters.
-- **Real access control** — roles, capabilities, sessions, TOTP MFA with encrypted secrets.
-- **⌘K everything** — Spotlight, a fuzzy command palette over the entire admin.
-- **Drafts stay drafts** — unpublished edits never leak to visitors.
+- **One content model under everything.** Pages, posts, components, custom collections, and any structured table you invent all live in the same store: `data_tables` and `data_rows`. There's no special-cased "pages" table hiding in a corner. Schemas, raw rows, imports, exports, and form submissions all sit in one consistent place.
+- **A Data workspace where you design your own collections.** At `/admin/data` you create custom post types and custom data tables with their own fields, then work the rows in a spreadsheet-style grid: search, sort, filter, bulk publish, bulk export. Custom post types come with a real editorial workflow — draft, scheduled, published — and version history on the published copy. Plain data tables are simple grids you can point at anything: the submissions from a form, a product catalog, a lightweight CRM, a list of testimonials. And every table you build is a content source a loop can render. Define a "Team" table once, loop it onto your about page, done.
+- **A content workspace for writing.** A focused surface for posts and collections, plus live mode so authors edit inside the real design of the site instead of a gray textarea.
+- **A media workspace that works like a file manager.** Folders and smart folders, bulk operations, usage tracking so you know where a file is actually used, replacement workflows, and pluggable storage adapters when you outgrow local disk.
+- **Access control that's real, not decorative.** Roles built from 36 capabilities, token-based sessions, TOTP two-factor with secrets encrypted at rest, account lockout with backoff after repeated failures, and step-up prompts before the dangerous stuff like deleting a user or signing out every device.
+- **⌘K for everything.** A fuzzy command palette over the whole admin. Jump anywhere, do anything, without touching the mouse.
+- **Drafts stay drafts.** Unpublished edits never leak to a visitor. What you didn't publish, they don't see.
 
 ### 📊 Analyze
 
 <img src="docs/assets/readme/analyze-dashboard.webp" alt="The Instatic dashboard — site stats, activity feed, and status widgets on a customizable grid" width="100%">
 
-A customizable dashboard with a widget registry, a full **audit log** of every meaningful admin action, and form submissions stored in your own tables — queryable, exportable, yours. This is the youngest pillar of the cycle and the one we're most actively growing — see the [roadmap](#this-is-the-inception).
+- **A dashboard you arrange yourself.** A 12-column grid of tile widgets you can drag, resize, and rearrange. Add the ones you care about in customize mode, and the layout saves per user. Plugins can ship their own widgets into the same grid.
+- **An audit log that doesn't forget.** Every meaningful admin action writes a row: logins, content changes, role edits, plugin lifecycle. It's append-only, so it's a real record of who did what and when, not something anyone can quietly rewrite.
+- **Form data that's yours.** Submissions sit in your own tables. Query them, export them, build on them. No vendor in the middle.
+
+This is the youngest pillar, and the one we're pushing hardest right now. First-party, privacy-respecting analytics are next. See the [roadmap](#early-on-purpose).
 
 ### 🔌 Extend
 
@@ -122,39 +122,44 @@ A customizable dashboard with a widget registry, a full **audit log** of every m
 <img src="docs/assets/readme/extend-plugins.webp" alt="The plugin system — sandboxed, permissioned, first-class" width="100%">
 -->
 
-Every CMS says it has plugins. Ours come with a containment policy.
+Every CMS has plugins. The difference here is where they run.
 
-Instatic plugins ship as zip packages with a manifest and run inside a **QuickJS-WASM sandbox** — no file system, no environment variables, no network unless the site owner explicitly grants it, host by host. **Plugins are guests, not roommates.** The twenty years of "a plugin took down my site and emailed my database to a stranger" stops here.
+An Instatic plugin is a zip package with a manifest, and it runs inside a **QuickJS-WASM sandbox**. No filesystem. No environment variables. No network at all, unless the site owner grants it, one host at a time. A plugin can't read your secrets or phone home, because the sandbox never hands it the door. The classic "a plugin took down my site and emailed the database to a stranger" story doesn't run here.
 
-Inside that sandbox, the SDK is genuinely powerful: routes, storage, lifecycle hooks, loop data sources, scheduled jobs, canvas modules, admin pages, media storage adapters, frontend assets.
+Inside that sandbox the SDK is genuinely capable. A plugin can add:
+
+- HTTP routes and its own admin pages
+- Storage and scheduled background jobs
+- Loop data sources, so your content loops can pull from anywhere
+- Canvas modules — new blocks that show up in the editor
+- Media storage adapters and frontend assets
+- Lifecycle hooks across install, activation, and beyond
 
 Start with the [plugin system docs](docs/features/plugin-system.md) and the [template plugin](examples/plugins/template/README.md).
 
 <br>
 
-## View source. That's the pitch.
+## Fast because there's almost nothing to load
 
 <!-- TODO shot — clean-output.webp: devtools view-source of a published page next to the rendered page.
 <img src="docs/assets/readme/clean-output.webp" alt="A published Instatic page and its source — semantic HTML, compact CSS" width="100%">
 -->
 
-Open any page published by a typical page builder and look at the source. We'll wait.
+A published Instatic page is mostly just a file sitting on disk. No framework to boot, no hydration step, no database round-trip on the common path. The browser pulls down semantic HTML and a compact stylesheet, and it's done. There's barely anything between the visitor and the content, so the pages feel instant.
 
-Instatic publishes **semantic HTML and compact CSS** — no React in your public pages, no editor runtime, no div-soup wrappers, no `data-builder-id` confetti. The admin app and everything that built the page stay out of the page.
+That speed isn't a setting you tune. It falls out of how publishing works, in three layers you never have to think about:
 
-Under the hood it's a three-layer pipeline:
+- **Static pages are baked straight to disk when you publish** and swapped in atomically. Visitors are served a file, not a render.
+- **Routes that genuinely change** hit an in-memory cache that's wiped wholesale on every publish, so nobody ever sees a stale page.
+- **The few truly per-visitor parts** are detected automatically and lazy-loaded by a runtime that weighs about 0.7 kB. Smaller than this paragraph.
 
-- **Static pages are baked to disk at publish time** and swapped atomically — visitors are served files, not renders.
-- **Dynamic routes** hit an in-memory render cache that's invalidated wholesale on every publish.
-- **Request-dependent fragments** are auto-detected and lazy-loaded by a runtime that weighs **~0.7 kB** — smaller than this paragraph's HTML.
-
-The result: websites that load like static files, because mostly they are — and never feel trapped inside the tool that made them. Full design: [the publisher](docs/features/publisher.md).
+What comes out the other end is plain HTML and compact CSS, all the way down. Nothing from the editor rides along: no React on your public pages, no editor runtime, no framework in the markup. And because it's just HTML and CSS, nothing holds your site hostage — you can read it, host it anywhere, or take it and leave. Full design: [the publisher](docs/features/publisher.md).
 
 <br>
 
 ## Quick start
 
-You need [Bun](https://bun.sh). That's it — the default dev setup is SQLite, zero external services.
+You need [Bun](https://bun.sh). Nothing else. The default dev setup runs on SQLite, so there are no extra services to stand up.
 
 ```sh
 git clone https://github.com/corebunch/instatic.git
@@ -163,56 +168,56 @@ bun install
 bun run dev
 ```
 
-Open `http://localhost:5173` — the first visit creates your site and owner account.
+Open `http://localhost:5173`. The first visit walks you through creating your site and your owner account.
 
-To run production mode locally (built admin served by the Bun server): `bun run start`, then `http://localhost:3001/admin`.
+Want to see it the way it actually ships? `bun run start` builds the admin and serves it from the Bun server at `http://localhost:3001/admin`.
 
-> **Backups, in one sentence:** back up the database (Postgres dump or the SQLite file) *and* the uploads volume — [details](docs/deployment/backup-restore.md).
-
-<br>
-
-## From the team behind Motion.page & Core Framework
-
-Instatic isn't our first rodeo. We're the team behind **[Motion.page](https://motion.page)** and **[Core Framework](https://coreframework.com)** — tools used by thousands of professionals who build websites for a living, mostly inside the WordPress ecosystem.
-
-We spent years making other platforms more bearable. Eventually the question became unavoidable: *what if the platform itself was just… right?* No legacy to route around, no markup we're not allowed to clean, no business model that requires holding your site hostage.
-
-So we built it. And we brought Core Framework with us — natively integrated, so the color shades, typography scales, spacing systems, and utility generators our users love are a core part of Instatic, not an add-on you install and pray over.
+> **Backups, in one sentence:** back up the database (a Postgres dump or the SQLite file) and the uploads folder, and you've backed up the whole site — [details](docs/deployment/backup-restore.md).
 
 <br>
 
-## This is the inception
+## Who's behind this
 
-Here's the uncomfortable fact for everyone else: **this is version 0.0.x.**
+We're the team behind **[Motion.page](https://motion.page)** and **[Core Framework](https://coreframework.com)** — tools that thousands of people use to build websites for a living, mostly in the WordPress world.
 
-The visual canvas, the Core Framework integration, the universal content model, the sandboxed plugin runtime, the AI agent, forms, loops, templates, media management, MFA, audit logging, one-click deploys, the clean-output publisher — all of that is the *starting point*. Where we're heading:
+We spent years making other platforms more bearable. At some point the obvious question wouldn't go away: what if the thing underneath was just right to begin with? No legacy to work around, no markup we're not allowed to touch, no business model that depends on keeping your site where we can see it.
 
-- **Deeper analytics** — first-party, privacy-respecting insight into your site, completing the analyze pillar.
-- **A growing module and plugin ecosystem** — more first-party blocks, more SDK surface, more examples.
-- **A more capable AI agent** — broader tools, deeper site awareness.
-- **Sharper everything** — we're pre-1.0 on purpose: young enough to keep the architecture clean, remove bad ideas, and build the CMS we actually want to use.
+So we built Instatic. And we brought Core Framework along, wired in as a core system, so the color shades, type scales, spacing, and utility classes our users already rely on are part of the product — not an add-on you install and hope for the best.
 
-APIs and workflows may still change before a stable 1.0. If you're allergic to motion, wait for 1.0. If you want to shape what the next twenty years of website ownership looks like — you're early, and early is the best seat.
+<br>
+
+## Early, on purpose
+
+Here's the honest part: this is version 0.0.x.
+
+Everything above — the canvas, Core Framework, the universal content model, the sandboxed plugins, the AI agent, forms, loops, templates, media, MFA, the audit log, one-click deploy, the clean publisher — is the starting line, not the finish. What's coming:
+
+- **Real analytics.** First-party and privacy-respecting, to round out the Analyze pillar.
+- **A bigger module and plugin ecosystem.** More first-party blocks, more SDK surface, more examples to copy from.
+- **A sharper AI agent.** More tools, deeper awareness of your actual site.
+- **Everything tighter.** We're pre-1.0 on purpose. It's the cheapest time to throw out bad ideas and keep the architecture clean.
+
+APIs and workflows can still shift before 1.0. If that makes you nervous, wait for 1.0 — no hard feelings. If you'd rather help shape what site ownership looks like for the next twenty years, now's the good seat.
 
 <br>
 
 ## For developers
 
-One Bun server. A Vite-built React admin. A publisher that emits pages you'd be proud to write by hand.
+One Bun server. A React admin built with Vite. A publisher that emits pages you'd be happy to have written yourself.
 
 | | |
 |---|---|
-| **Runtime** | Bun — server and tooling |
+| **Runtime** | Bun, for both server and tooling |
 | **Language** | TypeScript everywhere |
-| **Admin app** | React 19 (React Compiler enabled), Vite, Zustand + Mutative, CodeMirror, dnd-kit |
+| **Admin app** | React 19 (React Compiler on), Vite, Zustand + Mutative, CodeMirror, dnd-kit |
 | **Server** | `Bun.serve` with a hand-written router |
-| **Database** | SQLite or Postgres — one `DbClient` interface, selected by `DATABASE_URL` |
-| **Validation** | TypeBox at every untyped boundary — schemas are the source of truth |
+| **Database** | SQLite or Postgres — one `DbClient` interface, picked by `DATABASE_URL` |
+| **Validation** | TypeBox at every untyped boundary; schemas are the source of truth |
 | **Plugins** | QuickJS-WASM sandbox, owner-granted permissions |
-| **AI** | Provider-agnostic drivers over raw HTTP/SSE — no provider SDKs |
-| **Output** | Semantic HTML, compact CSS, static artefacts + auto-detected dynamic holes |
+| **AI** | Provider-agnostic drivers over raw HTTP/SSE, no vendor SDKs |
+| **Output** | Semantic HTML, compact CSS, baked static files plus auto-detected dynamic holes |
 
-The codebase is opinionated and the opinions are enforced — architectural rules live in `src/__tests__/architecture/` as tests, so the clean structure stays clean.
+The codebase is opinionated, and the opinions are enforced in code. Architectural rules live in `src/__tests__/architecture/` as actual tests, so the structure that keeps the output clean can't quietly rot.
 
 ```sh
 bun run build   # tsc -b && vite build
@@ -220,14 +225,14 @@ bun test
 bun run lint
 ```
 
-Dive in: [docs index](docs/README.md) · [architecture](docs/architecture.md) · [editor](docs/editor.md) · [server](docs/server.md) · [publisher](docs/features/publisher.md) · [plugin system](docs/features/plugin-system.md)
+Dig in: [docs index](docs/README.md) · [architecture](docs/architecture.md) · [editor](docs/editor.md) · [server](docs/server.md) · [publisher](docs/features/publisher.md) · [plugin system](docs/features/plugin-system.md)
 
 <br>
 
 ## Thanks
 
-Instatic's interface uses [Pixelarticons](https://pixelarticons.com/) by Gerrit Halfmann. A special thanks to Gerrit for making such a distinctive icon set and for kindly allowing its use in this open-source project.
+Instatic's interface uses [Pixelarticons](https://pixelarticons.com/) by Gerrit Halfmann. Thanks to Gerrit for a genuinely distinctive icon set, and for kindly letting us use it in an open-source project.
 
 ## License
 
-MIT. See [LICENSE](LICENSE). No tiers, no "open core", no asterisks.
+MIT. See [LICENSE](LICENSE). No tiers, no open-core asterisks, no "contact sales."


### PR DESCRIPTION
## What changed

A full rewrite of `README.md`, the GitHub front page. The previous copy read as generic AI marketing prose; this replaces it with plainer, more human writing and goes deeper on what the product actually does.

Section by section:

- **Opening** — new anti-stack framing ("a modern site usually means assembling a stack…"). Drops the WordPress-vs-Webflow trope entirely.
- **Deploy in one click** — replaced the stacked deploy buttons with a **provider table**. Railway (SQLite + Postgres) is marked *Recommended*; **Render, Fly.io, DigitalOcean** are listed as *Coming soon* for the one-click templates planned next.
- **One tool, the whole life of a site** — the five pillars (Design / Build / Manage / Analyze / Extend) rewritten with roughly 2× the concrete detail: typed Visual Component params + slots, the 28-tool BYO-model AI agent, Super Import, 36-capability access control + TOTP MFA, the QuickJS-WASM plugin sandbox, and more.
- **Data workspace** — new dedicated bullet under Manage: custom post types and custom data tables, form-submission collection, lightweight CRM use, and tables as loop content sources.
- **Publisher** — reframed around *speed* and the three-layer pipeline (baked static → render cache → ~0.7 kB per-visitor holes). Removed the not-credible "builder attributes everywhere" claim.
- **Quick start / Who's behind this / For developers / Thanks / License** — same information, de-slopped voice.
- **Roadmap heading** renamed `This is the inception` → `Early, on purpose`; the two in-page anchors that point at it were updated to `#early-on-purpose`.

## Why

The README is the product's storefront. The old copy didn't sound human and undersold the breadth of features. This makes it read like a person wrote it and surfaces more of what Instatic can do.

## Impact

Docs only. No code, no behavior change. Image paths, badges, and layout wrappers are unchanged.

## Verification

Prose/markdown change only — reviewed rendered structure and confirmed internal anchors (`#deploy-in-one-click`, `#quick-start`, `#early-on-purpose`) resolve. No build/test impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)