### PR TITLE
chore(release): prepare 0.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## Unreleased
 
+## 0.0.7 - 2026-06-29
+
+### AI & integrations
+
+- Added MCP connectors so external AI clients can use the CMS tool surface through scoped connector tokens.
+
+### Design and onboarding
+
+- Imported Core Framework defaults from onboarding so new sites start with the selected design system values in place.
+
+### Security
+
+- Hardened sanitizers and regular expressions flagged by CodeQL.
+
+### Documentation and deployment
+
+- Replaced the README hero screenshot with a YouTube-linked introductory video thumbnail.
+- Added README guidance explaining that image-based installs update by redeploying the latest image.
+
 ## 0.0.6 - 2026-06-26
 
 ### AI & agent tooling

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.6 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.7 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.6
+docker pull ghcr.io/corebunch/instatic:0.0.7
 ```
 
-The v0.0.6 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.7 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.6
+ghcr.io/corebunch/instatic:0.0.7
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.6` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.7` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.6
+Image=ghcr.io/corebunch/instatic:0.0.7
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.6
+ghcr.io/corebunch/instatic:0.0.7
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.6` |
+| Image | `ghcr.io/corebunch/instatic:0.0.7` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.6` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.7` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.6",
+  "version": "0.0.7",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },


### PR DESCRIPTION
## Summary

- Bumps the package version to 0.0.7.
- Updates deployment docs that pin the published GHCR image tag to 0.0.7.
- Adds the 0.0.7 changelog entry for the changes since v0.0.6.

## Why

The release workflow is tag-driven, and the repo's release docs require pinned deployment surfaces to be updated before tagging a new version.

## Verification

- `bun run build`
- `bun test`
- `bun run lint`

## Release follow-up

After this PR is merged, tag and push `v0.0.7` from the merge commit to trigger the release workflow.