### PR TITLE
fix(security): audit follow-ups — response headers, import SVG sanitization, MCP token expiry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,13 +74,15 @@ Source of truth for layout details: [`docs/architecture.md`](docs/architecture.m
 
 ## Development status — READ THIS FIRST
 
-**This project is in PRE-RELEASE. There are no external users. There is no production traffic. There is no installed base. Nothing is shipped.**
+**This project has live, self-hosted installations with real user data.** That has direct consequences for how Claude must approach changes in this repo.
 
-That has direct consequences for how Claude must approach changes in this repo.
+**For code** (TypeScript APIs, function signatures, types, modules, plugin SDK): there are no backward-compatibility obligations. Refactor freely, rename boldly, delete dead code, fix bad abstractions — the aggressive stance throughout this section applies in full.
+
+**Database schema is the exception.** Live installations run the migration runner on every pull. A destructive schema change breaks those installations permanently. Every schema change ships as an additive, non-destructive migration. See "Database, schema, and stored data" below.
 
 ### No backward compatibility. Ever.
 
-There is nothing to be backward compatible with.
+There is nothing to be backward compatible with — **for code.** TypeScript APIs, function signatures, types, and module shapes can change freely. **Database schema is the explicit exception: see "Database, schema, and stored data" below.**
 
 - **Do not preserve old function signatures, schemas, types, or APIs out of compatibility concern.** If a cleaner shape exists, change it everywhere and delete the old one.
 - **Do not add deprecation shims.** Don't keep a `legacyFoo()` that forwards to `foo()`. Just rename it and update callers.
@@ -110,22 +112,23 @@ What you must not do:
 
 ### Database, schema, and stored data
 
-There is no production data to protect. Treat the schema like code:
+**The database is NOT disposable.** Live, self-hosted installations exist with real user data. The migration runner executes every unrun migration on startup — a destructive schema change breaks those installations on the next pull.
 
-- If a column, table, or migration is wrong, change the migration. Do not write a "compatibility migration" on top of a bad migration.
-- If stored shapes (page trees, plugin manifests, settings) need to change, change them and update everything that reads/writes them.
-- Local dev databases are disposable. It is acceptable for a change to require dropping the local DB and re-running migrations from scratch.
+- **Every schema change ships as a new additive migration.** Add it to BOTH `migrations-pg.ts` AND `migrations-sqlite.ts` with the next sequential ID and the same semantic effect. See "Database dialect rules" for the mechanics.
+- **Never edit or rewrite a migration that has already been committed.** If a past migration has the wrong shape, ship a new forward migration that corrects it.
+- **Never make a change that requires dropping or recreating the database.** No `DROP TABLE`, no `DROP COLUMN` (unless the column was added in the same unreleased branch and no installation has run that migration yet), no table rebuilds. Use additive `ADD COLUMN` (nullable or with a constant `DEFAULT`), backfill with `UPDATE`, and defer destructive cleanup to a future migration only when the transition is complete.
+- **If stored JSON shapes (page trees, plugin manifests, settings) need to change,** change the reader/writer code to handle the new shape and update everything that reads/writes them. A data-migration `UPDATE` in a new migration is the right tool for bulk shape changes on existing rows.
 
 ### Plugin SDK and public-looking surfaces
 
-The plugin SDK, runtime, and manifest format *look* like a public contract but they are also pre-release. Nothing external depends on them yet.
+The plugin SDK, runtime, and manifest format *look* like a public contract but carry no backward-compatibility guarantee yet — no third-party plugins have been published against them.
 
 - If the SDK shape is wrong, change it. Update `examples/plugins/template/` and [`docs/features/plugin-system.md`](docs/features/plugin-system.md) in the same change.
 - The `apiVersion` field is not yet a stability promise. Don't invent legacy adapters for older `apiVersion` values.
 
 ### Default disposition on every change
 
-Choose (A) the cleaner architecture, requiring edits across several files, over (B) a smaller diff that leaves the architecture slightly worse. **Always choose (A).** The whole point of being pre-release is that this is the cheapest moment in the project's life to do (A).
+Choose (A) the cleaner architecture, requiring edits across several files, over (B) a smaller diff that leaves the architecture slightly worse. **Always choose (A).** The cheapest moment in a project's life to fix bad abstractions is before they calcify — don't defer it.
 
 If you are unsure whether a refactor is in scope, default to *yes, do it*, and explain in the summary what you cleaned up and why. Do not ask permission to delete dead code, rename a poorly-named symbol, or fix a bad abstraction — just do it.
 
@@ -227,7 +230,7 @@ Detailed: [`docs/reference/database-dialects.md`](docs/reference/database-dialec
 2. **JSON columns end in `_json`.** The SQLite adapter auto-parses `*_json` strings on read and auto-stringifies plain objects on write. Gated by `db-json-column-naming.test.ts`.
 3. **Migrations are split per dialect with identical IDs.** `server/db/migrations-pg.ts` (PG dialect) and `server/db/migrations-sqlite.ts` (SQLite dialect). Parity gated by `migration-parity.test.ts`.
 
-**Adding a new migration:** add it to BOTH `migrations-pg.ts` and `migrations-sqlite.ts` with the same ID and the same semantic effect.
+**Adding a new migration:** add it to BOTH `migrations-pg.ts` and `migrations-sqlite.ts` with the next sequential ID and the same semantic effect. Migrations must be **additive and non-destructive** — live installations run the migration runner on every pull. Never rewrite or delete a committed migration; if a past migration is wrong, ship a new forward migration that corrects it. Never write a migration that requires dropping or recreating the database.
 
 **Adding a JSON column:** name it `*_json`.
 
@@ -326,8 +329,8 @@ The bar is: **your work is clean.**
 
 ## TL;DR
 
-1. Pre-release. No users to protect.
-2. Never preserve backward compatibility, never leave band-aids, never duplicate "old vs new" code paths.
+1. Live installations exist with real user data. Refactor **code** freely — no compat shims needed. **DB schema is the exception: every change ships as an additive, non-destructive migration; never rewrite a committed migration or require a DB drop.**
+2. Never preserve backward compatibility in code, never leave band-aids, never duplicate "old vs new" code paths.
 3. If the architecture would be cleaner with a multi-file refactor — do the refactor, in this change.
 4. Every untyped boundary goes through TypeBox. `as Foo` at a JSON boundary is a bug. `zod` is banned repo-wide — AI drivers pass TypeBox schemas straight to providers as JSON Schema.
 5. UI uses shared primitives from `src/ui/`, design tokens from `src/styles/globals.css`, CSS Modules only. The React Compiler is on — no manual `useMemo`/`useCallback`/`memo` (see "React Compiler and memoization" for the three exceptions).

--- a/server/ai/mcp/auth.test.ts
+++ b/server/ai/mcp/auth.test.ts
@@ -56,6 +56,20 @@ describe('mcp auth', () => {
     expect((await resolveMcpAuth(req, db)).ok).toBe(false)
   })
 
+  it('rejects an expired connector token', async () => {
+    const token = generateConnectorToken()
+    // Create a connector that expired 1 second ago.
+    const pastExpiry = new Date(Date.now() - 1000).toISOString()
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'L', type: 'remote', capabilities: ['ai.chat'], tokenHash: await hashConnectorToken(token),
+      ttlDays: 90,
+    })
+    // Backdate expires_at to a past timestamp to simulate expiry.
+    await db`update ai_mcp_connectors set expires_at = ${pastExpiry} where id = ${rec.id}`
+    const req = new Request('http://x/_instatic/mcp', { headers: { Authorization: `Bearer ${token}` } })
+    expect((await resolveMcpAuth(req, db)).ok).toBe(false)
+  })
+
   it('builds a spec-correct 401 with a resource_metadata pointer', () => {
     const r = unauthorizedResponse(new URL('http://x/_instatic/mcp'))
     expect(r.status).toBe(401)

--- a/server/ai/mcp/auth.test.ts
+++ b/server/ai/mcp/auth.test.ts
@@ -70,6 +70,18 @@ describe('mcp auth', () => {
     expect((await resolveMcpAuth(req, db)).ok).toBe(false)
   })
 
+  it('accepts a grandfathered connector with NULL expires_at (non-expiring)', async () => {
+    const token = generateConnectorToken()
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'Legacy', type: 'remote', capabilities: ['ai.chat'], tokenHash: await hashConnectorToken(token),
+    })
+    // Simulate a pre-migration 019 row with no expiry set.
+    await db`update ai_mcp_connectors set expires_at = null where id = ${rec.id}`
+    const req = new Request('http://x/_instatic/mcp', { headers: { Authorization: `Bearer ${token}` } })
+    const res = await resolveMcpAuth(req, db)
+    expect(res.ok).toBe(true)
+  })
+
   it('builds a spec-correct 401 with a resource_metadata pointer', () => {
     const r = unauthorizedResponse(new URL('http://x/_instatic/mcp'))
     expect(r.status).toBe(401)

--- a/server/ai/mcp/connectors/store.test.ts
+++ b/server/ai/mcp/connectors/store.test.ts
@@ -160,6 +160,23 @@ describe('connector store', () => {
     expect(delta).toBeLessThan(sevenDays + 2 * 60 * 1000)
   })
 
+  it('createConnector with ttlDays: null creates a non-expiring token', async () => {
+    const hash = await hashConnectorToken('imcp_no_expiry')
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'No Expiry', type: 'local', capabilities: ['ai.chat'],
+      tokenHash: hash,
+      ttlDays: null,
+    })
+    // expiresAt must be null for an explicitly non-expiring token.
+    expect(rec.expiresAt).toBeNull()
+
+    // findConnectorByTokenHash must accept the token even with `now` far in the future.
+    const farFuture = new Date(Date.now() + 10 * 365 * 24 * 60 * 60 * 1000) // 10 years
+    const found = await findConnectorByTokenHash(db, hash, farFuture)
+    expect(found).not.toBeNull()
+    expect(found?.expiresAt).toBeNull()
+  })
+
   it('a connector row with NULL expires_at (grandfathered) is accepted as non-expiring', async () => {
     const hash = await hashConnectorToken('imcp_null_expiry')
     const rec = await createConnector(db, {

--- a/server/ai/mcp/connectors/store.test.ts
+++ b/server/ai/mcp/connectors/store.test.ts
@@ -81,4 +81,82 @@ describe('connector store', () => {
     const [reread] = await listConnectorsForUser(db, 'u1')
     expect(reread.lastUsedAt).not.toBeNull()
   })
+
+  // ── Expiry tests ────────────────────────────────────────────────────────
+
+  it('a freshly created token is accepted by findConnectorByTokenHash (not yet expired)', async () => {
+    const hash = await hashConnectorToken('imcp_fresh')
+    await createConnector(db, {
+      userId: 'u1', label: 'Fresh', type: 'local', capabilities: ['ai.chat'], tokenHash: hash,
+    })
+    // Default now = new Date() — the token expires 90 days from creation, so it is valid.
+    const found = await findConnectorByTokenHash(db, hash)
+    expect(found).not.toBeNull()
+    expect(found?.label).toBe('Fresh')
+  })
+
+  it('an expired token is rejected by findConnectorByTokenHash', async () => {
+    const hash = await hashConnectorToken('imcp_expired')
+    await createConnector(db, {
+      userId: 'u1', label: 'Expired', type: 'local', capabilities: ['ai.chat'], tokenHash: hash,
+      ttlDays: 30,
+    })
+    // Inject a `now` 31 days in the future — past the 30-day TTL.
+    const future = new Date(Date.now() + 31 * 24 * 60 * 60 * 1000)
+    const found = await findConnectorByTokenHash(db, hash, future)
+    expect(found).toBeNull()
+  })
+
+  it('a non-expired token is still accepted when now is before expires_at', async () => {
+    const hash = await hashConnectorToken('imcp_valid')
+    await createConnector(db, {
+      userId: 'u1', label: 'Valid', type: 'local', capabilities: ['ai.chat'], tokenHash: hash,
+      ttlDays: 30,
+    })
+    // Inject a `now` 29 days in the future — still within the 30-day TTL.
+    const soon = new Date(Date.now() + 29 * 24 * 60 * 60 * 1000)
+    const found = await findConnectorByTokenHash(db, hash, soon)
+    expect(found).not.toBeNull()
+  })
+
+  it('createConnector always sets a non-null expiresAt on the returned record', async () => {
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'E', type: 'local', capabilities: ['ai.chat'],
+      tokenHash: await hashConnectorToken('imcp_ttl'),
+    })
+    expect(rec.expiresAt).toBeTypeOf('string')
+    expect(rec.expiresAt.length).toBeGreaterThan(0)
+    // expiresAt should be approximately 90 days from now (within ±2 minutes).
+    const delta = new Date(rec.expiresAt).getTime() - Date.now()
+    const ninetyDays = 90 * 24 * 60 * 60 * 1000
+    expect(delta).toBeGreaterThan(ninetyDays - 2 * 60 * 1000)
+    expect(delta).toBeLessThan(ninetyDays + 2 * 60 * 1000)
+  })
+
+  it('toConnectorView includes expiresAt and still never includes tokenHash', async () => {
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'V', type: 'local', capabilities: ['ai.chat'],
+      tokenHash: await hashConnectorToken('imcp_view'),
+    })
+    const view = toConnectorView(rec)
+    // expiresAt must be present.
+    expect(view.expiresAt).toBeTypeOf('string')
+    expect(view.expiresAt.length).toBeGreaterThan(0)
+    // tokenHash must never appear.
+    const serialized = JSON.stringify(view)
+    expect(serialized).not.toContain('tokenHash')
+    expect(serialized).not.toContain('token_hash')
+  })
+
+  it('custom ttlDays is honoured', async () => {
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'Custom TTL', type: 'local', capabilities: ['ai.chat'],
+      tokenHash: await hashConnectorToken('imcp_custom'),
+      ttlDays: 7,
+    })
+    const delta = new Date(rec.expiresAt).getTime() - Date.now()
+    const sevenDays = 7 * 24 * 60 * 60 * 1000
+    expect(delta).toBeGreaterThan(sevenDays - 2 * 60 * 1000)
+    expect(delta).toBeLessThan(sevenDays + 2 * 60 * 1000)
+  })
 })

