### PR TITLE
fix(editor): show breakpoint style cascade in properties panel

### DIFF
--- a/src/__tests__/panels/breakpointStyleCascade.test.ts
+++ b/src/__tests__/panels/breakpointStyleCascade.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from 'bun:test'
+import { DEFAULT_BREAKPOINTS } from '@core/page-tree'
+import type { StyleRule } from '@core/page-tree'
+import {
+  mediaQueryMatchesViewportWidth,
+  resolveRuleCurrentStyles,
+  resolveViewportCascadeStyles,
+} from '@site/panels/PropertiesPanel/breakpointStyleCascade'
+
+function makeRule(overrides: Partial<StyleRule> = {}): StyleRule {
+  return {
+    id: 'cls-1',
+    name: 'grid',
+    selector: '.grid',
+    styles: {},
+    contextStyles: {},
+    ...overrides,
+  }
+}
+
+describe('mediaQueryMatchesViewportWidth', () => {
+  it('matches max-width queries at or below the threshold', () => {
+    expect(mediaQueryMatchesViewportWidth('(max-width: 768px)', 375)).toBe(true)
+    expect(mediaQueryMatchesViewportWidth('(max-width: 768px)', 768)).toBe(true)
+    expect(mediaQueryMatchesViewportWidth('(max-width: 768px)', 769)).toBe(false)
+  })
+
+  it('matches min-width queries at or above the threshold', () => {
+    expect(mediaQueryMatchesViewportWidth('(min-width: 768px)', 768)).toBe(true)
+    expect(mediaQueryMatchesViewportWidth('(min-width: 768px)', 1200)).toBe(true)
+    expect(mediaQueryMatchesViewportWidth('(min-width: 768px)', 767)).toBe(false)
+  })
+})
+
+describe('resolveViewportCascadeStyles', () => {
+  it('inherits tablet grid columns on mobile when mobile has no override', () => {
+    const rule = makeRule({
+      styles: { display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)' },
+      contextStyles: {
+        tablet: { gridTemplateColumns: 'repeat(3, 1fr)' },
+      },
+    })
+
+    const mobileWidth = DEFAULT_BREAKPOINTS.find((bp) => bp.id === 'mobile')!.width
+    const resolved = resolveViewportCascadeStyles({
+      rule,
+      breakpoints: DEFAULT_BREAKPOINTS,
+      viewportWidth: mobileWidth,
+    })
+
+    expect(resolved.gridTemplateColumns).toBe('repeat(3, 1fr)')
+  })
+
+  it('lets a narrower breakpoint override a wider one', () => {
+    const rule = makeRule({
+      styles: { gridTemplateColumns: 'repeat(4, 1fr)' },
+      contextStyles: {
+        tablet: { gridTemplateColumns: 'repeat(3, 1fr)' },
+        mobile: { gridTemplateColumns: 'repeat(2, 1fr)' },
+      },
+    })
+
+    const mobileWidth = DEFAULT_BREAKPOINTS.find((bp) => bp.id === 'mobile')!.width
+    const resolved = resolveViewportCascadeStyles({
+      rule,
+      breakpoints: DEFAULT_BREAKPOINTS,
+      viewportWidth: mobileWidth,
+    })
+
+    expect(resolved.gridTemplateColumns).toBe('repeat(2, 1fr)')
+  })
+
+  it('does not apply tablet overrides when editing at tablet width without mobile match', () => {
+    const rule = makeRule({
+      styles: { gridTemplateColumns: 'repeat(4, 1fr)' },
+      contextStyles: {
+        mobile: { gridTemplateColumns: 'repeat(2, 1fr)' },
+      },
+    })
+
+    const tabletWidth = DEFAULT_BREAKPOINTS.find((bp) => bp.id === 'tablet')!.width
+    const resolved = resolveViewportCascadeStyles({
+      rule,
+      breakpoints: DEFAULT_BREAKPOINTS,
+      viewportWidth: tabletWidth,
+    })
+
+    expect(resolved.gridTemplateColumns).toBe('repeat(4, 1fr)')
+  })
+})
+
+describe('resolveRuleCurrentStyles', () => {
+  it('returns base styles on desktop', () => {
+    const rule = makeRule({
+      styles: { display: 'flex' },
+      contextStyles: { tablet: { display: 'grid' } },
+    })
+
+    expect(
+      resolveRuleCurrentStyles({
+        rule,
+        breakpoints: DEFAULT_BREAKPOINTS,
+        activeContextId: null,
+        activeBreakpointId: 'desktop',
+        onCondition: false,
+      }).display,
+    ).toBe('flex')
+  })
+
+  it('cascades viewport overrides on breakpoint tabs', () => {
+    const rule = makeRule({
+      styles: { gridTemplateColumns: 'repeat(4, 1fr)' },
+      contextStyles: { tablet: { gridTemplateColumns: 'repeat(3, 1fr)' } },
+    })
+
+    expect(
+      resolveRuleCurrentStyles({
+        rule,
+        breakpoints: DEFAULT_BREAKPOINTS,
+        activeContextId: 'mobile',
+        activeBreakpointId: 'mobile',
+        onCondition: false,
+      }).gridTemplateColumns,
+    ).toBe('repeat(3, 1fr)')
+  })
+})

