### PR TITLE
refactor(page-tree): reuse traversal selectors in form analysis

### DIFF
--- a/src/__tests__/architecture/page-tree-single-source.test.ts
+++ b/src/__tests__/architecture/page-tree-single-source.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const PROJECT_ROOT = join(import.meta.dir, '../../../')
+
+const FORM_TREE_CONSUMERS = [
+  'src/core/forms/snapshot.ts',
+  'src/admin/pages/site/panels/PropertiesPanel/formSettingsAnalysis.ts',
+]
+
+function source(relativePath: string): string {
+  return readFileSync(join(PROJECT_ROOT, relativePath), 'utf8')
+}
+
+describe('Page-tree selector source of truth', () => {
+  test('form analysis uses @core/page-tree traversal helpers instead of local tree walkers', () => {
+    for (const file of FORM_TREE_CONSUMERS) {
+      const content = source(file)
+      expect(content, `${file} must not define a local recursive tree walker`).not.toMatch(
+        /\bfunction\s+walkTree\s*\(/,
+      )
+      expect(content, `${file} must not derive a parent map from children arrays`).not.toMatch(
+        /\bfunction\s+buildParentMap\s*\(/,
+      )
+    }
+  })
+})

--- a/src/__tests__/forms/formSettingsAnalysis.test.ts
+++ b/src/__tests__/forms/formSettingsAnalysis.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import type { DataTable } from '@core/data/schemas'
 import type { Page, PageNode } from '@core/page-tree'
+import { reindexNodeParents } from '@core/page-tree'
 import {
   analyzeFormSettings,
   buildDataTableDraftFromForm,
@@ -46,7 +47,7 @@ const table: DataTable = {
 }
 
 function makePage(): Page {
-  return {
+  return withParentIndex({
     id: 'page-home',
     slug: 'index',
     title: 'Home',
@@ -74,7 +75,12 @@ function makePage(): Page {
       submit: node('submit', 'base.submit', { label: 'Send', formId: '' }),
       'outside-input': node('outside-input', 'base.input', { fieldId: 'email', name: 'email' }),
     },
-  }
+  })
+}
+
+function withParentIndex(page: Page): Page {
+  reindexNodeParents(page.nodes)
+  return page
 }
 
 describe('analyzeFormSettings', () => {
@@ -144,7 +150,7 @@ describe('analyzeFormSettings', () => {
   })
 
   it('infers a create-table draft from controls inside the selected form', () => {
-    const page: Page = {
+    const page: Page = withParentIndex({
       id: 'page-home',
       slug: 'index',
       title: 'Home',
@@ -174,7 +180,7 @@ describe('analyzeFormSettings', () => {
         'label-consent': node('label-consent', 'base.label', { text: 'Consent', targetMode: 'auto', targetId: '' }),
         consent: node('consent', 'base.checkbox', { name: 'consent', required: true }),
       },
-    }
+    })
 
     const analysis = analyzeFormSettings({ page, nodeId: 'form' })
     expect(analysis.inferredFields).toEqual([

--- a/src/admin/pages/site/panels/PropertiesPanel/formSettingsAnalysis.ts
+++ b/src/admin/pages/site/panels/PropertiesPanel/formSettingsAnalysis.ts
@@ -1,7 +1,6 @@
 import type { CreateDataTableInput, DataField, DataTable, DataSelectOption } from '@core/data/schemas'
 import type { ImportFragment } from '@core/htmlImport'
-import type { Page, PageNode } from '@core/page-tree'
-import { createNode } from '@core/page-tree'
+import { createNode, flattenSubtree, getParent, type Page, type PageNode } from '@core/page-tree'
 import { formDisplayName, humanizeIdentifier, slugifyFormTableName } from './formSettingsNaming'
 
 export { formDisplayName } from './formSettingsNaming'
@@ -111,12 +110,11 @@ export function analyzeFormSettings(input: {
     return emptyAnalysis(selectedNode, table)
   }
 
-  const parentByNodeId = buildParentMap(page)
   const formNode = selectedNode.moduleId === 'base.form'
     ? selectedNode
-    : nearestAncestorForm(page, selectedNode.id, parentByNodeId)
+    : nearestAncestorForm(page, selectedNode.id)
   const form = formNode ? formSummary(formNode) : null
-  const inferredFields = formNode ? inferFieldsFromForm(page, formNode, parentByNodeId) : []
+  const inferredFields = formNode ? inferFieldsFromForm(page, formNode) : []
   const missingFields = table && formNode ? fieldsMissingFromForm(page, formNode, table) : []
   const kind = settingsKind(selectedNode.moduleId)
   const warnings: FormSettingsWarning[] = []
@@ -171,7 +169,7 @@ export function analyzeFormSettings(input: {
 
   let inferredTarget: FormTargetSummary | null = null
   if (kind === 'label') {
-    inferredTarget = inferLabelTarget(page, selectedNode, parentByNodeId)
+    inferredTarget = inferLabelTarget(page, selectedNode)
     if (!inferredTarget) {
       warnings.push({
         code: 'label_without_target',
@@ -351,7 +349,7 @@ function formSummary(node: PageNode): FormContextSummary {
 function duplicateNameWarnings(page: Page, formNode: PageNode): FormSettingsWarning[] {
   const seen = new Map<string, string>()
   const warnings: FormSettingsWarning[] = []
-  for (const nodeId of walkTree(page, formNode.id)) {
+  for (const nodeId of flattenSubtree(page, formNode.id)) {
     if (nodeId === formNode.id) continue
     const node = page.nodes[nodeId]
     if (!node || !FORM_CONTROL_MODULES.has(node.moduleId)) continue
@@ -373,15 +371,14 @@ function duplicateNameWarnings(page: Page, formNode: PageNode): FormSettingsWarn
 function inferFieldsFromForm(
   page: Page,
   formNode: PageNode,
-  parentByNodeId: Map<string, string>,
 ): DataField[] {
   const fields: DataField[] = []
   const usedIds = new Set<string>()
-  for (const nodeId of walkTree(page, formNode.id)) {
+  for (const nodeId of flattenSubtree(page, formNode.id)) {
     if (nodeId === formNode.id) continue
     const node = page.nodes[nodeId]
     if (!node || !FORM_CONTROL_MODULES.has(node.moduleId)) continue
-    const field = inferFieldFromControl(page, node, parentByNodeId, usedIds)
+    const field = inferFieldFromControl(page, node, usedIds)
     if (field) fields.push(field)
   }
   return fields
@@ -390,10 +387,9 @@ function inferFieldsFromForm(
 function inferFieldFromControl(
   page: Page,
   node: PageNode,
-  parentByNodeId: Map<string, string>,
   usedIds: Set<string>,
 ): DataField | null {
-  const label = labelForControl(page, node, parentByNodeId)
+  const label = labelForControl(page, node)
   const rawId = stringProp(node, 'fieldId', '')
     || stringProp(node, 'name', '')
     || stringProp(node, 'id', '')
@@ -462,7 +458,7 @@ function inferFieldFromControl(
 
 function fieldsMissingFromForm(page: Page, formNode: PageNode, table: DataTable): DataField[] {
   const representedFieldIds = new Set<string>()
-  for (const nodeId of walkTree(page, formNode.id)) {
+  for (const nodeId of flattenSubtree(page, formNode.id)) {
     if (nodeId === formNode.id) continue
     const node = page.nodes[nodeId]
     if (!node || !FORM_CONTROL_MODULES.has(node.moduleId)) continue
@@ -475,10 +471,8 @@ function fieldsMissingFromForm(page: Page, formNode: PageNode, table: DataTable)
 function labelForControl(
   page: Page,
   node: PageNode,
-  parentByNodeId: Map<string, string>,
 ): string {
-  const parentId = parentByNodeId.get(node.id)
-  const parent = parentId ? page.nodes[parentId] : null
+  const parent = getParent(page, node.id)
   if (parent) {
     const nodeIndex = parent.children.indexOf(node.id)
     for (const siblingId of parent.children.slice(0, nodeIndex).reverse()) {
@@ -510,7 +504,6 @@ function optionFieldsFromSelect(page: Page, selectNode: PageNode): DataSelectOpt
 function inferLabelTarget(
   page: Page,
   labelNode: PageNode,
-  parentByNodeId: Map<string, string>,
 ): FormTargetSummary | null {
   const explicit = stringProp(labelNode, 'targetId', '')
   if (stringProp(labelNode, 'targetMode', 'auto') === 'explicit' && explicit) {
@@ -520,12 +513,11 @@ function inferLabelTarget(
       : { nodeId: explicit, label: explicit }
   }
 
-  const parentId = parentByNodeId.get(labelNode.id)
-  const parent = parentId ? page.nodes[parentId] : null
+  const parent = getParent(page, labelNode.id)
   if (!parent) return null
   const labelIndex = parent.children.indexOf(labelNode.id)
   for (const siblingId of parent.children.slice(labelIndex + 1)) {
-    for (const candidateId of walkTree(page, siblingId)) {
+    for (const candidateId of flattenSubtree(page, siblingId)) {
       const candidate = page.nodes[candidateId]
       if (candidate && FORM_CONTROL_MODULES.has(candidate.moduleId)) {
         return { nodeId: candidate.id, label: controlLabel(candidate) }
@@ -535,39 +527,13 @@ function inferLabelTarget(
   return null
 }
 
-function nearestAncestorForm(
-  page: Page,
-  nodeId: string,
-  parentByNodeId: Map<string, string>,
-): PageNode | null {
-  let currentId = parentByNodeId.get(nodeId)
-  while (currentId) {
-    const current = page.nodes[currentId]
-    if (!current) return null
+function nearestAncestorForm(page: Page, nodeId: string): PageNode | null {
+  let current = getParent(page, nodeId)
+  while (current) {
     if (current.moduleId === 'base.form') return current
-    currentId = parentByNodeId.get(current.id)
+    current = getParent(page, current.id)
   }
   return null
-}
-
-function buildParentMap(page: Page): Map<string, string> {
-  const map = new Map<string, string>()
-  for (const node of Object.values(page.nodes)) {
-    for (const childId of node.children) map.set(childId, node.id)
-  }
-  return map
-}
-
-function walkTree(page: Page, startNodeId: string): string[] {
-  const out: string[] = []
-  const visit = (nodeId: string) => {
-    const node = page.nodes[nodeId]
-    if (!node) return
-    out.push(nodeId)
-    for (const childId of node.children) visit(childId)
-  }
-  visit(startNodeId)
-  return out
 }
 
 function stringProp(node: PageNode, key: string, fallback: string): string {

--- a/src/core/forms/snapshot.ts
+++ b/src/core/forms/snapshot.ts
@@ -1,4 +1,4 @@
-import type { Page, PageNode } from '@core/page-tree'
+import { flattenSubtree, getParent, type Page, type PageNode } from '@core/page-tree'
 import { normalizeIdentifierValue } from '@core/utils/identifier'
 import type {
   FormControlBinding,
@@ -19,7 +19,7 @@ const FORM_CONTROL_MODULES = new Set([
 export function derivePageFormSnapshots(page: Page): PublishedFormSnapshot[] {
   const snapshots: PublishedFormSnapshot[] = []
 
-  for (const nodeId of walkTree(page, page.rootNodeId)) {
+  for (const nodeId of flattenSubtree(page, page.rootNodeId)) {
     const node = page.nodes[nodeId]
     if (!node || node.moduleId !== 'base.form') continue
     const mode = stringProp(node, 'mode', 'cms')
@@ -36,7 +36,7 @@ function deriveFormSnapshot(
 ): PublishedFormSnapshot {
   const fallbackFormId = normalizeIdentifierValue(formNode.id, 'form')
   const formId = normalizeIdentifierValue(stringProp(formNode, 'formId', formNode.id), fallbackFormId)
-  const descendantIds = walkTree(page, formNode.id).filter((nodeId) => nodeId !== formNode.id)
+  const descendantIds = flattenSubtree(page, formNode.id).filter((nodeId) => nodeId !== formNode.id)
   const controls: FormControlBinding[] = []
   const labels: PublishedFormLabel[] = []
   const submits: PublishedFormSubmit[] = []
@@ -131,32 +131,18 @@ function inferLabelTarget(
     return target?.id ?? explicit
   }
 
-  const parentId = page.nodes[labelNode.id]?.parentId
-  if (!parentId) return null
-  const parent = page.nodes[parentId]
+  const parent = getParent(page, labelNode.id)
   if (!parent) return null
   const labelIndex = parent.children.indexOf(labelNode.id)
   const siblingIds = parent.children.slice(labelIndex + 1)
   for (const siblingId of siblingIds) {
-    for (const candidateId of walkTree(page, siblingId)) {
+    for (const candidateId of flattenSubtree(page, siblingId)) {
       if (candidateId === formNodeId) continue
       const candidate = page.nodes[candidateId]
       if (candidate && FORM_CONTROL_MODULES.has(candidate.moduleId)) return candidate.id
     }
   }
   return null
-}
-
-function walkTree(page: Page, startNodeId: string): string[] {
-  const out: string[] = []
-  const visit = (nodeId: string) => {
-    const node = page.nodes[nodeId]
-    if (!node) return
-    out.push(nodeId)
-    for (const childId of node.children) visit(childId)
-  }
-  visit(startNodeId)
-  return out
 }
 
 function stringProp(node: PageNode, key: string, fallback: string): string {


### PR DESCRIPTION
## What changed

- Replaced local recursive form tree walkers with `flattenSubtree` from `@core/page-tree`.
- Replaced the editor form analyzer's derived child-scan parent map with `getParent`, using the canonical parent index maintained by page-tree parsing/mutation boundaries.
- Added an architecture regression to prevent these form modules from reintroducing local tree-walk/parent-map helpers.
- Updated form analyzer fixtures to stamp `parentId` via `reindexNodeParents`, matching the production page-tree invariant.

## Why

Form publishing and editor-side form settings had their own tree traversal and parent lookup implementations. That duplicated logic bypassed the cycle-safe page-tree selector path and obscured the `parentId` source-of-truth invariant.

## Impact

Form snapshot generation and form settings analysis now depend on the same page-tree selector primitives as the rest of the editor engine. The form-specific inference behavior is unchanged and covered by existing tests.

## Verification

- `bun test src/__tests__/architecture/page-tree-single-source.test.ts` red before implementation, then passing
- `bun test src/__tests__/forms/formSnapshot.test.ts src/__tests__/forms/formSettingsAnalysis.test.ts`
- `bun run build`
- `bun test`
- `bun run lint`