### PR TITLE
fix(data): avoid blob-backed site export downloads

### DIFF
--- a/docs/features/site-transfer.md
+++ b/docs/features/site-transfer.md
@@ -18,6 +18,7 @@ The **Export site** dialog (`src/admin/pages/data/components/ExportDialog`) is a
   - `POST /admin/api/cms/import/preview` — analyze a bundle without applying (diff summary)
   - `POST /admin/api/cms/import[?strategy=...]` — apply the bundle
 - Export categories: **theme & settings** (the shell), each **content table**, the **media library**, **media folders**, and **redirects** — all on by default.
+- The admin dialog starts downloads with a same-origin form POST, not `fetch().blob()`, so large media-heavy bundles are streamed by the browser's download stack instead of being materialized in JavaScript blob storage.
 - UI entry (export): **Export site** in the Data workspace opens `src/admin/pages/data/components/ExportDialog`.
 - UI entry (import): drop the exported `.json` into the canonical Site Import modal (`src/admin/modals/SiteImport`). Spotlight and workspace **Import site** actions open this same global shell modal.
 - Three import strategies: `replace` (destructive — the full-restore path), `merge-add` (insert if new), `merge-overwrite` (upsert).
@@ -109,7 +110,7 @@ Folder and row authorship (`created_by_user_id`) is **reset to null** on import 
 
 `GET /admin/api/cms/export` or `POST /admin/api/cms/export`
 
-GET accepts filter options as query-string params. POST accepts a JSON body matching `ExportRequestSchema`:
+GET accepts filter options as query-string params. POST accepts either a JSON body matching `ExportRequestSchema` or an HTML form field named `exportRequest` containing that same JSON shape:
 
 ```ts
 {
@@ -126,6 +127,8 @@ GET accepts filter options as query-string params. POST accepts a JSON body matc
 ```
 
 The redesigned **Export site** dialog defaults every category on and content tables to all rows, so its one-click action is a complete full-site export. Opening a content table reveals a **per-row checklist** (pages, posts, components, …) with per-table All / None, so an operator can include or exclude individual entries; the dialog then sends that table with an explicit `rowIds` subset. A table left untouched is sent with no `rowIds` (the whole table) and never needs its rows fetched. `GET` supports whole-table selection only (`?tables=posts,pages`); row-level subsets are POST-only.
+
+The form field exists for the admin dialog's native attachment download path. It preserves row-level POST selection without forcing the returned bundle through a JS `Blob`.
 
 The handler:
 
@@ -329,7 +332,7 @@ A nightly cron can hit `/admin/api/cms/export` with an admin session cookie and 
   - `server/handlers/cms/export.ts` — `GET+POST /export`
   - `server/handlers/cms/import.ts` — `POST /import`
   - `server/handlers/cms/importPreview.ts` — `POST /import/preview`
-  - `src/core/persistence/cmsTransfer.ts` — client-side fetch helpers
+  - `src/core/persistence/cmsTransfer.ts` — client-side transfer helpers, including native export form submission
   - `server/util/pathWithin.ts` — `assertPathWithin` containment helper (media write sink)
 - Gate tests:
   - `src/__tests__/architecture/cmsTransferExport.test.ts`

--- a/server/handlers/cms/export.ts
+++ b/server/handlers/cms/export.ts
@@ -17,7 +17,7 @@
  * real selection and adds each asset's Base64 length analytically), so the
  * "Estimated size" line in the dialog can never drift from the real download.
  *
- * Filter options (GET → query string, POST → JSON body via ExportRequestSchema):
+ * Filter options (GET → query string, POST → JSON body or form field via ExportRequestSchema):
  *   tables       — comma-separated table ids (GET) or string[] (POST); default all
  *   rowIds       — comma-separated row ids (GET) or string[] (POST); default all
  *   includeMedia — `1`/`0` (GET) or boolean (POST); default false
