### PR TITLE
fix(security): harden sanitizers and regexes flagged by CodeQL

### DIFF
--- a/server/handlers/cms/__tests__/svgSanitize.test.ts
+++ b/server/handlers/cms/__tests__/svgSanitize.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import { sanitizeSvgBytes } from '../svgSanitize'
+
+const enc = new TextEncoder()
+const dec = new TextDecoder()
+
+function clean(svg: string): string {
+  return dec.decode(sanitizeSvgBytes(enc.encode(svg)))
+}
+
+describe('sanitizeSvgBytes', () => {
+  it('keeps benign SVG geometry intact', () => {
+    const out = clean('<svg viewBox="0 0 10 10"><rect width="10" height="10"/></svg>')
+    expect(out).toContain('<rect')
+    expect(out).toContain('viewBox')
+  })
+
+  it('strips a plain <script> block', () => {
+    const out = clean('<svg><script>alert(1)</script><rect/></svg>')
+    expect(out.toLowerCase()).not.toContain('<script')
+    expect(out).toContain('<rect')
+  })
+
+  // Regression for CodeQL js/bad-tag-filter (#34): the HTML parser ends a tag
+  // at the first `>`, so these close-tag variants must all be recognised.
+  it.each([
+    '<svg><script>alert(1)</script >x</svg>',
+    '<svg><script>alert(1)</script\t\nbar>x</svg>',
+    '<svg><script>alert(1)</script/>x</svg>',
+  ])('strips scripts with awkward close tags: %s', (input) => {
+    const out = clean(input).toLowerCase()
+    expect(out).not.toContain('alert(1)')
+    expect(out).not.toContain('<script')
+    expect(out).not.toContain('</script')
+  })
+
+  // Regression for CodeQL js/incomplete-multi-character-sanitization (#33): a
+  // single strip pass leaves a nested payload behind; the fixpoint loop must
+  // collapse it fully.
+  it('collapses split-tag obfuscation to a fixpoint', () => {
+    const out = clean('<svg><scr<script>ipt>alert(1)</scr</script>ipt><rect/></svg>').toLowerCase()
+    expect(out).not.toContain('<script')
+    expect(out).not.toContain('alert(1)')
+    expect(out).toContain('<rect')
+  })
+
+  it('strips <foreignObject> and <style> wrappers', () => {
+    const out = clean(
+      '<svg><foreignObject><div>x</div></foreignObject><style>@import url(javascript:alert(1))</style><rect/></svg>',
+    ).toLowerCase()
+    expect(out).not.toContain('<foreignobject')
+    expect(out).not.toContain('<style')
+    expect(out).toContain('<rect')
+  })
+
+  it('strips on* event handlers and javascript: URLs', () => {
+    const out = clean('<svg onload="alert(1)"><a href="javascript:alert(1)"><rect/></a></svg>').toLowerCase()
+    expect(out).not.toContain('onload')
+    expect(out).not.toContain('javascript:')
+  })
+
+  it('returns empty bytes for empty / whitespace input', () => {
+    expect(sanitizeSvgBytes(enc.encode('   ')).length).toBe(0)
+    expect(sanitizeSvgBytes(new Uint8Array(0)).length).toBe(0)
+  })
+})

--- a/server/handlers/cms/svgSanitize.ts
+++ b/server/handlers/cms/svgSanitize.ts
@@ -31,12 +31,23 @@
 // Each pattern targets one vector. The `gi` flags + `[\s\S]` (rather than `.`)
 // make every pattern span newlines and match case-insensitively.
 
+// Close-tag matcher: the HTML parser ends an element at the first `>` after the
+// tag name, so `</script bar>`, `</script\t\n>`, and `</script/>` all close a
+// `<script>`. `(?:[\s/][^>]*)?` after the name accepts any whitespace/junk run
+// up to that `>` while `\b`-anchoring rejects `</scriptfoo>`. A bare `<\/x\s*>`
+// (the previous form) missed these and is what CodeQL's bad-tag-filter flagged.
+const scriptClose = String.raw`<\/script(?:[\s/][^>]*)?>`
+const foreignObjectClose = String.raw`<\/foreignObject(?:[\s/][^>]*)?>`
+const styleClose = String.raw`<\/style(?:[\s/][^>]*)?>`
+
 /** `<script …>…</script>` including any attributes / whitespace / newlines. */
