### PR TITLE
fix(spotlight): use active canvas tree for layer commands

### DIFF
--- a/src/__tests__/spotlight/layersCommands.test.ts
+++ b/src/__tests__/spotlight/layersCommands.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { getLayersCommands } from '@admin/spotlight/commands/layers'
+import type { CommandRunContext } from '@admin/spotlight/types'
+import { useEditorStore } from '@site/store/store'
+import { makePage, makeSite, makeVC, makeVCNode, makeVCTree } from '../fixtures'
+
+function freshStore(): void {
+  useEditorStore.setState({
+    site: null,
+    activePageId: null,
+    activeDocument: null,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+function loadVisualComponentCanvas(): void {
+  const page = makePage({ id: 'page-1', rootNodeId: 'page-root' })
+  const vc = makeVC({
+    id: 'vc-card',
+    name: 'Card',
+    tree: makeVCTree('vc-root', [
+      makeVCNode({ id: 'vc-root', moduleId: 'base.body', children: ['vc-a', 'vc-b'] }),
+      makeVCNode({ id: 'vc-a', moduleId: 'base.text', props: { text: 'A' } }),
+      makeVCNode({ id: 'vc-b', moduleId: 'base.text', props: { text: 'B' } }),
+    ]),
+  })
+
+  useEditorStore.getState().loadSite(makeSite({ pages: [page], visualComponents: [vc] }))
+  useEditorStore.setState({
+    activePageId: 'page-1',
+    activeDocument: { kind: 'visualComponent', vcId: 'vc-card' },
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+function command(id: string) {
+  const found = getLayersCommands().find((candidate) => candidate.id === id)
+  if (!found) throw new Error(`Command ${id} not found`)
+  return found
+}
+
+async function runLayerCommand(commandId: string, selectedNodeIds: string[]): Promise<void> {
+  useEditorStore.setState({
+    selectedNodeId: selectedNodeIds[selectedNodeIds.length - 1] ?? null,
+    selectedNodeIds,
+  } as Parameters<typeof useEditorStore.setState>[0])
+
+  const ctx: CommandRunContext = {
+    workspace: 'site',
+    pathname: '/admin/site',
+    user: null as never,
+    editor: {
+      selectedNodeIds,
+      activePageId: 'page-1',
+      activeDocument: { kind: 'visualComponent', vcId: 'vc-card' },
+      canUndo: false,
+      canRedo: false,
+      activeBreakpointId: 'desktop',
+    },
+    args: {},
+    navigate: () => {},
+    closeSpotlight: () => {},
+    pushScope: () => {},
+    popScope: () => {},
+    runStepUp: async (action) => action(),
+  }
+
+  await command(commandId).run(ctx)
+}
+
+function vcChildren(): string[] {
+  const vc = useEditorStore.getState().site!.visualComponents[0]
+  return [...vc.tree.nodes['vc-root'].children]
+}
+
+beforeEach(() => {
+  freshStore()
+  loadVisualComponentCanvas()
+})
+
+describe('Spotlight layer commands', () => {
+  it('moves selected Visual Component nodes within the active canvas tree', async () => {
+    await runLayerCommand('layers.moveUp', ['vc-b'])
+    expect(vcChildren()).toEqual(['vc-b', 'vc-a'])
+
+    await runLayerCommand('layers.moveDown', ['vc-b'])
+    expect(vcChildren()).toEqual(['vc-a', 'vc-b'])
+  })
+
+  it('navigates parent and child selection inside the active Visual Component tree', async () => {
+    await runLayerCommand('layers.selectParent', ['vc-a'])
+    expect(useEditorStore.getState().selectedNodeId).toBe('vc-root')
+
+    await runLayerCommand('layers.selectFirstChild', ['vc-root'])
+    expect(useEditorStore.getState().selectedNodeId).toBe('vc-a')
+  })
+})

--- a/src/admin/spotlight/commands/layers.ts
+++ b/src/admin/spotlight/commands/layers.ts
@@ -17,10 +17,17 @@
  *   - Convert selection to Visual Component
  */
 
+import { getParent } from '@core/page-tree'
 import type { Command } from '../types'
 
 const hasSelection = (ctx: { editor?: { selectedNodeIds: ReadonlyArray<string> } }) =>
   (ctx.editor?.selectedNodeIds.length ?? 0) > 0
+
+async function getActiveLayerTree() {
+  const { useEditorStore, selectActiveCanvasPage } = await import('@site/store/store')
+  const store = useEditorStore.getState()
+  return { store, page: selectActiveCanvasPage(store) }
+}
 
 export function getLayersCommands(): Command[] {
   return [
@@ -286,18 +293,14 @@ export function getLayersCommands(): Command[] {
         const nodeId = ctx.editor?.selectedNodeIds[ctx.editor.selectedNodeIds.length - 1]
         if (!nodeId) return
         try {
-          const { useEditorStore } = await import('@site/store/store')
-          const store = useEditorStore.getState()
-          const page = store.site?.pages.find((p) => p.id === store.activePageId)
+          const { store, page } = await getActiveLayerTree()
           if (!page) return
-          const parentId = page.nodes[nodeId]?.parentId
-          if (!parentId) return
-          const parent = page.nodes[parentId]
+          const parent = getParent(page, nodeId)
           if (!parent) return
           const siblings = parent.children ?? []
           const idx = siblings.indexOf(nodeId)
           if (idx <= 0) return
-          store.moveNode(nodeId, parentId, idx - 1)
+          store.moveNode(nodeId, parent.id, idx - 1)
         } catch (err) {
           console.error('[spotlight] moveNode up failed:', err)
         }
@@ -320,18 +323,14 @@ export function getLayersCommands(): Command[] {
         const nodeId = ctx.editor?.selectedNodeIds[ctx.editor.selectedNodeIds.length - 1]
         if (!nodeId) return
         try {
-          const { useEditorStore } = await import('@site/store/store')
-          const store = useEditorStore.getState()
-          const page = store.site?.pages.find((p) => p.id === store.activePageId)
+          const { store, page } = await getActiveLayerTree()
           if (!page) return
-          const parentId = page.nodes[nodeId]?.parentId
-          if (!parentId) return
-          const parent = page.nodes[parentId]
+          const parent = getParent(page, nodeId)
           if (!parent) return
           const siblings = parent.children ?? []
           const idx = siblings.indexOf(nodeId)
           if (idx < 0 || idx >= siblings.length - 1) return
-          store.moveNode(nodeId, parentId, idx + 1)
+          store.moveNode(nodeId, parent.id, idx + 1)
         } catch (err) {
           console.error('[spotlight] moveNode down failed:', err)
         }
@@ -355,13 +354,11 @@ export function getLayersCommands(): Command[] {
         const nodeId = ctx.editor?.selectedNodeIds[ctx.editor.selectedNodeIds.length - 1]
         if (!nodeId) return
         try {
-          const { useEditorStore } = await import('@site/store/store')
-          const store = useEditorStore.getState()
-          const page = store.site?.pages.find((p) => p.id === store.activePageId)
+          const { store, page } = await getActiveLayerTree()
           if (!page) return
-          const parentId = page.nodes[nodeId]?.parentId
-          if (!parentId) return
-          store.selectNode(parentId)
+          const parent = getParent(page, nodeId)
+          if (!parent) return
+          store.selectNode(parent.id)
         } catch (err) {
           console.error('[spotlight] selectParent failed:', err)
         }
@@ -385,9 +382,7 @@ export function getLayersCommands(): Command[] {
         const nodeId = ctx.editor?.selectedNodeIds[ctx.editor.selectedNodeIds.length - 1]
         if (!nodeId) return
         try {
-          const { useEditorStore } = await import('@site/store/store')
-          const store = useEditorStore.getState()
-          const page = store.site?.pages.find((p) => p.id === store.activePageId)
+          const { store, page } = await getActiveLayerTree()
           if (!page) return
           const node = page.nodes[nodeId]
           const firstChild = node?.children?.[0]


### PR DESCRIPTION
## What changed

- Routed Spotlight layer move/navigation commands through `selectActiveCanvasPage` instead of manually looking up `site.pages` by `activePageId`.
- Used `getParent` from `@core/page-tree` for parent and sibling calculations.
- Added a regression test that runs the real Spotlight layer commands while editing a Visual Component canvas.

## Why

`layers.moveUp`, `layers.moveDown`, `layers.selectParent`, and `layers.selectFirstChild` calculated their target tree from the active page only. In Visual Component mode those commands silently no-op because selected VC node IDs do not exist in the active page tree, even though the store mutations they call are already VC-aware.

## Impact

Layer reordering and parent/child selection commands now work against whichever canvas document is active: normal pages or Visual Components.

## Verification

- `bun test src/__tests__/spotlight/layersCommands.test.ts` red before implementation, then passing
- `bun run build`
- `bun test`
- `bun run lint`