### PR TITLE
fix(content): route collection create/update/delete through step-up

### DIFF
--- a/src/__tests__/admin/data/contentCollectionStepUp.test.tsx
+++ b/src/__tests__/admin/data/contentCollectionStepUp.test.tsx
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import React, { type ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { MemoryRouter } from '@admin/lib/routing'
+import { AdminSessionProvider } from '@admin/session'
+import { StepUpProvider } from '@admin/shared/StepUp'
+import { ContentPage } from '@content/ContentPage'
+import { useEditorStore } from '@site/store/store'
+import { makeSite } from '../../fixtures'
+import { CORE_CAPABILITIES } from '@core/capabilities'
+import type { CmsCurrentUser } from '@core/persistence'
+
+const originalFetch = globalThis.fetch
+const now = '2026-06-10T10:00:00.000Z'
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+function adminUser(): CmsCurrentUser {
+  return {
+    id: 'content-admin',
+    email: 'admin@example.com',
+    displayName: 'Admin',
+    status: 'active',
+    role: {
+      id: 'owner',
+      slug: 'owner',
+      name: 'Owner',
+      description: '',
+      isSystem: true,
+      capabilities: [...CORE_CAPABILITIES],
+    },
+    capabilities: [...CORE_CAPABILITIES],
+    lastLoginAt: null,
+    failedLoginCount: 0,
+    lockedUntil: null,
+    passwordUpdatedAt: null,
+    mfaEnabled: false,
+    mfaEnabledAt: null,
+    mfaRecoveryCodesRemaining: 0,
+    stepUpAuthMode: 'required',
+    stepUpWindowMinutes: 15,
+    avatarMediaId: null,
+    avatarUrl: null,
+    gravatarHash: '',
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function postsTable() {
+  return {
+    id: 'posts',
+    name: 'Posts',
+    slug: 'posts',
+    kind: 'postType',
+    routeBase: '/posts',
+    singularLabel: 'Post',
+    pluralLabel: 'Posts',
+    primaryFieldId: 'title',
+    fields: [
+      { type: 'text', id: 'title', label: 'Title', required: true, builtIn: true },
+      { type: 'text', id: 'slug', label: 'Slug', required: true, builtIn: true },
+    ],
+    system: true,
+    rowCount: 0,
+    createdByUserId: null,
+    updatedByUserId: null,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function Providers({ children }: { children: ReactNode }) {
+  return (
+    <MemoryRouter initialEntries={['/admin/content']}>
+      <AdminSessionProvider user={adminUser()}>
+        <StepUpProvider>{children}</StepUpProvider>
+      </AdminSessionProvider>
+    </MemoryRouter>
+  )
+}
+
+function setupEditorShell(): void {
+  const site = makeSite({ name: 'Content Shell Site' })
+  useEditorStore.setState({
+    site,
+    activePageId: site.pages[0].id,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    activeBreakpointId: 'desktop',
+    propertiesPanel: { collapsed: false, x: 0, y: 0, width: 360 },
+    leftSidebarWidth: 320,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+describe('Content collection step-up flow', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    window.history.replaceState({}, '', '/')
+    setupEditorShell()
+  })
+
+  afterEach(() => {
+    cleanup()
+    globalThis.fetch = originalFetch
+  })
+
+  it('opens the shared step-up dialog and retries when creating a collection requires step-up', async () => {
+    let createAttempts = 0
+    const stepUpRequests: Array<Record<string, unknown>> = []
+
+    globalThis.fetch = mock(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+
+      if (url === '/admin/api/cms/data/tables' && init?.method !== 'POST') {
+        return json({ tables: [postsTable()] })
+      }
+
+      if (url === '/admin/api/cms/data/authors' && init?.method === 'GET') {
+        return json({ authors: [] })
+      }
+
+      // Initial selected collection rows + any newly-created collection rows.
+      if (url.includes('/admin/api/cms/data/tables/') && url.endsWith('/rows') && init?.method === 'GET') {
+        return json({ rows: [] })
+      }
+
+      if (url === '/admin/api/cms/data/tables' && init?.method === 'POST') {
+        createAttempts += 1
+        if (createAttempts === 1) return json({ error: 'step_up_required' }, 401)
+        return json({
+          table: {
+            id: 'products',
+            name: 'Products',
+            slug: 'products',
+            kind: 'postType',
+            routeBase: '/products',
+            singularLabel: 'Product',
+            pluralLabel: 'Products',
+            primaryFieldId: 'title',
+            fields: [
+              { type: 'text', id: 'title', label: 'Title', required: true, builtIn: true },
+              { type: 'text', id: 'slug', label: 'Slug', required: true, builtIn: true },
+            ],
+            system: false,
+            rowCount: 0,
+            createdByUserId: 'content-admin',
+            updatedByUserId: 'content-admin',
+            createdAt: now,
+            updatedAt: now,
+          },
+        }, 201)
+      }
+
+      if (url === '/admin/api/cms/auth/step-up' && init?.method === 'POST') {
+        stepUpRequests.push(JSON.parse(String(init.body)) as Record<string, unknown>)
+        return json({ ok: true, stepUpExpiresAt: '2026-06-10T10:15:00.000Z' })
+      }
+
+      if (url.endsWith('/admin/api/cms/plugins')) return json({ plugins: [], adminPages: [] })
+      if (url.endsWith('/admin/api/cms/site')) return json({ site: null }, 404)
+      if (url.endsWith('/admin/api/cms/publish/status')) return json({ ok: false }, 404)
+      if (url.endsWith('/admin/api/cms/media/folders')) return json({ folders: [] })
+
+      return json({ error: `Unhandled ${url}` }, 500)
+    }) as typeof fetch
+
+    render(
+      <Providers>
+        <ContentPage />
+      </Providers>,
+    )
+
+    fireEvent.click(await screen.findByRole('button', { name: 'New collection' }))
+    const dialog = await screen.findByRole('dialog', { name: 'New collection' })
+    fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'Products' } })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Create' }))
+
+    // The raw error code must never reach the UI — the step-up dialog opens instead.
+    expect(await screen.findByTestId('step-up-dialog')).toBeTruthy()
+    expect(screen.queryByText('step_up_required')).toBeNull()
+
+    fireEvent.change(screen.getByTestId('step-up-password'), {
+      target: { value: 'long-enough-password' },
+    })
+    fireEvent.click(screen.getByTestId('step-up-confirm'))
+
+    await waitFor(() => {
+      expect(createAttempts).toBe(2)
+    })
+    expect(stepUpRequests).toEqual([{ password: 'long-enough-password' }])
+    expect(screen.queryByTestId('step-up-dialog')).toBeNull()
+    expect(screen.queryByRole('dialog', { name: 'New collection' })).toBeNull()
+  })
+})

--- a/src/admin/pages/content/ContentPage.tsx
+++ b/src/admin/pages/content/ContentPage.tsx
@@ -45,6 +45,8 @@ import { useContentMediaPicker } from './hooks/useContentMediaPicker'
 import { useContentWorkspace } from './hooks/useContentWorkspace'
 import { publicContentPath } from './utils/contentEntryUtils'
 import { useAuthenticatedAdminUser } from '@admin/sessionContext'
+import { StepUpCancelledMessage, useStepUp } from '@admin/shared/StepUp'
+import { getErrorMessage } from '@core/utils/errorMessage'
 import { ContentAgentMount } from './agent/ContentAgentMount'
 import {
   canCreateContent,
@@ -114,6 +116,12 @@ export function ContentPage() {
   const canCreateEntries = canCreateContent(permissionUser)
   const canManageCollections = canManageContentCollections(permissionUser)
   const workspace = useContentWorkspace({ loadAuthors: canReassignAuthor })
+  // Collection schema mutations (create/update/delete) are step-up gated on
+  // the server — they change the public route surface — so they must run
+  // through `runStepUp`, which transparently opens the password re-entry
+  // dialog on a `step_up_required` response and retries. Without this the
+  // raw `step_up_required` error leaks into the dialog as visible text.
+  const { runStepUp } = useStepUp()
   const draft = useContentEntryDraft({
     selectedEntry: workspace.selectedEntry,
     updateSelectedEntry: workspace.updateSelectedEntry,
@@ -206,30 +214,39 @@ export function ContentPage() {
     })
   }
 
-  function handleUpdateCollection(
+  // Collection update/delete are step-up gated, so they bypass `withEntryOp`
+  // (whose generic catch would surface a step-up *cancellation* as a visible
+  // error). Instead they run through `runStepUp` directly and let the calling
+  // settings dialog render real errors; a cancellation is a silent no-op.
+  async function handleUpdateCollection(
     collection: DataTable,
     input: UpdateDataTableInput,
   ) {
-    return withEntryOp(() => workspace.updateCollection(collection.id, input), {
-      permitted: canManageCollections,
-      permMsg: 'Your role cannot manage content collections',
-      fallback: 'Could not update collection',
-      rethrow: true,
-    })
+    if (!canManageCollections) {
+      workspace.setError('Your role cannot manage content collections')
+      return
+    }
+    workspace.setError(null)
+    // Rejections propagate to the settings dialog, which keeps itself open and
+    // renders the message (and swallows `step_up_cancelled`).
+    await runStepUp(() => workspace.updateCollection(collection.id, input))
   }
 
-  function handleDeleteCollection(collection: DataTable) {
-    return withEntryOp(() => workspace.deleteCollection(collection.id), {
-      permitted: canManageCollections,
-      permMsg: 'Your role cannot manage content collections',
-      fallback: 'Could not delete collection',
-      rethrow: true,
-      apply: () => {
-        if (workspace.selectedCollectionId === collection.id) {
-          draft.applySelectedEntry(null)
-        }
-      },
-    })
+  async function handleDeleteCollection(collection: DataTable) {
+    if (!canManageCollections) {
+      workspace.setError('Your role cannot manage content collections')
+      return
+    }
+    workspace.setError(null)
+    try {
+      await runStepUp(() => workspace.deleteCollection(collection.id))
+      if (workspace.selectedCollectionId === collection.id) {
+        draft.applySelectedEntry(null)
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message === StepUpCancelledMessage) return
+      workspace.setError(getErrorMessage(err, 'Could not delete collection'))
+    }
   }
 
   function handleRenameEntry(
@@ -580,7 +597,9 @@ export function ContentPage() {
               setCollectionDialogOpen(false)
               return
             }
-            await workspace.createCollection(input)
+            // On a step-up cancellation `runStepUp` rejects before this line,
+            // so the dialog stays open (it swallows `step_up_cancelled`).
+            await runStepUp(() => workspace.createCollection(input))
             setCollectionDialogOpen(false)
           }}
         />

--- a/src/admin/pages/content/components/ContentCollectionCreateDialog/ContentCollectionCreateDialog.tsx
+++ b/src/admin/pages/content/components/ContentCollectionCreateDialog/ContentCollectionCreateDialog.tsx
@@ -15,6 +15,7 @@ import dialogStyles from '../../../../shared/dialogs/SiteCreateDialog/SiteCreate
 import styles from '../../ContentPage.module.css'
 import { slugFromTitle } from '@core/utils/slug'
 import { getErrorMessage } from '@core/utils/errorMessage'
+import { StepUpCancelledMessage } from '@admin/shared/StepUp'
 
 interface ContentCollectionCreateDialogProps {
   onCancel: () => void
@@ -98,6 +99,9 @@ export function ContentCollectionCreateDialog({
         }),
       })
     } catch (err) {
+      // A step-up cancellation means the user backed out of the password
+      // re-entry prompt — not a failure. Leave the dialog open, show nothing.
+      if (err instanceof Error && err.message === StepUpCancelledMessage) return
       setSubmitError(errorMessage(err))
     }
   }

--- a/src/admin/pages/content/components/ContentCollectionSettingsDialog/ContentCollectionSettingsDialog.tsx
+++ b/src/admin/pages/content/components/ContentCollectionSettingsDialog/ContentCollectionSettingsDialog.tsx
@@ -16,6 +16,7 @@ import dialogStyles from '../../../../shared/dialogs/SiteCreateDialog/SiteCreate
 import styles from '../../ContentPage.module.css'
 import { slugFromTitle } from '@core/utils/slug'
 import { getErrorMessage } from '@core/utils/errorMessage'
+import { StepUpCancelledMessage } from '@admin/shared/StepUp'
 
 interface ContentCollectionSettingsDialogProps {
   collection: DataTable
@@ -92,6 +93,9 @@ export function ContentCollectionSettingsDialog({
         fields: [...nextFields, ...customFields],
       })
     } catch (err) {
+      // A step-up cancellation means the user backed out of the password
+      // re-entry prompt — not a failure. Leave the dialog open, show nothing.
+      if (err instanceof Error && err.message === StepUpCancelledMessage) return
       setSubmitError(errorMessage(err))
     }
   }