-const SCRIPT_BLOCK_RE = /<script\b[\s\S]*?<\/script\s*>/gi
+const SCRIPT_BLOCK_RE = new RegExp(String.raw`<script\b[\s\S]*?${scriptClose}`, 'gi')
 /** A self-closing or unclosed `<script …/>` / `<script …>` with no close tag. */
 const SCRIPT_OPEN_RE = /<script\b[^>]*\/?>/gi
+/** A dangling `</script …>` close tag left after its opener was stripped. */
+const SCRIPT_CLOSE_RE = new RegExp(scriptClose, 'gi')
 /** `<foreignObject …>…</foreignObject>` — can carry arbitrary HTML. */
-const FOREIGN_OBJECT_RE = /<foreignObject\b[\s\S]*?<\/foreignObject\s*>/gi
+const FOREIGN_OBJECT_RE = new RegExp(String.raw`<foreignObject\b[\s\S]*?${foreignObjectClose}`, 'gi')
 const FOREIGN_OBJECT_OPEN_RE = /<foreignObject\b[^>]*\/?>/gi
 /** `<a …>` / `</a>` is allowed, but href values are scrubbed below. */
 /** `on*="…"` / `on*='…'` / `on*=value` event-handler attributes. */
@@ -49,12 +60,13 @@ const EVENT_HANDLER_RE = /\son[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi
 const JS_URL_ATTR_RE =
   /\s(?:xlink:href|href|src)\s*=\s*(?:"\s*javascript:[^"]*"|'\s*javascript:[^']*'|javascript:[^\s>]*)/gi
 /** `<style>…</style>` blocks — CSS can carry `@import url(javascript:…)`. */
-const STYLE_BLOCK_RE = /<style\b[\s\S]*?<\/style\s*>/gi
+const STYLE_BLOCK_RE = new RegExp(String.raw`<style\b[\s\S]*?${styleClose}`, 'gi')
 
-function stripVectors(svg: string): string {
+function stripVectorsOnce(svg: string): string {
   return svg
     .replace(SCRIPT_BLOCK_RE, '')
     .replace(SCRIPT_OPEN_RE, '')
+    .replace(SCRIPT_CLOSE_RE, '')
     .replace(FOREIGN_OBJECT_RE, '')
     .replace(FOREIGN_OBJECT_OPEN_RE, '')
     .replace(STYLE_BLOCK_RE, '')
@@ -63,15 +75,34 @@ function stripVectors(svg: string): string {
 }
 
 /**
+ * Strip every vector, then keep stripping until the string stops changing.
+ * Removing one wrapper can reveal a nested vector (`<scr<script>ipt>` collapses
+ * to `<script>`; `<scr<script>ipt>alert()</scr</script>ipt>` needs several
+ * passes), so a fixed pass count can leave a payload behind — which is exactly
+ * what CodeQL's incomplete-multi-character-sanitization flagged. Iterating to a
+ * fixpoint removes that class of bypass entirely. The input is bounded and each
+ * pass only ever shrinks it, so this always terminates.
+ */
+function stripVectors(svg: string): string {
+  let current = svg
+  // Bound iterations defensively; a shrinking string converges well before this.
+  for (let i = 0; i < 100; i++) {
+    const next = stripVectorsOnce(current)
+    if (next === current) return current
+    current = next
+  }
+  return current
+}
+
+/**
  * Sanitize an SVG byte buffer and return the re-encoded clean bytes.
  *
  * Decoding policy: UTF-8, BOM-tolerant, never throws on malformed input.
  * Re-encoding policy: UTF-8 without BOM.
  *
- * Idempotent: running twice removes nothing the first pass missed. A second
- * pass IS run, because removing one wrapper can reveal a nested vector (e.g.
- * `<scr<script>ipt>` collapses on the first pass into `<script>` which the
- * second pass then removes).
+ * Idempotent: `stripVectors` iterates to a fixpoint, so re-running removes
+ * nothing — split-tag obfuscation (`<scr<script>ipt>`) is already collapsed
+ * away inside that loop.
  *
  * Returns empty bytes only when the input decodes to an empty / whitespace
  * string — the caller treats that as "invalid SVG" and rejects the upload.
@@ -81,9 +112,7 @@ export function sanitizeSvgBytes(bytes: Uint8Array): Uint8Array {
   const original = decoder.decode(bytes)
   if (original.trim().length === 0) return new Uint8Array(0)
 
-  let cleaned = stripVectors(original)
-  // Second pass catches split-tag obfuscation (`<scr<script>ipt>`).
-  cleaned = stripVectors(cleaned)
+  const cleaned = stripVectors(original)
 
   if (cleaned.trim().length === 0) return new Uint8Array(0)
   return new TextEncoder().encode(cleaned)

--- a/server/publish/runtime/dependencyResolver.ts
+++ b/server/publish/runtime/dependencyResolver.ts
@@ -34,8 +34,10 @@ interface ResolveSiteDependencyLockOptions {
 }
 
 function registryPackageUrl(registryUrl: string, packageName: string): string {
+  // Scoped names keep their leading `@` literal (npm wants `@scope%2fname`),
+  // but every `/` is encoded — not just the first (CodeQL js/incomplete-sanitization).
   const encoded = packageName.startsWith('@')
-    ? packageName.replace('/', '%2f')
+    ? packageName.replaceAll('/', '%2f')
     : encodeURIComponent(packageName)
   return `${registryUrl.replace(/\/$/, '')}/${encoded}`
 }

--- a/src/__tests__/architecture/cms-handlers-capability-gated.test.ts
+++ b/src/__tests__/architecture/cms-handlers-capability-gated.test.ts
@@ -116,6 +116,8 @@ function listHandlerFiles(dir: string): string[] {
     const full = join(dir, entry)
     const s = statSync(full)
     if (s.isDirectory()) {
+      // Test files are never Bun.serve routes — skip the `__tests__` tree.
+      if (entry === '__tests__') continue
       out.push(...listHandlerFiles(full))
     } else if (s.isFile() && extname(entry) === '.ts') {
       out.push(full)

--- a/src/admin/shared/dialogs/SiteCreateDialog/siteItemNames.ts
+++ b/src/admin/shared/dialogs/SiteCreateDialog/siteItemNames.ts
@@ -9,7 +9,10 @@ export function slugifySiteItemName(value: string, fallback = 'page') {
 }
 
 function stripSitePrefix(value: string, prefix: string) {
-  return value.trim().replace(new RegExp(`^${prefix.replace(/\//g, '\\/')}`), '')
+  const trimmed = value.trim()
+  // Plain string match — no RegExp, so the prefix's `/` (and any other regex
+  // metacharacters) are treated literally (CodeQL js/incomplete-sanitization).
+  return trimmed.startsWith(prefix) ? trimmed.slice(prefix.length) : trimmed
 }
 
 function ensureExtension(value: string, extension: string) {

--- a/src/core/framework/scaleModule.ts
+++ b/src/core/framework/scaleModule.ts
@@ -377,8 +377,8 @@ function stepLabelsForGroup(group: { steps: string }): string[] {
 function expandClassPattern(pattern: string, step: string): string {
   const trimmed = pattern.trim().replace(/^\./, '')
   if (!trimmed) return ''
-  if (trimmed.includes('*')) return trimmed.replace('*', step)
-  if (trimmed.includes('{step}')) return trimmed.replace('{step}', step)
+  if (trimmed.includes('*')) return trimmed.replaceAll('*', step)
+  if (trimmed.includes('{step}')) return trimmed.replaceAll('{step}', step)
   return `${trimmed}-${step}`
 }
 

--- a/src/core/markdown/markdownDocument.ts
+++ b/src/core/markdown/markdownDocument.ts
@@ -718,14 +718,14 @@ function stringAttr(node: JSONNode, key: string, fallback: string): string {
 }
 
 function decodeEntities(text: string): string {
-  // Marked HTML-encodes `&`, `<`, `>`, `"` and `'` in inline text tokens.
-  // Decode the small fixed set so the editor sees the author's real input.
+  // Marked HTML-encodes `&`, `<`, `>`, `"`, `'`; decode the fixed set back.
+  // `&amp;` MUST be last, else `&amp;lt;`→`<` double-unescapes (js/double-escaping).
   return text
-    .replace(/&amp;/g, '&')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
     .replace(/&quot;/g, '"')
     .replace(/&#39;/g, "'")
+    .replace(/&amp;/g, '&')
 }
 
 /**

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -78,11 +78,32 @@ function getDOMPurify(): DOMPurifyRuntime | null {
   return null
 }
 
+// Close-tag matcher mirrors the SVG sanitizer: the HTML parser ends a tag at
+// the first `>`, so `</script bar>` and `</script\t\n>` both close a script.
+// `(?:[\s/][^>]*)?` accepts that trailing junk; a bare `<\/x\s*>` missed it
+// (CodeQL js/bad-tag-filter).
+const FALLBACK_SCRIPT_RE = /<script\b[^>]*>[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi
+const FALLBACK_STYLE_RE = /<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi
+const FALLBACK_TAG_RE = /<[^>]*>/g
+
+/**
+ * Regex HTML strip used ONLY when no DOMPurify runtime is available (one-off
+ * scripts; browser + Bun server both configure DOMPurify). Iterates to a
+ * fixpoint so split-tag obfuscation (`<scr<script>ipt>`) can't survive a single
+ * pass — CodeQL js/incomplete-multi-character-sanitization. Each pass only
+ * shrinks the string, so termination is guaranteed; the bound is defensive.
+ */
 function stripHtmlFallback(value: string): string {
-  return value
-    .replace(/<script\b[^>]*>[\s\S]*?<\/script\s*>/gi, '')
-    .replace(/<style\b[^>]*>[\s\S]*?<\/style\s*>/gi, '')
-    .replace(/<[^>]*>/g, '')
+  let current = value
+  for (let i = 0; i < 100; i++) {
+    const next = current
+      .replace(FALLBACK_SCRIPT_RE, '')
+      .replace(FALLBACK_STYLE_RE, '')
+      .replace(FALLBACK_TAG_RE, '')
+    if (next === current) return current
+    current = next
+  }
+  return current
 }
 
 // ---------------------------------------------------------------------------
@@ -163,12 +184,12 @@ export function sanitizeRichtext(
 
   const sanitized = String(purifier.sanitize(str, config))
 
-  // When plain-text mode is requested, apply a post-strip regex pass.
+  // When plain-text mode is requested, apply a post-strip pass.
   // DOMPurify's ALLOWED_TAGS:[] covers most cases but certain browsers / DOM
-  // implementations may preserve some inline elements. The regex pass is the
-  // guaranteed fallback.
+  // implementations may preserve some inline elements. The fixpoint stripper is
+  // the guaranteed fallback (and resists split-tag obfuscation).
   if (config._plainText) {
-    return sanitized.replace(/<[^>]*>/g, '').trim()
+    return stripHtmlFallback(sanitized).trim()
   }
 
   return sanitized

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -98,15 +98,19 @@ const FALLBACK_TAG_RE = /<[^>]*>/g
  * pass — CodeQL js/incomplete-multi-character-sanitization. Each pass only
  * shrinks the string, so termination is guaranteed; the bound is defensive.
  */
+function stripHtmlOnce(value: string): string {
+  return value
+    .replace(FALLBACK_SCRIPT_BLOCK_RE, '')
+    .replace(FALLBACK_SCRIPT_OPEN_RE, '')
+    .replace(FALLBACK_STYLE_BLOCK_RE, '')
+    .replace(FALLBACK_STYLE_OPEN_RE, '')
+    .replace(FALLBACK_TAG_RE, '')
+}
+
 function stripHtmlFallback(value: string): string {
   let current = value
   for (let i = 0; i < 100; i++) {
-    const next = current
-      .replace(FALLBACK_SCRIPT_BLOCK_RE, '')
-      .replace(FALLBACK_SCRIPT_OPEN_RE, '')
-      .replace(FALLBACK_STYLE_BLOCK_RE, '')
-      .replace(FALLBACK_STYLE_OPEN_RE, '')
-      .replace(FALLBACK_TAG_RE, '')
+    const next = stripHtmlOnce(current)
     if (next === current) return current
     current = next
   }

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -78,42 +78,37 @@ function getDOMPurify(): DOMPurifyRuntime | null {
   return null
 }
 
-// Mirror the proven server-side SVG sanitizer: remove the full block, THEN the
-// bare opener. Stripping `<script>…</script>` alone can leave a `<script`
-// opener behind (split-tag obfuscation / unbalanced tags), so each block regex
-// is paired with an opener regex that removes the residual `<script` / `<style`
-// — that pairing is what makes the `<script`/`<style` substring provably gone.
-// Close-tag patterns use `(?:[\s/][^>]*)?` because the HTML parser ends a tag
-// at the first `>` (`</script bar>` closes a script) — CodeQL js/bad-tag-filter.
-const FALLBACK_SCRIPT_BLOCK_RE = /<script\b[^>]*>[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi
-const FALLBACK_SCRIPT_OPEN_RE = /<script\b[^>]*\/?>/gi
-const FALLBACK_STYLE_BLOCK_RE = /<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi
-const FALLBACK_STYLE_OPEN_RE = /<style\b[^>]*\/?>/gi
-const FALLBACK_TAG_RE = /<[^>]*>/g
-
 /**
  * Regex HTML strip used ONLY when no DOMPurify runtime is available (one-off
- * scripts; browser + Bun server both configure DOMPurify). Iterates to a
- * fixpoint so split-tag obfuscation (`<scr<script>ipt>`) can't survive a single
- * pass — CodeQL js/incomplete-multi-character-sanitization. Each pass only
- * shrinks the string, so termination is guaranteed; the bound is defensive.
+ * scripts; browser + Bun server both configure DOMPurify).
+ *
+ * Three stages, each looped to a fixpoint with a single literal regex — the
+ * exact do-while-until-stable form CodeQL recognises as a complete sanitizer
+ * (js/incomplete-multi-character-sanitization). Looping matters because removing
+ * one match can reveal another: split-tag obfuscation `<scr<script>ipt>` only
+ * collapses after the inner match goes. Close tags use `(?:[\s/][^>]*)?` since
+ * the HTML parser ends a tag at the first `>` (js/bad-tag-filter). Each pass
+ * strictly shrinks the string, so every loop terminates.
+ *
+ * 1. drop `<script>…</script>` blocks (removes the JS source, not just the tag)
+ * 2. drop `<style>…</style>` blocks (CSS can carry `@import url(javascript:…)`)
+ * 3. drop every remaining tag, incl. bare/unbalanced `<script`/`<style` openers
  */
-function stripHtmlOnce(value: string): string {
-  return value
-    .replace(FALLBACK_SCRIPT_BLOCK_RE, '')
-    .replace(FALLBACK_SCRIPT_OPEN_RE, '')
-    .replace(FALLBACK_STYLE_BLOCK_RE, '')
-    .replace(FALLBACK_STYLE_OPEN_RE, '')
-    .replace(FALLBACK_TAG_RE, '')
-}
-
 function stripHtmlFallback(value: string): string {
   let current = value
-  for (let i = 0; i < 100; i++) {
-    const next = stripHtmlOnce(current)
-    if (next === current) return current
-    current = next
-  }
+  let previous: string
+  do {
+    previous = current
+    current = current.replace(/<script\b[^>]*>[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi, '')
+  } while (current !== previous)
+  do {
+    previous = current
+    current = current.replace(/<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi, '')
+  } while (current !== previous)
+  do {
+    previous = current
+    current = current.replace(/<[^>]*>/g, '')
+  } while (current !== previous)
   return current
 }
 

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -78,12 +78,17 @@ function getDOMPurify(): DOMPurifyRuntime | null {
   return null
 }
 
-// Close-tag matcher mirrors the SVG sanitizer: the HTML parser ends a tag at
-// the first `>`, so `</script bar>` and `</script\t\n>` both close a script.
-// `(?:[\s/][^>]*)?` accepts that trailing junk; a bare `<\/x\s*>` missed it
-// (CodeQL js/bad-tag-filter).
-const FALLBACK_SCRIPT_RE = /<script\b[^>]*>[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi
-const FALLBACK_STYLE_RE = /<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi
+// Mirror the proven server-side SVG sanitizer: remove the full block, THEN the
+// bare opener. Stripping `<script>…</script>` alone can leave a `<script`
+// opener behind (split-tag obfuscation / unbalanced tags), so each block regex
+// is paired with an opener regex that removes the residual `<script` / `<style`
+// — that pairing is what makes the `<script`/`<style` substring provably gone.
+// Close-tag patterns use `(?:[\s/][^>]*)?` because the HTML parser ends a tag
+// at the first `>` (`</script bar>` closes a script) — CodeQL js/bad-tag-filter.
+const FALLBACK_SCRIPT_BLOCK_RE = /<script\b[^>]*>[\s\S]*?<\/script(?:[\s/][^>]*)?>/gi
+const FALLBACK_SCRIPT_OPEN_RE = /<script\b[^>]*\/?>/gi
+const FALLBACK_STYLE_BLOCK_RE = /<style\b[^>]*>[\s\S]*?<\/style(?:[\s/][^>]*)?>/gi
+const FALLBACK_STYLE_OPEN_RE = /<style\b[^>]*\/?>/gi
 const FALLBACK_TAG_RE = /<[^>]*>/g
 
 /**
@@ -97,8 +102,10 @@ function stripHtmlFallback(value: string): string {
   let current = value
   for (let i = 0; i < 100; i++) {
     const next = current
-      .replace(FALLBACK_SCRIPT_RE, '')
-      .replace(FALLBACK_STYLE_RE, '')
+      .replace(FALLBACK_SCRIPT_BLOCK_RE, '')
+      .replace(FALLBACK_SCRIPT_OPEN_RE, '')
+      .replace(FALLBACK_STYLE_BLOCK_RE, '')
+      .replace(FALLBACK_STYLE_OPEN_RE, '')
       .replace(FALLBACK_TAG_RE, '')
     if (next === current) return current
     current = next

--- a/src/core/siteImport/htmlPagePlan.ts
+++ b/src/core/siteImport/htmlPagePlan.ts
@@ -242,7 +242,9 @@ function extractDocumentMetaFromRegex(htmlSource: string, htmlPath: string): Doc
   }
 
   const scriptRefs: ScriptRef[] = []
-  const scriptRe = /<script\b([^>]*)>([\s\S]*?)<\/script>/gi
+  // Close tag matches `</script>`, `</script >`, and `</script foo>` — the HTML
+  // parser ends the tag at the first `>` (CodeQL js/bad-tag-filter).
+  const scriptRe = /<script\b([^>]*)>([\s\S]*?)<\/script(?:[\s/][^>]*)?>/gi
   let scriptMatch: RegExpExecArray | null
   let inlineIndex = 0
   while ((scriptMatch = scriptRe.exec(htmlSource)) !== null) {


### PR DESCRIPTION
## What

Resolves CodeQL code-scanning alerts across the sanitization and string-handling surfaces.

**Real security fix**
- **`server/handlers/cms/svgSanitize.ts`** (#30–34) — the media-upload SVG sanitizer. Close-tag regexes now match `</script foo>`, `</script\t\n>`, and `</script/>` (HTML parsers end a tag at the first `>`; the old `<\/script\s*>` missed these — `js/bad-tag-filter`). Stripping now iterates to a **fixpoint** instead of a fixed 2 passes, so split-tag obfuscation (`<scr<script>ipt>`) can't survive (`js/incomplete-multi-character-sanitization`). Adds `__tests__/svgSanitize.test.ts` — the first test on this boundary.

**Defense-in-depth**
- **`src/core/sanitize.ts`** (#1–5) — same close-tag fix + fixpoint loop in the `stripHtmlFallback` path (only used when no DOMPurify runtime exists); plain-text post-strip reuses it.

**Correctness**
- **`src/core/markdown/markdownDocument.ts`** (#28) — `decodeEntities` decodes `&amp;` **last**, stopping the `&amp;lt;` → `<` double-unescape (`js/double-escaping`).
- **`src/admin/.../siteItemNames.ts`** (#13) — dynamic `RegExp` → `startsWith`/`slice`.
- **`src/core/framework/scaleModule.ts`** (#35) & **`server/publish/runtime/dependencyResolver.ts`** (#12) — `replace` → `replaceAll`.
- **`src/core/siteImport/htmlPagePlan.ts`** (#36) — importer script close-tag match hardened.

**Test infra**
- `cms-handlers-capability-gated.test.ts` skips `__tests__` dirs (test files aren't routes).

## Why

CodeQL flagged regex-based tag filtering and incomplete multi-character sanitization on the SVG upload boundary — the one path where these are genuinely security-relevant (uploads are served as `image/svg+xml` and embedded in published pages). The rest are low-risk hardenings and correctness fixes.

## Not addressed (false positives — recommend dismissing in GitHub)

- **#20** `js/stack-trace-exposure` (`server/http.ts`) — traced end-to-end: top-level catch returns a generic message, plugin routes return `.message` only, worker `stack` fields are log-only. No stack→response path exists.
- **#18** `RichTextCell.tsx` — preview is rendered as React text, which is HTML-escaped; not an injection sink.
- **#27** `iframeCanvasQuery.ts` — a test file. **#23** `scripts/bench/lib/report.ts` — a benchmark script.

## Verification

- `bun run build` ✓
- `bun run lint` ✓
- `bun test` ✓ (5741 pass, 0 fail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)