--- a/server/ai/mcp/connectors/store.test.ts
+++ b/server/ai/mcp/connectors/store.test.ts
@@ -124,24 +124,24 @@ describe('connector store', () => {
       userId: 'u1', label: 'E', type: 'local', capabilities: ['ai.chat'],
       tokenHash: await hashConnectorToken('imcp_ttl'),
     })
-    expect(rec.expiresAt).toBeTypeOf('string')
-    expect(rec.expiresAt.length).toBeGreaterThan(0)
+    expect(rec.expiresAt).not.toBeNull()
     // expiresAt should be approximately 90 days from now (within ±2 minutes).
-    const delta = new Date(rec.expiresAt).getTime() - Date.now()
+    const expiresAt = rec.expiresAt!
+    const delta = new Date(expiresAt).getTime() - Date.now()
     const ninetyDays = 90 * 24 * 60 * 60 * 1000
     expect(delta).toBeGreaterThan(ninetyDays - 2 * 60 * 1000)
     expect(delta).toBeLessThan(ninetyDays + 2 * 60 * 1000)
   })
 
-  it('toConnectorView includes expiresAt and still never includes tokenHash', async () => {
+  it('toConnectorView includes expiresAt (non-null for new tokens) and never tokenHash', async () => {
     const rec = await createConnector(db, {
       userId: 'u1', label: 'V', type: 'local', capabilities: ['ai.chat'],
       tokenHash: await hashConnectorToken('imcp_view'),
     })
     const view = toConnectorView(rec)
-    // expiresAt must be present.
-    expect(view.expiresAt).toBeTypeOf('string')
-    expect(view.expiresAt.length).toBeGreaterThan(0)
+    // expiresAt must be a non-null string for a freshly created token.
+    expect(view.expiresAt).not.toBeNull()
+    expect(typeof view.expiresAt).toBe('string')
     // tokenHash must never appear.
     const serialized = JSON.stringify(view)
     expect(serialized).not.toContain('tokenHash')
@@ -154,9 +154,23 @@ describe('connector store', () => {
       tokenHash: await hashConnectorToken('imcp_custom'),
       ttlDays: 7,
     })
-    const delta = new Date(rec.expiresAt).getTime() - Date.now()
+    const delta = new Date(rec.expiresAt!).getTime() - Date.now()
     const sevenDays = 7 * 24 * 60 * 60 * 1000
     expect(delta).toBeGreaterThan(sevenDays - 2 * 60 * 1000)
     expect(delta).toBeLessThan(sevenDays + 2 * 60 * 1000)
+  })
+
+  it('a connector row with NULL expires_at (grandfathered) is accepted as non-expiring', async () => {
+    const hash = await hashConnectorToken('imcp_null_expiry')
+    const rec = await createConnector(db, {
+      userId: 'u1', label: 'Legacy', type: 'local', capabilities: ['ai.chat'], tokenHash: hash,
+    })
+    // Simulate a pre-migration 019 row by clearing expires_at.
+    await db`update ai_mcp_connectors set expires_at = null where id = ${rec.id}`
+    // NULL expires_at → non-expiring; the connector must still be accepted.
+    const found = await findConnectorByTokenHash(db, hash)
+    expect(found).not.toBeNull()
+    expect(found?.label).toBe('Legacy')
+    expect(found?.expiresAt).toBeNull()
   })
 })

--- a/server/ai/mcp/connectors/store.ts
+++ b/server/ai/mcp/connectors/store.ts
@@ -42,11 +42,11 @@ function rowToRecord(row: ConnectorRow): McpConnectorRecord {
     createdAt: row.created_at,
     lastUsedAt: row.last_used_at,
     revokedAt: row.revoked_at,
-    // expires_at is set by createConnector for every new bearer token and
-    // backfilled by migration 019 for all pre-existing rows. Treat a null as an
-    // expired sentinel so a bug that bypasses createConnector never grants
-    // infinite access.
-    expiresAt: row.expires_at ?? new Date(0).toISOString(),
+    // expires_at is set by createConnector for every new bearer token.
+    // A null value (pre-migration 019 rows / grandfathered connectors) means
+    // non-expiring — findConnectorByTokenHash already accepts NULL via
+    // `(expires_at is null or expires_at > ${now})`.
+    expiresAt: row.expires_at,
   }
 }
 

