### PR TITLE
fix(agent): create loops through HTML import

### DIFF
--- a/docs/features/agent.md
+++ b/docs/features/agent.md
@@ -10,7 +10,7 @@ The agent runs on a provider-agnostic AI runtime (`server/ai/`) that can drive a
 
 - **Structure via HTML.** `insertHtml` and `replaceNodeHtml` accept semantic HTML strings; the browser executor calls `importHtml` (the same pipeline as the paste-HTML UI) to convert them into first-class, editable `PageNode`s.
 - **Styling via CSS.** The agent emits CSS the same way a human pastes it: a `<style>` block and/or `class=` attributes inside the `insertHtml`/`replaceNodeHtml` payload, or the standalone `applyCss` tool. The importer (`cssToStyleRules`) classifies every selector — a bare `.foo {}` rule becomes a reusable Selectors-panel class bound to `class="foo"`; any other selector (`.hero a`, `a:hover`, `nav > li`) becomes an ambient rule; `style=` attributes land on the node's inline styles. There is no structured `classes` parameter — the agent never hand-builds classes node-by-node at insert time. `applyCss` is the single tool for authoring/editing CSS on its own; it **upserts**, so re-applying a selector edits the existing rule (the way descendant/pseudo rules get restyled).
-- **28 tools total.** 6 server-side read tools (resolved server-side from the posted snapshot) + 22 browser-bridged write tools.
+- **29 tools total.** 7 server-side read tools (resolved server-side from the posted snapshot / DB) + 22 browser-bridged write tools.
 - **Two-endpoint bridge.** `POST /admin/api/ai/chat/site` opens an NDJSON stream. When the model calls a write tool, the server emits `toolRequest`; the browser executor applies it to the editor store and POSTs the `AiToolOutput` result to `POST /admin/api/ai/tool-result`.
 - **Provider-agnostic.** The runtime selects a driver (Anthropic, OpenAI, OpenRouter, Ollama) from the conversation's configured credential.
 - **Tool input schemas are a single source of truth** in `@core/ai` (`src/core/ai/toolSchemas.ts`). The server tool registry (`server/ai/tools/site/writeTools.ts`) and the browser executor (`executor.ts` + `tokenRunners.ts`) import the exact same schema objects — a constraint added once is enforced on both sides at build time. Gated by `ai-tool-schema-ssot.test.ts` and `ai-tools-typebox-only.test.ts`.
@@ -49,7 +49,7 @@ server/ai/
 ├── tools/
 │   ├── site/
 │   │   ├── writeTools.ts      — 22 browser-bridged write tools (TypeBox schemas)
-│   │   ├── readTools.ts       — 6 server-side read tools
+│   │   ├── readTools.ts       — 7 server-side read tools
 │   │   ├── render.ts          — server-side page render (`renderAgentPage`) + catalog derivations (`describeAgentModules`, `describeAgentTokens`, `filterTokenFamily`)
 │   │   ├── systemPrompt.ts    — HTML-native static prefix + buildDynamicSuffix
 │   │   └── snapshot.ts        — `SiteAgentSnapshotSchema` + `SiteAgentSnapshot` re-export + catalog output types (ModuleInfo, SnapshotTokens, …)
@@ -281,9 +281,9 @@ Requires `ai.tools.write`. Calls `resolveBridgeToolResult(bridgeId, requestId, r
 
 ## Tools
 
-### Read tools — 6, server-side
+### Read tools — 7, server-side
 
-Resolved server-side from the posted `SiteAgentSnapshot` (or, for `list_post_types`, the data repositories via `ctx.db`). No browser round-trip. Results are returned directly to the model.
+Resolved server-side from the posted `SiteAgentSnapshot` or the data repositories via `ctx.db`. No browser round-trip. Results are returned directly to the model.
 
 | Tool              | What it returns                                                         |
 |-------------------|-------------------------------------------------------------------------|
@@ -292,6 +292,7 @@ Resolved server-side from the posted `SiteAgentSnapshot` (or, for `list_post_typ
 | `list_breakpoints`| Configured breakpoints + active id                                      |
 | `list_pages`      | All pages in the site (id, title, slug, active, isHomepage, and `template`: `null` or `{ target, priority }`) |
 | `list_post_types` | Routable collections eligible as a `postTypes` template target — `{ slug, label, routeBase, kind }` per entry, filtered to a non-empty `routeBase`. Queries the data repositories via `ctx.db` |
+| `list_loop_sources` | Loop source ids, source fields, order/filter options, and data-table field catalogs with valid `{currentEntry.field}` tokens. For post/custom table loops, use source id `data.rows`, the returned table `id` as `<instatic-loop data-table-id>`, and the returned tokens inside the loop body |
 | `list_tokens`     | Design tokens: colors (with shades/tints), typography/spacing scale steps, font tokens — each with CSS variable + utility classes; optional `family` filter (`colors`\|`typography`\|`spacing`\|`fonts`) |
 
 ### Write tools — 22, browser-bridged
@@ -302,7 +303,7 @@ All 22 tools carry `execution: 'browser'` in their `AiTool` definition. The serv
 
 | Tool              | Input                                  | Success `data`                        | What it does                                           |
 |-------------------|----------------------------------------|---------------------------------------|--------------------------------------------------------|
