### PR TITLE
chore(release): prepare 0.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## Unreleased
 
+## 0.0.6 - 2026-06-26
+
+### AI & agent tooling
+
+- Added runtime code asset tools for agents so generated or edited runtime assets can be managed through the same agent workflow.
+
+### Site import, export, and transfer
+
+- Fixed site export downloads in environments where blob-backed responses were unreliable.
+- Streamed site transfer bundles and unified the import review flow around the transfer archive path.
+- Reused the CMS media client across site import code paths.
+
+### Templates, content, and publishing
+
+- Fixed dynamic data resolution inside outlet previews.
+- Stopped auto-creating post type templates; entry templates are now explicit pages users create and assign.
+- Hid the empty content settings panel until an entry is selected.
+
+### Editor and admin
+
+- Split non-site workspace layout state from the site editor layout.
+- Fixed Spotlight layer commands to operate on the active canvas tree.
+- Removed circular admin dependencies and restored lazy HMR loading.
+- Simplified admin color token vocabulary and added fluid typography and spacing token scales.
+
+### Quality
+
+- Reused page-tree traversal selectors in form analysis.
+- Expanded feature validation coverage across the admin, server, and architecture gates.
+
 ## 0.0.5 - 2026-06-17
 
 ### AI & agent tooling

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.5 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.6 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.5
+docker pull ghcr.io/corebunch/instatic:0.0.6
 ```
 
-The v0.0.5 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.6 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.5
+ghcr.io/corebunch/instatic:0.0.6
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.5` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.6` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.5
+Image=ghcr.io/corebunch/instatic:0.0.6
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.5
+ghcr.io/corebunch/instatic:0.0.6
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.5` |
+| Image | `ghcr.io/corebunch/instatic:0.0.6` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.5` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.6` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.5",
+  "version": "0.0.6",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },


### PR DESCRIPTION
## What changed

- Bumped the package version to `0.0.6`.
- Added the `0.0.6` changelog entry for the work merged after `v0.0.5`.
- Updated deployment docs to pin examples to `ghcr.io/corebunch/instatic:0.0.6`.

## Why

This prepares the next tagged release after the latest merged PR batch.

## Impact

Users following the deployment docs will pin the new `0.0.6` image once the release tag is published. The release workflow will publish the image and bundle when `v0.0.6` is pushed.

## Verification

- `bun install`
- `bun run build`
- `bun test` (5730 pass, 0 fail)
- `bun run lint`
- `git diff --check`