### PR DESCRIPTION
## What changed

Creating, updating, or deleting a **content collection** hits the step-up-gated data-tables endpoints (`POST`/`PATCH`/`DELETE /admin/api/cms/data/tables` — they change the site's public route surface). The Content page called the workspace mutations **directly**, without `useStepUp`, while the Data page wraps the equivalent table mutations in `runStepUp`.

So for any account with step-up auth (or MFA) enabled, the server's `401 { error: 'step_up_required' }` leaked straight into the collection dialog as raw red text (`step_up_required`) instead of opening the password re-entry dialog.

This wires the Content page to the same step-up flow as the Data page:

- `ContentPage` now uses `useStepUp()` and wraps **create / update / delete** collection mutations in `runStepUp(...)`.
- Both collection dialogs (`ContentCollectionCreateDialog`, `ContentCollectionSettingsDialog`) swallow `step_up_cancelled`, so backing out of the prompt is a silent no-op — matching `NewTableDialog`.
- Update/delete now bypass `withEntryOp`, whose generic catch would otherwise surface the cancellation as a visible error.

## Why

Bug reproduces on the latest deployed image (present on `main`). It only triggers for users with step-up/MFA enabled, which is why it wasn't caught earlier.

## Impact

Users with step-up auth can now create, rename/edit, and delete content collections — the password dialog appears and the action retries on success. No change for users with step-up disabled.

## Verification

- `bun run build` (tsc + vite) — clean
- `bun run lint` — clean
- `bun test src/__tests__/admin/data/contentCollectionStepUp.test.tsx src/__tests__/admin/data/dataTableStepUp.test.tsx` — pass
- `bun test src/__tests__/data/contentAdmin.test.tsx` — 23 pass

Adds `contentCollectionStepUp.test.tsx` covering create → step-up dialog → retry, asserting the raw `step_up_required` code never reaches the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)