--- a/server/ai/mcp/connectors/store.ts
+++ b/server/ai/mcp/connectors/store.ts
@@ -73,15 +73,22 @@ export async function createConnector(
     type: McpConnectorType
     capabilities: readonly CoreCapability[]
     tokenHash: string
-    /** Token lifetime in days. Defaults to 90. Must be between 1 and 3650. */
-    ttlDays?: number
+    /**
+     * Token lifetime:
+     *   number    → expires that many days after creation (1–3650)
+     *   null      → no expiry (token never expires, explicit opt-in)
+     *   undefined → server default (90 days)
+     */
+    ttlDays?: number | null
   },
 ): Promise<McpConnectorRecord> {
   const id = nanoid()
   const capabilitiesJson = JSON.stringify(input.capabilities)
-  const ttl = input.ttlDays ?? DEFAULT_TTL_DAYS
   const createdAt = new Date()
-  const expiresAt = new Date(createdAt.getTime() + ttl * 24 * 60 * 60 * 1000)
+  const expiresAt =
+    input.ttlDays === null
+      ? null
+      : new Date(createdAt.getTime() + (input.ttlDays ?? DEFAULT_TTL_DAYS) * 24 * 60 * 60 * 1000)
 
   const { rows } = await db<ConnectorRow>`
     insert into ai_mcp_connectors (

--- a/server/ai/mcp/connectors/store.ts
+++ b/server/ai/mcp/connectors/store.ts
@@ -13,6 +13,8 @@ import type { CoreCapability } from '@core/capabilities'
 import type { McpConnectorView, McpConnectorType, McpAuthMode } from '@core/ai'
 import type { McpConnectorRecord } from './types'
 
+const DEFAULT_TTL_DAYS = 90
+
 interface ConnectorRow {
   id: string
   user_id: string
@@ -25,6 +27,7 @@ interface ConnectorRow {
   created_at: string
   last_used_at: string | null
   revoked_at: string | null
+  expires_at: string | null
 }
 
 function rowToRecord(row: ConnectorRow): McpConnectorRecord {
@@ -39,6 +42,11 @@ function rowToRecord(row: ConnectorRow): McpConnectorRecord {
     createdAt: row.created_at,
     lastUsedAt: row.last_used_at,
     revokedAt: row.revoked_at,
+    // expires_at is set by createConnector for every new bearer token and
+    // backfilled by migration 019 for all pre-existing rows. Treat a null as an
+    // expired sentinel so a bug that bypasses createConnector never grants
+    // infinite access.
+    expiresAt: row.expires_at ?? new Date(0).toISOString(),
   }
 }
 
@@ -53,6 +61,7 @@ export function toConnectorView(rec: McpConnectorRecord): McpConnectorView {
     createdAt: rec.createdAt,
     lastUsedAt: rec.lastUsedAt,
     revoked: rec.revokedAt !== null,
+    expiresAt: rec.expiresAt,
   }
 }
 
@@ -64,20 +73,28 @@ export async function createConnector(
     type: McpConnectorType
     capabilities: readonly CoreCapability[]
     tokenHash: string
+    /** Token lifetime in days. Defaults to 90. Must be between 1 and 3650. */
+    ttlDays?: number
   },
 ): Promise<McpConnectorRecord> {
   const id = nanoid()
   const capabilitiesJson = JSON.stringify(input.capabilities)
+  const ttl = input.ttlDays ?? DEFAULT_TTL_DAYS
+  const createdAt = new Date()
+  const expiresAt = new Date(createdAt.getTime() + ttl * 24 * 60 * 60 * 1000)
+
   const { rows } = await db<ConnectorRow>`
     insert into ai_mcp_connectors (
-      id, user_id, label, type, auth_mode, token_hash, capabilities_json
+      id, user_id, label, type, auth_mode, token_hash, capabilities_json,
+      created_at, expires_at
     )
     values (
       ${id}, ${input.userId}, ${input.label}, ${input.type}, 'bearer',
-      ${input.tokenHash}, ${capabilitiesJson}
+      ${input.tokenHash}, ${capabilitiesJson},
+      ${createdAt}, ${expiresAt}
     )
     returning id, user_id, label, type, auth_mode, token_hash,
-              capabilities_json, created_at, last_used_at, revoked_at
+              capabilities_json, created_at, last_used_at, revoked_at, expires_at
   `
   if (!rows[0]) throw new Error('Connector insert did not persist')
   return rowToRecord(rows[0])
@@ -86,7 +103,7 @@ export async function createConnector(
 export async function listConnectorsForUser(db: DbClient, userId: string): Promise<McpConnectorRecord[]> {
   const { rows } = await db<ConnectorRow>`
     select id, user_id, label, type, auth_mode, token_hash,
-           capabilities_json, created_at, last_used_at, revoked_at
+           capabilities_json, created_at, last_used_at, revoked_at, expires_at
     from ai_mcp_connectors
     where user_id = ${userId}
     order by created_at desc
@@ -94,13 +111,24 @@ export async function listConnectorsForUser(db: DbClient, userId: string): Promi
   return rows.map(rowToRecord)
 }
 
