### PR TITLE
refactor(admin): remove circular deps and recover lazy HMR loads

### DIFF
--- a/docs/reference/architecture-tests.md
+++ b/docs/reference/architecture-tests.md
@@ -6,7 +6,7 @@ Catalog of every test in `src/__tests__/architecture/`. These are structural gat
 
 ## TL;DR
 
-- 89 gate files across structural domains: SQL, JSON columns, migrations, CSS, icons, primitives, page tree, sandbox, agent, router, content storage, boundary validation, module size, AI, auth, error handling, etc.
+- 90 gate files across structural domains: SQL, JSON columns, migrations, CSS, icons, primitives, page tree, sandbox, agent, router, content storage, boundary validation, module size, AI, auth, error handling, etc.
 - Naming convention: `<topic>.test.ts` (kebab-case) or `<group>-<topic>.test.ts`. A few legacy `task<N>-*` ids remain for live invariants; new gates should use topic names.
 - Run them all: `bun test src/__tests__/architecture/`.
 - Most are **import / source scans** — they parse the files in scope and assert / reject patterns. Some are unit-style (a small in-test database, a synthesized page tree).
@@ -114,6 +114,7 @@ See [docs/reference/ui-primitives.md](ui-primitives.md).
 | Test                                          | What it enforces                                                                 |
 |-----------------------------------------------|----------------------------------------------------------------------------------|
 | `canvasFastRefreshBoundaries.test.ts`         | `.tsx` files don't mix component + non-component exports (breaks HMR).           |
+| `no-circular-dependencies.test.ts`            | `madge` finds zero tsconfig-aware circular dependencies across `src` and `server`. |
 | `canvas-aware-selectors.test.ts`              | Canvas-related store selectors are subscribed correctly to canvas-state slices.  |
 | `admin-router-usage.test.ts`                  | Internal admin navigation uses `@admin/lib/routing`; raw `/admin` anchors and `react-router-dom` are banned. |
 | `framework-typography-spacing.test.ts`        | The site framework's typography / spacing tokens compile correctly.              |

--- a/server/repositories/media.ts
+++ b/server/repositories/media.ts
@@ -6,6 +6,7 @@ import {
   parseVariants,
   type MediaAssetRow,
 } from './mediaAssetMapping'
+import type { MediaAsset, MediaVariant } from './mediaTypes'
 
 // The row ↔ asset mapping unit (column constants, `MediaAssetRow`,
 // `mapMediaAssetRow`, and the JSON parsers) lives in `./mediaAssetMapping` so it
