### PR TITLE
feat(editor): select text module when clicking canvas text

### DIFF
--- a/src/__tests__/canvas/canvasEventTarget.test.ts
+++ b/src/__tests__/canvas/canvasEventTarget.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  isTextContentEventTarget,
+  resolveCanvasEventElement,
+  resolveDeepestCanvasNodeIdFromEvent,
+  resolvePreferredCanvasNodeIdFromEvent,
+} from '@site/canvas/canvasEventTarget'
+
+describe('canvasEventTarget', () => {
+  it('resolves text-node targets to their parent element', () => {
+    const parent = document.createElement('p')
+    parent.appendChild(document.createTextNode('Hello'))
+    const textNode = parent.firstChild!
+
+    expect(resolveCanvasEventElement(textNode)).toBe(parent)
+  })
+
+  it('treats ancestor nodes as non-targets when the click hits inner text', () => {
+    const container = document.createElement('div')
+    container.dataset.nodeId = 'container'
+    const heading = document.createElement('h1')
+    heading.dataset.nodeId = 'heading'
+    heading.dataset.moduleId = 'base.text'
+    heading.textContent = 'Title'
+    container.appendChild(heading)
+    document.body.appendChild(container)
+
+    const textNode = heading.firstChild!
+    expect(isTextContentEventTarget(textNode)).toBe(true)
+    expect(resolvePreferredCanvasNodeIdFromEvent(textNode)).toBe('heading')
+
+    container.remove()
+  })
+
+  it('returns the innermost data-node-id for text-node clicks', () => {
+    const container = document.createElement('div')
+    container.dataset.nodeId = 'container'
+    const heading = document.createElement('h1')
+    heading.dataset.nodeId = 'heading'
+    heading.textContent = 'Title'
+    container.appendChild(heading)
+
+    const textNode = heading.firstChild!
+    expect(resolveDeepestCanvasNodeIdFromEvent(textNode)).toBe('heading')
+  })
+
+  it('treats line breaks inside text modules as text-content hits', () => {
+    const heading = document.createElement('h1')
+    heading.dataset.nodeId = 'heading'
+    heading.dataset.moduleId = 'base.text'
+    const br = document.createElement('br')
+    heading.appendChild(document.createTextNode('Line one'))
+    heading.appendChild(br)
+
+    expect(isTextContentEventTarget(br)).toBe(true)
+    expect(resolvePreferredCanvasNodeIdFromEvent(br)).toBe('heading')
+  })
+})