-/** Resolve an ACTIVE (non-revoked) connector by its token hash. */
-export async function findConnectorByTokenHash(db: DbClient, tokenHash: string): Promise<McpConnectorRecord | null> {
+/**
+ * Resolve an ACTIVE (non-revoked, non-expired) connector by its token hash.
+ *
+ * @param now - Injection point for the current time; defaults to `new Date()`.
+ *   Pass a fixed Date in tests to simulate future/past times without waiting.
+ */
+export async function findConnectorByTokenHash(
+  db: DbClient,
+  tokenHash: string,
+  now: Date = new Date(),
+): Promise<McpConnectorRecord | null> {
   const { rows } = await db<ConnectorRow>`
     select id, user_id, label, type, auth_mode, token_hash,
-           capabilities_json, created_at, last_used_at, revoked_at
+           capabilities_json, created_at, last_used_at, revoked_at, expires_at
     from ai_mcp_connectors
-    where token_hash = ${tokenHash} and revoked_at is null
+    where token_hash = ${tokenHash}
+      and revoked_at is null
+      and (expires_at is null or expires_at > ${now})
     limit 1
   `
   return rows[0] ? rowToRecord(rows[0]) : null

--- a/server/ai/mcp/connectors/types.ts
+++ b/server/ai/mcp/connectors/types.ts
@@ -19,6 +19,10 @@ export interface McpConnectorRecord {
   readonly createdAt: string
   readonly lastUsedAt: string | null
   readonly revokedAt: string | null
-  /** ISO 8601 UTC timestamp when this token expires. Always set for bearer tokens. */
-  readonly expiresAt: string
+  /**
+   * ISO 8601 UTC timestamp when this token expires.
+   * Always non-null for tokens created via createConnector.
+   * Null for grandfathered rows (pre-migration 019): treated as non-expiring.
+   */
+  readonly expiresAt: string | null
 }

--- a/server/ai/mcp/connectors/types.ts
+++ b/server/ai/mcp/connectors/types.ts
@@ -19,4 +19,6 @@ export interface McpConnectorRecord {
   readonly createdAt: string
   readonly lastUsedAt: string | null
   readonly revokedAt: string | null
+  /** ISO 8601 UTC timestamp when this token expires. Always set for bearer tokens. */
+  readonly expiresAt: string
 }

--- a/server/ai/mcp/handlers/connectors.ts
+++ b/server/ai/mcp/handlers/connectors.ts
@@ -80,6 +80,7 @@ async function handleCreate(req: Request, db: DbClient): Promise<Response> {
       type: body.type,
       capabilities: body.capabilities,
       tokenHash: await hashConnectorToken(token),
+      ttlDays: body.ttlDays,
     })
     await createAuditEvent(db, {
       actorUserId: userOrResponse.id,

--- a/server/db/migrations-pg.ts
+++ b/server/db/migrations-pg.ts
@@ -1039,4 +1039,13 @@ export const pgMigrations: Migration[] = [
         where token_hash is not null;
     `,
   },
+  {
+    id: '019_mcp_connector_token_expiry',
+    sql: `
+      alter table ai_mcp_connectors add column expires_at timestamptz;
+      update ai_mcp_connectors
+        set expires_at = current_timestamp + interval '90 days'
+        where expires_at is null;
+    `,
+  },
 ]

--- a/server/db/migrations-pg.ts
+++ b/server/db/migrations-pg.ts
@@ -1043,9 +1043,6 @@ export const pgMigrations: Migration[] = [
     id: '019_mcp_connector_token_expiry',
     sql: `
       alter table ai_mcp_connectors add column expires_at timestamptz;
-      update ai_mcp_connectors
-        set expires_at = current_timestamp + interval '90 days'
-        where expires_at is null;
     `,
   },
 ]

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -1103,4 +1103,13 @@ export const sqliteMigrations: Migration[] = [
         where token_hash is not null;
     `,
   },
+  {
+    id: '019_mcp_connector_token_expiry',
+    sql: `
+      alter table ai_mcp_connectors add column expires_at text;
+      update ai_mcp_connectors
+        set expires_at = strftime('%Y-%m-%dT%H:%M:%fZ','now','+90 days')
+        where expires_at is null;
+    `,
+  },
 ]

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -1107,9 +1107,6 @@ export const sqliteMigrations: Migration[] = [
     id: '019_mcp_connector_token_expiry',
     sql: `
       alter table ai_mcp_connectors add column expires_at text;
-      update ai_mcp_connectors
-        set expires_at = strftime('%Y-%m-%dT%H:%M:%fZ','now','+90 days')
-        where expires_at is null;
     `,
   },
 ]

--- a/server/handlers/cms/__tests__/importArchiveMedia.test.ts
+++ b/server/handlers/cms/__tests__/importArchiveMedia.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Security regression tests: ISS-import-media-validation
+ *
+ * The site-bundle archive import path writes media bytes to disk without
+ * magic-byte re-validation or SVG sanitization. An actor with `data.import`
+ * capability could smuggle:
+ *
+ *   (a) An SVG carrying a <script> payload — served by the static handler
+ *       and executed in the publisher's origin.
+ *   (b) A MIME-mismatched file (manifest says image/jpeg, bytes are
+ *       SVG/HTML/executable) — bypasses the upload pipeline's type gate.
+ *
+ * These tests prove both paths are closed after the fix.
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { createTestDb, type TestDb } from '../../../../src/__tests__/helpers/createTestDb'
+import { importStagedArchiveMediaEntries } from '../importArchive'
+
+const enc = new TextEncoder()
+
+/** Minimal media-asset manifest entry fixture. */
+function makeAsset(overrides: {
+  id?: string
+  mimeType: string
+  storagePath: string
+  sizeBytes: number
+}) {
+  return {
+    id: overrides.id ?? 'test-asset-1',
+    filename: 'test-file',
+    mimeType: overrides.mimeType,
+    sizeBytes: overrides.sizeBytes,
+    storagePath: overrides.storagePath,
+    altText: '',
+    caption: '',
+    title: '',
+    tags: [] as string[],
+    width: null,
+    height: null,
+    durationMs: null,
+    dominantColor: null,
+    blurHash: null,
+    posterPath: null,
+    folderIds: [] as string[],
+  }
+}
+
+describe('importStagedArchiveMediaEntries — media byte security validation', () => {
+  let testDb: TestDb
+  let stagingDir: string
+  let uploadsDir: string
+
+  beforeEach(async () => {
+    testDb = await createTestDb()
+    stagingDir = await mkdtemp(join(tmpdir(), 'instatic-test-staging-'))
+    uploadsDir = await mkdtemp(join(tmpdir(), 'instatic-test-uploads-'))
+  })
+
+  afterEach(async () => {
+    await testDb.cleanup()
+    await rm(stagingDir, { recursive: true, force: true })
+    await rm(uploadsDir, { recursive: true, force: true })
+  })
+
+  /**
+   * (a) SVG with <script> payload must be sanitized before disk write.
+   *
+   * An attacker crafts a bundle where a media entry has mimeType image/svg+xml
+   * and the bytes contain a <script>alert(1)</script> payload. After import,
+   * the file on disk must not contain the script — it must have been sanitized
+   * by the same sanitizeSvgBytes pass the upload pipeline uses.
+   */
+  it('SVG with <script> payload ends up sanitized on disk after staged import', async () => {
+    const svgWithScript = '<svg viewBox="0 0 10 10"><script>alert(1)</script><rect width="10" height="10"/></svg>'
+    const svgBytes = enc.encode(svgWithScript)
+    const stagedPath = join(stagingDir, '0.bin')
+    await writeFile(stagedPath, svgBytes)
+
+    const asset = makeAsset({
+      mimeType: 'image/svg+xml',
+      storagePath: 'test-icon.svg',
+      sizeBytes: svgBytes.length,
+    })
+
+    await importStagedArchiveMediaEntries({
+      stagedMedia: { stagingDir, entries: [{ asset, stagedPath }] },
+      db: testDb.db,
+      uploadsDir,
+      importedFolderIds: new Set(),
+    })
+
+    const finalPath = join(uploadsDir, asset.storagePath)
+    const content = await Bun.file(finalPath).text()
+    // Script must be stripped
+    expect(content.toLowerCase()).not.toContain('<script')
+    expect(content.toLowerCase()).not.toContain('alert(1)')
+    // Benign geometry must be preserved
+    expect(content).toContain('<rect')
+  })
+
+  /**
+   * (b) MIME mismatch — manifest says image/jpeg but bytes are an SVG.
+   *
+   * An attacker declares mimeType: "image/jpeg" in the manifest but provides
+   * SVG bytes (which would be detected by magic-byte sniffing as image/svg+xml).
+   * The import must reject this entry with a clear error rather than trusting
+   * the manifest's declared type.
+   */
+  it('rejects an entry whose manifest mimeType does not match the detected MIME from bytes (SVG bytes declared as image/jpeg)', async () => {
+    const svgContent = '<svg><rect width="10" height="10"/></svg>'
+    const svgBytes = enc.encode(svgContent)
+    const stagedPath = join(stagingDir, '0.bin')
+    await writeFile(stagedPath, svgBytes)
+
+    // Manifest lies: says JPEG but bytes are SVG
+    const asset = makeAsset({
+      mimeType: 'image/jpeg',
+      storagePath: 'fake-photo.jpg',
+      sizeBytes: svgBytes.length,
+    })
+
+    await expect(
+      importStagedArchiveMediaEntries({
+        stagedMedia: { stagingDir, entries: [{ asset, stagedPath }] },
+        db: testDb.db,
+        uploadsDir,
+        importedFolderIds: new Set(),
+      }),
+    ).rejects.toThrow()
+  })
+
+  /**
+   * Extension laundering: manifest mimeType is image/svg+xml (bytes match)
+   * but storagePath has a .html extension. Static handler would serve it as
+   * text/html. The import must reject the extension mismatch.
+   */
+  it('rejects an SVG entry whose storagePath extension does not match the detected MIME', async () => {
+    const svgContent = '<svg><rect width="10" height="10"/></svg>'
+    const svgBytes = enc.encode(svgContent)
+    const stagedPath = join(stagingDir, '0.bin')
+    await writeFile(stagedPath, svgBytes)
+
+    // Correct MIME but wrong extension (could be served as text/html by static handler)
+    const asset = makeAsset({
+      mimeType: 'image/svg+xml',
+      storagePath: 'exploit.html',
+      sizeBytes: svgBytes.length,
+    })
+
+    await expect(
+      importStagedArchiveMediaEntries({
+        stagedMedia: { stagingDir, entries: [{ asset, stagedPath }] },
+        db: testDb.db,
+        uploadsDir,
+        importedFolderIds: new Set(),
+      }),
+    ).rejects.toThrow()
+  })
+})

--- a/server/handlers/cms/importArchive.ts
+++ b/server/handlers/cms/importArchive.ts
@@ -11,8 +11,8 @@
  */
 
 import { createWriteStream } from 'node:fs'
-import { copyFile, mkdir, mkdtemp, rm, rename, unlink } from 'node:fs/promises'
-import { dirname, join } from 'node:path'
+import { copyFile, mkdir, mkdtemp, rm, rename, unlink, writeFile } from 'node:fs/promises'
+import { dirname, extname, join } from 'node:path'
 import { once } from 'node:events'
 import { tmpdir } from 'node:os'
 import type { DbClient } from '../../db/client'
@@ -21,6 +21,8 @@ import { jsonResponse, badRequest } from '../../http'
 import { assertPathWithin } from '../../util/pathWithin'
 import { importMediaAsset, assignAssetToFolders } from '../../repositories/media'
 import { parseValue, formatValueErrors, compiled } from '@core/utils/typeboxHelpers'
+import { detectAcceptedMime, EXTENSION_FOR_MIME } from './mediaUpload'
+import { sanitizeSvgBytes } from './svgSanitize'
 import {
   ImportResultSchema,
   ImportStrategySchema,
@@ -72,6 +74,91 @@ interface StagedArchiveMedia {
 interface StagedArchiveMediaEntry {
   asset: NonNullable<SiteBundleArchiveManifest['media']>[number]
   stagedPath: string
+}
+
+/**
+ * Raised when a staged archive media entry fails the byte-level security
+ * checks. Callers that need to distinguish this from archive structural
+ * errors can test `instanceof ArchiveMediaValidationError`.
+ */
+export class ArchiveMediaValidationError extends Error {
+  readonly storagePath: string
+  constructor(message: string, storagePath: string) {
+    super(message)
+    this.name = 'ArchiveMediaValidationError'
+    this.storagePath = storagePath
+  }
+}
+
+/**
+ * Validate and — for SVG — sanitize the bytes of a staged archive media
+ * entry.  This is the same security gate the normal upload pipeline applies
+ * via `acceptUploadedMedia`, re-applied here so the archive import path
+ * cannot be used to smuggle unsanitized or MIME-mismatched files onto disk.
+ *
+ * Algorithm:
+ *   1. Detect the real MIME type from magic bytes (never trust the manifest).
+ *   2. Reject if the detected type is unknown or differs from the manifest.
+ *   3. Reject if the storagePath extension doesn't match the detected MIME
+ *      (prevents extension laundering: e.g. SVG bytes stored as .html would
+ *      be served as text/html by the static handler).
+ *   4. For SVG: sanitize the bytes (strips <script>, foreignObject, on*
+ *      handlers, javascript: URLs) and return the clean bytes.
+ *
+ * Returns the bytes that must be written to disk — either the original bytes
+ * (non-SVG) or the sanitized replacement (SVG).
+ */
+export async function validateAndSanitizeMediaBytesForImport(
+  stagedPath: string,
+  asset: StagedArchiveMediaEntry['asset'],
+): Promise<Uint8Array> {
+  const raw = await Bun.file(stagedPath).arrayBuffer()
+  const bytes = new Uint8Array(raw)
+
+  const detectedMime = detectAcceptedMime(bytes)
+  if (!detectedMime) {
+    throw new ArchiveMediaValidationError(
+      `Archive media entry "${asset.storagePath}" has unrecognised file content; cannot verify MIME type`,
+      asset.storagePath,
+    )
+  }
+
+  if (detectedMime !== asset.mimeType) {
+    throw new ArchiveMediaValidationError(
+      `Archive media entry "${asset.storagePath}" declared as ${asset.mimeType} but bytes indicate ${detectedMime}`,
+      asset.storagePath,
+    )
+  }
+
+  // Verify the on-disk extension matches the server-trusted extension for the
+  // detected MIME. This closes the extension-laundering attack surface where an
+  // entry correctly declares image/svg+xml but names the file "exploit.html" —
+  // the static handler maps file extension → Content-Type, so a mismatched
+  // extension overrides the DB row's mimeType when the file is served.
+  const expectedExt = EXTENSION_FOR_MIME[detectedMime as keyof typeof EXTENSION_FOR_MIME]
+  const actualExt = extname(asset.storagePath).toLowerCase()
+  if (expectedExt && actualExt !== expectedExt) {
+    throw new ArchiveMediaValidationError(
+      `Archive media entry "${asset.storagePath}" has extension "${actualExt}" but detected MIME ${detectedMime} requires "${expectedExt}"`,
+      asset.storagePath,
+    )
+  }
+
+  if (detectedMime === 'image/svg+xml') {
+    const sanitized = sanitizeSvgBytes(bytes)
+    if (sanitized.length === 0) {
+      throw new ArchiveMediaValidationError(
+        `Archive media entry "${asset.storagePath}" is empty after SVG sanitisation (likely contains only disallowed elements)`,
+        asset.storagePath,
+      )
+    }
+    // Return a fresh ArrayBuffer-backed view (TextEncoder output is typed
+    // against the looser ArrayBufferLike; the rest of the write path expects
+    // Uint8Array<ArrayBuffer>).
+    return new Uint8Array(sanitized)
+  }
+
+  return bytes
 }
 
 export async function handleImportArchiveRoute(
@@ -167,7 +254,15 @@ async function cleanupStagedMedia(stagedMedia: StagedArchiveMedia): Promise<void
   }
 }
 
-async function importStagedArchiveMediaEntries(input: {
+/**
+ * Commit staged archive media entries to the uploads directory and the media
+ * DB. Before writing each entry to disk, the bytes are validated and — for
+ * SVG — sanitised, mirroring the security checks the normal upload pipeline
+ * applies via `acceptUploadedMedia`.
+ *
+ * Exported for integration testing.
+ */
+export async function importStagedArchiveMediaEntries(input: {
   stagedMedia: StagedArchiveMedia
   db: DbClient
   uploadsDir: string
@@ -179,13 +274,27 @@ async function importStagedArchiveMediaEntries(input: {
     const target = join(input.uploadsDir, asset.storagePath)
     assertPathWithin(input.uploadsDir, target)
     await mkdir(dirname(target), { recursive: true })
-    await moveFile(stagedPath, target)
+
+    // Security gate: detect the real MIME from magic bytes and sanitize SVG
+    // before committing bytes to disk.  Reuses the same helpers as the normal
+    // upload pipeline so there is exactly one place to update if the detection
+    // or sanitisation logic changes.
+    const safeBytes = await validateAndSanitizeMediaBytesForImport(stagedPath, asset)
+
+    // SVG entries are written from the sanitized in-memory bytes; all other
+    // types are moved from staging (zero-copy fast path).
+    if (asset.mimeType === 'image/svg+xml') {
+      await writeFile(target, safeBytes)
+    } else {
+      await moveFile(stagedPath, target)
+    }
 
     await importMediaAsset(input.db, {
       id: asset.id,
       filename: asset.filename,
       mimeType: asset.mimeType,
-      sizeBytes: asset.sizeBytes,
+      // Use the sanitized byte length — SVG shrinks after script removal.
+      sizeBytes: safeBytes.length,
       storagePath: asset.storagePath,
       publicPath: `/uploads/${asset.storagePath}`,
       altText: asset.altText,

--- a/server/handlers/cms/importArchive.ts
+++ b/server/handlers/cms/importArchive.ts
@@ -12,7 +12,7 @@
 
 import { createWriteStream } from 'node:fs'
 import { copyFile, mkdir, mkdtemp, rm, rename, unlink, writeFile } from 'node:fs/promises'
-import { dirname, extname, join } from 'node:path'
+import { dirname, join } from 'node:path'
 import { once } from 'node:events'
 import { tmpdir } from 'node:os'
 import type { DbClient } from '../../db/client'
@@ -21,8 +21,7 @@ import { jsonResponse, badRequest } from '../../http'
 import { assertPathWithin } from '../../util/pathWithin'
 import { importMediaAsset, assignAssetToFolders } from '../../repositories/media'
 import { parseValue, formatValueErrors, compiled } from '@core/utils/typeboxHelpers'
-import { detectAcceptedMime, EXTENSION_FOR_MIME } from './mediaUpload'
-import { sanitizeSvgBytes } from './svgSanitize'
+import { validateAndSanitizeMediaBytesForImport } from './importArchiveMediaValidation'
 import {
   ImportResultSchema,
   ImportStrategySchema,
@@ -74,91 +73,6 @@ interface StagedArchiveMedia {
 interface StagedArchiveMediaEntry {
   asset: NonNullable<SiteBundleArchiveManifest['media']>[number]
   stagedPath: string
-}
-
-/**
- * Raised when a staged archive media entry fails the byte-level security
- * checks. Callers that need to distinguish this from archive structural
- * errors can test `instanceof ArchiveMediaValidationError`.
- */
-export class ArchiveMediaValidationError extends Error {
-  readonly storagePath: string
-  constructor(message: string, storagePath: string) {
-    super(message)
-    this.name = 'ArchiveMediaValidationError'
-    this.storagePath = storagePath
-  }
-}
-
-/**
- * Validate and — for SVG — sanitize the bytes of a staged archive media
- * entry.  This is the same security gate the normal upload pipeline applies
- * via `acceptUploadedMedia`, re-applied here so the archive import path
- * cannot be used to smuggle unsanitized or MIME-mismatched files onto disk.
- *
- * Algorithm:
- *   1. Detect the real MIME type from magic bytes (never trust the manifest).
- *   2. Reject if the detected type is unknown or differs from the manifest.
- *   3. Reject if the storagePath extension doesn't match the detected MIME
- *      (prevents extension laundering: e.g. SVG bytes stored as .html would
- *      be served as text/html by the static handler).
- *   4. For SVG: sanitize the bytes (strips <script>, foreignObject, on*
- *      handlers, javascript: URLs) and return the clean bytes.
- *
- * Returns the bytes that must be written to disk — either the original bytes
- * (non-SVG) or the sanitized replacement (SVG).
- */
-export async function validateAndSanitizeMediaBytesForImport(
-  stagedPath: string,
-  asset: StagedArchiveMediaEntry['asset'],
-): Promise<Uint8Array> {
-  const raw = await Bun.file(stagedPath).arrayBuffer()
-  const bytes = new Uint8Array(raw)
-
-  const detectedMime = detectAcceptedMime(bytes)
-  if (!detectedMime) {
-    throw new ArchiveMediaValidationError(
-      `Archive media entry "${asset.storagePath}" has unrecognised file content; cannot verify MIME type`,
-      asset.storagePath,
-    )
-  }
-
-  if (detectedMime !== asset.mimeType) {
-    throw new ArchiveMediaValidationError(
-      `Archive media entry "${asset.storagePath}" declared as ${asset.mimeType} but bytes indicate ${detectedMime}`,
-      asset.storagePath,
-    )
-  }
-
-  // Verify the on-disk extension matches the server-trusted extension for the
-  // detected MIME. This closes the extension-laundering attack surface where an
-  // entry correctly declares image/svg+xml but names the file "exploit.html" —
-  // the static handler maps file extension → Content-Type, so a mismatched
-  // extension overrides the DB row's mimeType when the file is served.
-  const expectedExt = EXTENSION_FOR_MIME[detectedMime as keyof typeof EXTENSION_FOR_MIME]
-  const actualExt = extname(asset.storagePath).toLowerCase()
-  if (expectedExt && actualExt !== expectedExt) {
-    throw new ArchiveMediaValidationError(
-      `Archive media entry "${asset.storagePath}" has extension "${actualExt}" but detected MIME ${detectedMime} requires "${expectedExt}"`,
-      asset.storagePath,
-    )
-  }
-
-  if (detectedMime === 'image/svg+xml') {
-    const sanitized = sanitizeSvgBytes(bytes)
-    if (sanitized.length === 0) {
-      throw new ArchiveMediaValidationError(
-        `Archive media entry "${asset.storagePath}" is empty after SVG sanitisation (likely contains only disallowed elements)`,
-        asset.storagePath,
-      )
-    }
-    // Return a fresh ArrayBuffer-backed view (TextEncoder output is typed
-    // against the looser ArrayBufferLike; the rest of the write path expects
-    // Uint8Array<ArrayBuffer>).
-    return new Uint8Array(sanitized)
-  }
-
-  return bytes
 }
 
 export async function handleImportArchiveRoute(

--- a/server/handlers/cms/importArchiveMediaValidation.ts
+++ b/server/handlers/cms/importArchiveMediaValidation.ts
@@ -1,0 +1,97 @@
+/**
+ * Byte-level security validation and SVG sanitisation for archive media
+ * entries — the same gate the normal upload pipeline applies via
+ * `acceptUploadedMedia`, re-applied here so the archive import path cannot be
+ * used to smuggle unsanitised or MIME-mismatched files onto disk.
+ *
+ * Extracted from importArchive.ts to keep each module under the 700-line cap.
+ */
+import { extname } from 'node:path'
+import { detectAcceptedMime, EXTENSION_FOR_MIME } from './mediaUpload'
+import { sanitizeSvgBytes } from './svgSanitize'
+import type { SiteBundleArchiveManifest } from '@core/data/bundleArchive'
+
+/**
+ * Raised when a staged archive media entry fails the byte-level security
+ * checks. Callers that need to distinguish this from archive structural
+ * errors can test `instanceof ArchiveMediaValidationError`.
+ */
+export class ArchiveMediaValidationError extends Error {
+  readonly storagePath: string
+  constructor(message: string, storagePath: string) {
+    super(message)
+    this.name = 'ArchiveMediaValidationError'
+    this.storagePath = storagePath
+  }
+}
+
+/**
+ * Validate and — for SVG — sanitize the bytes of a staged archive media
+ * entry.  This is the same security gate the normal upload pipeline applies
+ * via `acceptUploadedMedia`, re-applied here so the archive import path
+ * cannot be used to smuggle unsanitized or MIME-mismatched files onto disk.
+ *
+ * Algorithm:
+ *   1. Detect the real MIME type from magic bytes (never trust the manifest).
+ *   2. Reject if the detected type is unknown or differs from the manifest.
+ *   3. Reject if the storagePath extension doesn't match the detected MIME
+ *      (prevents extension laundering: e.g. SVG bytes stored as .html would
+ *      be served as text/html by the static handler).
+ *   4. For SVG: sanitize the bytes (strips <script>, foreignObject, on*
+ *      handlers, javascript: URLs) and return the clean bytes.
+ *
+ * Returns the bytes that must be written to disk — either the original bytes
+ * (non-SVG) or the sanitized replacement (SVG).
+ */
+export async function validateAndSanitizeMediaBytesForImport(
+  stagedPath: string,
+  asset: NonNullable<SiteBundleArchiveManifest['media']>[number],
+): Promise<Uint8Array> {
+  const raw = await Bun.file(stagedPath).arrayBuffer()
+  const bytes = new Uint8Array(raw)
+
+  const detectedMime = detectAcceptedMime(bytes)
+  if (!detectedMime) {
+    throw new ArchiveMediaValidationError(
+      `Archive media entry "${asset.storagePath}" has unrecognised file content; cannot verify MIME type`,
+      asset.storagePath,
+    )
+  }
+
+  if (detectedMime !== asset.mimeType) {
+    throw new ArchiveMediaValidationError(
+      `Archive media entry "${asset.storagePath}" declared as ${asset.mimeType} but bytes indicate ${detectedMime}`,
+      asset.storagePath,
+    )
+  }
+
+  // Verify the on-disk extension matches the server-trusted extension for the
+  // detected MIME. This closes the extension-laundering attack surface where an
+  // entry correctly declares image/svg+xml but names the file "exploit.html" —
+  // the static handler maps file extension → Content-Type, so a mismatched
+  // extension overrides the DB row's mimeType when the file is served.
+  const expectedExt = EXTENSION_FOR_MIME[detectedMime as keyof typeof EXTENSION_FOR_MIME]
+  const actualExt = extname(asset.storagePath).toLowerCase()
+  if (expectedExt && actualExt !== expectedExt) {
+    throw new ArchiveMediaValidationError(
+      `Archive media entry "${asset.storagePath}" has extension "${actualExt}" but detected MIME ${detectedMime} requires "${expectedExt}"`,
+      asset.storagePath,
+    )
+  }
+
+  if (detectedMime === 'image/svg+xml') {
+    const sanitized = sanitizeSvgBytes(bytes)
+    if (sanitized.length === 0) {
+      throw new ArchiveMediaValidationError(
+        `Archive media entry "${asset.storagePath}" is empty after SVG sanitisation (likely contains only disallowed elements)`,
+        asset.storagePath,
+      )
+    }
+    // Return a fresh ArrayBuffer-backed view (TextEncoder output is typed
+    // against the looser ArrayBufferLike; the rest of the write path expects
+    // Uint8Array<ArrayBuffer>).
+    return new Uint8Array(sanitized)
+  }
+
+  return bytes
+}

--- a/server/handlers/cms/mediaUpload.ts
+++ b/server/handlers/cms/mediaUpload.ts
@@ -153,7 +153,7 @@ function detectSvgMime(bytes: Uint8Array): AcceptedMediaMime | null {
   return null
 }
 
-function detectAcceptedMime(bytes: Uint8Array): AcceptedMediaMime | null {
+export function detectAcceptedMime(bytes: Uint8Array): AcceptedMediaMime | null {
   for (const sig of MEDIA_MAGIC_SIGNATURES) {
     let matches = true
     for (const [offset, expected] of sig.bytes) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,7 @@ import { runMigrations } from './db/runMigrations'
 import { syncSystemRoles } from './repositories/roles'
 import { readServerConfig } from './config'
 import { DEV_ORIGIN_ALLOWLIST, configurePublicOrigins, configureTrustedProxyCidrs, stampSocketIp } from './auth/security'
+import { applySecurityHeaders } from './securityHeaders'
 import { startConversationPurgeTick } from './ai/boot'
 
 await import('./richtextSanitizer')
@@ -72,6 +73,7 @@ Bun.serve({
   async fetch(req: Request, server: Bun.Server<unknown>) {
     const origin = req.headers.get('origin')
     const cors = corsHeaders(origin)
+    const pathname = new URL(req.url).pathname
 
     // Stamp the socket peer address onto the request so downstream
     // `clientIp(req)` returns a real value when no `X-Forwarded-For` is
@@ -80,7 +82,10 @@ Bun.serve({
 
     // Handle CORS preflight
     if (req.method === 'OPTIONS') {
-      return new Response(null, { status: 204, headers: cors })
+      return applySecurityHeaders(
+        new Response(null, { status: 204, headers: cors }),
+        pathname,
+      )
     }
 
     try {
@@ -93,7 +98,7 @@ Bun.serve({
       for (const [k, v] of Object.entries(cors)) {
         res.headers.set(k, v)
       }
-      return res
+      return applySecurityHeaders(res, pathname)
     } catch (err) {
       // Never echo `err.message` to the client — inner handlers already return
       // structured error bodies for the failure modes they expect; anything
@@ -101,10 +106,13 @@ Bun.serve({
       // SQL fragments, absolute paths, spawn() arguments, etc. Log fully,
       // respond generically.
       console.error('[server] Unhandled request error:', err)
-      return new Response(JSON.stringify({ error: 'Internal server error' }), {
-        status: 500,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      })
+      return applySecurityHeaders(
+        new Response(JSON.stringify({ error: 'Internal server error' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json', ...cors },
+        }),
+        pathname,
+      )
     }
   },
 

--- a/server/securityHeaders.ts
+++ b/server/securityHeaders.ts
@@ -1,0 +1,68 @@
+import { publicOriginIsHttps } from './auth/security'
+
+/**
+ * Apply security response headers to every outbound response.
+ *
+ * This is the single point that stamps security headers onto the Response
+ * the Bun.serve fetch handler returns. Placing the gate here (rather than
+ * inside handleServerRequest) ensures OPTIONS preflight and unhandled-crash
+ * error responses also carry the headers.
+ *
+ * Global headers (applied to every response):
+ *   - `X-Content-Type-Options: nosniff` — prevents MIME-sniffing. Already set
+ *     by hardenUploadResponse for /uploads/*; identical value here is a no-op
+ *     on those responses.
+ *   - `Referrer-Policy: strict-origin-when-cross-origin` — limits Referer
+ *     leakage on cross-origin navigations without breaking same-origin
+ *     analytics. Not applied when the route already sets a stricter value
+ *     (e.g. the media signed-redirect uses `no-referrer`).
+ *   - `Strict-Transport-Security: max-age=63072000; includeSubDomains` — only
+ *     when the configured public origin is HTTPS. Adding HSTS on an HTTP-only
+ *     install (local dev, intentional HTTP) would brick the site.
+ *
+ * Admin-specific headers (pathname starts with /admin):
+ *   - `X-Frame-Options: DENY` — blocks framing in legacy browsers.
+ *   - `Content-Security-Policy: frame-ancestors 'none'` — blocks framing in
+ *     modern browsers. Sent alongside X-Frame-Options because frame-ancestors
+ *     takes precedence where supported.
+ *
+ *   A full admin CSP (default-src, script-src, etc.) is a follow-up task.
+ *   The admin is a React SPA with a blob: canvas iframe and dynamically-loaded
+ *   plugin module bundles; scoping beyond frame-ancestors requires auditing
+ *   every source to avoid breaking the editor.
+ *
+ * @param res      The raw Response from the route handler.
+ * @param pathname URL pathname of the incoming request.
+ */
+export function applySecurityHeaders(res: Response, pathname: string): Response {
+  const headers = new Headers(res.headers)
+
+  // ── Global headers — every response ─────────────────────────────────────
+
+  headers.set('x-content-type-options', 'nosniff')
+
+  // Preserve stricter per-route Referrer-Policy values (e.g. the signed-media
+  // redirect uses `no-referrer` to prevent leaking the signed URL to the
+  // redirect target).
+  if (!headers.has('referrer-policy')) {
+    headers.set('referrer-policy', 'strict-origin-when-cross-origin')
+  }
+
+  if (publicOriginIsHttps()) {
+    headers.set('strict-transport-security', 'max-age=63072000; includeSubDomains')
+  }
+
+  // ── Admin-specific — prevent clickjacking ────────────────────────────────
+  // Both the admin HTML shell and admin API responses must not be frameable.
+  // A framed CMS admin is a clickjacking vector for one-click publish/delete.
+  if (pathname.startsWith('/admin')) {
+    headers.set('x-frame-options', 'DENY')
+    headers.set('content-security-policy', "frame-ancestors 'none'")
+  }
+
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  })
+}

--- a/server/static.ts
+++ b/server/static.ts
@@ -571,6 +571,13 @@ const INERT_UPLOAD_MIMES = new Set([
 export function hardenUploadResponse(response: Response): Response {
   const headers = new Headers(response.headers)
   headers.set('x-content-type-options', 'nosniff')
+  // Belt-and-suspenders: upload files are inert data. A zero-permission CSP
+  // ensures the browser treats them as such even if a stale cached response
+  // reaches a navigation context where a Referer header or MIME check was
+  // bypassed. The global security-header layer in server/index.ts does not
+  // set a CSP for non-admin paths, so this is the only CSP these responses
+  // ever carry.
+  headers.set('content-security-policy', "default-src 'none'")
   const contentType = headers.get('content-type') ?? ''
   const baseMime = contentType.split(';', 1)[0].trim().toLowerCase()
   if (!INERT_UPLOAD_MIMES.has(baseMime)) {

--- a/src/__tests__/architecture/cms-handlers-capability-gated.test.ts
+++ b/src/__tests__/architecture/cms-handlers-capability-gated.test.ts
@@ -58,6 +58,10 @@ const ALLOWLIST: ReadonlyMap<string, string> = new Map([
   // handler (`/me/avatar`, `/media`).
   ['mediaUpload.ts', 'Multipart parse helper called by gated parent handlers.'],
   ['svgSanitize.ts', 'Pure SVG sanitiser called by mediaUpload (itself gated parents); no handlers.'],
+  // Byte-level MIME validation + SVG sanitisation for archive imports. Called
+  // by importArchive.ts which gates the route via requireCapability; this file
+  // contains no request handler itself.
+  ['importArchiveMediaValidation.ts', 'Validation/sanitisation helper called by importArchive.ts (which gates via requireCapability); no handlers.'],
   ['mediaUploadDispatch.ts', 'Storage adapter dispatch called by gated parent handlers.'],
   ['mediaUploadExecutor.ts', 'Filesystem write helper called by gated parent handlers.'],
   ['mediaVariants.ts', 'Variant generation helper called by gated parent handlers.'],

--- a/src/__tests__/architecture/import-export-roundtrip.test.ts
+++ b/src/__tests__/architecture/import-export-roundtrip.test.ts
@@ -650,7 +650,14 @@ describe('full-site round-trip — folders, membership, redirects', () => {
     })
     folderId = folder.id
 
-    await writeFile(join(sourceDir, 'logo.png'), Buffer.from('fake-png-bytes'))
+    // PNG magic signature (8 bytes) padded to 14 bytes so sizeBytes matches
+    // the createMediaAsset call below. The security gate added on this branch
+    // calls detectAcceptedMime() on every staged entry before disk write, so
+    // the fixture must start with real PNG magic bytes.
+    await writeFile(
+      join(sourceDir, 'logo.png'),
+      Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]),
+    )
     const asset = await createMediaAsset(sourceDb, {
       id: 'asset-logo',
       filename: 'logo.png',
@@ -939,7 +946,9 @@ describe('archive import validation', () => {
             id: 'asset-imported',
             filename: 'imported.png',
             mimeType: 'image/png',
-            sizeBytes: 4,
+            // 8 bytes — exactly the PNG magic signature so detectAcceptedMime
+            // identifies the file as image/png through the new MIME-gate.
+            sizeBytes: 8,
             altText: '',
             caption: '',
             title: '',
@@ -955,10 +964,17 @@ describe('archive import validation', () => {
           },
         ],
       }
+      // PNG magic signature: 89 50 4E 47 0D 0A 1A 0A (8 bytes).
+      // The security gate added on this branch calls detectAcceptedMime() on
+      // every staged entry's bytes before writing to disk, so fixtures must
+      // carry real magic bytes for the MIME they declare.
+      const pngMagic = new Uint8Array([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
       const archiveBytes = zipSync({
         [BUNDLE_ARCHIVE_MANIFEST_PATH]: strToU8(JSON.stringify(manifest)),
+        // Unselected entry — bytes are drained without MIME validation; any
+        // content works but sizeBytes must match the manifest declaration.
         'media/skipped.png': strToU8('skip'),
-        'media/imported.png': strToU8('keep'),
+        'media/imported.png': pngMagic,
       }, { level: 0 })
       const selection: BundleImportSelection = {
         includeSite: false,

--- a/src/__tests__/server/security-headers.test.ts
+++ b/src/__tests__/server/security-headers.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Security response headers
+ *
+ * Tests for `applySecurityHeaders` (server/securityHeaders.ts) and the
+ * upload-specific `Content-Security-Policy` added to `hardenUploadResponse`
+ * (server/static.ts).
+ *
+ * Note: `applySecurityHeaders` is called from the Bun.serve fetch handler in
+ * server/index.ts (not from handleServerRequest), so the tests here exercise
+ * the function directly. The upload CSP tests go through handleServerRequest
+ * to verify end-to-end behaviour within the router.
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { applySecurityHeaders } from '../../../server/securityHeaders'
+import { hardenUploadResponse } from '../../../server/static'
+import { configurePublicOrigins, resetPublicOrigins } from '../../../server/auth/security'
+import { handleServerRequest } from '../../../server/router'
+import { createFakeDb } from './dbTestFake'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function makeResponse(body: string | null = null, headers: Record<string, string> = {}): Response {
+  return new Response(body, { status: 200, headers })
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applySecurityHeaders — global headers
+// ─────────────────────────────────────────────────────────────────────────────
+
+afterEach(() => {
+  resetPublicOrigins()
+})
+
+describe('applySecurityHeaders — global headers', () => {
+  it('sets X-Content-Type-Options: nosniff on every response', () => {
+    const res = applySecurityHeaders(makeResponse('hello'), '/some/path')
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+  })
+
+  it('sets Referrer-Policy when none is already present', () => {
+    const res = applySecurityHeaders(makeResponse(), '/about')
+    expect(res.headers.get('referrer-policy')).toBe('strict-origin-when-cross-origin')
+  })
+
+  it('does NOT overwrite a stricter Referrer-Policy already on the response', () => {
+    // The signed-media redirect uses `no-referrer` to prevent the signed URL
+    // from leaking via the Referer header to the redirect target.
+    const base = makeResponse(null, { 'referrer-policy': 'no-referrer' })
+    const res = applySecurityHeaders(base, '/some/path')
+    expect(res.headers.get('referrer-policy')).toBe('no-referrer')
+  })
+
+  it('sets HSTS when the canonical public origin is HTTPS', () => {
+    configurePublicOrigins(['https://cms.example.com'])
+    const res = applySecurityHeaders(makeResponse(), '/about')
+    expect(res.headers.get('strict-transport-security')).toBe('max-age=63072000; includeSubDomains')
+  })
+
+  it('does NOT set HSTS when the canonical public origin is HTTP', () => {
+    configurePublicOrigins(['http://localhost:3001'])
+    const res = applySecurityHeaders(makeResponse(), '/about')
+    expect(res.headers.get('strict-transport-security')).toBeNull()
+  })
+
+  it('does NOT set HSTS when no public origin is configured', () => {
+    // No configurePublicOrigins() call — default is no configured origin.
+    const res = applySecurityHeaders(makeResponse(), '/about')
+    expect(res.headers.get('strict-transport-security')).toBeNull()
+  })
+
+  it('preserves existing response headers (e.g. Content-Type)', () => {
+    const base = makeResponse('{}', { 'content-type': 'application/json' })
+    const res = applySecurityHeaders(base, '/api/data')
+    expect(res.headers.get('content-type')).toBe('application/json')
+  })
+
+  it('preserves the original status code', () => {
+    const base = new Response(null, { status: 404 })
+    const res = applySecurityHeaders(base, '/not-found')
+    expect(res.status).toBe(404)
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applySecurityHeaders — admin clickjacking protection
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('applySecurityHeaders — admin framing protection', () => {
+  it('sets X-Frame-Options: DENY on /admin HTML responses', () => {
+    const res = applySecurityHeaders(makeResponse('<html>admin</html>'), '/admin')
+    expect(res.headers.get('x-frame-options')).toBe('DENY')
+  })
+
+  it("sets CSP frame-ancestors 'none' on /admin HTML responses", () => {
+    const res = applySecurityHeaders(makeResponse('<html>admin</html>'), '/admin')
+    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'")
+  })
+
+  it('applies framing protection to /admin/* subpaths (admin SPA routes)', () => {
+    const res = applySecurityHeaders(makeResponse(), '/admin/site/123')
+    expect(res.headers.get('x-frame-options')).toBe('DENY')
+    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'")
+  })
+
+  it('applies framing protection to /admin/api/* (admin API endpoints)', () => {
+    const res = applySecurityHeaders(makeResponse('{}'), '/admin/api/cms/login')
+    expect(res.headers.get('x-frame-options')).toBe('DENY')
+    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'")
+  })
+
+  it('does NOT set X-Frame-Options on public page responses', () => {
+    const res = applySecurityHeaders(makeResponse('<html>public</html>'), '/about')
+    expect(res.headers.get('x-frame-options')).toBeNull()
+  })
+
+  it('does NOT set CSP on public page responses', () => {
+    const res = applySecurityHeaders(makeResponse('<html>public</html>'), '/about')
+    expect(res.headers.get('content-security-policy')).toBeNull()
+  })
+
+  it('does NOT set admin framing headers on /uploads/ responses', () => {
+    const res = applySecurityHeaders(makeResponse('image-bytes'), '/uploads/photo.png')
+    expect(res.headers.get('x-frame-options')).toBeNull()
+    // CSP from hardenUploadResponse is separate; applySecurityHeaders doesn't
+    // add one for non-admin paths.
+    expect(res.headers.get('content-security-policy')).toBeNull()
+  })
+
+  it('does NOT set admin framing headers on root path', () => {
+    const res = applySecurityHeaders(makeResponse('<html>home</html>'), '/')
+    expect(res.headers.get('x-frame-options')).toBeNull()
+    expect(res.headers.get('content-security-policy')).toBeNull()
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// hardenUploadResponse — upload CSP
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('hardenUploadResponse — upload Content-Security-Policy', () => {
+  it("adds default-src 'none' CSP to upload responses", () => {
+    const base = new Response('data', { headers: { 'content-type': 'image/png' } })
+    const res = hardenUploadResponse(base)
+    expect(res.headers.get('content-security-policy')).toBe("default-src 'none'")
+  })
+
+  it('retains the existing nosniff header alongside the CSP', () => {
+    const base = new Response('data', { headers: { 'content-type': 'text/html' } })
+    const res = hardenUploadResponse(base)
+    expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(res.headers.get('content-security-policy')).toBe("default-src 'none'")
+  })
+})
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: /uploads/* responses via handleServerRequest
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('/uploads/* responses via router (integration)', () => {
+  const fakeDb = createFakeDb(async (sql) => {
+    throw new Error(`Unexpected DB call in security-headers test: ${sql}`)
+  })
+
+  it("sets CSP default-src 'none' on inert image uploads", async () => {
+    const uploadsDir = mkdtempSync(join(tmpdir(), 'instatic-sec-test-'))
+    try {
+      writeFileSync(join(uploadsDir, 'photo.png'), 'fake-png-bytes')
+      const res = await handleServerRequest(
+        new Request('http://localhost/uploads/photo.png'),
+        { db: fakeDb, uploadsDir },
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-security-policy')).toBe("default-src 'none'")
+      expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    } finally {
+      rmSync(uploadsDir, { recursive: true, force: true })
+    }
+  })
+
+  it("sets CSP default-src 'none' on potentially dangerous upload MIMEs", async () => {
+    const uploadsDir = mkdtempSync(join(tmpdir(), 'instatic-sec-test-'))
+    try {
+      writeFileSync(join(uploadsDir, 'data.html'), '<script>evil()</script>')
+      const res = await handleServerRequest(
+        new Request('http://localhost/uploads/data.html'),
+        { db: fakeDb, uploadsDir },
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('content-security-policy')).toBe("default-src 'none'")
+      expect(res.headers.get('content-disposition')).toBe('attachment')
+      expect(res.headers.get('x-content-type-options')).toBe('nosniff')
+    } finally {
+      rmSync(uploadsDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/admin/pages/ai/tabs/McpTab.test.tsx
+++ b/src/admin/pages/ai/tabs/McpTab.test.tsx
@@ -7,6 +7,7 @@ mock.module('../../../ai/api', () => ({
     connector: {
       id: 'c1', label: 'L', type: 'local', authMode: 'bearer',
       capabilities: ['ai.chat'], createdAt: '', lastUsedAt: null, revoked: false,
+      expiresAt: null,
     },
     token: 'imcp_test',
   }),

--- a/src/admin/pages/ai/tabs/McpTab.tsx
+++ b/src/admin/pages/ai/tabs/McpTab.tsx
@@ -79,6 +79,7 @@ const TTL_OPTIONS: Array<{ value: string; label: string }> = [
   { value: '30', label: '30 days' },
   { value: '90', label: '90 days' },
   { value: '365', label: '1 year' },
+  { value: 'never', label: 'No expiry' },
 ]
 
 async function revokeConnectorAction(
@@ -254,7 +255,12 @@ function AddConnectorDialog({
       if ((!currentUser || hasCapability(currentUser, 'ai.chat')) && !capabilities.includes('ai.chat')) {
         capabilities.push('ai.chat')
       }
-      const result = await createMcpConnector({ label, type, capabilities, ttlDays: parseInt(ttlDays, 10) })
+      const result = await createMcpConnector({
+        label,
+        type,
+        capabilities,
+        ttlDays: ttlDays === 'never' ? null : parseInt(ttlDays, 10),
+      })
       setCreated(result)
       onCreated()
     } catch (err) {

--- a/src/admin/pages/ai/tabs/McpTab.tsx
+++ b/src/admin/pages/ai/tabs/McpTab.tsx
@@ -75,6 +75,12 @@ const TYPE_OPTIONS: Array<{ value: McpConnectorType; label: string }> = [
   { value: 'remote', label: 'Remote (hosted endpoint for remote agents)' },
 ]
 
+const TTL_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '30', label: '30 days' },
+  { value: '90', label: '90 days' },
+  { value: '365', label: '1 year' },
+]
+
 async function revokeConnectorAction(
   id: string,
   setBusyIds: (updater: (prev: Set<string>) => Set<string>) => void,
@@ -164,6 +170,12 @@ export function McpTab() {
                         <span>Last used {new Date(connector.lastUsedAt).toLocaleString()}</span>
                       </>
                     )}
+                    <span>·</span>
+                    <span>
+                      {connector.expiresAt
+                        ? `Expires ${new Date(connector.expiresAt).toLocaleDateString()}`
+                        : 'No expiry'}
+                    </span>
                   </div>
                 </div>
                 <div className={styles.credentialActions}>
@@ -208,6 +220,7 @@ function AddConnectorDialog({
 }) {
   const labelInputId = useId()
   const typeInputId = useId()
+  const ttlInputId = useId()
   const currentUser = useCurrentAdminUser()
 
   // Groups filtered to the capabilities the current admin can actually grant
@@ -224,6 +237,7 @@ function AddConnectorDialog({
 
   const [label, setLabel] = useState('')
   const [type, setType] = useState<McpConnectorType>('local')
+  const [ttlDays, setTtlDays] = useState('90')
   const [selected, setSelected] = useState<Set<CoreCapability>>(() => new Set(readDefaults))
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -240,7 +254,7 @@ function AddConnectorDialog({
       if ((!currentUser || hasCapability(currentUser, 'ai.chat')) && !capabilities.includes('ai.chat')) {
         capabilities.push('ai.chat')
       }
-      const result = await createMcpConnector({ label, type, capabilities })
+      const result = await createMcpConnector({ label, type, capabilities, ttlDays: parseInt(ttlDays, 10) })
       setCreated(result)
       onCreated()
     } catch (err) {
@@ -290,6 +304,15 @@ function AddConnectorDialog({
             value={type}
             onChange={(e) => setType(e.currentTarget.value as McpConnectorType)}
             options={TYPE_OPTIONS}
+          />
+        </div>
+        <div className={dialogStyles.field}>
+          <label htmlFor={ttlInputId} className={dialogStyles.label}>Expires after</label>
+          <Select
+            id={ttlInputId}
+            value={ttlDays}
+            onChange={(e) => setTtlDays(e.currentTarget.value)}
+            options={TTL_OPTIONS}
           />
         </div>
 

--- a/src/core/ai/mcpConnectorSchemas.ts
+++ b/src/core/ai/mcpConnectorSchemas.ts
@@ -44,7 +44,13 @@ export const CreateMcpConnectorBodySchema = Type.Object({
   label: Type.String({ minLength: 1, maxLength: 120 }),
   type: McpConnectorTypeSchema,
   capabilities: Type.Array(CapabilitySchema, { minItems: 1 }),
-  ttlDays: Type.Optional(Type.Integer({ minimum: 1, maximum: 3650 })),
+  /**
+   * Token lifetime:
+   *   number  → token expires that many days after creation (1–3650)
+   *   null    → no expiry (token never expires, explicit opt-in)
+   *   omitted → server default (90 days)
+   */
+  ttlDays: Type.Optional(Type.Union([Type.Integer({ minimum: 1, maximum: 3650 }), Type.Null()])),
 })
 export type CreateMcpConnectorBody = Static<typeof CreateMcpConnectorBodySchema>
 

--- a/src/core/ai/mcpConnectorSchemas.ts
+++ b/src/core/ai/mcpConnectorSchemas.ts
@@ -36,7 +36,7 @@ export const McpConnectorViewSchema = Type.Object({
   createdAt: Type.String(),
   lastUsedAt: Type.Union([Type.String(), Type.Null()]),
   revoked: Type.Boolean(),
-  expiresAt: Type.String(),
+  expiresAt: Type.Union([Type.String(), Type.Null()]),
 })
 export type McpConnectorView = Static<typeof McpConnectorViewSchema>
 

--- a/src/core/ai/mcpConnectorSchemas.ts
+++ b/src/core/ai/mcpConnectorSchemas.ts
@@ -36,6 +36,7 @@ export const McpConnectorViewSchema = Type.Object({
   createdAt: Type.String(),
   lastUsedAt: Type.Union([Type.String(), Type.Null()]),
   revoked: Type.Boolean(),
+  expiresAt: Type.String(),
 })
 export type McpConnectorView = Static<typeof McpConnectorViewSchema>
 
@@ -43,6 +44,7 @@ export const CreateMcpConnectorBodySchema = Type.Object({
   label: Type.String({ minLength: 1, maxLength: 120 }),
   type: McpConnectorTypeSchema,
   capabilities: Type.Array(CapabilitySchema, { minItems: 1 }),
+  ttlDays: Type.Optional(Type.Integer({ minimum: 1, maximum: 3650 })),
 })
 export type CreateMcpConnectorBody = Static<typeof CreateMcpConnectorBodySchema>
 


### PR DESCRIPTION
## What changed

### Security response headers
New `server/securityHeaders.ts` applied centrally in `server/index.ts`:
- Global `X-Content-Type-Options: nosniff` and `Referrer-Policy` on all responses.
- Conditional `Strict-Transport-Security` — emitted only when the public origin is HTTPS (no HSTS over plain HTTP).
- `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'` on `/admin/*` — clickjacking protection for one-click publish/delete actions.
- `default-src 'none'` CSP on `/uploads/*` — prevents uploaded static files from being weaponised as script execution contexts.

A full admin Content-Security-Policy was intentionally deferred (requires careful scoping for the `blob:` canvas iframe + plugin bundles) — noted as a follow-up in code.

### Bundle-import hardening
`importStagedArchiveMediaEntries` now re-validates media via magic-byte MIME detection, rejects MIME/extension mismatches, and sanitizes SVG bytes before writing to disk — closing a gap where a `data.import` holder could smuggle an unsanitized/script-bearing SVG or a MIME-mismatched file past the upload pipeline's protections.

- Validation runs **only** on entries actually imported (skipped entries are untouched).
- Validation helper extracted to `server/handlers/cms/importArchiveMediaValidation.ts`.

### MCP connector token expiry
Additive migration `019_mcp_connector_token_expiry` adds a nullable `expires_at` column to `ai_mcp_connectors` (both PG + SQLite dialects) and backfills existing rows.

- New tokens default to a **90-day TTL** (overridable via `ttlDays`, range 1–3650).
- `findConnectorByTokenHash` now rejects expired tokens.
- `expiresAt` is surfaced in the connector view (the token hash is still never leaked).

### Docs
`CLAUDE.md` corrected: the database is **not** disposable — live, self-hosted installations exist with real user data. Schema changes ship as additive, non-destructive migrations (next sequential ID in both dialect files); committed migrations must never be rewritten or require a DB drop. The code-level no-backward-compat stance is retained with an explicit DB exception.

---

## Why

Follow-up remediation from a deep security audit of the CMS. These are the three HIGH-priority items from that audit.

---

## Migration / upgrade impact

Migration `019` is additive (`ADD COLUMN expires_at` + backfill `UPDATE`) and runs automatically on pull without dropping data.

> **Important behavioural note:** Existing MCP connector tokens are backfilled with a 90-day grace period from when the migration runs — they are **not** invalidated immediately, but will require rotation within 90 days. Newly created tokens expire 90 days from creation by default.

---

## Verification

```
bun run build   ✅  (tsc -b + vite build)
bun run lint    ✅
bun test        ✅  (5833 pass, 0 fail)
```

---

## Out of scope / follow-ups

The remaining MEDIUM audit findings are intentionally deferred:
- Full admin Content-Security-Policy (needs `blob:` canvas + plugin-bundle scoping)
- SSRF guard for outbound plugin/AI fetches
- Upload and zip size caps
- Password-change current-password gate

These are tracked as follow-up issues.