--- a/src/__tests__/panels/propertiesPanel-redesign.test.tsx
+++ b/src/__tests__/panels/propertiesPanel-redesign.test.tsx
@@ -788,6 +788,56 @@ describe('LayoutSection — grid block', () => {
     expect(fourColsSegment.getAttribute('aria-pressed')).toBe('true')
   })
 
+  it('shows tablet grid columns on the mobile tab via viewport cascade', () => {
+    const { nodeId, classIds } = loadSiteWithClasses(1)
+    const clsId = classIds[0]
+    useEditorStore.getState().updateClassStyles(clsId, {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(4, 1fr)',
+    })
+    useEditorStore.getState().setClassContextStyles(clsId, 'tablet', {
+      gridTemplateColumns: 'repeat(3, 1fr)',
+    })
+    useEditorStore.setState({ activeBreakpointId: 'mobile' } as Parameters<typeof useEditorStore.setState>[0])
+    selectNode(nodeId)
+    render(<PropertiesPanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: /edit class \.class-1/i }))
+
+    const columnGroup = screen.getByRole('group', { name: /grid template columns/i })
+    const threeColsSegment = columnGroup.querySelector('button[aria-label="3 tracks"]') as HTMLButtonElement
+    expect(threeColsSegment.getAttribute('aria-pressed')).toBe('true')
+
+    // Inherited from tablet — nothing stored on the mobile override bag.
+    expect(screen.queryByTestId('class-style-section-dot-layout')).toBeNull()
+  })
+
+  it('writes mobile-only overrides without touching tablet or base', () => {
+    const { nodeId, classIds } = loadSiteWithClasses(1)
+    const clsId = classIds[0]
+    useEditorStore.getState().updateClassStyles(clsId, {
+      display: 'grid',
+      gridTemplateColumns: 'repeat(4, 1fr)',
+    })
+    useEditorStore.getState().setClassContextStyles(clsId, 'tablet', {
+      gridTemplateColumns: 'repeat(3, 1fr)',
+    })
+    useEditorStore.setState({ activeBreakpointId: 'mobile' } as Parameters<typeof useEditorStore.setState>[0])
+    selectNode(nodeId)
+    render(<PropertiesPanel />)
+
+    fireEvent.click(screen.getByRole('button', { name: /edit class \.class-1/i }))
+
+    const columnGroup = screen.getByRole('group', { name: /grid template columns/i })
+    const twoColsSegment = columnGroup.querySelector('button[aria-label="2 tracks"]') as HTMLButtonElement
+    fireEvent.click(twoColsSegment)
+
+    const rule = useEditorStore.getState().site!.styleRules[clsId]
+    expect(rule.styles.gridTemplateColumns).toBe('repeat(4, 1fr)')
+    expect(rule.contextStyles.tablet?.gridTemplateColumns).toBe('repeat(3, 1fr)')
+    expect(rule.contextStyles.mobile?.gridTemplateColumns).toBe('repeat(2, 1fr)')
+  })
+
   it('falls back to a custom-value chip when gridTemplateColumns is a non-preset template', () => {
     const { nodeId, classIds } = loadSiteWithClasses(1)
     const clsId = classIds[0]

--- a/src/admin/pages/site/panels/PropertiesPanel/StyleRuleComposer.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/StyleRuleComposer.tsx
@@ -10,6 +10,7 @@ import { useEditorStore } from '@site/store/store'
 import type { StyleRule, CSSPropertyBag } from '@core/page-tree'
 import { StyleSectionsEditor } from './StyleSectionsEditor'
 import { getActiveStyleTab } from './cssControlTypes'
+import { resolveRuleCurrentStyles } from './breakpointStyleCascade'
 
 // ---------------------------------------------------------------------------
 // Props
@@ -34,6 +35,7 @@ export function StyleRuleComposer({
   mode: _mode = 'contextual',
 }: StyleRuleComposerProps) {
   const activeBreakpointId = useEditorStore((s) => s.activeBreakpointId)
+  const breakpoints = useEditorStore((s) => s.site?.breakpoints ?? [])
   // The editing context is owned by the canvas toolbar's context switcher:
   // either the active viewport (base / breakpoint) or a custom condition. The
   // selector validates the active condition id against the registry and returns
@@ -66,9 +68,13 @@ export function StyleRuleComposer({
   const storedStyles: Record<string, unknown> = activeContextId
     ? (cls.contextStyles[activeContextId] ?? {})
     : cls.styles
-  const currentStyles: Record<string, unknown> = activeContextId
-    ? { ...cls.styles, ...storedStyles }
-    : cls.styles
+  const currentStyles = resolveRuleCurrentStyles({
+    rule: cls,
+    breakpoints,
+    activeContextId,
+    activeBreakpointId,
+    onCondition,
+  })
 
   const handleChange = (key: keyof CSSPropertyBag, value: string | number | undefined) => {
     const patch = { [key]: value ?? null } as Partial<CSSPropertyBag>

--- a/src/admin/pages/site/panels/PropertiesPanel/breakpointStyleCascade.ts
+++ b/src/admin/pages/site/panels/PropertiesPanel/breakpointStyleCascade.ts
@@ -1,0 +1,80 @@
+/**
+ * breakpointStyleCascade — resolve the effective CSS bag shown in the
+ * Properties panel at the active viewport, mirroring the published CSS cascade.
+ *
+ * `storedStyles` stays scoped to the active breakpoint/condition override bag
+ * (what is explicitly set *here*). `currentStyles` merges base styles with
+ * every viewport context whose @media query matches the active canvas width.
+ */
+
+import type { Breakpoint, StyleRule } from '@core/page-tree'
+import { breakpointMediaQuery } from '@core/page-tree'
+import { compareViewportContextCascade } from '@core/publisher/classCss'
+
+const PURE_MAX_WIDTH_QUERY_RE = /^\(\s*max-width\s*:\s*(\d+(?:\.\d+)?)\s*px\s*\)$/i
+const PURE_MIN_WIDTH_QUERY_RE = /^\(\s*min-width\s*:\s*(\d+(?:\.\d+)?)\s*px\s*\)$/i
+
+/** Whether a breakpoint media query matches the given canvas viewport width. */
+export function mediaQueryMatchesViewportWidth(query: string, viewportWidth: number): boolean {
+  const normalized = query.trim()
+  const maxMatch = normalized.match(PURE_MAX_WIDTH_QUERY_RE)
+  if (maxMatch) return viewportWidth <= Number(maxMatch[1])
+  const minMatch = normalized.match(PURE_MIN_WIDTH_QUERY_RE)
+  if (minMatch) return viewportWidth >= Number(minMatch[1])
+  return false
+}
+
+/** Base styles plus every matching viewport override, in CSS cascade order. */
+export function resolveViewportCascadeStyles(input: {
+  rule: StyleRule
+  breakpoints: readonly Breakpoint[]
+  viewportWidth: number
+}): Record<string, unknown> {
+  const { rule, breakpoints, viewportWidth } = input
+  let merged: Record<string, unknown> = { ...rule.styles }
+
+  const ordered = breakpoints
+    .map((breakpoint, index) => ({ breakpoint, index }))
+    .sort(compareViewportContextCascade)
+
+  for (const { breakpoint } of ordered) {
+    const bag = rule.contextStyles[breakpoint.id]
+    if (!bag || Object.keys(bag).length === 0) continue
+    const query = breakpointMediaQuery(breakpoint)
+    if (!mediaQueryMatchesViewportWidth(query, viewportWidth)) continue
+    merged = { ...merged, ...bag }
+  }
+
+  return merged
+}
+
+/**
+ * Effective styles for property controls: base on desktop, full viewport
+ * cascade on breakpoint tabs, base + condition bag on custom conditions.
+ */
+export function resolveRuleCurrentStyles(input: {
+  rule: StyleRule
+  breakpoints: readonly Breakpoint[]
+  activeContextId: string | null
+  activeBreakpointId: string | undefined
+  onCondition: boolean
+}): Record<string, unknown> {
+  const { rule, activeContextId, activeBreakpointId, onCondition, breakpoints } = input
+
+  if (!activeContextId) return { ...rule.styles }
+
+  if (onCondition) {
+    return { ...rule.styles, ...(rule.contextStyles[activeContextId] ?? {}) }
+  }
+
+  const viewport = breakpoints.find((bp) => bp.id === activeBreakpointId)
+  if (!viewport) {
+    return { ...rule.styles, ...(rule.contextStyles[activeContextId] ?? {}) }
+  }
+
+  return resolveViewportCascadeStyles({
+    rule,
+    breakpoints,
+    viewportWidth: viewport.width,
+  })
+}


### PR DESCRIPTION
## Summary
- Properties panel `currentStyles` mirrors CSS cascade (tablet grid cols visible on mobile tab).
- Set indicators remain scoped to the active breakpoint override bag.

## Test plan
- [x] `bun test src/__tests__/panels/breakpointStyleCascade.test.ts`
- [ ] Manual: desktop 4 cols, tablet 3, mobile tab shows 3; mobile override to 2

Made with [Cursor](https://cursor.com)