### PR TITLE
docs(readme): link interface demo video

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,11 @@ A self-hosted CMS where the visual editor, content engine, and publisher all liv
 
 <br>
 
-<img src="docs/assets/readme/hero-editor.webp" alt="The Instatic visual editor — canvas-first, multiple breakpoints side by side" width="100%">
+<a href="https://www.youtube.com/watch?v=zyjCF_TaLlg">
+  <img src="https://img.youtube.com/vi/zyjCF_TaLlg/maxresdefault.jpg" alt="Watch the Instatic interface demo on YouTube" width="100%">
+</a>
+
+*Watch the introductory video about Instatic on YouTube.*
 
 </div>
 
@@ -52,6 +56,10 @@ Railway is the fastest way to get Instatic live. Pick a template, hit the button
 | **DigitalOcean** | — | — | *Coming soon* |
 
 SQLite is the right default for most sites. Reach for Postgres when you've got a team of authors or want managed database backups.
+
+### Updating is just a redeploy
+
+When a new Instatic version is available, update by redeploying the latest image. Your database and uploads stay on the attached storage, so the app container can be replaced without rebuilding the site from scratch.
 
 Prefer your own hardware? Instatic is a single Docker image:
 


### PR DESCRIPTION
## Summary

- Replaces the README hero interface screenshot with a YouTube-linked thumbnail for the introductory Instatic video.
- Adds a short caption so readers understand the thumbnail opens the video on YouTube.
- Adds update guidance under the one-click deploy section explaining that upgrades are handled by redeploying the latest image.

## Why

GitHub README rendering does not support playable iframe-style YouTube embeds, so the README uses the supported linked-thumbnail pattern instead. The deploy section now also answers the natural follow-up question of how updates work after install.

## Verification

- `bun run build`
- `bun test`
- `bun run lint`