@@ -13,64 +14,7 @@ import {
 // duplication. This module owns the asset domain types (`MediaAsset`,
 // `MediaVariant`) and every CRUD query.
 
-export interface MediaVariant {
-  width: number
-  height: number
-  format: 'webp' | 'jpeg' | 'png' | 'avif'
-  /**
-   * Public URL the renderer emits (`/uploads/<storage>` for local; an
-   * absolute URL like `https://cdn.example.com/...` for `'public-url'`
-   * adapters; `/uploads/<storage>` again for `'signed-redirect'` /
-   * `'proxy'` adapters because the router resolves them on request).
-   */
-  path: string
-  sizeBytes: number
-  /**
-   * Adapter-internal storage handle. For local-disk this is the basename
-   * under `uploadsDir`; for S3 it's the bucket key. Used by `dispatchDelete`
-   * to remove the right bytes when the asset is purged.
-   */
-  storagePath: string
-  /** Adapter id that wrote this variant; `''` for the built-in local-disk adapter. */
-  storageAdapterId: string
-}
-
-export interface MediaAsset {
-  id: string
-  filename: string
-  mimeType: string
-  sizeBytes: number
-  publicPath: string
-  uploadedByUserId: string | null
-  createdAt: string
-  altText: string
-  caption: string
-  title: string
-  tags: string[]
-  width: number | null
-  height: number | null
-  durationMs: number | null
-  dominantColor: string | null
-  deletedAt: string | null
-  replacedAt: string | null
-  folderIds: string[]
-  blurHash: string | null
-  variants: MediaVariant[]
-  posterPath: string | null
-  /**
-   * Id of the storage adapter that wrote this asset. Empty string for the
-   * built-in local-disk adapter (historical assets keep this default).
-   * Reads dispatch through THIS field, not the currently-elected adapter,
-   * so an election swap can't strand existing rows.
-   */
-  storageAdapterId: string
-  /**
-   * True when the bytes live outside the host's uploads dir
-   * (servingMode `'public-url'`). The hard-delete path uses this to choose
-   * between local `rm` and `adapter.delete()`.
-   */
-  externallyHosted: boolean
-}
+export type { MediaAsset, MediaVariant } from './mediaTypes'
 
 interface CreateMediaAssetInput {
   id: string

--- a/server/repositories/mediaAssetMapping.ts
+++ b/server/repositories/mediaAssetMapping.ts
@@ -18,7 +18,7 @@
  */
 
 import { isoDate, isoDateOrNull } from '@core/utils/isoDate'
-import type { MediaAsset, MediaVariant } from './media'
+import type { MediaAsset, MediaVariant } from './mediaTypes'
 
 /**
  * Single source of truth for the hydrated media-asset projection. Spliced into

--- a/server/repositories/mediaTypes.ts
+++ b/server/repositories/mediaTypes.ts
@@ -1,0 +1,50 @@
+/**
+ * Media repository domain types.
+ *
+ * Kept outside the CRUD repository and row mapper so both can share the same
+ * asset shape without importing each other.
+ */
+
+export interface MediaVariant {
+  width: number
+  height: number
+  format: 'webp' | 'jpeg' | 'png' | 'avif'
+  /**
+   * Public URL the renderer emits (`/uploads/<storage>` for local; an absolute
+   * URL for public external storage; local route again for redirect/proxy modes).
+   */
+  path: string
+  sizeBytes: number
+  /** Adapter-internal storage handle. */
+  storagePath: string
+  /** Adapter id that wrote this variant; `''` for the built-in local adapter. */
+  storageAdapterId: string
+}
+
+export interface MediaAsset {
+  id: string
+  filename: string
+  mimeType: string
+  sizeBytes: number
+  publicPath: string
+  uploadedByUserId: string | null
+  createdAt: string
+  altText: string
+  caption: string
+  title: string
+  tags: string[]
+  width: number | null
+  height: number | null
+  durationMs: number | null
+  dominantColor: string | null
+  deletedAt: string | null
+  replacedAt: string | null
+  folderIds: string[]
+  blurHash: string | null
+  variants: MediaVariant[]
+  posterPath: string | null
+  /** Empty string for the built-in local-disk adapter. */
+  storageAdapterId: string
+  /** True when bytes live outside the host uploads dir. */
+  externallyHosted: boolean
+}

--- a/src/__tests__/architecture/canvasFastRefreshBoundaries.test.ts
+++ b/src/__tests__/architecture/canvasFastRefreshBoundaries.test.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs'
+import { readdirSync, readFileSync, statSync } from 'node:fs'
 import { join } from 'node:path'
 import { describe, expect, it } from 'bun:test'
 
@@ -6,6 +6,17 @@ const SRC_ROOT = join(import.meta.dir, '..', '..')
 
 function readSource(path: string): string {
   return readFileSync(join(SRC_ROOT, path), 'utf8')
+}
+
+function collectFiles(dir: string): string[] {
+  const files: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const stat = statSync(full)
+    if (stat.isDirectory()) files.push(...collectFiles(full))
+    else if (entry.endsWith('Editor.tsx')) files.push(full)
+  }
+  return files
 }
 
 describe('Canvas Fast Refresh boundaries', () => {
@@ -33,5 +44,20 @@ describe('Canvas Fast Refresh boundaries', () => {
     const source = readSource('admin/pages/site/canvas/ModuleSandboxFrame.tsx')
 
     expect(source).not.toContain('export function createSandboxSrcDoc')
+  })
+
+  it('keeps base module editors independent of registration barrels', () => {
+    const editorFiles = collectFiles(join(SRC_ROOT, 'modules/base'))
+    expect(editorFiles.length).toBeGreaterThan(0)
+
+    const offenders: string[] = []
+    for (const file of editorFiles) {
+      const source = readFileSync(file, 'utf8')
+      if (/from ['"]\.\/index['"]/.test(source)) {
+        offenders.push(file.replace(`${SRC_ROOT}/`, ''))
+      }
+    }
+
+    expect(offenders).toEqual([])
   })
 })

--- a/src/__tests__/architecture/no-circular-dependencies.test.ts
+++ b/src/__tests__/architecture/no-circular-dependencies.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { join } from 'node:path'
+
+const ROOT = join(import.meta.dir, '../../..')
+
+function decode(bytes: Uint8Array): string {
+  return new TextDecoder().decode(bytes)
+}
+
+describe('Circular dependencies', () => {
+  it('keeps the tsconfig-aware source graph cycle-free', () => {
+    const result = Bun.spawnSync({
+      cmd: [
+        process.execPath,
+        'x',
+        'madge',
+        '--circular',
+        '--ts-config',
+        'tsconfig.json',
+        '--extensions',
+        'ts,tsx',
+        'src',
+        'server',
+      ],
+      cwd: ROOT,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const output = `${decode(result.stdout)}${decode(result.stderr)}`
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `Circular dependencies found. Run the same command locally for the full graph:\n` +
+          `bun x madge --circular --ts-config tsconfig.json --extensions ts,tsx src server\n\n` +
+          output,
+      )
+    }
+
+    expect(output).toContain('No circular dependency found')
+  })
+})

--- a/src/__tests__/architecture/site-editor-shell-lazy-body.test.ts
+++ b/src/__tests__/architecture/site-editor-shell-lazy-body.test.ts
@@ -24,6 +24,9 @@ describe('Site editor shell lazy body', () => {
     const body = readAdminFile('layouts/AdminCanvasLayout/AdminCanvasEditorBody.tsx')
 
     expect(layout).toContain("import('./AdminCanvasEditorBody')")
+    expect(layout).toContain('prewarmedLazy<AdminCanvasEditorBodyProps>')
+    expect(layout).toContain('<LazyChunkBoundary')
+    expect(layout).toContain('onReset={AdminCanvasEditorBody.reset}')
     expect(layout).toContain('scheduleAfterFirstPaint')
     expect(layout).not.toContain("@dnd-kit/core")
     expect(layout).not.toContain("@admin/pages/site/canvas")
@@ -60,6 +63,7 @@ describe('Site editor shell lazy body', () => {
     // shell must still paint canvas-shaped skeleton frames; otherwise cold Site
     // loads show only the toolbar over an empty black workspace.
     expect(layout).toContain('<AdminCanvasEditorBodyLoading />')
+    expect(layout).toContain('fallback={<AdminCanvasEditorBodyLoading />}')
     expect(layout).toContain('@admin/shared/CanvasFrameSkeleton')
     expect(layout).toContain('<CanvasFrameSkeletonFrame')
     expect(layout).not.toContain('<span>Loading editor</span>')

--- a/src/admin/layouts/AdminCanvasLayout/AdminCanvasLayout.tsx
+++ b/src/admin/layouts/AdminCanvasLayout/AdminCanvasLayout.tsx
@@ -54,6 +54,8 @@ import {
   CanvasFrameSkeletonFrame,
   DEFAULT_CANVAS_FRAME_SKELETON_BREAKPOINTS,
 } from '@admin/shared/CanvasFrameSkeleton'
+import { LazyChunkBoundary } from '@admin/lib/LazyChunkBoundary'
+import { prewarmedLazy } from '@admin/lib/prewarmedLazy'
 import styles from './AdminCanvasLayout.module.css'
 import { lazy, Suspense, useEffect, useState } from 'react'
 import { useCurrentAdminUser } from '@admin/sessionContext'
@@ -67,8 +69,16 @@ import {
 import { EditorPermissionsProvider } from '@site/EditorPermissionsProvider'
 import type { EditorPermissions } from '@site/editorPermissionsContext'
 
-const AdminCanvasEditorBody = lazy(() =>
-  import('./AdminCanvasEditorBody').then((m) => ({ default: m.AdminCanvasEditorBody })),
+interface AdminCanvasEditorBodyProps {
+  canEditDraftSite: boolean
+  canSaveSite: boolean
+  loadError: string | null
+}
+
+const AdminCanvasEditorBody = prewarmedLazy<AdminCanvasEditorBodyProps>(
+  () =>
+    import('./AdminCanvasEditorBody').then((m) => ({ default: m.AdminCanvasEditorBody })),
+  { displayName: 'AdminCanvasEditorBody' },
 )
 
 // SettingsModal is heavy (~37 KB raw) and closed 99% of the time. lazy()
@@ -216,13 +226,18 @@ export function AdminCanvasLayout() {
         />
 
         {loadEditorBody ? (
-          <Suspense fallback={<AdminCanvasEditorBodyLoading />}>
+          <LazyChunkBoundary
+            location="site-editor-body"
+            fallback={<AdminCanvasEditorBodyLoading />}
+            resetKeys={[site?.id ?? null]}
+            onReset={AdminCanvasEditorBody.reset}
+          >
             <AdminCanvasEditorBody
               canEditDraftSite={canEditDraftSite}
               canSaveSite={canSaveSite}
               loadError={loadError}
             />
-          </Suspense>
+          </LazyChunkBoundary>
         ) : (
           <AdminCanvasEditorBodyLoading />
         )}

--- a/src/admin/lib/LazyChunkBoundary.module.css
+++ b/src/admin/lib/LazyChunkBoundary.module.css
@@ -1,0 +1,46 @@
+.chunkFailure {
+  box-sizing: border-box;
+  display: grid;
+  flex: 1 1 auto;
+  width: 100%;
+  min-height: 260px;
+  min-width: 0;
+  place-items: center;
+  padding: 32px;
+  background: var(--editor-bg);
+  color: var(--editor-text);
+}
+
+.panel {
+  display: flex;
+  width: min(460px, 100%);
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: var(--editor-radius);
+  box-shadow: var(--panel-shadow);
+}
+
+.title {
+  margin: 0;
+  color: var(--editor-text-bright);
+  font-size: 14px;
+  font-weight: 650;
+  line-height: 1.3;
+}
+
+.message {
+  margin: 0;
+  color: var(--editor-text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+  overflow-wrap: anywhere;
+}
+
+.actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/admin/lib/LazyChunkBoundary.tsx
+++ b/src/admin/lib/LazyChunkBoundary.tsx
@@ -1,0 +1,133 @@
+import {
+  Fragment,
+  Suspense,
+  useEffect,
+  useState,
+  type ReactNode,
+} from 'react'
+import { ErrorBoundary } from '@ui/components/ErrorBoundary'
+import { Button } from '@ui/components/Button'
+import { ReloadIcon } from 'pixel-art-icons/icons/reload'
+import styles from './LazyChunkBoundary.module.css'
+
+const DEFAULT_TIMEOUT_MS = 8000
+const EMPTY_RESET_KEYS: ReadonlyArray<unknown> = []
+
+interface LazyChunkBoundaryProps {
+  location: string
+  fallback: ReactNode
+  resetKeys?: ReadonlyArray<unknown>
+  timeoutMs?: number
+  onReset?: () => void
+  children: ReactNode
+}
+
+export function LazyChunkBoundary({
+  location,
+  fallback,
+  resetKeys = EMPTY_RESET_KEYS,
+  timeoutMs = DEFAULT_TIMEOUT_MS,
+  onReset,
+  children,
+}: LazyChunkBoundaryProps) {
+  const [attempt, setAttempt] = useState(0)
+  const boundaryResetKeys = [...resetKeys, attempt]
+
+  function retry(resetErrorBoundary?: () => void) {
+    onReset?.()
+    setAttempt((current) => current + 1)
+    resetErrorBoundary?.()
+  }
+
+  return (
+    <ErrorBoundary
+      location={location}
+      resetKeys={boundaryResetKeys}
+      fallback={({ chain, reset }) => (
+        <LazyChunkFailure
+          titleId={`lazy-chunk-boundary-${location}-title`}
+          title="Editor chunk failed to load"
+          message={chain[0]?.message ?? 'The editor chunk could not be loaded.'}
+          onRetry={() => retry(reset)}
+        />
+      )}
+    >
+      <Suspense
+        fallback={(
+          <LazyChunkPendingFallback
+            key={`${attempt}:${timeoutMs}`}
+            fallback={fallback}
+            timeoutMs={timeoutMs}
+            onRetry={() => retry()}
+          />
+        )}
+      >
+        <LazyChunkAttempt key={attempt}>{children}</LazyChunkAttempt>
+      </Suspense>
+    </ErrorBoundary>
+  )
+}
+
+function LazyChunkAttempt({ children }: { children: ReactNode }) {
+  return <Fragment>{children}</Fragment>
+}
+
+function LazyChunkPendingFallback({
+  fallback,
+  timeoutMs,
+  onRetry,
+}: {
+  fallback: ReactNode
+  timeoutMs: number
+  onRetry: () => void
+}) {
+  const [timedOut, setTimedOut] = useState(timeoutMs <= 0)
+
+  useEffect(() => {
+    if (timeoutMs <= 0) return
+    const timeoutId = window.setTimeout(() => setTimedOut(true), timeoutMs)
+    return () => window.clearTimeout(timeoutId)
+  }, [timeoutMs])
+
+  if (!timedOut) return <Fragment>{fallback}</Fragment>
+
+  return (
+    <LazyChunkFailure
+      titleId="lazy-chunk-boundary-pending-title"
+      title="Editor is still loading"
+      message="The dev server has not delivered the editor chunk yet. Retry the import instead of waiting on the loading view."
+      onRetry={onRetry}
+    />
+  )
+}
+
+function LazyChunkFailure({
+  titleId,
+  title,
+  message,
+  onRetry,
+}: {
+  titleId: string
+  title: string
+  message: string
+  onRetry: () => void
+}) {
+  return (
+    <section
+      className={styles.chunkFailure}
+      role="alert"
+      aria-labelledby={titleId}
+    >
+      <div className={styles.panel}>
+        <h2 id={titleId} className={styles.title}>{title}</h2>
+        <p className={styles.message}>{message}</p>
+        <div className={styles.actions}>
+          <Button variant="secondary" size="sm" onClick={onRetry}>
+            <ReloadIcon size={13} aria-hidden="true" />
+            <span>Retry</span>
+          </Button>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/admin/lib/prewarmedLazy.ts
+++ b/src/admin/lib/prewarmedLazy.ts
@@ -79,6 +79,12 @@ type PrewarmedComponent<TProps> = ComponentType<TProps> & {
    * itself is the side effect.
    */
   preload: () => Promise<unknown>
+  /**
+   * Clear cached import state so a failed dev-server / HMR chunk can be
+   * requested again. Also invalidates any pending import that resolves after
+   * reset, preventing stale failures from re-poisoning the next attempt.
+   */
+  reset: () => void
 }
 
 /**
@@ -96,28 +102,43 @@ type PrewarmedComponent<TProps> = ComponentType<TProps> & {
  * the helper itself, though one is required upstream to catch the
  * cold-path throw.
  */
-export function prewarmedLazy<TProps extends Record<string, unknown> = Record<string, unknown>>(
+export function prewarmedLazy<TProps extends object = Record<string, unknown>>(
   loader: ModuleLoader,
   options: PrewarmedLazyOptions = {},
 ): PrewarmedComponent<TProps> {
   let cached: ComponentType<TProps> | null = null
   let pending: Promise<unknown> | null = null
   let failure: unknown = null
+  let generation = 0
 
   function preload(): Promise<unknown> {
+    if (cached !== null) return Promise.resolve(cached)
     if (pending !== null) return pending
+    failure = null
+    const loadGeneration = generation
     pending = (loader() as Promise<unknown>)
       .then((mod) => {
+        if (loadGeneration !== generation) return
         // Accept either `{ default: Component }` or a bare component.
         const exported = (mod as { default?: ComponentType<TProps> }).default
         cached = (exported ?? (mod as unknown as ComponentType<TProps>))
+        pending = null
       })
       .catch((err: unknown) => {
+        if (loadGeneration !== generation) return
         failure = err
+        pending = null
         // Re-throw so any other callers of preload() see the rejection.
         throw err
       })
     return pending
+  }
+
+  function reset(): void {
+    generation += 1
+    cached = null
+    pending = null
+    failure = null
   }
 
   function PrewarmedLazy(props: TProps): ReactElement {
@@ -141,6 +162,6 @@ export function prewarmedLazy<TProps extends Record<string, unknown> = Record<st
 
   // Attach `.preload()` so the host (AuthenticatedAdmin) can schedule
   // background preloads for non-active pages after the active page has
-  // painted. Idempotent — multiple calls return the same promise.
-  return Object.assign(PrewarmedLazy, { preload }) as PrewarmedComponent<TProps>
+  // painted. `.reset()` gives retry buttons a way to clear a failed import.
+  return Object.assign(PrewarmedLazy, { preload, reset }) as PrewarmedComponent<TProps>
 }

--- a/src/admin/modals/SiteImport/steps/AnalyzeStep.tsx
+++ b/src/admin/modals/SiteImport/steps/AnalyzeStep.tsx
@@ -27,7 +27,7 @@ import { WarningDiamondSolidIcon } from 'pixel-art-icons/icons/warning-diamond-s
 import { ChevronRightIcon } from 'pixel-art-icons/icons/chevron-right'
 import { DragAndDropSolidIcon } from 'pixel-art-icons/icons/drag-and-drop-solid'
 import type { ImportPlan, StylesheetImportMode } from '@core/siteImport'
-import type { ImportSelection } from '../SiteImportModal'
+import type { ImportSelection } from '../shared/importPlanning'
 import { StylesheetModeRows } from './StylesheetModeRows'
 import { ImportStepper } from '../shared/ImportStepper'
 import { withSiteImportCategoryTints } from '../shared/importCategoryAccent'

--- a/src/admin/pages/content/hooks/useEditorMediaDrop.ts
+++ b/src/admin/pages/content/hooks/useEditorMediaDrop.ts
@@ -24,7 +24,8 @@
 import { useEffect, useRef } from 'react'
 import { nanoid } from 'nanoid'
 import type { Editor } from '@tiptap/core'
-import { MEDIA_UPLOAD_PLACEHOLDER_NAME, type MediaUploadKind } from '../nodes/MediaUploadPlaceholder'
+import { MEDIA_UPLOAD_PLACEHOLDER_NAME } from '../nodes/MediaUploadPlaceholder'
+import type { MediaUploadKind } from '../nodes/MediaUploadPlaceholderTypes'
 import { mediaKindOf, uploadMediaInline } from './uploadMediaInline'
 import { getErrorMessage } from '@core/utils/errorMessage'
 

--- a/src/admin/pages/content/nodes/MediaUploadPlaceholder.ts
+++ b/src/admin/pages/content/nodes/MediaUploadPlaceholder.ts
@@ -22,9 +22,11 @@
 import { Node, mergeAttributes } from '@tiptap/core'
 import { ReactNodeViewRenderer } from '@tiptap/react'
 import { MediaUploadPlaceholderView } from './MediaUploadPlaceholderView'
-
-export type MediaUploadKind = 'image' | 'video'
-type MediaUploadStatus = 'uploading' | 'failed'
+import type {
+  MediaUploadKind,
+  MediaUploadPlaceholderAttributes,
+  MediaUploadStatus,
+} from './MediaUploadPlaceholderTypes'
 
 interface MediaUploadPlaceholderOptions {
   /**
@@ -37,20 +39,6 @@ interface MediaUploadPlaceholderOptions {
    * replacement.
    */
   onCancel: (uploadId: string) => void
-}
-
-export interface MediaUploadPlaceholderAttributes {
-  /** Stable identifier the host uses to find this placeholder for replacement. */
-  uploadId: string
-  filename: string
-  kind: MediaUploadKind
-  /** 0..1 — driven by XHR upload-progress events. */
-  progress: number
-  status: MediaUploadStatus
-  /** Optional error message when `status === 'failed'`. */
-  error: string | null
-  /** Object URL of the source File so we can show a thumbnail. Caller revokes on swap. */
-  previewUrl: string | null
 }
 
 export const MEDIA_UPLOAD_PLACEHOLDER_NAME = 'mediaUploadPlaceholder'

--- a/src/admin/pages/content/nodes/MediaUploadPlaceholderTypes.ts
+++ b/src/admin/pages/content/nodes/MediaUploadPlaceholderTypes.ts
@@ -1,0 +1,16 @@
+export type MediaUploadKind = 'image' | 'video'
+export type MediaUploadStatus = 'uploading' | 'failed'
+
+export interface MediaUploadPlaceholderAttributes {
+  /** Stable identifier the host uses to find this placeholder for replacement. */
+  uploadId: string
+  filename: string
+  kind: MediaUploadKind
+  /** 0..1 — driven by XHR upload-progress events. */
+  progress: number
+  status: MediaUploadStatus
+  /** Optional error message when `status === 'failed'`. */
+  error: string | null
+  /** Object URL of the source File so we can show a thumbnail. Caller revokes on swap. */
+  previewUrl: string | null
+}

--- a/src/admin/pages/content/nodes/MediaUploadPlaceholderView.tsx
+++ b/src/admin/pages/content/nodes/MediaUploadPlaceholderView.tsx
@@ -15,7 +15,7 @@ import { NodeViewWrapper, type NodeViewProps } from '@tiptap/react'
 import { Button } from '@ui/components/Button'
 import { CloseIcon } from 'pixel-art-icons/icons/close'
 import styles from './MediaUploadPlaceholderView.module.css'
-import type { MediaUploadPlaceholderAttributes } from './MediaUploadPlaceholder'
+import type { MediaUploadPlaceholderAttributes } from './MediaUploadPlaceholderTypes'
 
 interface MediaUploadCancelHandler {
   (uploadId: string): void
@@ -47,7 +47,14 @@ export function MediaUploadPlaceholderView(props: MediaUploadPlaceholderViewProp
       <div className={styles.preview}>
         {attrs.previewUrl
           ? attrs.kind === 'video'
-            ? <video src={attrs.previewUrl} muted className={styles.thumb} />
+            ? (
+              <video
+                src={attrs.previewUrl}
+                muted
+                aria-label={`${attrs.filename} upload preview`}
+                className={styles.thumb}
+              />
+            )
             : <img src={attrs.previewUrl} alt="" className={styles.thumb} />
           : (
             <div className={styles.thumbEmpty} aria-hidden="true">

--- a/src/admin/pages/site/agent/agentSlice.ts
+++ b/src/admin/pages/site/agent/agentSlice.ts
@@ -17,14 +17,12 @@
 
 import { nanoid } from 'nanoid'
 import type { EditorStoreSliceCreator } from '@site/store/types'
-import type { AiToolOutput } from '@core/ai'
 import { ApiError } from '@core/http'
 import {
   listConversations,
   getConversation,
   deleteConversation,
   updateConversationProvider,
-  type ConversationView,
 } from '@admin/ai/api'
 import {
   createConversationForScope,
@@ -32,138 +30,21 @@ import {
   rehydrateMessages,
 } from './agentApi'
 import { readNdjsonStream } from './ndjsonStream'
-import { processStreamEvent, ServerStreamEventSchema, type EditorStoreSet } from './streamEvents'
+import { processStreamEvent, ServerStreamEventSchema } from './streamEvents'
+import type {
+  AgentSlice,
+  AgentSliceConfig,
+  AgentSliceGet,
+  EditorStoreSet,
+} from './agentSliceTypes'
+export type { AgentSlice, AgentSliceConfig } from './agentSliceTypes'
 import type {
   AgentBridgeRuntime,
   AgentMessage,
   AgentRequestBody,
   AgentTextStreamSink,
-  AgentToolScope,
 } from './types'
 import { getErrorMessage } from '@core/utils/errorMessage'
-
-// ---------------------------------------------------------------------------
-// Scope-agnostic config — the site editor and the content workspace each
-// supply their own. See `createAgentSlice(config)` below.
-// ---------------------------------------------------------------------------
-
-export interface AgentSliceConfig {
-  /**
-   * Conversation scope. Used in URL paths (`/admin/api/ai/chat/${scope}`,
-   * `?scope=${scope}`), conversation-create body, and the per-scope default
-   * lookup. Keep it aligned with `server/ai/runtime/types.ts → ToolScope`.
-   */
-  readonly scope: AgentToolScope
-  /**
-   * Build the per-request snapshot. The slice has no knowledge of the host
-   * store's shape; the config closure pulls from whatever store the host
-   * mounted the agent in (site editor reads page tree; content workspace
-   * reads active doc + collections).
-   */
-  buildSnapshot(): unknown
-  /**
-   * Dispatch a write-tool request. The slice forwards the server's
-   * `toolRequest` event to this function and POSTs the result back; the
-   * config's implementation talks to the host's bridge (executor.ts for
-   * site, contentBridge.ts for content, …).
-   */
-  dispatchTool(toolName: string, input: unknown): Promise<AiToolOutput>
-  /**
-   * Optional copy override for the "no AI provider configured" error so
-   * each scope can point the user at the right /admin/ai page.
-   */
-  readonly noProviderMessage?: string
-}
-
-// ---------------------------------------------------------------------------
-// Slice interface
-// ---------------------------------------------------------------------------
-
-export interface AgentSlice {
-  // ── UI state ───────────────────────────────────────────────────────────────
-  isAgentOpen: boolean
-  isAgentStreaming: boolean
-  agentMessages: AgentMessage[]
-  agentError: string | null
-  /**
-   * Active conversation row id in `ai_conversations`. Created lazily on the
-   * first sendAgentMessage call (uses the site default credential/model);
-   * persisted across messages in this editor session. Reset by
-   * clearAgentMessages or startNewAgentConversation.
-   */
-  agentConversationId: string | null
-  /** Currently-active (credentialId, modelId) — surfaced by the model picker. */
-  agentActiveCredentialId: string | null
-  agentActiveModelId: string | null
-  /** Conversation summaries for the history popover. */
-  agentConversations: ConversationView[]
-  /**
-   * "Context used" for the composer meter — the provider-normalised total
-   * input the model processed on the latest turn. Hydrated from the persisted
-   * conversation snapshot on load, updated live from each turn's `usage` event,
-   * and null for a fresh conversation with no turns yet (the meter then shows
-   * 0 against the window). The window half is resolved separately by the view
-   * layer from the model catalogue.
-   */
-  agentContextTokens: number | null
-
-  // ── Actions ────────────────────────────────────────────────────────────────
-  openAgent(): void
-  closeAgent(): void
-  toggleAgent(): void
-
-  /**
-   * Send a user message and stream the assistant response.
-   * Routes via the Vite proxy `/admin/api/ai/chat/site` → local Bun server →
-   * driver resolved from the conversation's credential.
-   *
-   * Creates the conversation row on first call using the site default. If no
-   * default is configured server-side, surfaces a "set up a provider" error.
-   */
-  sendAgentMessage(content: string): Promise<void>
-
-  /** Abort an in-progress streaming request. */
-  abortAgent(): void
-
-  /** Clear all messages, reset error state, and forget the active conversation. */
-  clearAgentMessages(): void
-
-  /** Fetch the latest conversation list (site scope) for the history popover. */
-  loadAgentConversations(): Promise<void>
-
-  /** Load an existing conversation: hydrate messages and set it as active. */
-  loadAgentConversation(id: string): Promise<void>
-
-  /**
-   * Start a brand-new conversation thread. Same as clearAgentMessages but
-   * surfaces a distinct intent: the user wants to start a new chat (the
-   * next sendAgentMessage will create a fresh conversation row).
-   */
-  startNewAgentConversation(): void
-
-  /**
-   * Soft-delete a conversation. Clears the active one if it matches.
-   */
-  deleteAgentConversation(id: string): Promise<void>
-
-  /**
-   * Change which credential + model the current conversation uses. If a
-   * conversation row exists, PUTs the change so the next send uses the new
-   * provider. If no current conversation, stages the values for the next
-   * conversation-create call.
-   */
-  setAgentProvider(credentialId: string, modelId: string): Promise<void>
-
-  /**
-   * Preload the per-scope default `(credential, model)` (from
-   * `/admin/api/ai/defaults`) and stage it as the active selection, so the
-   * model picker shows the configured default up-front and the first send
-   * uses it directly — no `Default` placeholder, no send-time "no provider"
-   * surprise. No-op when a conversation is already active or the user has
-   * already made an explicit pick. Called by the panel when it opens.
-   */
-  loadScopeDefault(): Promise<void>
-}
 
 // Session-id is in-memory only. While the editor stays open, follow-up
 // messages reuse the SDK session id (Claude has continuity across the
@@ -180,10 +61,6 @@ export interface AgentSlice {
 declare module '@site/store/types' {
   interface EditorStore extends AgentSlice {}
 }
-
-// `get` as the slice creator hands it to its actions. The helpers below only
-// read AgentSlice keys, so a narrow getter is sufficient.
-type AgentSliceGet = Parameters<EditorStoreSliceCreator<AgentSlice>>[1]
 
 interface ResolvedCredentials {
   credentialId: string

--- a/src/admin/pages/site/agent/agentSliceConfig.site.ts
+++ b/src/admin/pages/site/agent/agentSliceConfig.site.ts
@@ -17,7 +17,7 @@
  * doesn't escape into the generic `createAgentSlice` factory.
  */
 
-import type { AgentSliceConfig } from './agentSlice'
+import type { AgentSliceConfig } from './agentSliceTypes'
 import { buildCurrentPageContext } from './pageContext'
 import { executeAgentTool } from './executor'
 import { getAgentStoreApi } from './storeRef'

--- a/src/admin/pages/site/agent/agentSliceTypes.ts
+++ b/src/admin/pages/site/agent/agentSliceTypes.ts
@@ -1,0 +1,57 @@
+import type { EditorStoreSliceCreator } from '@site/store/types'
+import type { AiToolOutput } from '@core/ai'
+import type { ConversationView } from '@admin/ai/api'
+import type { AgentMessage, AgentToolScope } from './types'
+
+export interface AgentSliceConfig {
+  /**
+   * Conversation scope. Used in URL paths (`/admin/api/ai/chat/${scope}`,
+   * `?scope=${scope}`), conversation-create body, and the per-scope default
+   * lookup. Keep it aligned with `server/ai/runtime/types.ts → ToolScope`.
+   */
+  readonly scope: AgentToolScope
+  /**
+   * Build the per-request snapshot. The slice has no knowledge of the host
+   * store's shape; the config closure pulls from whatever store the host
+   * mounted the agent in.
+   */
+  buildSnapshot(): unknown
+  /**
+   * Dispatch a write-tool request. The slice forwards the server's
+   * `toolRequest` event to this function and POSTs the result back.
+   */
+  dispatchTool(toolName: string, input: unknown): Promise<AiToolOutput>
+  /**
+   * Optional copy override for the "no AI provider configured" error so
+   * each scope can point the user at the right /admin/ai page.
+   */
+  readonly noProviderMessage?: string
+}
+
+export interface AgentSlice {
+  isAgentOpen: boolean
+  isAgentStreaming: boolean
+  agentMessages: AgentMessage[]
+  agentError: string | null
+  agentConversationId: string | null
+  agentActiveCredentialId: string | null
+  agentActiveModelId: string | null
+  agentConversations: ConversationView[]
+  agentContextTokens: number | null
+
+  openAgent(): void
+  closeAgent(): void
+  toggleAgent(): void
+  sendAgentMessage(content: string): Promise<void>
+  abortAgent(): void
+  clearAgentMessages(): void
+  loadAgentConversations(): Promise<void>
+  loadAgentConversation(id: string): Promise<void>
+  startNewAgentConversation(): void
+  deleteAgentConversation(id: string): Promise<void>
+  setAgentProvider(credentialId: string, modelId: string): Promise<void>
+  loadScopeDefault(): Promise<void>
+}
+
+export type EditorStoreSet = Parameters<EditorStoreSliceCreator<AgentSlice>>[0]
+export type AgentSliceGet = Parameters<EditorStoreSliceCreator<AgentSlice>>[1]

--- a/src/admin/pages/site/agent/index.ts
+++ b/src/admin/pages/site/agent/index.ts
@@ -9,7 +9,7 @@
 
 // Slice factory + its public contract.
 export { createAgentSlice } from './agentSlice'
-export type { AgentSlice, AgentSliceConfig } from './agentSlice'
+export type { AgentSlice, AgentSliceConfig } from './agentSliceTypes'
 
 // Site-editor wiring (scope, snapshot, dispatcher) handed to the factory.
 export { siteAgentSliceConfig } from './agentSliceConfig.site'

--- a/src/admin/pages/site/agent/streamEvents.ts
+++ b/src/admin/pages/site/agent/streamEvents.ts
@@ -25,9 +25,8 @@
 import { nanoid } from 'nanoid'
 import { aiToolError, type AiToolOutput } from '@core/ai'
 import { Type } from '@core/utils/typeboxHelpers'
-import type { EditorStoreSliceCreator } from '@site/store/types'
 import { postToolResult } from './agentApi'
-import type { AgentSlice } from './agentSlice'
+import type { EditorStoreSet } from './agentSliceTypes'
 import type {
   AgentBridgeRuntime,
   AgentTextStreamSink,
@@ -87,10 +86,6 @@ export const ServerStreamEventSchema = Type.Union([
   Type.Object({ type: Type.Literal('done') }),
   Type.Object({ type: Type.Literal('error'), message: Type.String() }),
 ])
-
-// `set` as the slice creator hands it to its actions — the processor only
-// touches AgentSlice keys, so a narrow AgentSlice-typed setter is sufficient.
-export type EditorStoreSet = Parameters<EditorStoreSliceCreator<AgentSlice>>[0]
 
 // ---------------------------------------------------------------------------
 // Stream event processor

--- a/src/admin/spotlight/state.ts
+++ b/src/admin/spotlight/state.ts
@@ -16,76 +16,9 @@
  *   - argMode: tracks argument-collection flow for commands with args
  *   - pendingConfirm: tracks first-Enter on a destructive command (5 s window)
  */
-
-import type { Command, ScopeFrame } from './types'
 import { applyOpenAction } from './stateHandlers'
-
-// ─── Arg mode ─────────────────────────────────────────────────────────────────
-
-/**
- * State captured while collecting arguments for a command.
- * `argIndex` is the index of the arg currently being filled.
- * `values` holds all previously completed arg values keyed by arg.id.
- */
-export interface ArgModeState {
-  command: Command
-  argIndex: number
-  values: Record<string, string>
-}
-
-// ─── State ────────────────────────────────────────────────────────────────────
-
-export interface SpotlightOpenState {
-  phase: 'open'
-  query: string
-  /** Stack of active scopes; top of stack = active scope. Default: ['root']. */
-  scopeStack: ScopeFrame[]
-  highlightedIndex: number
-  /** Async provider results keyed by providerId (Phase 3). */
-  asyncResults: Record<string, Command[]>
-  /** Provider ids currently in-flight (Phase 3). */
-  loadingProviders: Set<string>
-  /**
-   * Phase 2: Arg-collection mode. Non-null when a command with `args` has been
-   * selected and we're collecting one argument at a time via the input.
-   */
-  argMode: ArgModeState | null
-  /**
-   * Phase 2: ID of the destructive command awaiting a second Enter to confirm.
-   * Cleared by CLEAR_PENDING_CONFIRM (timeout or Escape or second Enter runs).
-   */
-  pendingConfirm: string | null
-}
-
-export type SpotlightState =
-  | { phase: 'closed' }
-  | SpotlightOpenState
-
-// ─── Actions ─────────────────────────────────────────────────────────────────
-
-export type SpotlightAction =
-  | { type: 'OPEN' }
-  | { type: 'CLOSE' }
-  | { type: 'TOGGLE' }
-  | { type: 'SET_QUERY'; query: string }
-  | { type: 'SET_HIGHLIGHTED'; index: number }
-  | { type: 'HIGHLIGHT_NEXT' }
-  | { type: 'HIGHLIGHT_PREV' }
-  | { type: 'PUSH_SCOPE'; scopeId: string; pendingArgs?: Record<string, string> }
-  | { type: 'POP_SCOPE' }
-  | { type: 'SET_ASYNC_RESULTS'; providerId: string; results: Command[] }
-  | { type: 'SET_LOADING_PROVIDER'; providerId: string; loading: boolean }
-  /** Phase 3: reset all async results and loading state (scope change / close). */
-  | { type: 'ASYNC_RESET' }
-  | { type: 'RESULT_COUNT_CHANGED'; count: number }
-  // ── Phase 2: Arg mode ────────────────────────────────────────────────────
-  | { type: 'ENTER_ARG_MODE'; command: Command }
-  | { type: 'SAVE_ARG_AND_ADVANCE'; argId: string; value: string }
-  | { type: 'BACK_ARG' }
-  | { type: 'EXIT_ARG_MODE' }
-  // ── Phase 2: Destructive confirm ─────────────────────────────────────────
-  | { type: 'SET_PENDING_CONFIRM'; commandId: string }
-  | { type: 'CLEAR_PENDING_CONFIRM' }
+import type { SpotlightAction, SpotlightOpenState, SpotlightState } from './stateTypes'
+export type { ArgModeState, SpotlightAction, SpotlightOpenState, SpotlightState } from './stateTypes'
 
 // ─── Initial state ────────────────────────────────────────────────────────────
 

--- a/src/admin/spotlight/stateHandlers.ts
+++ b/src/admin/spotlight/stateHandlers.ts
@@ -18,7 +18,7 @@ import type {
   SpotlightAction,
   SpotlightOpenState,
   SpotlightState,
-} from './state'
+} from './stateTypes'
 
 /** Action variants that are only valid while `state.phase === 'open'`. */
 type OpenOnlyAction = Exclude<

--- a/src/admin/spotlight/stateTypes.ts
+++ b/src/admin/spotlight/stateTypes.ts
@@ -1,0 +1,55 @@
+import type { Command, ScopeFrame } from './types'
+
+export interface ArgModeState {
+  command: Command
+  argIndex: number
+  values: Record<string, string>
+}
+
+export interface SpotlightOpenState {
+  phase: 'open'
+  query: string
+  /** Stack of active scopes; top of stack = active scope. Default: ['root']. */
+  scopeStack: ScopeFrame[]
+  highlightedIndex: number
+  /** Async provider results keyed by providerId (Phase 3). */
+  asyncResults: Record<string, Command[]>
+  /** Provider ids currently in-flight (Phase 3). */
+  loadingProviders: Set<string>
+  /**
+   * Phase 2: Arg-collection mode. Non-null when a command with `args` has been
+   * selected and we're collecting one argument at a time via the input.
+   */
+  argMode: ArgModeState | null
+  /**
+   * Phase 2: ID of the destructive command awaiting a second Enter to confirm.
+   * Cleared by CLEAR_PENDING_CONFIRM (timeout or Escape or second Enter runs).
+   */
+  pendingConfirm: string | null
+}
+
+export type SpotlightState =
+  | { phase: 'closed' }
+  | SpotlightOpenState
+
+export type SpotlightAction =
+  | { type: 'OPEN' }
+  | { type: 'CLOSE' }
+  | { type: 'TOGGLE' }
+  | { type: 'SET_QUERY'; query: string }
+  | { type: 'SET_HIGHLIGHTED'; index: number }
+  | { type: 'HIGHLIGHT_NEXT' }
+  | { type: 'HIGHLIGHT_PREV' }
+  | { type: 'PUSH_SCOPE'; scopeId: string; pendingArgs?: Record<string, string> }
+  | { type: 'POP_SCOPE' }
+  | { type: 'SET_ASYNC_RESULTS'; providerId: string; results: Command[] }
+  | { type: 'SET_LOADING_PROVIDER'; providerId: string; loading: boolean }
+  /** Phase 3: reset all async results and loading state (scope change / close). */
+  | { type: 'ASYNC_RESET' }
+  | { type: 'RESULT_COUNT_CHANGED'; count: number }
+  | { type: 'ENTER_ARG_MODE'; command: Command }
+  | { type: 'SAVE_ARG_AND_ADVANCE'; argId: string; value: string }
+  | { type: 'BACK_ARG' }
+  | { type: 'EXIT_ARG_MODE' }
+  | { type: 'SET_PENDING_CONFIRM'; commandId: string }
+  | { type: 'CLEAR_PENDING_CONFIRM' }

--- a/src/core/fonts/schemas.ts
+++ b/src/core/fonts/schemas.ts
@@ -13,7 +13,7 @@ import { compiledCheck } from '@core/utils/typeboxCompiler'
 import {
   normalizeFontTokenVariable,
   sanitizeFontFallbackStack,
-} from './tokens'
+} from './tokenStrings'
 
 // ---------------------------------------------------------------------------
 // FontSource

--- a/src/core/fonts/tokenStrings.ts
+++ b/src/core/fonts/tokenStrings.ts
@@ -1,0 +1,41 @@
+/**
+ * Font token string helpers.
+ *
+ * Pure string normalization/sanitization used by both persisted font schemas
+ * and runtime token resolution. Kept separate from `tokens.ts` so schema
+ * parsing never imports the domain helpers that depend on schema-derived types.
+ */
+
+export function normalizeFontTokenVariable(raw: string): string {
+  const normalized = raw
+    .trim()
+    .replace(/^-+/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+  if (!normalized) return ''
+  return normalized.startsWith('font-') ? normalized : `font-${normalized}`
+}
+
+export function fontTokenCssVariable(variable: string): string {
+  const normalized = normalizeFontTokenVariable(variable)
+  return normalized ? `--${normalized}` : ''
+}
+
+export function fontTokenValueExpr(variable: string): string {
+  const cssVariable = fontTokenCssVariable(variable)
+  return cssVariable ? `var(${cssVariable})` : ''
+}
+
+export function suggestFontTokenVariable(label: string): string {
+  return normalizeFontTokenVariable(label || 'font')
+}
+
+export function sanitizeFontFallbackStack(raw: string | undefined): string {
+  const cleaned = (raw ?? '')
+    .split(',')
+    .map((part) => part.trim().replace(/["\\\n\r<>;{}]/g, ''))
+    .filter((part) => part.length > 0)
+  if (cleaned.length === 0) return 'sans-serif'
+  return cleaned.join(', ')
+}

--- a/src/core/fonts/tokens.ts
+++ b/src/core/fonts/tokens.ts
@@ -1,29 +1,12 @@
 import type { FontEntry, FontToken, SiteFontsSettings } from './schemas'
-
-export function normalizeFontTokenVariable(raw: string): string {
-  const normalized = raw
-    .trim()
-    .replace(/^-+/, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '')
-  if (!normalized) return ''
-  return normalized.startsWith('font-') ? normalized : `font-${normalized}`
-}
-
-export function fontTokenCssVariable(variable: string): string {
-  const normalized = normalizeFontTokenVariable(variable)
-  return normalized ? `--${normalized}` : ''
-}
-
-export function fontTokenValueExpr(variable: string): string {
-  const cssVariable = fontTokenCssVariable(variable)
-  return cssVariable ? `var(${cssVariable})` : ''
-}
-
-export function suggestFontTokenVariable(label: string): string {
-  return normalizeFontTokenVariable(label || 'font')
-}
+export {
+  fontTokenCssVariable,
+  fontTokenValueExpr,
+  normalizeFontTokenVariable,
+  sanitizeFontFallbackStack,
+  suggestFontTokenVariable,
+} from './tokenStrings'
+import { normalizeFontTokenVariable, sanitizeFontFallbackStack } from './tokenStrings'
 
 export function makeUniqueFontTokenVariable(
   desired: string,
@@ -70,15 +53,6 @@ function fallbackForFontCategory(category: string | undefined): string {
 
 export function defaultFontTokenFallback(entry: FontEntry | undefined): string {
   return fallbackForFontCategory(entry?.category)
-}
-
-export function sanitizeFontFallbackStack(raw: string | undefined): string {
-  const cleaned = (raw ?? '')
-    .split(',')
-    .map((part) => part.trim().replace(/["\\\n\r<>;{}]/g, ''))
-    .filter((part) => part.length > 0)
-  if (cleaned.length === 0) return 'sans-serif'
-  return cleaned.join(', ')
 }
 
 function escapeCssString(value: string): string {

--- a/src/core/html-sanitize/index.ts
+++ b/src/core/html-sanitize/index.ts
@@ -1,0 +1,49 @@
+/**
+ * HTML and URL sanitisation leaf.
+ *
+ * Pure helpers shared by publisher, markdown rendering, module render helpers,
+ * and server-side HTML injection code. This module deliberately depends on
+ * nothing in the publisher so lower-level renderers can use the same escaping
+ * rules without pulling in the whole publishing engine.
+ */
+
+const HTML_ESCAPE_MAP: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+}
+
+/**
+ * HTML-escape the five characters that are dangerous in HTML text and
+ * attribute contexts. Non-strings are stringified for module render helpers
+ * that receive prop values as unknown.
+ */
+export function escapeHtml(value: unknown): string {
+  return String(value ?? '').replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch])
+}
+
+/**
+ * Return true when a URL is safe for href/src/action attributes.
+ * Blocks javascript:, vbscript:, and data: schemes after the same tab/newline
+ * normalisation browsers apply during URL parsing.
+ */
+export function isSafeUrl(url: string): boolean {
+  const normalized = url.replace(/[\t\n\r]/g, '').trim().toLowerCase()
+  return (
+    !normalized.startsWith('javascript:') &&
+    !normalized.startsWith('vbscript:') &&
+    !normalized.startsWith('data:')
+  )
+}
+
+/**
+ * Validate a URL and HTML-escape it for safe interpolation into an attribute.
+ * Unsafe values collapse to "#".
+ */
+export function safeUrl(value: unknown): string {
+  const str = String(value ?? '')
+  if (!isSafeUrl(str)) return '#'
+  return escapeHtml(str)
+}

--- a/src/core/layouts-schema/index.ts
+++ b/src/core/layouts-schema/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Saved-layout schema/type leaf.
+ *
+ * Keeps persisted layout shapes available to the page-tree shell without
+ * importing the broad `@core/layouts` barrel back into the page-tree graph.
+ */
+
+export {
+  SavedLayoutSchema,
+  layoutNameError,
+  layoutSlugFromName,
+  parseSavedLayout,
+} from '../layouts/schemas'
+export type { SavedLayout } from '../layouts/schemas'

--- a/src/core/layouts/schemas.ts
+++ b/src/core/layouts/schemas.ts
@@ -26,7 +26,7 @@ import {
   reindexNodeParents,
   type PageNode,
   type StyleRule,
-} from '@core/page-tree'
+} from '@core/page-tree-schema'
 
 // ---------------------------------------------------------------------------
 // SavedLayout — top-level saved-layout document

--- a/src/core/markdown/renderMarkdown.ts
+++ b/src/core/markdown/renderMarkdown.ts
@@ -32,7 +32,7 @@
  */
 
 import { Marked, type Tokens } from 'marked'
-import { escapeHtml, isSafeUrl } from '@core/publisher'
+import { escapeHtml, isSafeUrl } from '@core/html-sanitize'
 
 export { firstMediaPathFromMarkdown as firstImagePathFromMarkdown } from './markdownDocument'
 

--- a/src/core/module-engine-schema/index.ts
+++ b/src/core/module-engine-schema/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Module-engine schema/type leaf.
+ *
+ * Use this from low-level core modules that only need module definition or
+ * property-control shapes. Importing the broad `@core/module-engine` barrel also
+ * pulls registry/runtime helpers into the dependency graph.
+ */
+
+export type {
+  AnyModuleDefinition,
+  IModuleRegistry,
+  InlineEditBinding,
+  ModuleComponentProps,
+  ModuleDefinition,
+  ModuleDependencies,
+  NodeWrapperProps,
+  RenderOutput,
+} from '../module-engine/types'
+
+export type {
+  PropertyCondition,
+  PropertyControl,
+  PropertyControlLayout,
+  PropertySchema,
+  TextControlNormalize,
+} from '../module-engine/propertySchema'
+
+export {
+  PropertyControlSchema,
+  PropertySchemaSchema,
+  resolvePropertyControlCategory,
+} from '../module-engine/propertySchema'
+
+export { resolveHtmlTagBadge } from '../module-engine/htmlTagBadge'

--- a/src/core/module-engine/dependencies.ts
+++ b/src/core/module-engine/dependencies.ts
@@ -1,7 +1,7 @@
-import type { SiteDocument } from '@core/page-tree'
 import type { AnyModuleDefinition, IModuleRegistry, ModuleDependencies } from './types'
 import type { SitePackageJson } from '@core/site-dependencies/manifest'
 import { isSafePackageName } from '@core/site-dependencies/packageNames'
+import type { BaseNode } from '@core/page-tree-schema'
 
 export interface NormalizedModuleDependency {
   name: string
@@ -16,6 +16,11 @@ export interface SiteModuleDependencyUsage {
   modules: string[]
   moduleIds: string[]
   placements: number
+}
+
+interface ModuleDependencySite {
+  pages: ReadonlyArray<{ nodes: Record<string, BaseNode> }>
+  visualComponents: ReadonlyArray<{ tree: { nodes: Record<string, BaseNode> } }>
 }
 
 export function normalizeModuleDependencies(
@@ -59,7 +64,7 @@ export function getMissingModuleDependencies(
 }
 
 export function getSiteModuleDependencyUsage(
-  site: Pick<SiteDocument, 'pages' | 'visualComponents'> | null | undefined,
+  site: ModuleDependencySite | null | undefined,
   registry: IModuleRegistry,
 ): Map<string, SiteModuleDependencyUsage> {
   const usage = new Map<string, SiteModuleDependencyUsage>()

--- a/src/core/module-engine/runtimeResolver.ts
+++ b/src/core/module-engine/runtimeResolver.ts
@@ -27,7 +27,7 @@ import {
   type NormalizedModuleDependency,
 } from './dependencies'
 import type { SitePackageJson } from '@core/site-dependencies/manifest'
-import type { RuntimePackageImportmap } from '@core/site-runtime'
+import type { RuntimePackageImportmap } from '@core/site-runtime-schema'
 
 interface RuntimeResolverOptions {
   packageJson?: SitePackageJson

--- a/src/core/page-tree-schema/index.ts
+++ b/src/core/page-tree-schema/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Page-tree schema/type leaf.
+ *
+ * This is the acyclic public surface for page-tree primitives: node schemas,
+ * tree shapes, tolerant parsers, and tree-local helpers that do not depend on
+ * SiteDocument, visual components, layouts, publisher, or the module registry.
+ */
+
+export {
+  BaseNodeSchema,
+  parseBaseNodeFields,
+} from '../page-tree/baseNode'
+export type { BaseNode } from '../page-tree/baseNode'
+
+export { asPlainObject } from '../page-tree/parseHelpers'
+
+export { NodeTreeSchema } from '../page-tree/treeSchema'
+export type { NodeTree } from '../page-tree/treeSchema'
+
+export {
+  PageNodeSchema,
+  parsePageNode,
+} from '../page-tree/pageNode'
+export type { PageNode } from '../page-tree/pageNode'
+
+export { PageSchema, parsePage } from '../page-tree/page'
+export type { Page } from '../page-tree/page'
+
+export {
+  StyleRuleSchema,
+  parseStyleRule,
+} from '../page-tree/styleRule'
+export type { StyleRule } from '../page-tree/styleRule'
+
+export { reindexNodeParents } from '../page-tree/parentIndex'
+export {
+  collectSubtreeIds,
+  getAncestors,
+  getChildren,
+  getNode,
+  getNodeOrThrow,
+  getParent,
+  isAncestor,
+} from '../page-tree/selectors'
+export { deleteSubtree, removeNodeSubtrees } from '../page-tree/subtreeRemoval'
+
+export { DynamicPropBindingSchema } from '../page-tree/dynamicBinding'
+export type { DynamicPropBinding } from '../page-tree/dynamicBinding'

--- a/src/core/page-tree/explorerPathPlans.ts
+++ b/src/core/page-tree/explorerPathPlans.ts
@@ -2,8 +2,8 @@ import { isSafePath, normalizePath } from '@core/files/pathValidation'
 import type { SiteFile } from '@core/files/schemas'
 import {
   extractRuntimeImportSpecifiers,
-  type SiteRuntimeConfig,
 } from '@core/site-runtime'
+import type { SiteRuntimeConfig } from '@core/site-runtime-schema'
 import type { SiteDocument } from './siteDocument'
 import type { StructuralSiteExplorerSectionId } from './siteExplorer'
 import { isHomePage, pageSlugError } from './slugs'

--- a/src/core/page-tree/nodeDisplayName.ts
+++ b/src/core/page-tree/nodeDisplayName.ts
@@ -24,9 +24,8 @@
  */
 
 import type { PageNode } from './pageNode'
-import type { VisualComponent } from '@core/visualComponents'
-import type { AnyModuleDefinition } from '@core/module-engine'
-import { resolveHtmlTagBadge } from '@core/module-engine'
+import type { VisualComponent } from '@core/visual-components-schema'
+import { resolveHtmlTagBadge, type AnyModuleDefinition } from '@core/module-engine-schema'
 import { classNamesForClassIds, type StyleRuleRegistry } from './classNames'
 
 export function getNodeDisplayName(

--- a/src/core/page-tree/selectors.ts
+++ b/src/core/page-tree/selectors.ts
@@ -182,7 +182,7 @@ export function resolveProps(
 // Property condition evaluation
 // ---------------------------------------------------------------------------
 
-import type { PropertyCondition, PropertySchema } from '@core/module-engine'
+import type { PropertyCondition, PropertySchema } from '@core/module-engine-schema'
 
 /**
  * Evaluate a declarative PropertyCondition against a props object.

--- a/src/core/page-tree/siteDocument.ts
+++ b/src/core/page-tree/siteDocument.ts
@@ -41,8 +41,8 @@ import { SiteFileSchema, type SiteFile, type SiteFileType } from '@core/files/sc
 import { SiteRuntimeConfigSchema, type SiteRuntimeConfig } from '@core/site-runtime/schemas'
 import { normalizeSiteRuntimeConfig } from '@core/site-runtime/runtimeConfig'
 import { SitePackageJsonSchema, type SitePackageJson } from '@core/site-dependencies/manifest'
-import { type VisualComponent } from '@core/visualComponents'
-import type { SavedLayout } from '@core/layouts'
+import { type VisualComponent } from '@core/visual-components-schema'
+import type { SavedLayout } from '@core/layouts-schema'
 import type { Page } from './page'
 import {
   SiteExplorerOrganizationSchema,

--- a/src/core/page-tree/siteExplorer.ts
+++ b/src/core/page-tree/siteExplorer.ts
@@ -3,8 +3,7 @@ import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
 import { compiledCheck, compiledDecode } from '@core/utils/typeboxCompiler'
 import type { SiteFile } from '@core/files/schemas'
 import type { Page } from './page'
-import type { SiteDocument } from './siteDocument'
-import type { VisualComponent } from '@core/visualComponents'
+import type { VisualComponent } from '@core/visual-components-schema'
 import { isHomePage } from './slugs'
 import { addFolderPrefixes, parentPathForPath } from './explorerPaths'
 
@@ -73,6 +72,10 @@ interface SiteExplorerSources {
   pages: readonly Page[]
   visualComponents: readonly VisualComponent[]
   files: readonly SiteFile[]
+}
+
+interface SiteExplorerDocument extends SiteExplorerSources {
+  explorer: SiteExplorerOrganization | undefined
 }
 
 export function createDefaultSiteExplorerOrganization(): SiteExplorerOrganization {
@@ -635,6 +638,6 @@ function orderedSelectedItems(
   return section.items.filter((item) => selectedIds.has(item.id))
 }
 
-export function reconcileSiteExplorerInPlace(site: SiteDocument): void {
+export function reconcileSiteExplorerInPlace(site: SiteExplorerDocument): void {
   site.explorer = reconcileSiteExplorerOrganization(site.explorer, site)
 }

--- a/src/core/page-tree/siteSelectors.ts
+++ b/src/core/page-tree/siteSelectors.ts
@@ -8,7 +8,7 @@
  * cache invalidates when the data changes.
  */
 import type { SiteDocument } from './siteDocument'
-import type { VisualComponent } from '@core/visualComponents'
+import type { VisualComponent } from '@core/visual-components-schema'
 
 // ---------------------------------------------------------------------------
 // Internal caches

--- a/src/core/publisher/utils.ts
+++ b/src/core/publisher/utils.ts
@@ -21,68 +21,11 @@
  *     per-file reimplementations (same pattern that fixed CWE-116 for HTML escaping).
  */
 
-// ---------------------------------------------------------------------------
-// HTML escaping
-// ---------------------------------------------------------------------------
-
-const HTML_ESCAPE_MAP: Record<string, string> = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#x27;',
-}
-
-/**
- * HTML-escape the 5 characters that are dangerous in HTML text / attribute contexts.
- * Accepts `unknown` — non-strings are stringified first (graceful handling of
- * number props passed as unknown in typed module render signatures).
- */
-export function escapeHtml(value: unknown): string {
-  return String(value ?? '').replace(/[&<>"']/g, (ch) => HTML_ESCAPE_MAP[ch])
-}
-
-// ---------------------------------------------------------------------------
-// URL validation
-// ---------------------------------------------------------------------------
-
-/**
- * Return true if a URL is safe to use in href/src/action attributes.
- * Blocks javascript:, vbscript:, and data: URL schemes.
- *
- * Normalisation: strips \t, \n, \r before scheme detection — the WHATWG URL parser
- * removes these characters too, so `java\tscript:` would be treated as `javascript:`
- * by browsers (CWE-79 bypass). We must mirror that normalisation.
- *
- * data: URIs are blocked because:
- * - `data:text/html,...` in href opens a new browsing context with arbitrary HTML/JS,
- *   bypassing the published page's CSP (which only governs the current document).
- * - `data:image/svg+xml,...` may embed JavaScript in SVG content.
- * For safe inline images, host apps should use CDN URLs or properly hosted assets.
- */
-export function isSafeUrl(url: string): boolean {
-  const normalized = url.replace(/[\t\n\r]/g, '').trim().toLowerCase()
-  return (
-    !normalized.startsWith('javascript:') &&
-    !normalized.startsWith('vbscript:') &&
-    !normalized.startsWith('data:')
-  )
-}
-
-/**
- * Validate a URL and HTML-escape it for safe use in an HTML attribute.
- *
- * - Unsafe URLs (javascript:/vbscript:) are replaced with '#'.
- * - Safe URLs are HTML-escaped (e.g. `&` in query strings → `&amp;`).
- *
- * Accepts `unknown` for convenience in module render() signatures.
- * Use this for ALL URL props in module render() functions.
- */
-export function safeUrl(value: unknown): string {
-  const str = String(value ?? '')
-  if (!isSafeUrl(str)) return '#'
-  return escapeHtml(str)
-}
+// HTML and URL helpers live in the dependency-free `@core/html-sanitize` leaf.
+// Re-exported here so publisher-side consumers can keep importing from the
+// publisher barrel without making markdown/template code depend on the full
+// publisher graph.
+export { escapeHtml, isSafeUrl, safeUrl } from '@core/html-sanitize'
 
 // ---------------------------------------------------------------------------
 // CSS value sanitisation

--- a/src/core/site-runtime-schema/index.ts
+++ b/src/core/site-runtime-schema/index.ts
@@ -1,0 +1,34 @@
+/**
+ * Site runtime schema/type leaf.
+ *
+ * Consumers that only need persisted runtime shapes import this leaf instead of
+ * the broad `@core/site-runtime` barrel, which also exports normalization and
+ * import-analysis behavior.
+ */
+
+export type {
+  LockedSiteDependency,
+  PublishedPageRuntimeAssets,
+  PublishedRuntimeScriptAsset,
+  RuntimePackageDependencyUsage,
+  RuntimePackageImportmap,
+  RuntimeScriptEntry,
+  SiteAssetScope,
+  SiteDependencyLock,
+  SiteRuntimeConfig,
+  SiteRuntimeDiagnostic,
+  SiteRuntimeTarget,
+  SiteScriptFormat,
+  SiteScriptPlacement,
+  SiteScriptRuntimeConfig,
+  SiteScriptTiming,
+  SiteStyleRuntimeConfig,
+} from '../site-runtime/schemas'
+
+export {
+  PublishedPageRuntimeAssetsSchema,
+  RuntimePackageImportmapSchema,
+  SiteDependencyLockSchema,
+  SiteRuntimeConfigSchema,
+  SiteRuntimeDiagnosticSchema,
+} from '../site-runtime/schemas'

--- a/src/core/site-runtime/runtimeConfig.ts
+++ b/src/core/site-runtime/runtimeConfig.ts
@@ -1,5 +1,4 @@
 import { isSafePackageName } from '@core/site-dependencies/packageNames'
-import type { Page } from '@core/page-tree'
 import type { SiteFile } from '@core/files/schemas'
 import type {
   LockedSiteDependency,
@@ -20,7 +19,7 @@ import type {
 interface CollectRuntimeScriptsInput {
   files: SiteFile[]
   runtime: SiteRuntimeConfig
-  page: Page
+  page: RuntimeScopedPage
   target: SiteRuntimeTarget
 }
 
@@ -28,7 +27,12 @@ interface CollectRuntimeScriptsInput {
 interface CollectAppliedStylesInput {
   files: SiteFile[]
   runtime: SiteRuntimeConfig
-  page: Page
+  page: RuntimeScopedPage
+}
+
+interface RuntimeScopedPage {
+  id: string
+  template?: unknown
 }
 
 const DEFAULT_SITE_DEPENDENCY_LOCK: SiteDependencyLock = {

--- a/src/core/templates/dynamicBindings.ts
+++ b/src/core/templates/dynamicBindings.ts
@@ -26,46 +26,17 @@
  */
 
 import type { DynamicPropBinding } from '@core/page-tree'
-import type { LoopItem } from '@core/loops/types'
 import { renderMarkdownToHtml } from '@core/markdown/renderMarkdown'
 import { isRichtextPropKey } from '@core/sanitize'
-import type {
-  PageFrame,
-  SiteFrame,
-  RouteFrame,
-} from './contextFrames'
+import type { TemplateRenderDataContext } from './renderDataContext'
+
+export type { TemplateRenderDataContext } from './renderDataContext'
 import {
   containsTokens,
   interpolateTokens,
   readFrame,
   walkFieldPath,
 } from './tokenInterpolation'
-
-/**
- * Render-time context handed to the publisher.
- *
- * `entryStack` is an IMMUTABLE snapshot for the current frame. The publisher's
- * loop renderer does not push/pop in place — for each iteration it derives a
- * new context with `entryStack: [...baseStack, item]`, so a subtree rendered
- * inside the loop body (including a VC ref) sees a stable per-iteration stack
- * rather than a live, mutating list. Stack-top resolves
- * `source: 'currentEntry'`; one below resolves `source: 'parentEntry'`.
- *
- * The three named frames (`page`, `site`, `route`) are always provided
- * on every render — they're built once by the publisher and referenced
- * by the corresponding binding sources.
- *
- * Every field is `readonly`: a render pass treats the whole context as an
- * immutable input. This keeps the resolver branchless for the common case
- * (frame lookup is a property read) and makes the per-iteration derivation
- * the only way to extend the stack.
- */
-export interface TemplateRenderDataContext {
-  readonly entryStack: readonly LoopItem[]
-  readonly page?: PageFrame
-  readonly site?: SiteFrame
-  readonly route?: RouteFrame
-}
 
 /**
  * Resolve a single binding to its runtime value.

--- a/src/core/templates/renderDataContext.ts
+++ b/src/core/templates/renderDataContext.ts
@@ -1,0 +1,25 @@
+/**
+ * Render-time data context shared by structured dynamic bindings and inline
+ * token interpolation.
+ */
+
+import type { LoopItem } from '@core/loops/types'
+import type {
+  PageFrame,
+  RouteFrame,
+  SiteFrame,
+} from './contextFrames'
+
+/**
+ * Render-time context handed to the publisher.
+ *
+ * `entryStack` is an immutable snapshot for the current frame. Stack-top
+ * resolves `currentEntry`; one below resolves `parentEntry`. The named frames
+ * are built by the publisher and referenced by their matching binding sources.
+ */
+export interface TemplateRenderDataContext {
+  readonly entryStack: readonly LoopItem[]
+  readonly page?: PageFrame
+  readonly site?: SiteFrame
+  readonly route?: RouteFrame
+}

--- a/src/core/templates/tokenInterpolation.ts
+++ b/src/core/templates/tokenInterpolation.ts
@@ -28,7 +28,7 @@
  */
 
 import type { DynamicPropBinding } from '@core/page-tree'
-import type { TemplateRenderDataContext } from './dynamicBindings'
+import type { TemplateRenderDataContext } from './renderDataContext'
 
 // ---------------------------------------------------------------------------
 // Source identifiers — must match DynamicBindingSourceSchema

--- a/src/core/visual-components-schema/index.ts
+++ b/src/core/visual-components-schema/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Visual Components schema/type leaf.
+ *
+ * Import this from lower-level core modules that only need the persisted Visual
+ * Component shapes. The broad `@core/visualComponents` barrel also exports
+ * instantiation, slot-sync, deletion-impact, and virtual-page behavior.
+ */
+
+export {
+  VCNodeSchema,
+  VisualComponentSchema,
+  parseVisualComponent,
+} from '../visualComponents/schemas'
+export type {
+  VCNode,
+  VCParam,
+  VCParamType,
+  VisualComponent,
+} from '../visualComponents/schemas'

--- a/src/core/visualComponents/deletionImpact.ts
+++ b/src/core/visualComponents/deletionImpact.ts
@@ -9,8 +9,9 @@
  * Constraint #269: no imports from editor / editor-store here.
  */
 
-import type { SiteDocument } from '@core/page-tree'
 import { forEachVCRef } from './vcRefs'
+import type { BaseNode, Page } from '@core/page-tree-schema'
+import type { VisualComponent } from './schemas'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -43,6 +44,13 @@ export interface VCDeletionImpact {
   vcCount: number
 }
 
+interface SiteWithVisualComponents {
+  pages: ReadonlyArray<Pick<Page, 'id' | 'title' | 'nodes'>>
+  visualComponents: ReadonlyArray<Pick<VisualComponent, 'id' | 'name'> & {
+    tree: { nodes: Record<string, BaseNode> }
+  }>
+}
+
 // ---------------------------------------------------------------------------
 // previewVCDeletion
 // ---------------------------------------------------------------------------
@@ -58,7 +66,7 @@ export interface VCDeletionImpact {
  * actionable information for the user.
  */
 export function previewVCDeletion(
-  site: SiteDocument,
+  site: SiteWithVisualComponents,
   vcId: string,
 ): VCDeletionImpact | null {
   const vc = site.visualComponents.find((v) => v.id === vcId)

--- a/src/core/visualComponents/instantiate.ts
+++ b/src/core/visualComponents/instantiate.ts
@@ -23,7 +23,7 @@
  */
 
 import { Type } from '@sinclair/typebox'
-import type { BaseNode } from '@core/page-tree'
+import type { BaseNode } from '@core/page-tree-schema'
 import { compiledCheck } from '@core/utils/typeboxCompiler'
 import type { VisualComponent, VCNode } from './schemas'
 import { VCNodeSchema } from './schemas'

--- a/src/core/visualComponents/schemas.ts
+++ b/src/core/visualComponents/schemas.ts
@@ -9,7 +9,14 @@
  */
 
 import { Type, type Static, withFallback } from '@core/utils/typeboxHelpers'
-import { BaseNodeSchema, NodeTreeSchema, type BaseNode, asPlainObject, parseBaseNodeFields, reindexNodeParents } from '@core/page-tree'
+import {
+  BaseNodeSchema,
+  NodeTreeSchema,
+  asPlainObject,
+  parseBaseNodeFields,
+  reindexNodeParents,
+  type BaseNode,
+} from '@core/page-tree-schema'
 
 // ---------------------------------------------------------------------------
 // VCParamType — valid param type values

--- a/src/core/visualComponents/slotSync.ts
+++ b/src/core/visualComponents/slotSync.ts
@@ -16,7 +16,7 @@
  */
 
 import { nanoid } from 'nanoid'
-import { deleteSubtree, type BaseNode } from '@core/page-tree'
+import { deleteSubtree, type BaseNode } from '@core/page-tree-schema'
 import type { VisualComponent } from './schemas'
 
 // ---------------------------------------------------------------------------

--- a/src/core/visualComponents/virtualPage.ts
+++ b/src/core/visualComponents/virtualPage.ts
@@ -18,7 +18,7 @@
  * generated from `crypto.randomUUID()` and never collide with the prefix).
  */
 
-import type { Page, PageNode } from '@core/page-tree'
+import type { Page, PageNode } from '@core/page-tree-schema'
 import type { VisualComponent } from './schemas'
 
 /**

--- a/src/modules/base/button/ButtonEditor.tsx
+++ b/src/modules/base/button/ButtonEditor.tsx
@@ -14,7 +14,7 @@ import { anchorRel } from '@modules/base/shared/anchorTarget'
 import { htmlAttributesForReact } from '@modules/base/shared/htmlAttributes'
 import { inlineEditableElementProps } from '@modules/base/shared/inlineText'
 import { resolveButtonAnchor } from './anchor'
-import type { ButtonStoredProps } from './index'
+import type { ButtonStoredProps } from './props'
 
 export const ButtonEditor: React.FC<ModuleComponentProps<ButtonStoredProps>> = ({
   props,

--- a/src/modules/base/button/index.ts
+++ b/src/modules/base/button/index.ts
@@ -8,25 +8,15 @@
 import type { ModuleDefinition } from '@core/module-engine'
 import { registry } from '@core/module-engine'
 import { CursorClickSolidIcon } from 'pixel-art-icons/icons/cursor-click-solid'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
-import { AnchorTargetSchema, ANCHOR_TARGET_OPTIONS, anchorRel } from '@modules/base/shared/anchorTarget'
+import { Value } from '@core/utils/typeboxHelpers'
+import { ANCHOR_TARGET_OPTIONS, anchorRel } from '@modules/base/shared/anchorTarget'
 import {
   htmlAttributesAttr,
   htmlAttributesControl,
-  HtmlAttributesPropSchemaOptions,
 } from '@modules/base/shared/htmlAttributes'
 import { resolveButtonAnchor } from './anchor'
 import { ButtonEditor } from './ButtonEditor'
-
-const ButtonPropsSchema = Type.Object({
-  label: Type.String({ default: 'Get Started' }),
-  href: Type.String({ default: '' }),
-  target: AnchorTargetSchema,
-  disabled: Type.Boolean({ default: false }),
-  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
-})
-
-export type ButtonStoredProps = Static<typeof ButtonPropsSchema>
+import { ButtonPropsSchema, type ButtonStoredProps } from './props'
 
 export const ButtonModule: ModuleDefinition<ButtonStoredProps> = {
   id: 'base.button',

--- a/src/modules/base/button/props.ts
+++ b/src/modules/base/button/props.ts
@@ -1,0 +1,13 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+import { AnchorTargetSchema } from '@modules/base/shared/anchorTarget'
+import { HtmlAttributesPropSchemaOptions } from '@modules/base/shared/htmlAttributes'
+
+export const ButtonPropsSchema = Type.Object({
+  label: Type.String({ default: 'Get Started' }),
+  href: Type.String({ default: '' }),
+  target: AnchorTargetSchema,
+  disabled: Type.Boolean({ default: false }),
+  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
+})
+
+export type ButtonStoredProps = Static<typeof ButtonPropsSchema>

--- a/src/modules/base/container/ContainerEditor.tsx
+++ b/src/modules/base/container/ContainerEditor.tsx
@@ -37,7 +37,7 @@ import { resolveHtmlTag, VOID_HTML_ELEMENTS } from '@modules/base/utils/htmlTag'
 import { htmlAttributesForReact } from '@modules/base/shared/htmlAttributes'
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { ContainerSolidIcon } from 'pixel-art-icons/icons/container-solid'
-import type { ContainerStoredProps } from './index'
+import type { ContainerStoredProps } from './props'
 
 export const ContainerEditor: React.FC<ModuleComponentProps<ContainerStoredProps>> = ({
   props,

--- a/src/modules/base/container/index.ts
+++ b/src/modules/base/container/index.ts
@@ -20,18 +20,10 @@ import {
 import {
   htmlAttributesAttr,
   htmlAttributesControl,
-  HtmlAttributesPropSchemaOptions,
 } from '@modules/base/shared/htmlAttributes'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import { ContainerEditor } from './ContainerEditor'
-
-const ContainerPropsSchema = Type.Object({
-  tag: Type.String({ default: 'div' }),
-  customTag: Type.String({ default: '' }),
-  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
-})
-
-export type ContainerStoredProps = Static<typeof ContainerPropsSchema>
+import { ContainerPropsSchema, type ContainerStoredProps } from './props'
 
 export const ContainerModule: ModuleDefinition<ContainerStoredProps> = {
   id: 'base.container',

--- a/src/modules/base/container/props.ts
+++ b/src/modules/base/container/props.ts
@@ -1,0 +1,10 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+import { HtmlAttributesPropSchemaOptions } from '@modules/base/shared/htmlAttributes'
+
+export const ContainerPropsSchema = Type.Object({
+  tag: Type.String({ default: 'div' }),
+  customTag: Type.String({ default: '' }),
+  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
+})
+
+export type ContainerStoredProps = Static<typeof ContainerPropsSchema>

--- a/src/modules/base/image/ImageEditor.tsx
+++ b/src/modules/base/image/ImageEditor.tsx
@@ -24,7 +24,7 @@ import { useCmsMediaAssetByPath } from '@admin/pages/media/hooks/useCmsMediaAsse
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
 import { htmlAttributesForReact } from '@modules/base/shared/htmlAttributes'
-import type { ImageStoredProps } from './index'
+import type { ImageStoredProps } from './props'
 import { shouldUseBlurPlaceholder } from './placeholder'
 
 // Best-guess CSS width for the canvas preview tile. Triggers DPR-aware

--- a/src/modules/base/image/index.ts
+++ b/src/modules/base/image/index.ts
@@ -19,46 +19,24 @@
  */
 import type { ModuleDefinition } from '@core/module-engine'
 import type { RenderResolvedMedia } from '@core/publisher'
-import { Type, Value } from '@core/utils/typeboxHelpers'
-import type { Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import { registry } from '@core/module-engine'
 import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
 import { escapeHtml, safeUrl } from '@modules/base/utils/escape'
 import {
   htmlAttributesAttr,
   htmlAttributesControl,
-  HtmlAttributesPropSchemaOptions,
 } from '@modules/base/shared/htmlAttributes'
 import { buildMediaSrcset } from '@modules/base/utils/mediaAttrs'
 import { ImageEditor } from './ImageEditor'
 import { shouldUseBlurPlaceholder } from './placeholder'
+import { ImagePropsSchema, type ImageStoredProps } from './props'
 
 // ---------------------------------------------------------------------------
 // Props schema — authored fields only. Publisher-injected fields (_resolved*)
 // are NOT declared here; validateNodeProps merges them over the cleaned props
 // so they survive the coercion step untouched.
 // ---------------------------------------------------------------------------
-
-const ImagePropsSchema = Type.Object({
-  src: Type.String({ default: '' }),
-  loading: Type.Union([Type.Literal('lazy'), Type.Literal('eager')], { default: 'lazy' }),
-  /**
-   * `fetchpriority` hint. Use `'high'` for hero / above-the-fold images,
-   * `'low'` for offscreen marketing chrome.
-   */
-  fetchPriority: Type.Union(
-    [Type.Literal('auto'), Type.Literal('high'), Type.Literal('low')],
-    { default: 'auto' },
-  ),
-  decoding: Type.Union(
-    [Type.Literal('async'), Type.Literal('sync'), Type.Literal('auto')],
-    { default: 'async' },
-  ),
-  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
-})
-
-/** Authored (stored) props — shape the user edits and the database persists. */
-export type ImageStoredProps = Static<typeof ImagePropsSchema>
 
 /**
  * Full render-time props. Intersects the authored schema shape with

--- a/src/modules/base/image/props.ts
+++ b/src/modules/base/image/props.ts
@@ -1,0 +1,18 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+import { HtmlAttributesPropSchemaOptions } from '@modules/base/shared/htmlAttributes'
+
+export const ImagePropsSchema = Type.Object({
+  src: Type.String({ default: '' }),
+  loading: Type.Union([Type.Literal('lazy'), Type.Literal('eager')], { default: 'lazy' }),
+  fetchPriority: Type.Union(
+    [Type.Literal('auto'), Type.Literal('high'), Type.Literal('low')],
+    { default: 'auto' },
+  ),
+  decoding: Type.Union(
+    [Type.Literal('async'), Type.Literal('sync'), Type.Literal('auto')],
+    { default: 'async' },
+  ),
+  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
+})
+
+export type ImageStoredProps = Static<typeof ImagePropsSchema>

--- a/src/modules/base/link/LinkEditor.tsx
+++ b/src/modules/base/link/LinkEditor.tsx
@@ -13,7 +13,7 @@ import { anchorRel } from '@modules/base/shared/anchorTarget'
 import { htmlAttributesForReact } from '@modules/base/shared/htmlAttributes'
 import { inlineEditableElementProps } from '@modules/base/shared/inlineText'
 import { linkUsesChildren } from './content'
-import type { LinkStoredProps } from './index'
+import type { LinkStoredProps } from './props'
 
 export const LinkEditor: React.FC<ModuleComponentProps<LinkStoredProps>> = ({ props, children, mcClassName, nodeWrapperProps, inlineEdit }) => {
   const childCount = Array.isArray(children) ? children.length : children != null ? 1 : 0

--- a/src/modules/base/link/index.ts
+++ b/src/modules/base/link/index.ts
@@ -8,24 +8,15 @@ import type { ModuleDefinition } from '@core/module-engine'
 import { registry } from '@core/module-engine'
 import { LinkIcon } from 'pixel-art-icons/icons/link'
 import { safeUrl } from '@modules/base/utils/escape'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
-import { AnchorTargetSchema, ANCHOR_TARGET_OPTIONS, anchorRel } from '@modules/base/shared/anchorTarget'
+import { Value } from '@core/utils/typeboxHelpers'
+import { ANCHOR_TARGET_OPTIONS, anchorRel } from '@modules/base/shared/anchorTarget'
 import {
   htmlAttributesAttr,
   htmlAttributesControl,
-  HtmlAttributesPropSchemaOptions,
 } from '@modules/base/shared/htmlAttributes'
 import { linkUsesChildren } from './content'
 import { LinkEditor } from './LinkEditor'
-
-const LinkPropsSchema = Type.Object({
-  href: Type.String({ default: '#' }),
-  text: Type.String({ default: 'Click here' }),
-  target: AnchorTargetSchema,
-  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
-})
-
-export type LinkStoredProps = Static<typeof LinkPropsSchema>
+import { LinkPropsSchema, type LinkStoredProps } from './props'
 
 export const LinkModule: ModuleDefinition<LinkStoredProps> = {
   id: 'base.link',

--- a/src/modules/base/link/props.ts
+++ b/src/modules/base/link/props.ts
@@ -1,0 +1,12 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+import { AnchorTargetSchema } from '@modules/base/shared/anchorTarget'
+import { HtmlAttributesPropSchemaOptions } from '@modules/base/shared/htmlAttributes'
+
+export const LinkPropsSchema = Type.Object({
+  href: Type.String({ default: '#' }),
+  text: Type.String({ default: 'Click here' }),
+  target: AnchorTargetSchema,
+  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
+})
+
+export type LinkStoredProps = Static<typeof LinkPropsSchema>

--- a/src/modules/base/list/ListEditor.tsx
+++ b/src/modules/base/list/ListEditor.tsx
@@ -9,7 +9,7 @@ import React from 'react'
 import type { ModuleComponentProps } from '@core/module-engine'
 import styles from './list.module.css'
 import { parseItems } from './items'
-import type { ListStoredProps } from './index'
+import type { ListStoredProps } from './props'
 
 export const ListEditor: React.FC<ModuleComponentProps<ListStoredProps>> = ({ props, mcClassName, nodeWrapperProps }) => {
   const items = parseItems(props.items || '')

--- a/src/modules/base/list/index.ts
+++ b/src/modules/base/list/index.ts
@@ -6,19 +6,11 @@
  */
 import type { ModuleDefinition } from '@core/module-engine'
 import { registry } from '@core/module-engine'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import { ListBoxSolidIcon } from 'pixel-art-icons/icons/list-box-solid'
 import { parseItems } from './items'
 import { ListEditor } from './ListEditor'
-
-const ListPropsSchema = Type.Object({
-  items: Type.String({ default: '' }),
-  listType: Type.Union([Type.Literal('unordered'), Type.Literal('ordered')], {
-    default: 'unordered',
-  }),
-})
-
-export type ListStoredProps = Static<typeof ListPropsSchema>
+import { ListPropsSchema, type ListStoredProps } from './props'
 
 export const ListModule: ModuleDefinition<ListStoredProps> = {
   id: 'base.list',

--- a/src/modules/base/list/props.ts
+++ b/src/modules/base/list/props.ts
@@ -1,0 +1,10 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const ListPropsSchema = Type.Object({
+  items: Type.String({ default: '' }),
+  listType: Type.Union([Type.Literal('unordered'), Type.Literal('ordered')], {
+    default: 'unordered',
+  }),
+})
+
+export type ListStoredProps = Static<typeof ListPropsSchema>

--- a/src/modules/base/outlet/OutletEditor.tsx
+++ b/src/modules/base/outlet/OutletEditor.tsx
@@ -27,7 +27,7 @@ import { resolveHtmlTag } from '@modules/base/utils/htmlTag'
 import { ReadOnlyNodeTree } from '@modules/base/utils/ReadOnlyNodeTree'
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { TextPlusIcon } from 'pixel-art-icons/icons/text-plus'
-import type { OutletStoredProps } from './index'
+import type { OutletStoredProps } from './props'
 
 export const OutletEditor: React.FC<ModuleComponentProps<OutletStoredProps>> = ({
   props,

--- a/src/modules/base/outlet/index.ts
+++ b/src/modules/base/outlet/index.ts
@@ -16,7 +16,7 @@
  */
 import type { ModuleDefinition } from '@core/module-engine'
 import { registry } from '@core/module-engine'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import { TargetSolidIcon } from 'pixel-art-icons/icons/target-solid'
 import {
   customHtmlTagControl,
@@ -24,19 +24,7 @@ import {
   resolveHtmlTag,
 } from '@modules/base/utils/htmlTag'
 import { OutletEditor } from './OutletEditor'
-
-const OutletPropsSchema = Type.Object({
-  tag: Type.String({ default: 'main' }),
-  customTag: Type.String({ default: '' }),
-  /**
-   * Binding target only — the publisher fills this with the current entry's
-   * body HTML. Never hand-edited; its `schema` control is `hidden: true` so it
-   * carries a richtext type for escaping but renders no panel control.
-   */
-  html: Type.String({ default: '' }),
-})
-
-export type OutletStoredProps = Static<typeof OutletPropsSchema>
+import { OutletPropsSchema, type OutletStoredProps } from './props'
 
 export const OutletModule: ModuleDefinition<OutletStoredProps> = {
   id: 'base.outlet',

--- a/src/modules/base/outlet/props.ts
+++ b/src/modules/base/outlet/props.ts
@@ -1,0 +1,9 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const OutletPropsSchema = Type.Object({
+  tag: Type.String({ default: 'main' }),
+  customTag: Type.String({ default: '' }),
+  html: Type.String({ default: '' }),
+})
+
+export type OutletStoredProps = Static<typeof OutletPropsSchema>

--- a/src/modules/base/slotInstance/SlotInstanceEditor.tsx
+++ b/src/modules/base/slotInstance/SlotInstanceEditor.tsx
@@ -13,7 +13,7 @@ import type { ModuleComponentProps } from '@core/module-engine'
 import { resolveSlotName } from '@core/visualComponents'
 import { TargetSolidIcon } from 'pixel-art-icons/icons/target-solid'
 import styles from './SlotInstance.module.css'
-import type { SlotInstanceStoredProps } from './index'
+import type { SlotInstanceStoredProps } from './props'
 
 export const SlotInstanceEditor: React.FC<ModuleComponentProps<SlotInstanceStoredProps>> = ({
   props,

--- a/src/modules/base/slotInstance/index.ts
+++ b/src/modules/base/slotInstance/index.ts
@@ -20,13 +20,8 @@ import type { ModuleDefinition } from '@core/module-engine'
 import { registry } from '@core/module-engine'
 import { TargetSolidIcon } from 'pixel-art-icons/icons/target-solid'
 import { SlotInstanceEditor } from './SlotInstanceEditor'
-import { Type, Value } from '@core/utils/typeboxHelpers'
-import type { Static } from '@core/utils/typeboxHelpers'
-
-const SlotInstancePropsSchema = Type.Object({
-  slotName: Type.String({ default: 'children' }),
-})
-export type SlotInstanceStoredProps = Static<typeof SlotInstancePropsSchema>
+import { Value } from '@core/utils/typeboxHelpers'
+import { SlotInstancePropsSchema, type SlotInstanceStoredProps } from './props'
 
 const SlotInstanceModule: ModuleDefinition<SlotInstanceStoredProps> = {
   id: 'base.slot-instance',

--- a/src/modules/base/slotInstance/props.ts
+++ b/src/modules/base/slotInstance/props.ts
@@ -1,0 +1,7 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const SlotInstancePropsSchema = Type.Object({
+  slotName: Type.String({ default: 'children' }),
+})
+
+export type SlotInstanceStoredProps = Static<typeof SlotInstancePropsSchema>

--- a/src/modules/base/slotOutlet/SlotOutletEditor.tsx
+++ b/src/modules/base/slotOutlet/SlotOutletEditor.tsx
@@ -16,7 +16,7 @@ import { resolveSlotName } from '@core/visualComponents'
 import { useEditorStore } from '@site/store/store'
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { TargetSolidIcon } from 'pixel-art-icons/icons/target-solid'
-import type { SlotOutletStoredProps } from './index'
+import type { SlotOutletStoredProps } from './props'
 
 export const SlotOutletEditor: React.FC<ModuleComponentProps<SlotOutletStoredProps>> = ({ props, nodeWrapperProps }) => {
   const isVCEditMode = useEditorStore((s) => s.activeDocument?.kind === 'visualComponent')

--- a/src/modules/base/slotOutlet/index.ts
+++ b/src/modules/base/slotOutlet/index.ts
@@ -14,13 +14,8 @@ import type { ModuleDefinition } from '@core/module-engine'
 import { registry } from '@core/module-engine'
 import { TargetSolidIcon } from 'pixel-art-icons/icons/target-solid'
 import { SlotOutletEditor } from './SlotOutletEditor'
-import { Type, Value } from '@core/utils/typeboxHelpers'
-import type { Static } from '@core/utils/typeboxHelpers'
-
-const SlotOutletPropsSchema = Type.Object({
-  slotName: Type.String({ default: 'children' }),
-})
-export type SlotOutletStoredProps = Static<typeof SlotOutletPropsSchema>
+import { Value } from '@core/utils/typeboxHelpers'
+import { SlotOutletPropsSchema, type SlotOutletStoredProps } from './props'
 
 export const SlotOutletModule: ModuleDefinition<SlotOutletStoredProps> = {
   id: 'base.slot-outlet',

--- a/src/modules/base/slotOutlet/props.ts
+++ b/src/modules/base/slotOutlet/props.ts
@@ -1,0 +1,7 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const SlotOutletPropsSchema = Type.Object({
+  slotName: Type.String({ default: 'children' }),
+})
+
+export type SlotOutletStoredProps = Static<typeof SlotOutletPropsSchema>

--- a/src/modules/base/svg/SvgEditor.tsx
+++ b/src/modules/base/svg/SvgEditor.tsx
@@ -13,7 +13,7 @@ import type { ModuleComponentProps } from '@core/module-engine'
 import { sanitizeSvg } from '@core/sanitize'
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
-import type { SvgStoredProps } from './index'
+import type { SvgStoredProps } from './props'
 
 export const SvgEditor: React.FC<ModuleComponentProps<SvgStoredProps>> = ({
   props,

--- a/src/modules/base/svg/index.ts
+++ b/src/modules/base/svg/index.ts
@@ -15,17 +15,9 @@ import { registry } from '@core/module-engine'
 import type { ModuleDefinition } from '@core/module-engine'
 import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
 import { escapeHtml } from '@core/publisher'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import { SvgEditor } from './SvgEditor'
-
-const SvgPropsSchema = Type.Object({
-  /** Raw inline SVG markup (e.g. `<svg viewBox="0 0 24 24">…</svg>`). */
-  svg: Type.String({ default: '' }),
-  /** Accessible label; when set, emitted as `role="img" aria-label`. */
-  title: Type.String({ default: '' }),
-})
-
-export type SvgStoredProps = Static<typeof SvgPropsSchema>
+import { SvgPropsSchema, type SvgStoredProps } from './props'
 
 const SvgModule: ModuleDefinition<SvgStoredProps> = {
   id: 'base.svg',

--- a/src/modules/base/svg/props.ts
+++ b/src/modules/base/svg/props.ts
@@ -1,0 +1,8 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const SvgPropsSchema = Type.Object({
+  svg: Type.String({ default: '' }),
+  title: Type.String({ default: '' }),
+})
+
+export type SvgStoredProps = Static<typeof SvgPropsSchema>

--- a/src/modules/base/text/TextEditor.tsx
+++ b/src/modules/base/text/TextEditor.tsx
@@ -19,7 +19,7 @@ import type { ModuleComponentProps } from '@core/module-engine'
 import { htmlAttributesForReact } from '@modules/base/shared/htmlAttributes'
 import { inlineEditableElementProps, rawTextToBreakHtml } from '@modules/base/shared/inlineText'
 import { normalizeTag } from './tags'
-import type { TextStoredProps } from './index'
+import type { TextStoredProps } from './props'
 
 export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
   props,

--- a/src/modules/base/text/index.ts
+++ b/src/modules/base/text/index.ts
@@ -7,40 +7,15 @@
 import { registry } from '@core/module-engine'
 import type { ModuleDefinition } from '@core/module-engine'
 import { TextStartTIcon } from 'pixel-art-icons/icons/text-start-t'
-import { Type, Value, type Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import {
   htmlAttributesAttr,
   htmlAttributesControl,
-  HtmlAttributesPropSchemaOptions,
 } from '@modules/base/shared/htmlAttributes'
 import { textToBreakHtml } from '@modules/base/shared/inlineText'
 import { TextEditor } from './TextEditor'
 import { normalizeTag } from './tags'
-
-const TextPropsSchema = Type.Object({
-  text: Type.String({ default: 'Add your text here.' }),
-  tag: Type.Union(
-    [
-      Type.Literal('p'),
-      Type.Literal('none'),
-      Type.Literal('h1'),
-      Type.Literal('h2'),
-      Type.Literal('h3'),
-      Type.Literal('h4'),
-      Type.Literal('h5'),
-      Type.Literal('h6'),
-      Type.Literal('span'),
-      Type.Literal('div'),
-      Type.Literal('small'),
-      Type.Literal('strong'),
-      Type.Literal('em'),
-    ],
-    { default: 'p' },
-  ),
-  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
-})
-
-export type TextStoredProps = Static<typeof TextPropsSchema>
+import { TextPropsSchema, type TextStoredProps } from './props'
 
 export const TextModule: ModuleDefinition<TextStoredProps> = {
   id: 'base.text',

--- a/src/modules/base/text/props.ts
+++ b/src/modules/base/text/props.ts
@@ -1,0 +1,27 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+import { HtmlAttributesPropSchemaOptions } from '@modules/base/shared/htmlAttributes'
+
+export const TextPropsSchema = Type.Object({
+  text: Type.String({ default: 'Add your text here.' }),
+  tag: Type.Union(
+    [
+      Type.Literal('p'),
+      Type.Literal('none'),
+      Type.Literal('h1'),
+      Type.Literal('h2'),
+      Type.Literal('h3'),
+      Type.Literal('h4'),
+      Type.Literal('h5'),
+      Type.Literal('h6'),
+      Type.Literal('span'),
+      Type.Literal('div'),
+      Type.Literal('small'),
+      Type.Literal('strong'),
+      Type.Literal('em'),
+    ],
+    { default: 'p' },
+  ),
+  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
+})
+
+export type TextStoredProps = Static<typeof TextPropsSchema>

--- a/src/modules/base/video/VideoEditor.tsx
+++ b/src/modules/base/video/VideoEditor.tsx
@@ -27,7 +27,7 @@ import { buildVariantSrcset, pickVariantUrl } from '@admin/pages/media/utils/var
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { VideoSolidIcon } from 'pixel-art-icons/icons/video-solid'
 import { parseYoutubeId, youtubeEmbedUrl } from './youtube'
-import type { VideoStoredProps } from './index'
+import type { VideoStoredProps } from './props'
 
 // Canvas tile width hint — drives the poster variant pick. Videos in the
 // editor preview usually render at half the published-page width because

--- a/src/modules/base/video/index.ts
+++ b/src/modules/base/video/index.ts
@@ -26,49 +26,19 @@
 import { registry } from '@core/module-engine'
 import type { ModuleDefinition } from '@core/module-engine'
 import type { RenderResolvedMedia } from '@core/publisher'
-import { Type, Value } from '@core/utils/typeboxHelpers'
-import type { Static } from '@core/utils/typeboxHelpers'
+import { Value } from '@core/utils/typeboxHelpers'
 import { VideoSolidIcon } from 'pixel-art-icons/icons/video-solid'
 import { safeUrl } from '@modules/base/utils/escape'
 import { buildMediaSrcset, pickMediaVariantUrl } from '@modules/base/utils/mediaAttrs'
 import { VideoEditor } from './VideoEditor'
 import { parseYoutubeId, youtubeEmbedUrl } from './youtube'
+import { VideoPropsSchema, type VideoStoredProps } from './props'
 
 // ---------------------------------------------------------------------------
 // Props schema — authored fields only. The publisher-injected field
 // (_resolvedMediaByKey) is NOT declared here; validateNodeProps merges it
 // over the cleaned props so it survives the coercion step untouched.
 // ---------------------------------------------------------------------------
-
-const VideoPropsSchema = Type.Object({
-  /**
-   * Source URL. Accepts:
-   *   - A library path like `/uploads/intro.mp4` (resolved by the publisher)
-   *   - An external video URL (`https://example.com/clip.webm`)
-   *   - Any standard YouTube URL — auto-detected, rendered as an iframe
-   */
-  videoUrl: Type.String({ default: '' }),
-  /**
-   * Poster frame. For uploaded videos, the browser's native poster.
-   * For YouTube URLs, also rendered behind the iframe so the page shows
-   * our responsive image immediately while YouTube lazy-loads.
-   */
-  poster: Type.String({ default: '' }),
-  autoplay: Type.Boolean({ default: false }),
-  loop: Type.Boolean({ default: false }),
-  muted: Type.Boolean({ default: false }),
-  controls: Type.Boolean({ default: true }),
-  /** Required for iOS so an uploaded video doesn't take over the screen. */
-  playsinline: Type.Boolean({ default: true }),
-  /** Bandwidth hint for uploaded videos. Ignored for YouTube embeds. */
-  preload: Type.Union(
-    [Type.Literal('none'), Type.Literal('metadata'), Type.Literal('auto')],
-    { default: 'metadata' },
-  ),
-})
-
-/** Authored (stored) props — shape the user edits and the database persists. */
-export type VideoStoredProps = Static<typeof VideoPropsSchema>
 
 /**
  * Full render-time props. Intersects the authored schema shape with the

--- a/src/modules/base/video/props.ts
+++ b/src/modules/base/video/props.ts
@@ -1,0 +1,17 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const VideoPropsSchema = Type.Object({
+  videoUrl: Type.String({ default: '' }),
+  poster: Type.String({ default: '' }),
+  autoplay: Type.Boolean({ default: false }),
+  loop: Type.Boolean({ default: false }),
+  muted: Type.Boolean({ default: false }),
+  controls: Type.Boolean({ default: true }),
+  playsinline: Type.Boolean({ default: true }),
+  preload: Type.Union(
+    [Type.Literal('none'), Type.Literal('metadata'), Type.Literal('auto')],
+    { default: 'metadata' },
+  ),
+})
+
+export type VideoStoredProps = Static<typeof VideoPropsSchema>

--- a/src/modules/base/visualComponentRef/VisualComponentRefEditor.tsx
+++ b/src/modules/base/visualComponentRef/VisualComponentRefEditor.tsx
@@ -25,7 +25,7 @@ import type { BaseNode } from '@core/page-tree'
 import { BracesIcon } from 'pixel-art-icons/icons/braces'
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
 import { VCInlineTree } from './VCInlineTree'
-import type { VisualComponentRefStoredProps } from './index'
+import type { VisualComponentRefStoredProps } from './props'
 
 export const VisualComponentRefEditor: React.FC<ModuleComponentProps<VisualComponentRefStoredProps>> = ({
   props,

--- a/src/modules/base/visualComponentRef/index.ts
+++ b/src/modules/base/visualComponentRef/index.ts
@@ -19,15 +19,11 @@ import { registry } from '@core/module-engine'
 import type { ModuleDefinition } from '@core/module-engine'
 import { BracesIcon } from 'pixel-art-icons/icons/braces'
 import { VisualComponentRefEditor } from './VisualComponentRefEditor'
-import { Type, Value } from '@core/utils/typeboxHelpers'
-import type { Static } from '@core/utils/typeboxHelpers'
-
-const VisualComponentRefPropsSchema = Type.Object({
-  componentId: Type.String({ default: '' }),
-  /** Per-param value overrides — keyed by VCParam.id (stable across renames) */
-  propOverrides: Type.Record(Type.String(), Type.Unknown(), { default: {} }),
-})
-export type VisualComponentRefStoredProps = Static<typeof VisualComponentRefPropsSchema>
+import { Value } from '@core/utils/typeboxHelpers'
+import {
+  VisualComponentRefPropsSchema,
+  type VisualComponentRefStoredProps,
+} from './props'
 
 export const VisualComponentRefModule: ModuleDefinition<VisualComponentRefStoredProps> = {
   id: 'base.visual-component-ref',

--- a/src/modules/base/visualComponentRef/props.ts
+++ b/src/modules/base/visualComponentRef/props.ts
@@ -1,0 +1,8 @@
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const VisualComponentRefPropsSchema = Type.Object({
+  componentId: Type.String({ default: '' }),
+  propOverrides: Type.Record(Type.String(), Type.Unknown(), { default: {} }),
+})
+
+export type VisualComponentRefStoredProps = Static<typeof VisualComponentRefPropsSchema>


### PR DESCRIPTION
## Summary

- Reduced the tsconfig-aware source graph from 31 circular dependencies to 0 by extracting pure leaf schema/type/helper barrels and moving cycle-sensitive internals off broad barrels.
- Added retryable lazy/HMR loading for the Site editor body: failed prewarmed imports clear their failed state, expose `reset()`, and render a retryable chunk boundary instead of leaving the admin on an endless skeleton.
- Added architecture coverage for zero circular dependencies and tightened the Fast Refresh/lazy-body gates.

## Impact

The broad app-facing barrels remain available, while cycle-sensitive internals now depend on pure leaves such as `@core/page-tree-schema`, `@core/module-engine-schema`, `@core/site-runtime-schema`, `@core/visual-components-schema`, and `@core/html-sanitize`. Base module editor components no longer import their registration barrels, which keeps Fast Refresh boundaries component-only.

## Verification

- `bun x madge --circular --ts-config tsconfig.json --extensions ts,tsx src server` — processed 2282 files, 3 warnings, 0 circular dependencies.
- `bun test src/__tests__/architecture/no-circular-dependencies.test.ts` — 1 pass, 0 fail.
- `bun test src/__tests__/architecture/canvasFastRefreshBoundaries.test.ts src/__tests__/architecture/site-editor-shell-lazy-body.test.ts` — 8 pass, 0 fail.
- `bun run build` — passed.
- `bun test` — 5486 pass, 0 fail.
- `bun run lint` — passed.

## Manual Smoke

- Ran local disposable dev stack on `PORT=3102`, `VITE_PORT=5175`, `VITE_ALLOWED_ORIGIN=http://localhost:5175`, `DATABASE_URL=sqlite:./.tmp/e2e-hmr.db`, `UPLOADS_DIR=./.tmp/e2e-hmr-uploads`.
- Opened `/admin/site`, completed local setup, loaded the Site editor body past the skeleton, added a base Container module, temporarily edited `src/modules/base/container/ContainerEditor.tsx`, and observed Vite HMR update the canvas placeholder without falling back to an endless skeleton. The temporary probe edit was reverted before commit.