### PR TITLE
test(ui): isolate toast bus state between tests

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -302,7 +302,10 @@ if (typeof (globalThis as { EventSource?: unknown }).EventSource === 'undefined'
 {
   const { afterEach } = await import('bun:test')
   const { cleanup } = await import('@testing-library/react')
+  const { __resetToastBusForTests } = await import('@ui/components/Toast/toastBus')
   afterEach(() => {
     cleanup()
+    __resetToastBusForTests()
+    document.getElementById('toast-root')?.remove()
   })
 }

--- a/src/__tests__/ui/toastBus.test.ts
+++ b/src/__tests__/ui/toastBus.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  __resetToastBusForTests,
+  pushToast,
+  subscribeToasts,
+  type Toast,
+} from '@ui/components/Toast/toastBus'
+
+afterEach(() => {
+  __resetToastBusForTests()
+})
+
+describe('toastBus', () => {
+  it('sends the current queue snapshot to new subscribers', () => {
+    const id = pushToast({
+      kind: 'success',
+      title: 'Saved',
+      durationMs: null,
+    })
+    let capturedToasts: ReadonlyArray<Toast> = []
+
+    const unsubscribe = subscribeToasts((snapshot) => {
+      capturedToasts = snapshot
+    })
+
+    expect(capturedToasts.map((toast) => toast.id)).toEqual([id])
+    unsubscribe()
+  })
+
+  it('resets queued toasts and listeners for test isolation', () => {
+    pushToast({
+      kind: 'info',
+      title: 'Before reset',
+      durationMs: null,
+    })
+    let staleListenerCalls = 0
+    subscribeToasts(() => {
+      staleListenerCalls += 1
+    })
+
+    __resetToastBusForTests()
+    pushToast({
+      kind: 'info',
+      title: 'After reset',
+      durationMs: null,
+    })
+    let capturedToasts: ReadonlyArray<Toast> = []
+    const unsubscribe = subscribeToasts((snapshot) => {
+      capturedToasts = snapshot
+    })
+
+    expect(staleListenerCalls).toBe(1)
+    expect(capturedToasts).toHaveLength(1)
+    expect(capturedToasts[0]?.title).toBe('After reset')
+    unsubscribe()
+  })
+})

--- a/src/ui/components/Toast/toastBus.ts
+++ b/src/ui/components/Toast/toastBus.ts
@@ -103,7 +103,14 @@ export function dismissToast(id: string): void {
  */
 export function subscribeToasts(listener: Listener): () => void {
   listeners.add(listener)
+  listener(toasts.slice())
   return () => {
     listeners.delete(listener)
   }
+}
+
+export function __resetToastBusForTests(): void {
+  counter = 0
+  toasts.splice(0)
+  listeners.clear()
 }


### PR DESCRIPTION
## Summary
- reset the Toast bus singleton from global test teardown after React cleanup
- make Toast bus subscribers receive the current queue snapshot immediately, matching the documented contract
- add focused Toast bus coverage for snapshot delivery and test isolation

## Why
The v0.0.6 release workflow failed in `toastProvider.test.tsx` because earlier module-inserter tests left success toasts in the global Toast bus. When the provider test published its own toasts, the snapshot included stale queue entries from previous tests.

## Verification
- `bun install`
- `bun test src/__tests__/ui/toastBus.test.ts src/__tests__/ui/toastProvider.test.tsx`
- `bun test src/__tests__/toolbar/modulePickerDropdown.test.tsx src/__tests__/ui/toastProvider.test.tsx`
- `bun test` (5715 pass, 1 skipped bundle-size test before build, 0 fail)
- `bun run build`
- `bun test src/__tests__/architecture/bundle-size-budgets.test.ts`
- `bun run lint`
- `git diff --check`