@@ -138,7 +138,9 @@ export async function handleExportRoute(
   let includeRedirects: boolean
 
   if (req.method === 'POST') {
-    const exportReq = await readValidatedBody(req, ExportRequestSchema)
+    const exportReq = await readValidatedBody(req, ExportRequestSchema, {
+      formJsonField: 'exportRequest',
+    })
     if (!exportReq) {
       return jsonResponse({ error: 'Invalid export request body' }, { status: 400 })
     }

--- a/server/http.ts
+++ b/server/http.ts
@@ -3,6 +3,12 @@ import { safeParseValue } from '@core/utils/typeboxHelpers'
 
 interface ReadValidatedBodyOptions {
   maxBytes?: number
+  /**
+   * Allows a standard browser form POST to carry a JSON payload in one field.
+   * Used for native attachment downloads where `fetch().blob()` would force the
+   * browser to materialize the whole response in JS memory/blob storage.
+   */
+  formJsonField?: string
 }
 
 export class RequestBodyTooLargeError extends Error {
@@ -45,15 +51,36 @@ export async function readValidatedBody<T extends TSchema>(
 ): Promise<Static<T> | null> {
   let raw: unknown
   try {
-    raw = options.maxBytes === undefined
-      ? await req.json()
-      : await readJsonWithLimit(req, options.maxBytes)
+    const formJsonField = options.formJsonField
+    if (shouldReadFormJsonField(req, formJsonField) && formJsonField) {
+      raw = await readFormJsonField(req, formJsonField)
+    } else if (options.maxBytes === undefined) {
+      raw = await req.json()
+    } else {
+      raw = await readJsonWithLimit(req, options.maxBytes)
+    }
   } catch (err) {
     if (err instanceof RequestBodyTooLargeError) throw err
     return null
   }
   const parsed = safeParseValue(schema, raw)
   return parsed.ok ? (parsed.value as Static<T>) : null
+}
+
+function shouldReadFormJsonField(req: Request, fieldName: string | undefined): boolean {
+  if (!fieldName) return false
+  const contentType = req.headers.get('content-type')?.toLowerCase() ?? ''
+  return (
+    contentType.startsWith('application/x-www-form-urlencoded') ||
+    contentType.startsWith('multipart/form-data')
+  )
+}
+
+async function readFormJsonField(req: Request, fieldName: string): Promise<unknown> {
+  const form = await req.formData()
+  const value = form.get(fieldName)
+  if (typeof value !== 'string') return null
+  return JSON.parse(value)
 }
 
 async function readJsonWithLimit(req: Request, maxBytes: number): Promise<unknown> {

--- a/src/__tests__/admin/data/exportDialog.test.tsx
+++ b/src/__tests__/admin/data/exportDialog.test.tsx
@@ -7,8 +7,8 @@
  *   2.  Toggling the active category's switch flips its aria-checked
  *   3.  Selecting the Media category shows its switch (on by default = full export)
  *   4.  "Select none" disables Download and updates the footer summary
- *   5.  Download success — fetch body carries every include* flag (full export)
- *   6.  Download error — inline alert shown, error toast pushed, onClose NOT called
+ *   5.  Download starts — form body carries every include* flag (full export)
+ *   6.  Download start error — inline alert shown, error toast pushed, onClose NOT called
  *   7.  Cancel calls onClose
  *   8.  Estimate is fetched and shrinks when media is toggled OFF
  *   9.  Row scope — initialScope='selected' shows the Selected segment, pressed
@@ -90,14 +90,17 @@ const originalFetch = globalThis.fetch
 let savedCreateObjectURL: typeof URL.createObjectURL
 let savedRevokeObjectURL: typeof URL.revokeObjectURL
 let savedAnchorClick: typeof HTMLAnchorElement.prototype.click
+let savedFormSubmit: typeof HTMLFormElement.prototype.submit
 
 beforeEach(() => {
   savedCreateObjectURL = URL.createObjectURL
   savedRevokeObjectURL = URL.revokeObjectURL
   savedAnchorClick = HTMLAnchorElement.prototype.click
+  savedFormSubmit = HTMLFormElement.prototype.submit
   URL.createObjectURL = (_obj: Blob | MediaSource) => 'blob:mock-url'
   URL.revokeObjectURL = (_url: string) => {}
   HTMLAnchorElement.prototype.click = function (this: HTMLAnchorElement) {}
+  HTMLFormElement.prototype.submit = function (this: HTMLFormElement) {}
   globalThis.fetch = defaultFetch()
 })
 
@@ -106,6 +109,7 @@ afterEach(() => {
   URL.createObjectURL = savedCreateObjectURL
   URL.revokeObjectURL = savedRevokeObjectURL
   HTMLAnchorElement.prototype.click = savedAnchorClick
+  HTMLFormElement.prototype.submit = savedFormSubmit
   cleanup()
 })
 
@@ -156,19 +160,23 @@ describe('ExportDialog', () => {
     expect(screen.getByText(/0 of \d+ categories selected/i)).toBeTruthy()
   })
 
-  it('download success — fetch body carries every include flag (full export)', async () => {
+  it('download starts — form body carries every include flag (full export)', async () => {
     let onCloseCalled = false
-    let fetchBodyStr: string | null = null
+    let submittedForm: HTMLFormElement | null = null
+    let exportFetchCalled = false
 
-    globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+    globalThis.fetch = async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString()
       if (url.startsWith('/admin/api/cms/export/summary')) return jsonResponse({ media: 2, mediaFolders: 1, redirects: 1 })
       if (url === '/admin/api/cms/export/estimate') return jsonResponse({ bytes: 1000 })
       if (url === '/admin/api/cms/export') {
-        fetchBodyStr = (init?.body as string) ?? null
-        return jsonResponse('{}')
+        exportFetchCalled = true
+        return jsonResponse({ error: 'Export downloads must not go through fetch' }, 500)
       }
       return jsonResponse({ error: `Unexpected request: ${url}` }, 500)
+    }
+    HTMLFormElement.prototype.submit = function (this: HTMLFormElement) {
+      submittedForm = Array.from(document.forms).find((form) => form.target === this.target) ?? null
     }
 
     let capturedToasts: Toast[] = []
@@ -187,8 +195,16 @@ describe('ExportDialog', () => {
 
       await waitFor(() => { expect(onCloseCalled).toBe(true) })
 
-      expect(fetchBodyStr).not.toBeNull()
-      const body = JSON.parse(fetchBodyStr!) as {
+      expect(exportFetchCalled).toBe(false)
+      expect(submittedForm).not.toBeNull()
+      expect(submittedForm!.method.toLowerCase()).toBe('post')
+      expect(submittedForm!.action.endsWith('/admin/api/cms/export')).toBe(true)
+      expect(submittedForm!.target).toBeTruthy()
+      expect(document.querySelector(`iframe[name="${submittedForm!.target}"]`)).toBeTruthy()
+
+      const input = submittedForm!.querySelector('input[name="exportRequest"]') as HTMLInputElement | null
+      expect(input).not.toBeNull()
+      const body = JSON.parse(input!.value) as {
         tables: { tableId: string; rowIds?: string[] }[]
         includeMedia: boolean
         includeSite: boolean
@@ -205,21 +221,23 @@ describe('ExportDialog', () => {
       expect(body.includeMediaFolders).toBe(true)
       expect(body.includeRedirects).toBe(true)
 
-      expect(capturedToasts.some((t) => t.kind === 'success' && t.title === 'Export complete')).toBe(true)
+      expect(capturedToasts.some((t) => t.kind === 'success' && t.title === 'Export started')).toBe(true)
     } finally {
       unsub()
     }
   })
 
-  it('download error — inline alert shown, error toast pushed, onClose NOT called', async () => {
+  it('download start error — inline alert shown, error toast pushed, onClose NOT called', async () => {
     let onCloseCalled = false
 
     globalThis.fetch = async (input: RequestInfo | URL) => {
       const url = typeof input === 'string' ? input : input.toString()
       if (url.startsWith('/admin/api/cms/export/summary')) return jsonResponse({ media: 0, mediaFolders: 0, redirects: 0 })
       if (url === '/admin/api/cms/export/estimate') return jsonResponse({ bytes: 1000 })
-      if (url === '/admin/api/cms/export') return jsonResponse({ error: 'boom' }, 500)
       return jsonResponse({ error: `Unexpected: ${url}` }, 500)
+    }
+    HTMLFormElement.prototype.submit = function () {
+      throw new Error('Browser refused to start the download')
     }
 
     let capturedToasts: Toast[] = []
@@ -285,7 +303,7 @@ describe('ExportDialog', () => {
   })
 
   it('content table detail lists rows as a checklist; toggling updates the count + request', async () => {
-    let lastExportBody: string | null = null
+    let submittedForm: HTMLFormElement | null = null
     globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString()
       if (url.startsWith('/admin/api/cms/export/summary')) return jsonResponse({ media: 0, mediaFolders: 0, redirects: 0 })
@@ -298,8 +316,11 @@ describe('ExportDialog', () => {
           ],
         })
       }
-      if (url === '/admin/api/cms/export') { lastExportBody = (init?.body as string) ?? null; return jsonResponse('{}') }
+      if (url === '/admin/api/cms/export') return jsonResponse({ error: 'Export downloads must not go through fetch' }, 500)
       return jsonResponse({ error: `Unexpected request: ${url}` }, 500)
+    }
+    HTMLFormElement.prototype.submit = function (this: HTMLFormElement) {
+      submittedForm = Array.from(document.forms).find((form) => form.target === this.target) ?? null
     }
 
     render(<ExportDialog open={true} onClose={() => {}} tables={[POSTS_TABLE]} />)
@@ -315,8 +336,10 @@ describe('ExportDialog', () => {
     await waitFor(() => { expect(screen.getByText(/1 of 2 entries selected/i)).toBeTruthy() })
 
     fireEvent.click(screen.getByRole('button', { name: /download bundle/i }))
-    await waitFor(() => { expect(lastExportBody).not.toBeNull() })
-    const body = JSON.parse(lastExportBody!) as { tables: { tableId: string; rowIds?: string[] }[] }
+    await waitFor(() => { expect(submittedForm).not.toBeNull() })
+    const input = submittedForm!.querySelector('input[name="exportRequest"]') as HTMLInputElement | null
+    expect(input).not.toBeNull()
+    const body = JSON.parse(input!.value) as { tables: { tableId: string; rowIds?: string[] }[] }
     const posts = body.tables.find((t) => t.tableId === 'posts')
     expect(posts?.rowIds).toEqual(['p2'])
   })

--- a/src/__tests__/architecture/cmsTransferExport.test.ts
+++ b/src/__tests__/architecture/cmsTransferExport.test.ts
@@ -105,6 +105,18 @@ function makePostRequest(path: string, cookie: string, body: unknown): Request {
   return req
 }
 
+function makeFormPostRequest(path: string, cookie: string, body: unknown): Request {
+  const form = new URLSearchParams()
+  form.set('exportRequest', JSON.stringify(body))
+  const req = new Request(`http://localhost${path}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: form,
+  })
+  req.headers.set('cookie', cookie)
+  return req
+}
+
 // ---------------------------------------------------------------------------
 // Shared state set up in beforeAll
 // ---------------------------------------------------------------------------
@@ -282,6 +294,28 @@ describe('handleExportRoute — POST { tables: [{ tableId: "posts", rowIds: [id1
     expect(tableIds).toContain('posts')
     expect(tableIds).not.toContain('pages')
     expect(tableIds).not.toContain(CUSTOM_TABLE_ID)
+  })
+
+  test('accepts form-encoded exportRequest for browser-native downloads', async () => {
+    const req = makeFormPostRequest('/admin/api/cms/export', cookie, {
+      tables: [{ tableId: 'posts', rowIds: [post1Id] }],
+      includeMedia: true,
+      includeSite: false,
+      includeMediaFolders: false,
+      includeRedirects: false,
+    })
+    const res = await handleExportRoute(req, db, { uploadsDir: '/tmp/test-uploads-export' })
+    expect(res!.status).toBe(200)
+    expect(res!.headers.get('content-disposition')).toContain('attachment')
+
+    const body = JSON.parse(await res!.text())
+    const bundle = parseValue(SiteBundleSchema, body)
+
+    expect(bundle.site).toBeUndefined()
+    expect(bundle.rows.map((r) => r.id)).toEqual([post1Id])
+    expect(bundle.media).toEqual([])
+    expect(bundle.mediaFolders).toBeUndefined()
+    expect(bundle.redirects).toBeUndefined()
   })
 })
 

--- a/src/admin/pages/data/components/ExportDialog/ExportDialog.tsx
+++ b/src/admin/pages/data/components/ExportDialog/ExportDialog.tsx
@@ -25,7 +25,7 @@ import { Dialog } from '@ui/components/Dialog'
 import { Switch } from '@ui/components/Switch'
 import { pushToast } from '@ui/components/Toast'
 import { assignRailAccents, railTintVar } from '@ui/railAccent'
-import { exportSiteBundle, getExportSummary } from '@core/persistence/cmsTransfer'
+import { getExportSummary, submitSiteBundleExport } from '@core/persistence/cmsTransfer'
 import { listCmsDataRows } from '@core/persistence/cmsData'
 import { isAbortError } from '@core/http'
 import { getErrorMessage } from '@core/utils/errorMessage'
@@ -101,22 +101,6 @@ function rowTitle(row: DataRow, table: DataTableListItem): string {
   return row.slug || '(untitled)'
 }
 
-function makeTimestampedFilename(): string {
-  const ts = new Date().toISOString().slice(0, 19).replace(/[:.]/g, '-')
-  return `site-bundle-${ts}.json`
-}
-
-function triggerDownload(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob)
-  const a = document.createElement('a')
-  a.href = url
-  a.download = filename
-  document.body.appendChild(a)
-  a.click()
-  document.body.removeChild(a)
-  URL.revokeObjectURL(url)
-}
-
 /** Build the initial per-table pick map. */
 function initialPicks(
   tables: DataTableListItem[],
@@ -150,11 +134,14 @@ async function runExport(
 ): Promise<void> {
   setExporting(true)
   setError(null)
-  const filename = makeTimestampedFilename()
   try {
-    const blob = await exportSiteBundle(request)
-    triggerDownload(blob, filename)
-    pushToast({ kind: 'success', title: 'Export complete', body: filename, location: 'data-workspace' })
+    submitSiteBundleExport(request)
+    pushToast({
+      kind: 'success',
+      title: 'Export started',
+      body: 'Your browser will save the bundle when it is ready.',
+      location: 'data-workspace',
+    })
     onClose()
   } catch (err) {
     console.error('[ExportDialog] Export failed:', err)

--- a/src/core/persistence/cmsTransfer.ts
+++ b/src/core/persistence/cmsTransfer.ts
@@ -4,15 +4,15 @@
  *   POST /admin/api/cms/import/preview
  *   POST /admin/api/cms/import?strategy=<strategy>
  *
- * All HTTP calls use `credentials: 'include'`. Export returns a raw Blob
- * (the endpoint streams an attachment, not an envelope). Preview and import
- * return standard JSON envelopes validated with TypeBox via `readEnvelope`.
+ * Export uses a same-origin browser form POST so the browser owns the attachment
+ * download stream. Preview and import return standard JSON envelopes validated
+ * with TypeBox via `readEnvelope`.
  */
 
 import type { SiteBundle, BundlePreview, ImportResult, ImportStrategy, ExportRequest, ExportEstimate, ExportSummary } from '@core/data/bundleSchema'
 import { SiteBundleSchema, BundlePreviewSchema, ImportResultSchema, ExportEstimateSchema, ExportSummarySchema } from '@core/data/bundleSchema'
 import { parseValue, formatValueErrors, compiled } from '@core/utils/typeboxHelpers'
-import { apiRequest, readEnvelope, assertOk } from '@core/http'
+import { apiRequest, readEnvelope } from '@core/http'
 
 // ---------------------------------------------------------------------------
 // SiteBundleParseError
@@ -37,28 +37,58 @@ export class SiteBundleParseError extends Error {
 }
 
 // ---------------------------------------------------------------------------
-// exportSiteBundle
+// submitSiteBundleExport
 // ---------------------------------------------------------------------------
 
 /**
  * POST /admin/api/cms/export
  *
- * Returns the raw Blob of the JSON bundle so callers can trigger a browser
- * download or read the bytes themselves. Uses POST so arbitrary-length
- * `rowIds` arrays don't hit URL length limits.
+ * Starts a native browser attachment download through a hidden form POST. This
+ * keeps arbitrary-length `rowIds` arrays out of the URL while avoiding
+ * `fetch().blob()`, which forces large full-site bundles into JS blob storage
+ * before the browser can save them.
  *
  * The export endpoint returns raw JSON with `content-disposition: attachment`,
- * NOT the standard `{ data, error }` envelope — so we do NOT use `readEnvelope`.
+ * NOT the standard `{ data, error }` envelope — so this helper intentionally
+ * does not use `apiRequest` / `readEnvelope`.
  */
-export async function exportSiteBundle(opts: ExportRequest): Promise<Blob> {
-  const res = await fetch('/admin/api/cms/export', {
-    method: 'POST',
-    credentials: 'include',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify(opts),
-  })
-  await assertOk(res, 'Failed to export site')
-  return res.blob()
+export function submitSiteBundleExport(opts: ExportRequest): void {
+  if (typeof document === 'undefined' || !document.body) {
+    throw new Error('Export download requires a browser document')
+  }
+
+  const targetName = `instatic-export-${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+  const iframe = document.createElement('iframe')
+  iframe.name = targetName
+  iframe.hidden = true
+  iframe.setAttribute('aria-hidden', 'true')
+
+  const form = document.createElement('form')
+  form.method = 'POST'
+  form.action = '/admin/api/cms/export'
+  form.target = targetName
+  form.enctype = 'application/x-www-form-urlencoded'
+  form.hidden = true
+  form.setAttribute('aria-hidden', 'true')
+
+  const input = document.createElement('input')
+  input.type = 'hidden'
+  input.name = 'exportRequest'
+  input.value = JSON.stringify(opts)
+  form.appendChild(input)
+
+  document.body.append(iframe, form)
+  try {
+    form.submit()
+  } catch (err) {
+    form.remove()
+    iframe.remove()
+    throw err
+  }
+
+  // Keep the iframe mounted; removing the target can cancel slow attachment streams.
+  form.remove()
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Switch the Export site bundle download from `fetch().blob()` to a native same-origin form POST targeted at a hidden iframe.
- Allow `POST /admin/api/cms/export` to accept a form field named `exportRequest` containing the same TypeBox-validated export request JSON.
- Update export dialog/server tests and transfer docs for the native attachment path.

## Why
Large media-heavy bundles should be streamed by the browser download stack instead of being fully materialized into JavaScript blob storage before saving. This preserves row-level POST selections without reintroducing URL length limits.

## Verification
- `bun test src/__tests__/admin/data/exportDialog.test.tsx src/__tests__/architecture/cmsTransferExport.test.ts`
- `bun test`
- `bun run build`
- `bun run lint`
- `bun run doctor --verbose --diff` (exits 0; warning-only existing `ExportDialog` structure/style diagnostics remain)
- Browser smoke with disposable local data: Data -> Export site -> Download bundle; no console errors, no inline alert, dialog closes, hidden export iframe is created.