--- a/src/__tests__/canvas/textNodeClickSelection.test.tsx
+++ b/src/__tests__/canvas/textNodeClickSelection.test.tsx
@@ -1,0 +1,151 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import React from 'react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
+import { DndContext } from '@dnd-kit/core'
+import { useEditorStore } from '@site/store/store'
+import { setEditorSelectPreference } from '@site/preferences/editorPreferences'
+import { CanvasRoot } from '@site/canvas/CanvasRoot'
+import { queryCanvasElement, waitForCanvasElement } from './iframeCanvasQuery'
+import { makeNode, makePage, makeSite } from '../fixtures'
+import '@modules/base'
+
+const originalFetch = globalThis.fetch
+
+function renderCanvas() {
+  return render(<DndContext><CanvasRoot /></DndContext>)
+}
+
+function setupContainerWithTextPage() {
+  const root = makeNode({ id: 'root', moduleId: 'base.body', children: ['container'] })
+  const container = makeNode({
+    id: 'container',
+    moduleId: 'base.container',
+    children: ['heading'],
+  })
+  const heading = makeNode({
+    id: 'heading',
+    moduleId: 'base.text',
+    props: { text: 'Click me', tag: 'h1' },
+  })
+  const page = makePage({
+    id: 'page-1',
+    rootNodeId: 'root',
+    nodes: { root, container, heading },
+  })
+
+  useEditorStore.setState({
+    site: makeSite({ pages: [page] }),
+    activePageId: 'page-1',
+    activeDocument: null,
+    activeBreakpointId: 'desktop',
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+function setupTagNoneTextPage() {
+  const root = makeNode({ id: 'root', moduleId: 'base.body', children: ['bare'] })
+  const bare = makeNode({
+    id: 'bare',
+    moduleId: 'base.text',
+    props: { text: 'Bare text', tag: 'none' },
+  })
+  const page = makePage({
+    id: 'page-1',
+    rootNodeId: 'root',
+    nodes: { root, bare },
+  })
+
+  useEditorStore.setState({
+    site: makeSite({ pages: [page] }),
+    activePageId: 'page-1',
+    activeDocument: null,
+    activeBreakpointId: 'desktop',
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+}
+
+/** Simulate a browser click whose event.target is the #text node, not the element. */
+function clickTextNodeContent(element: HTMLElement) {
+  const textNode = Array.from(element.childNodes).find((node) => node.nodeType === Node.TEXT_NODE)
+  if (!textNode) throw new Error('Expected a text node child')
+
+  const event = new MouseEvent('click', { bubbles: true, cancelable: true })
+  Object.defineProperty(event, 'target', { value: textNode, enumerable: true })
+  element.dispatchEvent(event)
+}
+
+beforeEach(() => {
+  cleanup()
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ value: null }), { status: 200 })) as typeof fetch
+  useEditorStore.setState({
+    site: null,
+    activePageId: null,
+    activeDocument: null,
+    selectedNodeId: null,
+    selectedNodeIds: [],
+    hoveredNodeId: null,
+    _historyPast: [],
+    _historyFuture: [],
+    canUndo: false,
+    canRedo: false,
+    hasUnsavedChanges: false,
+  } as Parameters<typeof useEditorStore.setState>[0])
+})
+
+afterEach(() => {
+  cleanup()
+  globalThis.fetch = originalFetch
+})
+
+describe('text node click selection', () => {
+  it('selects the text module when clicking rendered text inside a container', async () => {
+    setupContainerWithTextPage()
+    renderCanvas()
+
+    const headingEl = await waitForCanvasElement<HTMLElement>('[data-node-id="heading"]')
+    await act(async () => {
+      clickTextNodeContent(headingEl)
+    })
+
+    expect(useEditorStore.getState().selectedNodeId).toBe('heading')
+  })
+
+  it('selects tag:none text via its canvas-only host element', async () => {
+    setupTagNoneTextPage()
+    renderCanvas()
+
+    const hostEl = await waitForCanvasElement<HTMLElement>('[data-node-id="bare"][data-instatic-canvas-text-host]')
+    fireEvent.click(hostEl)
+
+    expect(useEditorStore.getState().selectedNodeId).toBe('bare')
+    expect(queryCanvasElement('[data-node-id="container"]')).toBeNull()
+  })
+
+  it('keeps text selection in active expanded mode when clicking text pixels', async () => {
+    setEditorSelectPreference('propertiesSectionsMode', 'active')
+    setupContainerWithTextPage()
+    renderCanvas()
+
+    const headingEl = await waitForCanvasElement<HTMLElement>('[data-node-id="heading"]')
+    await act(async () => {
+      clickTextNodeContent(headingEl)
+    })
+
+    expect(useEditorStore.getState().selectedNodeId).toBe('heading')
+  })
+})

--- a/src/admin/pages/site/canvas/NodeRenderer.tsx
+++ b/src/admin/pages/site/canvas/NodeRenderer.tsx
@@ -40,6 +40,11 @@ import {
 import { bagToReactStyle } from '@core/publisher'
 import { getCanvasNodeClassIds, getCanvasNodeClassName } from './canvasNodeClassName'
 import { findEnclosingComponentRef, type AnnotatedPageNode } from './canvasSelectionUtils'
+import {
+  eventClickTarget,
+  isCanvasNodeEventForElement,
+  resolvePreferredCanvasNodeIdFromEvent,
+} from './canvasEventTarget'
 import { useLoopPreviewItems } from './useLoopPreviewItems'
 import styles from './NodeRenderer.module.css'
 
@@ -113,6 +118,9 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
   const { onNodeClick, onNodeHover, onNodeContextMenu, onNodeDoubleClick } = use(CanvasSelectionContext)
 
   const handleNodeClick = (clickedNodeId: string, e: React.MouseEvent) => {
+    const clickTarget = eventClickTarget(e)
+    const preferredNodeId =
+      resolvePreferredCanvasNodeIdFromEvent(clickTarget) ?? clickedNodeId
     // B3 — VC lock-down: redirect clicks inside inlined VC bodies to the ref node.
     // Imperative store access is correct here (event handler, not render path).
     const state = useEditorStore.getState()
@@ -121,16 +129,23 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
       if (page) {
         const enclosing = findEnclosingComponentRef(
           page.nodes as Record<string, AnnotatedPageNode>,
-          clickedNodeId,
+          preferredNodeId,
         )
         if (enclosing !== null && !enclosing.isInsideSlotContent) {
           // Clicked inside a VC body (not slot content) — route to the ref.
-          onNodeClick(enclosing.refId, e, breakpointId)
+          onNodeClick(enclosing.refId, e, breakpointId, clickTarget)
           return
         }
       }
     }
-    onNodeClick(clickedNodeId, e, breakpointId)
+    onNodeClick(preferredNodeId, e, breakpointId, clickTarget)
+  }
+
+  const handleNodeDoubleClick = (clickedNodeId: string, e: React.MouseEvent) => {
+    const clickTarget = eventClickTarget(e)
+    const preferredNodeId =
+      resolvePreferredCanvasNodeIdFromEvent(clickTarget) ?? clickedNodeId
+    onNodeDoubleClick(preferredNodeId, e, breakpointId)
   }
 
   const handleNodeContextMenu = (clickedNodeId: string, e: React.MouseEvent) => {
@@ -261,6 +276,7 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
     ...(inlineStyle ? { style: inlineStyle } : {}),
     ...(isHovered && !isSelected ? { 'data-hovered': 'true' as const } : {}),
     onPointerDownCapture: (e) => {
+      if (!isClosestCanvasNodeTarget(e.target, e.currentTarget)) return
       if (!shouldSuppressAuthoredFormControlEvent(e.target, e.currentTarget)) return
       e.preventDefault()
       e.stopPropagation()
@@ -268,6 +284,7 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
       handleNodeClick(nodeId, e as unknown as React.MouseEvent)
     },
     onMouseDownCapture: (e) => {
+      if (!isClosestCanvasNodeTarget(e.target, e.currentTarget)) return
       if (!shouldSuppressAuthoredFormControlEvent(e.target, e.currentTarget)) return
       e.preventDefault()
       e.stopPropagation()
@@ -303,7 +320,7 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
       if (isCanvasEditorControlTarget(e.target, e.currentTarget)) return
       e.preventDefault()
       e.stopPropagation()
-      onNodeDoubleClick(nodeId, e as unknown as React.MouseEvent, breakpointId)
+      handleNodeDoubleClick(nodeId, e as unknown as React.MouseEvent)
     },
     onDoubleClick: (e) => {
       if (!isClosestCanvasNodeTarget(e.target, e.currentTarget)) return
@@ -313,7 +330,7 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
       }
       e.preventDefault()
       e.stopPropagation()
-      onNodeDoubleClick(nodeId, e as unknown as React.MouseEvent, breakpointId)
+      handleNodeDoubleClick(nodeId, e as unknown as React.MouseEvent)
     },
     onContextMenuCapture: (e) => {
       if (!isClosestCanvasNodeTarget(e.target, e.currentTarget)) return
@@ -494,7 +511,6 @@ function LoopIterationsPreview({ node, baseTemplateContext }: LoopIterationsPrev
 // element the canvas does, so the canvas DOM matches the published DOM 1:1.
 
 const CANVAS_EDITOR_CONTROL_SELECTOR = '[data-canvas-interactive="true"]'
-const CANVAS_NODE_SELECTOR = '[data-node-id]'
 const CANVAS_FORM_CONTROL_SELECTOR = 'input, textarea, select, button, option, optgroup'
 let latestSuppressedPointerTarget: EventTarget | null = null
 
@@ -531,12 +547,7 @@ function isClosestCanvasNodeTarget(
   target: EventTarget | null,
   currentTarget: EventTarget | null,
 ): boolean {
-  if (!isElementLike(target) || !isElementLike(currentTarget)) {
-    return true
-  }
-
-  const closestNode = target.closest(CANVAS_NODE_SELECTOR)
-  return closestNode === currentTarget
+  return isCanvasNodeEventForElement(target, currentTarget)
 }
 
 function isCanvasEditorControlTarget(

--- a/src/admin/pages/site/canvas/canvasEventTarget.ts
+++ b/src/admin/pages/site/canvas/canvasEventTarget.ts
@@ -1,0 +1,104 @@
+/**
+ * canvasEventTarget — resolve pointer/keyboard event targets inside canvas
+ * iframes to the element that owns canvas selection.
+ *
+ * Clicks on rendered text often arrive with a `#text` node as `event.target`.
+ * Ancestor module roots used to treat that as a hit on themselves and steal
+ * selection from the inner semantic text element. Resolve text/comment targets
+ * to their parent element before comparing `[data-node-id]` ownership.
+ *
+ * Always prefer `nativeEvent.target` over React's `event.target` when calling
+ * these helpers — in iframe portals the synthetic target can differ from the
+ * DOM node the author actually clicked.
+ */
+
+import { registry } from '@core/module-engine'
+
+const CANVAS_NODE_SELECTOR = '[data-node-id]'
+
+function isElementLike(value: EventTarget | null): value is Element {
+  return value != null && typeof (value as { closest?: unknown }).closest === 'function'
+}
+
+/** The DOM target that originated the interaction. */
+export function eventClickTarget(event: { nativeEvent: Event }): EventTarget | null {
+  return event.nativeEvent.target
+}
+
+/** Normalize text/comment targets to the nearest Element host. */
+export function resolveCanvasEventElement(target: EventTarget | null): Element | null {
+  if (target == null) return null
+  if (isElementLike(target)) return target
+  const parent = (target as Node).parentElement
+  return parent ?? null
+}
+
+/** True when the module's copy is edited in the Properties panel (Module section). */
+export function isContentTextModuleId(moduleId: string | undefined): boolean {
+  if (!moduleId) return false
+  if (moduleId === 'base.text') return true
+  return registry.get(moduleId)?.inlineTextEdit != null
+}
+
+/**
+ * True when the click landed on visible text glyphs (or a line break inside
+ * a text-bearing module), not on a container's empty padding/border box.
+ */
+export function isTextContentEventTarget(target: EventTarget | null): boolean {
+  if (target == null) return false
+  if ((target as Node).nodeType === Node.TEXT_NODE) return true
+  if (!isElementLike(target)) return false
+  if (target.tagName === 'BR') {
+    const owner = target.closest<HTMLElement>(CANVAS_NODE_SELECTOR)
+    return isContentTextModuleId(owner?.dataset.moduleId)
+  }
+  return false
+}
+
+/**
+ * True when `currentTarget` is the nearest canvas node root for the event.
+ * Returns false for ancestor nodes so the innermost module can handle the
+ * interaction during capture/bubble.
+ */
+export function isCanvasNodeEventForElement(
+  target: EventTarget | null,
+  currentTarget: EventTarget | null,
+): boolean {
+  if (!isElementLike(currentTarget)) return true
+
+  const resolvedTarget = resolveCanvasEventElement(target)
+  if (!resolvedTarget) return false
+
+  const closestNode = resolvedTarget.closest(CANVAS_NODE_SELECTOR)
+  return closestNode === currentTarget
+}
+
+/** Innermost `[data-node-id]` element under the event target, if any. */
+export function resolveDeepestCanvasNodeIdFromEvent(
+  target: EventTarget | null,
+): string | null {
+  const resolvedTarget = resolveCanvasEventElement(target)
+  if (!resolvedTarget) return null
+  const closestNode = resolvedTarget.closest<HTMLElement>(CANVAS_NODE_SELECTOR)
+  return closestNode?.dataset.nodeId ?? null
+}
+
+/**
+ * Resolve the node id that should be selected for this click.
+ *
+ * Text-pixel hits prefer the innermost module whose copy is edited in the
+ * Properties panel (`base.text`, button label, childless link text, …).
+ */
+export function resolvePreferredCanvasNodeIdFromEvent(
+  target: EventTarget | null,
+): string | null {
+  const resolvedTarget = resolveCanvasEventElement(target)
+  if (!resolvedTarget) return null
+
+  if (isTextContentEventTarget(target)) {
+    const owner = resolvedTarget.closest<HTMLElement>(CANVAS_NODE_SELECTOR)
+    if (owner?.dataset.nodeId) return owner.dataset.nodeId
+  }
+
+  return resolveDeepestCanvasNodeIdFromEvent(target)
+}

--- a/src/modules/base/text/TextEditor.tsx
+++ b/src/modules/base/text/TextEditor.tsx
@@ -32,9 +32,7 @@ export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
   // Editing: the element becomes the contentEditable surface (content seeded
   // from the frozen initial HTML inside inlineEditableElementProps). `tag: none`
   // has no published element, but an active edit session still needs a host —
-  // a `<span>` is the minimal one. This branch is effectively unreachable for
-  // tag:none from the canvas: the display branch below renders no element, so
-  // there is nothing to double-click to start a session.
+  // a `<span>` is the minimal one.
   if (inlineEdit) {
     const EditTag = (tag === 'none' ? 'span' : tag) as React.ElementType
     return React.createElement(EditTag, {
@@ -45,16 +43,19 @@ export const TextEditor: React.FC<ModuleComponentProps<TextStoredProps>> = ({
     })
   }
 
-  // Display: `tag: none` emits NO element, exactly like the publisher
-  // (`src/modules/base/text/index.ts` render() returns bare text). Wrapping it
-  // in any element here would let descendant selectors such as `.parent span`
-  // paint the text in the canvas while leaving the published page untouched —
-  // a canvas/publish fidelity break. Bare text keeps the canvas DOM identical
-  // to the published DOM. The cost: a tag:none node owns no element, so it has
-  // no in-canvas selection ring / hover / inline-edit; it is selected and
-  // edited via the Layers + Properties panels instead.
+  // Display: `tag: none` publishes bare text with no wrapper element. The canvas
+  // still needs a host for selection/hover/inline-edit, so wrap the fragment in
+  // a canvas-only inline span that carries the module's editor attributes.
   if (tag === 'none') {
-    return <BareText text={props.text ?? ''} />
+    return (
+      <span
+        {...nodeWrapperProps}
+        className={mcClassName}
+        data-instatic-canvas-text-host=""
+      >
+        <BareText text={props.text ?? ''} />
+      </span>
+    )
   }
 
   // Display: escaped text with newlines as <br>, matching the publisher.


### PR DESCRIPTION
## Summary
- Clicks on visible text select the inner text module instead of an outer container.
- Adds a canvas-only host element for `tag: none` text nodes.

## Test plan
- [x] `bun test src/__tests__/canvas/canvasEventTarget.test.ts src/__tests__/canvas/textNodeClickSelection.test.tsx`
- [ ] Manual: click rendered text → base.text selected in properties panel

Made with [Cursor](https://cursor.com)