### PR TITLE
fix(content): hide empty settings panel

### DIFF
--- a/docs/features/content-workspace.md
+++ b/docs/features/content-workspace.md
@@ -115,6 +115,8 @@ Collections are `data_tables` with `kind: 'postType'`. The four system tables (`
 ## Settings panel and reopen notch
 
 `ContentSettingsPanel` is the right-hand panel. It is entry-specific: it renders only when an entry is selected (`contentRightPanel` is `undefined` when `workspace.selectedEntry` is `null`).
+`AdminWorkspaceCanvasLayout` treats an absent `contentRightPanel` as "no right panel available",
+so a persisted open state never reserves an empty right rail on a fresh install or after the last entry is cleared.
 
 The panel exposes: status selector, slug, author (if the user has `canEditAnyContent`), collection (move entry), SEO title, SEO description, featured media.
 

--- a/src/__tests__/data/contentAdmin.test.tsx
+++ b/src/__tests__/data/contentAdmin.test.tsx
@@ -10,6 +10,7 @@ import { ContentPage } from '@content/ContentPage'
 import { AdminSessionProvider } from '@admin/session'
 import { StepUpProvider } from '@admin/shared/StepUp'
 import { useAdminUi } from '@admin/state/adminUi'
+import { useWorkspaceLayout } from '@admin/state/workspaceLayout'
 import { useEditorStore } from '@site/store/store'
 import { makeSite } from '../fixtures'
 import { Toolbar } from '@site/toolbar/Toolbar'
@@ -306,6 +307,11 @@ beforeEach(() => {
     canRedo: false,
     hasUnsavedChanges: false,
   } as Parameters<typeof useEditorStore.setState>[0])
+  useWorkspaceLayout.setState({
+    leftSidebarWidth: 320,
+    rightPanel: { collapsed: false, width: 360 },
+    dataSidebarCollapsed: false,
+  })
 
   const calls: FetchCall[] = []
   ;(globalThis as typeof globalThis & { __contentFetchCalls?: FetchCall[] }).__contentFetchCalls = calls
@@ -343,6 +349,16 @@ beforeEach(() => {
           ...makeRow('entry_1', 'posts', draft.cells ?? {}),
           updatedAt: '2026-05-01T10:01:00.000Z',
         },
+      })
+    }
+
+    if (url === '/admin/api/cms/data/rows/entry_1' && init?.method === 'DELETE') {
+      return json({
+        row: makeRow('entry_1', 'posts', { title: 'Untitled', slug: 'untitled' }, {
+          authorUserId: ownerAuthor.id,
+          author: ownerAuthor,
+          deletedAt: '2026-05-01T10:01:00.000Z',
+        }),
       })
     }
 
@@ -570,6 +586,10 @@ describe('ContentPage', () => {
   })
 
   it('hides the right settings panel until an entry is selected, then shows it', async () => {
+    useWorkspaceLayout.setState({
+      rightPanel: { collapsed: false, width: 360 },
+    })
+
     render(
       <AdminTestProviders>
         <ContentPage />
@@ -581,6 +601,11 @@ describe('ContentPage', () => {
 
     // No entry selected → settings panel must not be in the DOM.
     expect(screen.queryByTestId('content-settings-panel')).toBeNull()
+    expect(screen.getByTestId('right-sidebar').getAttribute('data-expanded')).toBe('false')
+    expect(
+      screen.getByTestId('right-sidebar').style.getPropertyValue('--right-sidebar-panel-width'),
+    ).toBe('0px')
+    expect(screen.queryByTestId('right-sidebar-panel-slot')).toBeNull()
 
     fireEvent.click(
       within(screen.getByRole('region', { name: 'Posts' }))
@@ -589,6 +614,7 @@ describe('ContentPage', () => {
 
     // After creating (and auto-selecting) an entry, the settings panel appears.
     expect(await screen.findByTestId('content-settings-panel')).toBeDefined()
+    expect(screen.getByTestId('right-sidebar').getAttribute('data-expanded')).toBe('true')
   })
 
   it('reopens the selected entry settings panel from the canvas corner after closing it', async () => {
@@ -615,6 +641,44 @@ describe('ContentPage', () => {
 
     expect(await screen.findByTestId('content-settings-panel')).toBeDefined()
     expect(screen.queryByRole('button', { name: /open settings panel/i })).toBeNull()
+  })
+
+  it('does not reopen the settings preference when the last selected entry is cleared', async () => {
+    render(
+      <AdminTestProviders>
+        <ContentPage />
+      </AdminTestProviders>,
+    )
+
+    const postsRegion = await screen.findByRole('region', { name: 'Posts' })
+    fireEvent.click(within(postsRegion).getByRole('button', { name: /new post/i }))
+
+    expect(await screen.findByTestId('content-settings-panel')).toBeDefined()
+    fireEvent.click(screen.getByRole('button', { name: /close settings panel/i }))
+    expect(useWorkspaceLayout.getState().rightPanel.collapsed).toBe(true)
+
+    const entryButton = (await within(postsRegion).findByText('Untitled')).closest('button')
+    expect(entryButton).toBeTruthy()
+    fireEvent.contextMenu(entryButton as HTMLButtonElement, { clientX: 240, clientY: 320 })
+    fireEvent.click(
+      within(screen.getByRole('menu', { name: 'Content item options' }))
+        .getByRole('menuitem', { name: /^delete$/i }),
+    )
+
+    const calls = (globalThis as typeof globalThis & { __contentFetchCalls?: FetchCall[] }).__contentFetchCalls ?? []
+    await waitFor(() => {
+      expect(calls.some((call) =>
+        String(call.input) === '/admin/api/cms/data/rows/entry_1' &&
+        call.init?.method === 'DELETE'
+      )).toBe(true)
+    })
+    await waitFor(() => {
+      expect(within(postsRegion).queryByText('Untitled')).toBeNull()
+    })
+
+    expect(screen.queryByTestId('content-settings-panel')).toBeNull()
+    expect(screen.getByTestId('right-sidebar').getAttribute('data-expanded')).toBe('false')
+    expect(useWorkspaceLayout.getState().rightPanel.collapsed).toBe(true)
   })
 
   it('shows entry authors in the content list and reassigns the selected entry author', async () => {

--- a/src/admin/layouts/AdminWorkspaceCanvasLayout/AdminWorkspaceCanvasLayout.tsx
+++ b/src/admin/layouts/AdminWorkspaceCanvasLayout/AdminWorkspaceCanvasLayout.tsx
@@ -62,8 +62,9 @@ export function AdminWorkspaceCanvasLayout({
   const settingsOpen = useAdminUi((s) => s.settingsOpen)
   const rightPanelCollapsed = useWorkspaceLayout((s) => s.rightPanel.collapsed)
   const setRightPanel = useWorkspaceLayout((s) => s.setRightPanel)
-  const hasRightSidebar = workspace !== 'media' && !rightPanelCollapsed
-  const hasReopenableRightPanel = workspace !== 'media' && Boolean(contentRightPanel) && !hasRightSidebar
+  const rightPanelAvailable = workspace !== 'media' && Boolean(contentRightPanel)
+  const hasRightSidebar = rightPanelAvailable && !rightPanelCollapsed
+  const hasReopenableRightPanel = rightPanelAvailable && !hasRightSidebar
 
   return (
     <div className={styles.shell} data-editor-density={density}>
@@ -98,7 +99,7 @@ export function AdminWorkspaceCanvasLayout({
             )}
           </div>
           <WorkspaceRightSidebar
-            hidden={workspace === 'media'}
+            hidden={!rightPanelAvailable}
             contentPanel={contentRightPanel}
           />
         </div>

--- a/src/admin/pages/content/hooks/useContentWorkspace.ts
+++ b/src/admin/pages/content/hooks/useContentWorkspace.ts
@@ -70,7 +70,7 @@ export function useContentWorkspace({
   // needs a stable identity for react-hooks/exhaustive-deps.
   const selectEntry = useCallback((entry: DataRow | null) => {
     setSelectedEntry(entry)
-    setRightPanel({ collapsed: false })
+    if (entry) setRightPanel({ collapsed: false })
   }, [setRightPanel])
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- Gate the shared workspace right sidebar on real right-panel content so persisted open state cannot reserve an empty rail.
- Preserve a closed Content settings preference when selection is cleared.
- Add Content regressions for empty installs and deleting the last selected entry.

## Root Cause
The shared workspace layout expanded from persisted right-panel state without checking whether the current workspace had right-panel content. Content also reopened the right panel for `selectEntry(null)`, so clearing the active entry could rewrite the preference to open.

## Impact
Fresh installs and empty Content collections now show the full canvas without an empty right rail. Selecting or creating an entry still opens the settings panel, and the reopen notch still appears only when an entry-backed panel exists.

## Verification
- `bun run build`
- `bun test`
- `bun run lint`
- `bunx react-doctor@latest --verbose --diff`
- `bunx react-doctor@latest --verbose --scope changed --base main`