-| `insertHtml`      | `{ parentId, index?, html }`           | `{ nodeIds }` or `{ cssRulesCreated, cssRulesUpdated }` | Parse HTML (+ any `<style>` CSS) → import as `PageNode`s under `parentId`. A `<style>`-only payload (no elements) upserts CSS rules without inserting nodes (prefer `applyCss` for that) |
+| `insertHtml`      | `{ parentId, index?, html }`           | `{ nodeIds }` or `{ cssRulesCreated, cssRulesUpdated }` | Parse HTML (+ any `<style>` CSS) → import as `PageNode`s under `parentId`. Custom `<instatic-loop>` elements import as real Loop nodes; `<instatic-outlet>` imports as a template outlet. A `<style>`-only payload (no elements) upserts CSS rules without inserting nodes (prefer `applyCss` for that) |
 | `getNodeHtml`     | `{ nodeId }`                           | `{ html }`                            | Render subtree to HTML via the publisher's `renderNode`|
 | `replaceNodeHtml` | `{ nodeId, html }`                     | `{ nodeIds }` or `{ cssRulesCreated, cssRulesUpdated }` | Delete existing children; re-import HTML under the same parent. A `<style>`-only payload upserts CSS rules WITHOUT touching the children |
 
@@ -318,6 +319,21 @@ Styling rides on the `html` payload — there is no separate `classes` parameter
 **Authoring CSS with `applyCss`.** `applyCss({ css })` is the single tool for CSS that isn't attached to inserted structure. The agent passes real CSS text (e.g. `".hero a:hover { color: var(--primary) }"`); it runs through the same `cssToStyleRules` classifier and is **upserted** into the registry by `upsertCssRules`: a bare `.foo {}` selector creates or edits a reusable class, any other selector (`.hero a`, `a:hover`, `nav > li`, `::before`, `h1`) creates or edits an ambient rule, `@media` folds into per-breakpoint/condition overrides, and supported `@keyframes` become ambient raw CSS rules. Re-applying a selector **merges** onto the existing rule — so the same tool both creates new styles and restyles existing descendant/pseudo rules (the case the retired `updateClassStyles` could not express). Returns `{ cssRulesCreated, cssRulesUpdated }`. Framework-generated token/utility classes are never overwritten. `insertHtml`/`replaceNodeHtml` also accept a `<style>`-only payload and route it through the same upsert as a forgiving fallback, but `applyCss` is the canonical path.
 
 Note the deliberate split: `applyCss` and `<style>`-only payloads **upsert** (the agent's intent is to author/edit CSS), whereas a `<style>` block that accompanies *elements* in an insert is **additive** (`mergeImportedStyleRules` — it never clobbers a shared class as a side effect of dropping in structure).
+
+**Loops through HTML.** A repeated list is authored with the custom importer marker:
+
+```html
+<instatic-loop data-source-id="data.rows" data-table-id="<table id>" data-order-by="publishedAt" data-direction="desc" data-limit="3">
+  <article>
+    <a href="{currentEntry.permalink}">
+      <img src="{currentEntry.featuredMedia}">
+      <h3>{currentEntry.title}</h3>
+    </a>
+  </article>
+</instatic-loop>
+```
+
+The agent calls `list_loop_sources` first to get the valid source id, data table id, order options, and field tokens. The token grammar is single-brace `{currentEntry.field}`; aliases such as `{{post.title}}` are invalid and should never be generated.
 
 **Node edits**
 
@@ -433,7 +449,7 @@ The previous tool surface required the model to reference internal module ids (`
 
 The same importer that powers the Agent's `insertHtml` tool also powers the paste-HTML UI — see `docs/features/html-import.md`. No duplicated mapping logic.
 
-**Reads are HTML-native.** The `read_page` tool replaced the five JSON page-tree tools (`inspect_page`, `inspect_node`, `search_nodes`, `list_classes`, `inspect_class`). The `snapshot-tokens` benchmark compares that retired JSON surface with the live `read_page` tool result. `read_page` renders the active page via `publishPage(..., { annotateNodeIds: true })`, returning an annotated `<body>` where every element carries `uid="<nodeId>"`, plus page-relevant CSS rather than the public full-site CSS bundle. The response is cleaned and size-budgeted; if `pageInfo.nextPart` is set, subsequent `read_page({ part })` calls return the remaining cleaned ranges. The agent reads `uid` values from the HTML and passes them verbatim to write tools — no separate node-lookup round-trip. Catalog tools (`list_modules`, `list_tokens`, `list_pages`, `list_breakpoints`) describe things not visible in the page HTML (what is insertable, design token CSS vars, page list) and remain as JSON tools.
+**Reads are HTML-native.** The `read_page` tool replaced the five JSON page-tree tools (`inspect_page`, `inspect_node`, `search_nodes`, `list_classes`, `inspect_class`). The `snapshot-tokens` benchmark compares that retired JSON surface with the live `read_page` tool result. `read_page` renders the active page via `publishPage(..., { annotateNodeIds: true })`, returning an annotated `<body>` where every element carries `uid="<nodeId>"`, plus page-relevant CSS rather than the public full-site CSS bundle. The response is cleaned and size-budgeted; if `pageInfo.nextPart` is set, subsequent `read_page({ part })` calls return the remaining cleaned ranges. The agent reads `uid` values from the HTML and passes them verbatim to write tools — no separate node-lookup round-trip. Catalog tools (`list_modules`, `list_tokens`, `list_pages`, `list_post_types`, `list_loop_sources`, `list_breakpoints`) describe things not visible in the page HTML (what is insertable, design token CSS vars, page list, CMS route targets, and loop binding fields) and remain as JSON tools.
 
 ---
 
@@ -578,7 +594,7 @@ When `POST /admin/api/ai/credentials` creates a new credential, `seedEmptyDefaul
   - `src/core/ai/toolSchemas.ts` — all site write-tool input schemas (single source of truth; imported by both the server registry and the browser executor)
   - `src/core/ai/index.ts` — barrel re-exporting the above
   - `server/ai/tools/site/writeTools.ts` — 22 browser-bridged write tool definitions (uses `@core/ai` input schemas)
-  - `server/ai/tools/site/readTools.ts` — 6 server-side read tool definitions
+  - `server/ai/tools/site/readTools.ts` — 7 server-side read tool definitions
   - `server/ai/tools/site/render.ts` — `renderAgentPage`, `describeAgentModules`, `describeAgentTokens`, `filterTokenFamily`
   - `server/ai/tools/site/systemPrompt.ts` — HTML-native system prompt
   - `server/ai/tools/site/snapshot.ts` — `SiteAgentSnapshotSchema` + `SiteAgentSnapshot` re-export + catalog output types (`ModuleInfo`, `SnapshotTokens`, …)

--- a/docs/features/html-import.md
+++ b/docs/features/html-import.md
@@ -96,6 +96,7 @@ Callers splice the fragment into the page tree via `insertImportedNodes(parentId
 | Selector | Module | Props set | Recurse |
 |---|---|---|---|
 | `instatic-outlet` | `base.outlet` | none (the CMS content outlet) | **No** |
+| `instatic-loop` | `base.loop` | `sourceId`, `filters.tableId`, `orderBy`, `direction`, `limit`, `offset`, `pagination`, `pageSize`, optional `tag` / `customTag` from `data-*` attrs | Yes |
 | `h1`–`h6`, `p`, `span`, `small`, `strong`, `em` | `base.text` | `text` = `el.textContent`, `tag` = tag name | No |
 | `a` with class `btn` | `base.button` | `label` = `el.textContent`, `href`, `target` | No |
 | `a` (no `btn` class) | `base.link` | `text` = `el.textContent`, `href`, `target` | No |
@@ -116,6 +117,7 @@ Callers splice the fragment into the page tree via `insertImportedNodes(parentId
 **Key details:**
 
 - **`<instatic-outlet>` → `base.outlet`.** The custom element marks where matched content flows in a CMS template. It maps to a childless `base.outlet` node (any inner markup is ignored — the composer fills it). This rule lets the AI agent and hand-authored template HTML place the single content outlet inline via the normal import path. See [templates.md](templates.md) and [agent.md](agent.md).
+- **`<instatic-loop>` → `base.loop`.** The custom element lets the AI agent and hand-authored snippets create a real Loop through the same HTML import path. Children recurse normally and become loop variants. Loop configuration is read from attributes: `data-source-id`, `data-table-id` (stored as `filters.tableId`), `data-order-by`, `data-direction`, `data-limit`, `data-offset`, `data-pagination`, `data-page-size`, and optional `data-tag` / `data-custom-tag`. See [loops.md](loops.md) and [agent.md](agent.md).
 - `base.text` uses `tag` (not a separate `level` or heading prop) — the tag name is passed through directly. Imported bare DOM text uses `tag: 'none'`, which publishes text without an element wrapper.
 - **Direct text inside a recursing container is preserved.** The walker iterates `childNodes` (not just `children`): element children route through the rules, and each significant text node becomes a synthesized `base.text` child with `tag: 'none'` in document order. That no-wrapper text mode publishes back to bare text, so `<div class="num">98%</div>` and `<li>Buy milk</li>` import as containers holding their original text without adding selector-visible wrapper elements. Whitespace-only text (indentation between tags) is skipped; internal whitespace runs collapse to single spaces, and boundary spaces are kept when the text run sits between element siblings.
 - **`<body>` metadata is preserved separately.** Classes, safe HTML attributes (`id`, ARIA, `data-*`, etc.), and harvested inline styles on `<body>` are returned as `fragment.body` rather than inserted into `rootIds`. Full-site import applies them to `base.body`; paste-style HTML import can ignore them without changing the fragment structure.

--- a/docs/features/loops.md
+++ b/docs/features/loops.md
@@ -2,7 +2,7 @@
 
 The `base.loop` module — iterates a **loop entity source** and renders its child variants per item. Powers post listings, product grids, related-articles sections, media galleries, anything that displays a collection.
 
-Loop sources are pluggable: built-in sources (`content.entries`, `site.pages`, `site.media`) cover the universal store; plugins can register more via the SDK.
+Loop sources are pluggable: built-in sources (`data.rows`, `site.pages`, `site.media`) cover the universal store; plugins can register more via the SDK.
 
 ---
 
@@ -25,7 +25,7 @@ src/core/loops/
 ├── registry.ts              — LoopSourceRegistry singleton (`loopSourceRegistry`)
 └── sources/
     ├── index.ts             — register the three built-ins at boot
-    ├── dataRows.ts          — content.entries (any data_table)
+    ├── dataRows.ts          — data.rows (any data_table)
     ├── sitePages.ts         — site.pages (+ shared helpers re-exported via barrel)
     └── siteMedia.ts         — site.media
 
@@ -41,7 +41,7 @@ server/publish/loopPrefetch.ts    — server-side pre-fetch before render
 
 ```ts
 interface LoopEntitySource {
-  /** Namespaced id — 'content.entries', 'site.pages', 'site.media', 'acme.products' */
+  /** Namespaced id — 'data.rows', 'site.pages', 'site.media', 'acme.products' */
   id:           string
   label:        string
   description?: string
@@ -70,7 +70,7 @@ interface LoopEntitySource {
    * A `requestDependent` (non-perVisitor) hole is rendered at request time and
    * cached by Layer B per `(nodeId, query, publishVersion)`.
    *
-   * Built-in sources (`content.entries`, `site.pages`, `site.media`) are
+   * Built-in sources (`data.rows`, `site.pages`, `site.media`) are
    * publish-time-deterministic — leave this unset. Plugin sources that hit
    * live external APIs should set it.
    */
@@ -107,7 +107,7 @@ Sources are **stateless** — they receive everything they need via the `ctx` ar
 
 ## Built-in sources
 
-### `content.entries`
+### `data.rows`
 
 Iterates rows in any `data_table`. The user picks the table in the Properties panel; filters narrow by status, author, category-like fields, date.
 
@@ -286,16 +286,33 @@ Subscription granularity: the hook never subscribes to the whole `site` document
 
 ## Cookbook
 
-### Use the built-in `content.entries` source
+### Use the built-in `data.rows` source
 
 1. Insert a `base.loop` node into the page.
-2. In the Properties panel, set `sourceId = 'content.entries'`, pick the `data_table` (e.g. "Posts").
+2. In the Properties panel, set `sourceId = 'data.rows'`, pick the `data_table` (e.g. "Posts").
 3. Set filters (`status: published`, `category: 'tech'`).
 4. Set order (`publishedAt:desc`).
 5. Configure variants:
    - Drop a `base.container` as the loop's first child — this is variant A.
    - Add nodes inside: a heading bound to `currentEntry.title`, content bound to `currentEntry.body`, an image bound to `currentEntry.featuredMedia`.
 6. Publish. Each iteration renders the variant with the item's fields substituted.
+
+### Build a loop with the AI agent
+
+The site-scope AI agent stays on the HTML-native edit surface. It calls `list_loop_sources` to get valid source ids, table ids, order options, and `{currentEntry.field}` tokens, then inserts an `<instatic-loop>` marker through `insertHtml` / `replaceNodeHtml`:
+
+```html
+<instatic-loop data-source-id="data.rows" data-table-id="tbl_posts" data-order-by="publishedAt" data-direction="desc" data-limit="3">
+  <article>
+    <a href="{currentEntry.permalink}">
+      <img src="{currentEntry.featuredMedia}">
+      <h3>{currentEntry.title}</h3>
+    </a>
+  </article>
+</instatic-loop>
+```
+
+The HTML importer maps the marker to a real `base.loop` node, preserving classes and styles the same way it does for ordinary imported HTML. Token syntax is single-brace `{currentEntry.field}`; `{{post.title}}` and other alias-style tokens are not valid.
 
 ### Register a plugin loop source
 
@@ -402,7 +419,7 @@ For static multi-page navigation (no JS required):
 - [docs/architecture.md](../architecture.md) — universal `entryStack`
 - [docs/features/publisher.md](publisher.md) — `renderLoop` is one of two specialized renderers
 - [docs/features/templates.md](templates.md) — `currentEntry` resolves the same way for templates and loops
-- [docs/features/content-storage.md](content-storage.md) — `data_tables` + `data_rows` is the source for `content.entries`
+- [docs/features/content-storage.md](content-storage.md) — `data_tables` + `data_rows` is the source for `data.rows`
 - [docs/features/plugin-system.md](plugin-system.md) — plugin loop sources
 - Source-of-truth files:
   - `src/core/loops/index.ts` — public barrel (`pageToLoopItem`, `filterPagesForLoop`, types)

--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -161,7 +161,7 @@ See [docs/features/visual-components.md](visual-components.md) for the VC modeli
 
 When the walker hits a `base.loop` node, it calls `renderLoop`:
 
-1. Resolves the loop's entity source (a built-in source like `content.entries`, `site.pages`, `site.media`, or a plugin-registered source).
+1. Resolves the loop's entity source (a built-in source like `data.rows`, `site.pages`, `site.media`, or a plugin-registered source).
 2. Pulls items from the loop fetch result (pre-warmed by `loopPrefetch.ts` during publish).
 3. Walks the loop's child variants in round-robin. For each item it derives a fresh child `RenderConfig` whose `templateContext.entryStack` is a **new array** `[...baseStack, item]` — there is no in-place push/pop on a shared array, so child nodes' `dynamicBindings` resolve `currentEntry.<field>` against that item while a VC ref (or nested loop) in the body sees an immutable per-iteration snapshot. The outer config is never mutated, so the loop's siblings keep seeing the outer template entry.
 4. Concatenates the rendered variant HTML and returns it. If `pagination === 'infinite'`, the loop id is added to `acc.infiniteLoopIds` so `publishPage` knows to inject the loop runtime.

--- a/server/ai/tools/site/readTools.ts
+++ b/server/ai/tools/site/readTools.ts
@@ -3,14 +3,19 @@
  *
  * `read_page` is the primary surface: it renders the active page into the
  * published HTML the agent edits (annotated `<body>` + `<style>` bundle). The
- * remaining four tools are catalogs that describe things NOT present in the
- * page's own HTML (insertable modules, design tokens, sibling pages,
+ * other tools are catalogs that describe things NOT present in the page's own
+ * HTML (insertable modules, design tokens, sibling pages, loop sources,
  * breakpoints). Each tool casts `ctx.snapshot` to SiteAgentSnapshot at the top
  * of its handler — the runtime is scope-agnostic and hands tools an `unknown`
  * snapshot.
  */
 
 import { Type, type Static } from '@core/utils/typeboxHelpers'
+import '@core/loops/sources'
+import { buildDataMeta } from '@core/data/fields'
+import type { DataMetaField } from '@core/data/schemas'
+import { loopSourceRegistry } from '@core/loops/registry'
+import type { LoopSourceField } from '@core/loops/types'
 import type { AiTool } from '../types'
 import type { SiteAgentSnapshot } from './snapshot'
 import { listDataTablesWithCounts } from '../../../repositories/data'
@@ -167,6 +172,115 @@ const listPostTypesTool: AiTool = {
 }
 
 // ---------------------------------------------------------------------------
+// list_loop_sources
+// ---------------------------------------------------------------------------
+
+const ListLoopSourcesInput = Type.Object({})
+
+type AgentBindingFormat = NonNullable<LoopSourceField['format']>
+
+interface AgentBindingField {
+  id: string
+  label: string
+  token: string
+  format?: AgentBindingFormat
+  type?: DataMetaField['type']
+}
+
+function currentEntryToken(fieldId: string): string {
+  return `{currentEntry.${fieldId}}`
+}
+
+function loopFieldToAgentField(field: LoopSourceField): AgentBindingField {
+  return {
+    id: field.id,
+    label: field.label,
+    token: currentEntryToken(field.id),
+    ...(field.format ? { format: field.format } : {}),
+  }
+}
+
+function dataMetaFieldFormat(field: DataMetaField): AgentBindingFormat | undefined {
+  switch (field.type) {
+    case 'richText':
+      return 'html'
+    case 'url':
+      return 'url'
+    case 'media':
+      return 'media'
+    default:
+      return undefined
+  }
+}
+
+function dataMetaFieldToAgentField(field: DataMetaField): AgentBindingField {
+  const format = dataMetaFieldFormat(field)
+  return {
+    id: field.id,
+    label: field.label,
+    type: field.type,
+    token: currentEntryToken(field.id),
+    ...(format ? { format } : {}),
+  }
+}
+
+function mergeBindingFields(fields: AgentBindingField[]): AgentBindingField[] {
+  const byId = new Map<string, AgentBindingField>()
+  for (const field of fields) byId.set(field.id, field)
+  return Array.from(byId.values())
+}
+
+const listLoopSourcesTool: AiTool = {
+  name: 'list_loop_sources',
+  scope: 'site',
+  execution: 'server',
+  requiredCapabilities: ['site.read'],
+  description:
+    'List loop source ids and the valid dynamic data tokens for loop children. Use before creating a <instatic-loop>. For posts/custom tables use sourceId "data.rows" and pass the chosen table id as data-table-id; inside the loop use returned tokens like {currentEntry.title}, never {{post.title}}.',
+  inputSchema: ListLoopSourcesInput,
+  handler: async (_input, ctx) => {
+    const sources = loopSourceRegistry.list().map((source) => ({
+      id: source.id,
+      label: source.label,
+      description: source.description,
+      requestDependent: source.requestDependent === true,
+      perVisitor: source.perVisitor === true,
+      fields: source.fields.map(loopFieldToAgentField),
+      filterSchema: source.filterSchema,
+      orderByOptions: source.orderByOptions,
+    }))
+    const tables = await listDataTablesWithCounts(ctx.db)
+    const dataMeta = buildDataMeta(tables)
+    const dataRowsSource = loopSourceRegistry.get('data.rows')
+    const dataRowsFields = dataRowsSource?.fields.map(loopFieldToAgentField) ?? []
+    return {
+      usage: {
+        loopElement: '<instatic-loop data-source-id="data.rows" data-table-id="<table id>" data-order-by="publishedAt" data-direction="desc" data-limit="3">...</instatic-loop>',
+        tokenSyntax: '{currentEntry.field}',
+        invalidTokenSyntax: '{{post.field}}',
+      },
+      sources,
+      dataTables: dataMeta.tables.map((table) => ({
+        id: table.id,
+        slug: table.slug,
+        name: table.name,
+        kind: table.kind,
+        singularLabel: table.singularLabel,
+        pluralLabel: table.pluralLabel,
+        primaryFieldId: table.primaryFieldId,
+        routable: table.routable,
+        versioned: table.versioned,
+        rowCount: tables.find((t) => t.id === table.id)?.rowCount ?? 0,
+        fields: mergeBindingFields([
+          ...table.fields.map(dataMetaFieldToAgentField),
+          ...dataRowsFields,
+        ]),
+      })),
+    }
+  },
+}
+
+// ---------------------------------------------------------------------------
 // list_breakpoints
 // ---------------------------------------------------------------------------
 
@@ -199,5 +313,6 @@ export const siteReadTools: AiTool[] = [
   listTokensTool,
   listPagesTool,
   listPostTypesTool,
+  listLoopSourcesTool,
   listBreakpointsTool,
 ]

--- a/server/ai/tools/site/systemPrompt.ts
+++ b/server/ai/tools/site/systemPrompt.ts
@@ -42,6 +42,11 @@ Pages:
 - Page ids appear in the dynamic suffix's "Pages:" line. Pass those verbatim to duplicatePage / deletePage / renamePage. NEVER invent a page id.
 - addPage makes the new page active and returns \`pageId\` + \`rootNodeId\`. To build into it, pass \`rootNodeId\` (NOT the pageId) as insertHtml's parentId, then keep inserting. Don't call addPage twice for the same page — the slug is auto-uniqued, so a second call makes a second page.
 
+Loops (repeated CMS/data lists):
+- To create a real loop, call list_loop_sources first. Use the returned source ids, data table ids, orderBy options, and tokens.
+- In insertHtml/replaceNodeHtml, write \`<instatic-loop data-source-id="data.rows" data-table-id="<table id>" data-order-by="publishedAt" data-direction="desc" data-limit="3">...</instatic-loop>\`. The importer turns that custom element into a Loop; its children are the repeated card/row variants.
+- Inside a loop, use returned tokens exactly: \`{currentEntry.title}\`, \`{currentEntry.permalink}\`, \`{currentEntry.featuredMedia}\`. NEVER use \`{{post.title}}\`, \`{{post.url}}\`, or a made-up alias; invalid tokens render literally or empty.
+
 Templates (CMS layouts):
 - A template is a page that WRAPS other content. Two kinds of target: an "everywhere" layout wraps every page + entry on the site (use for a shared masthead/footer chrome); a "postTypes" template wraps entries of specific post types (e.g. each blog post). The dynamic suffix marks templates as [template:everywhere] or [template:slug,…] on the Pages line.
 - The wrapped content flows into a single \`<instatic-outlet>\` you place inside the template's HTML (via insertHtml) — put it where the page/entry body should appear, with the template's chrome (header/nav/footer) around it. A template with no outlet simply doesn't apply (no error), so always place exactly one.

--- a/server/ai/tools/site/writeTools.ts
+++ b/server/ai/tools/site/writeTools.ts
@@ -75,7 +75,7 @@ const insertHtmlTool: AiTool = {
   execution: 'browser',
   requiredCapabilities: SITE_STRUCTURE_CAPS,
   description:
-    'Insert semantic HTML as a subtree of editable nodes under an existing parent. Write structure as HTML (<section>, <h1>, <a>, <button>, <img>, <ul>, ...) and style it with CSS in the same call: put a <style> block in the HTML and/or class= attributes. The importer parses every rule — a bare `.foo {}` selector becomes a reusable Selectors-panel class bound to class="foo"; any other selector (`.hero a`, `a:hover`, `nav > li`) becomes an ambient rule. Inline style= attributes land on the node\'s inline styles. To author or edit CSS on its own — pseudo/hover/descendant selectors, or restyling existing rules — use the dedicated applyCss tool instead (insertHtml is for inserting structure).',
+    'Insert semantic HTML as a subtree of editable nodes under an existing parent. Write structure as HTML (<section>, <h1>, <a>, <button>, <img>, <ul>, ...) and style it with CSS in the same call: put a <style> block in the HTML and/or class= attributes. Custom importer markers: <instatic-loop data-source-id="…" ...> creates a real Loop node (call list_loop_sources first for source/table ids and {currentEntry.*} tokens); <instatic-outlet> creates a template content outlet. The importer parses every rule — a bare `.foo {}` selector becomes a reusable Selectors-panel class bound to class="foo"; any other selector (`.hero a`, `a:hover`, `nav > li`) becomes an ambient rule. Inline style= attributes land on the node\'s inline styles. To author or edit CSS on its own — pseudo/hover/descendant selectors, or restyling existing rules — use the dedicated applyCss tool instead (insertHtml is for inserting structure).',
   inputSchema: InsertHtmlInputSchema,
 }
 
@@ -94,7 +94,7 @@ const replaceNodeHtmlTool: AiTool = {
   execution: 'browser',
   requiredCapabilities: SITE_STRUCTURE_CAPS,
   description:
-    "Replace a node subtree's children with new HTML. The target node is preserved as the parent; its existing children are rebuilt from the HTML. Style with CSS exactly as in insertHtml: a <style> block and/or class= attributes; bare `.foo` selectors become reusable classes, other selectors become ambient rules. To author or edit CSS on its own (without rebuilding children), use the dedicated applyCss tool instead.",
+    "Replace a node subtree's children with new HTML. The target node is preserved as the parent; its existing children are rebuilt from the HTML. Style with CSS exactly as in insertHtml: a <style> block and/or class= attributes; bare `.foo` selectors become reusable classes, other selectors become ambient rules. Custom importer markers work here too: <instatic-loop data-source-id=\"…\" ...> creates a real Loop node and <instatic-outlet> creates a template content outlet. To author or edit CSS on its own (without rebuilding children), use the dedicated applyCss tool instead.",
   inputSchema: ReplaceNodeHtmlInputSchema,
 }
 

--- a/src/__tests__/agent/agentTools.test.ts
+++ b/src/__tests__/agent/agentTools.test.ts
@@ -45,6 +45,7 @@ describe('site read tools', () => {
   it('exposes exactly read_page + the catalog tools', () => {
     expect(siteReadTools.map((t) => t.name).sort()).toEqual([
       'list_breakpoints',
+      'list_loop_sources',
       'list_modules',
       'list_pages',
       'list_post_types',
@@ -58,6 +59,58 @@ describe('site read tools', () => {
     expect(tool.execution).toBe('server')
     expect(tool.mutates).toBeFalsy()
     expect(typeof tool.handler).toBe('function')
+  })
+
+  it('list_loop_sources exposes source ids, data table ids, and valid currentEntry tokens', async () => {
+    const tool = siteReadTools.find((t) => t.name === 'list_loop_sources')!
+    const ctx = {
+      snapshot: snapshot(),
+      db: async () => ({
+        rows: [
+          {
+            id: 'tbl_posts',
+            name: 'Posts',
+            slug: 'posts',
+            kind: 'postType',
+            route_base: '/posts',
+            singular_label: 'Post',
+            plural_label: 'Posts',
+            primary_field_id: 'title',
+            fields_json: [
+              { id: 'title', label: 'Title', type: 'text', required: true, builtIn: true },
+              { id: 'featuredMedia', label: 'Featured media', type: 'media', mediaKind: 'image', builtIn: true },
+              { id: 'readTime', label: 'Read time', type: 'text' },
+            ],
+            system: true,
+            created_by_user_id: null,
+            updated_by_user_id: null,
+            created_at: '2026-01-01T00:00:00.000Z',
+            updated_at: '2026-01-01T00:00:00.000Z',
+            row_count: 2,
+          },
+        ],
+      }),
+    } as unknown as ToolContext
+
+    const result = (await tool.handler!({}, ctx)) as {
+      sources: Array<{ id: string; fields: Array<{ id: string; token: string }> }>
+      dataTables: Array<{ id: string; slug: string; fields: Array<{ id: string; token: string }> }>
+    }
+
+    expect(result.sources.find((s) => s.id === 'data.rows')?.fields).toContainEqual(
+      expect.objectContaining({ id: 'permalink', token: '{currentEntry.permalink}' }),
+    )
+    expect(result.dataTables).toContainEqual(
+      expect.objectContaining({
+        id: 'tbl_posts',
+        slug: 'posts',
+        fields: expect.arrayContaining([
+          expect.objectContaining({ id: 'title', token: '{currentEntry.title}' }),
+          expect.objectContaining({ id: 'featuredMedia', token: '{currentEntry.featuredMedia}' }),
+          expect.objectContaining({ id: 'readTime', token: '{currentEntry.readTime}' }),
+        ]),
+      }),
+    )
   })
 
   it('read_page returns annotated HTML + a <style> css bundle with paging metadata', async () => {

--- a/src/__tests__/htmlImport/mapping.test.ts
+++ b/src/__tests__/htmlImport/mapping.test.ts
@@ -1270,6 +1270,47 @@ describe('base.outlet — <instatic-outlet>', () => {
 })
 
 // ---------------------------------------------------------------------------
+// base.loop — <instatic-loop> custom element
+// ---------------------------------------------------------------------------
+
+describe('base.loop — <instatic-loop>', () => {
+  it('maps <instatic-loop> to a configured base.loop node with child variants', () => {
+    const result = importHtml(`
+      <instatic-loop
+        class="cards"
+        data-source-id="data.rows"
+        data-table-id="tbl_posts"
+        data-order-by="publishedAt"
+        data-direction="desc"
+        data-limit="3"
+        data-offset="1"
+        data-pagination="infinite"
+        data-page-size="2"
+      >
+        <article><h2>{currentEntry.title}</h2></article>
+      </instatic-loop>
+    `)
+
+    expect(result.rootIds).toHaveLength(1)
+    const loop = result.nodes[result.rootIds[0]!]!
+    expect(loop.moduleId).toBe('base.loop')
+    expect(loop.classIds).toEqual(['cards'])
+    expect(loop.props).toEqual(expect.objectContaining({
+      sourceId: 'data.rows',
+      filters: { tableId: 'tbl_posts' },
+      orderBy: 'publishedAt',
+      direction: 'desc',
+      limit: 3,
+      offset: 1,
+      pagination: 'infinite',
+      pageSize: 2,
+    }))
+    expect(loop.children).toHaveLength(1)
+    expect(result.nodes[loop.children[0]!]!.moduleId).toBe('base.container')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // 13. Empty input and edge cases
 // ---------------------------------------------------------------------------
 

--- a/src/core/htmlImport/rules.ts
+++ b/src/core/htmlImport/rules.ts
@@ -88,6 +88,10 @@ function optionalFormIdentifier(el: Element): string {
   return normalizeIdentifierValue(attr(el, 'form'))
 }
 
+function integerAttr(el: Element, name: string, fallback: number, min: number): number {
+  return Math.max(min, Math.floor(numberAttr(el, name, fallback)))
+}
+
 function normalizeInputType(el: Element): typeof TEXT_INPUT_TYPES[number] {
   const type = normalizedAttr(el, 'type') || 'text'
   return TEXT_INPUT_TYPES.includes(type as typeof TEXT_INPUT_TYPES[number])
@@ -105,6 +109,23 @@ function submitLabel(el: Element): string {
   return label || 'Submit'
 }
 
+function mapLoopProps(el: Element): Record<string, unknown> {
+  const tableId = attr(el, 'data-table-id')
+  const customTag = attr(el, 'data-custom-tag')
+  const tag = attr(el, 'data-tag')
+  return {
+    sourceId: attr(el, 'data-source-id'),
+    filters: tableId ? { tableId } : {},
+    orderBy: attr(el, 'data-order-by'),
+    direction: normalizedAttr(el, 'data-direction') === 'asc' ? 'asc' : 'desc',
+    limit: integerAttr(el, 'data-limit', 10, 1),
+    offset: integerAttr(el, 'data-offset', 0, 0),
+    pagination: normalizedAttr(el, 'data-pagination') === 'infinite' ? 'infinite' : 'none',
+    pageSize: integerAttr(el, 'data-page-size', 10, 1),
+    ...(customTag ? { tag: 'custom', customTag } : tag ? { tag } : {}),
+  }
+}
+
 export const HTML_TO_MODULE_RULES: ImportRule[] = [
   // CMS content outlet → base.outlet (LEAF). The agent (and any hand-authored
   // template HTML) writes `<instatic-outlet>` to mark where matched content —
@@ -113,6 +134,16 @@ export const HTML_TO_MODULE_RULES: ImportRule[] = [
   {
     match: 'instatic-outlet',
     map: () => ({ moduleId: 'base.outlet', props: {} }),
+  },
+
+  // CMS loop → base.loop (RECURSE). The agent writes this custom element when
+  // it needs a real Loop module while staying in the HTML-native insert path.
+  // Children become loop variants; each iteration resolves `{currentEntry.*}`
+  // tokens against the selected source item.
+  {
+    match: 'instatic-loop',
+    map: (el) => ({ moduleId: 'base.loop', props: mapLoopProps(el) }),
+    recurse: true,
   },
 
   // Headings / paragraphs / inline phrasing → base.text (LEAF).

--- a/src/core/loops/registry.ts
+++ b/src/core/loops/registry.ts
@@ -1,7 +1,7 @@
 /**
  * LoopSourceRegistry — singleton holding registered LoopEntitySources.
  *
- * Built-in sources (content.entries, site.pages, site.media) self-register
+ * Built-in sources (data.rows, site.pages, site.media) self-register
  * on import via `src/core/loops/sources/index.ts`. Plugins register
  * additional sources through the plugin SDK.
  *
@@ -21,7 +21,7 @@ class LoopSourceRegistry implements ILoopSourceRegistry {
     if (!id || !id.includes('.')) {
       throw new Error(
         `[LoopSourceRegistry] Invalid source ID "${id}". ` +
-          `IDs must be namespaced: "namespace.source-name" (e.g. "content.entries").`,
+          `IDs must be namespaced: "namespace.source-name" (e.g. "data.rows").`,
       )
     }
   }

--- a/src/core/loops/types.ts
+++ b/src/core/loops/types.ts
@@ -14,7 +14,7 @@
  * featured media) happen in the source's `fetch()` so the resolver stays
  * a one-line lookup.
  *
- * IDs MUST be namespaced (e.g. `content.entries`, `site.pages`,
+ * IDs MUST be namespaced (e.g. `data.rows`, `site.pages`,
  * `acme.products`) so plugins can't shadow built-in sources. Enforced by
  * the registry and by the architecture test
  * `loop-source-id-format.test.ts`.
@@ -54,7 +54,7 @@ export interface LoopSourceField {
 /**
  * A single item produced by a `LoopEntitySource`. The `fields` map carries
  * resolved values — never IDs that need a second lookup. For example, a
- * `content.entries` LoopItem stores `featuredMediaPath` (the resolved
+ * `data.rows` LoopItem stores `featuredMediaPath` (the resolved
  * public URL) rather than just `featuredMediaId`.
  *
  * The shape is intentionally generic across source types so that the same
@@ -177,7 +177,7 @@ export interface LoopFetchResult {
  * (see `src/core/plugin-sdk`).
  */
 export interface LoopEntitySource {
-  /** Namespaced ID, e.g. `content.entries`, `site.pages`, `acme.products`. */
+  /** Namespaced ID, e.g. `data.rows`, `site.pages`, `acme.products`. */
   id: string
   /** Human label for the source picker. */
   label: string
@@ -191,7 +191,7 @@ export interface LoopEntitySource {
    * the Layer B render cache or a Layer C hole.
    *
    * Default (`false` / unset): the source is publish-time-deterministic.
-   * Built-in sources (`content.entries`, `site.pages`, `site.media`) all
+   * Built-in sources (`data.rows`, `site.pages`, `site.media`) all
    * leave this unset — they pull from the CMS database at publish time and
    * bake the result into the static HTML. Plugin sources that hit live
    * external APIs should set this to `true`.

--- a/src/modules/base/loop/index.ts
+++ b/src/modules/base/loop/index.ts
@@ -7,7 +7,7 @@
  * children cycle (1,2,3,1,2,3…). Empty list of children renders nothing.
  *
  * Data comes from a registered `LoopEntitySource` (see
- * `src/core/loops/types.ts`). Built-ins are content.entries, site.pages,
+ * `src/core/loops/types.ts`). Built-ins are data.rows, site.pages,
  * site.media. Plugins can register more.
  *
  * The publisher's `renderLoop()` interceptor handles rendering — this


### PR DESCRIPTION
## What changed

- Added a `list_loop_sources` site AI tool that exposes loop source ids, data table ids, ordering/filter metadata, and valid `{currentEntry.field}` binding tokens.
- Added `<instatic-loop>` support to the HTML importer so AI-authored HTML creates a real `base.loop` node instead of a plain container.
- Updated the site agent prompt/write-tool descriptions and docs to guide agents away from invalid `{{post.*}}` bindings.
- Added coverage for the new loop source catalog and importer mapping.

## Why

The site agent could previously guess loop bindings and source ids, but it had no read tool for the available dynamic data tokens. More importantly, the HTML import path had no loop marker, so attempts to create a loop through `replaceNodeHtml` imported as ordinary container markup.

## Impact

Agents can now create post/data loops through the existing HTML-native write surface using `<instatic-loop data-source-id="data.rows" data-table-id="...">`, and loop children can use returned `{currentEntry.*}` tokens reliably.

## Verification

- `bun install`
- `bun run build`
- `bun test`
- `bun run lint`