### PR TITLE
fix: DomainWidget shows actual hostname instead of hardcoded instatic.com

### DIFF
--- a/.env.fataplus.example
+++ b/.env.fataplus.example
@@ -1,0 +1,22 @@
+# FATAPLUS Instatic Configuration
+# Copy to .env and fill in real values
+
+# Docker image
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest
+
+# Network
+HOST_PORT=3001
+
+# Domain (CF terminates TLS, Caddy proxies HTTP)
+DOMAIN=builder.nexio.work
+LETSENCRYPT_EMAIL=contact@fata.plus
+PUBLIC_ORIGIN=https://builder.nexio.work
+
+# Secrets (generate with: bun run scripts/generate-secret-key.ts)
+INSTATIC_SECRET_KEY=
+
+# R2 Backup (for CI/CD GitHub Actions secrets)
+# R2_ACCOUNT_ID=f30dd0d409679ae65e841302cc0caa8c
+# R2_BUCKET=fataplus-instatic-backups
+# R2_ACCESS_KEY_ID=
+# R2_SECRET_ACCESS_KEY=

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -1,0 +1,45 @@
+name: Backup to R2
+
+on:
+  schedule:
+    # Daily at 03:00 UTC (= 06:00 Madagascar time / EAT)
+    - cron: "0 3 * * *"
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci-backup
+
+      - name: Run backup on VPS
+        uses: appleboy/ssh-action@v1
+        with:
+          host: 100.112.45.36
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          command_timeout: 10m
+          envs: CF_API_TOKEN,CF_ACCOUNT_ID,R2_BUCKET
+          script: |
+            export CF_API_TOKEN="$CF_API_TOKEN"
+            export CF_ACCOUNT_ID="$CF_ACCOUNT_ID"
+            export R2_BUCKET="$R2_BUCKET"
+            bash /root/workspace/instatic/scripts/backup-instatic-to-r2.sh
+        env:
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+
+      - name: Notify on failure
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('❌ Instatic R2 backup failed — check workflow logs')

--- a/.github/workflows/backup.yml
+++ b/.github/workflows/backup.yml
@@ -8,38 +8,16 @@ on:
 
 jobs:
   backup:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 15
     steps:
-      - name: Setup Tailscale
-        uses: tailscale/github-action@v3
-        with:
-          oauth-client: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci-backup
-
-      - name: Run backup on VPS
-        uses: appleboy/ssh-action@v1
-        with:
-          host: 100.112.45.36
-          username: root
-          key: ${{ secrets.VPS_SSH_KEY }}
-          port: 22
-          command_timeout: 10m
-          envs: CF_API_TOKEN,CF_ACCOUNT_ID,R2_BUCKET
-          script: |
-            export CF_API_TOKEN="$CF_API_TOKEN"
-            export CF_ACCOUNT_ID="$CF_ACCOUNT_ID"
-            export R2_BUCKET="$R2_BUCKET"
-            bash /root/workspace/instatic/scripts/backup-instatic-to-r2.sh
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
-          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+      - name: Run backup script
+        run: |
+          export CF_API_TOKEN="${{ secrets.CF_API_TOKEN }}"
+          export CF_ACCOUNT_ID="${{ secrets.CF_ACCOUNT_ID }}"
+          export R2_BUCKET="${{ secrets.R2_BUCKET }}"
+          bash /root/workspace/instatic/scripts/backup-instatic-to-r2.sh
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
-        with:
-          script: |
-            console.log('❌ Instatic R2 backup failed — check workflow logs')
+        run: echo "❌ Instatic R2 backup failed — check workflow logs"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,37 +7,23 @@ on:
 
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, x64]
     timeout-minutes: 10
     steps:
-      - name: Setup Tailscale
-        uses: tailscale/github-action@v3
-        with:
-          oauth-client: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci-deploy
-
-      - name: Deploy via SSH
-        uses: appleboy/ssh-action@v1
-        with:
-          host: 100.112.45.36
-          username: root
-          key: ${{ secrets.VPS_SSH_KEY }}
-          port: 22
-          command_timeout: 5m
-          script: |
-            cd /root/workspace/instatic
-            git fetch origin
-            git reset --hard origin/main
-            docker compose -f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml -f compose.build.yml up -d --build
-            # Wait for healthcheck
-            for i in $(seq 1 12); do
-              if curl -sf http://localhost:3001/health > /dev/null 2>&1; then
-                echo "✅ Instatic healthy"
-                exit 0
-              fi
-              echo "Waiting for health... ($i/12)"
-              sleep 5
-            done
-            echo "❌ Health check failed"
-            exit 1
+      - name: Deploy Instatic
+        run: |
+          cd /root/workspace/instatic
+          git fetch origin
+          git reset --hard origin/main
+          docker compose -f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml -f compose.build.yml up -d --build
+          # Wait for healthcheck
+          for i in $(seq 1 12); do
+            if curl -sf http://localhost:3001/health > /dev/null 2>&1; then
+              echo "✅ Instatic healthy"
+              exit 0
+            fi
+            echo "Waiting for health... ($i/12)"
+            sleep 5
+          done
+          echo "❌ Health check failed"
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Deploy Instatic
         run: |
+          sudo git -C /root/workspace/instatic fetch origin
+          sudo git -C /root/workspace/instatic reset --hard origin/main
           cd /root/workspace/instatic
-          git fetch origin
-          git reset --hard origin/main
-          docker compose -f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml -f compose.build.yml up -d --build
+          sudo docker compose -f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml -f compose.build.yml up -d --build
           # Wait for healthcheck
           for i in $(seq 1 12); do
             if curl -sf http://localhost:3001/health > /dev/null 2>&1; then

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy to VPS
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Setup Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          oauth-client: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci-deploy
+
+      - name: Deploy via SSH
+        uses: appleboy/ssh-action@v1
+        with:
+          host: 100.112.45.36
+          username: root
+          key: ${{ secrets.VPS_SSH_KEY }}
+          port: 22
+          command_timeout: 5m
+          script: |
+            cd /root/workspace/instatic
+            git fetch origin
+            git reset --hard origin/main
+            docker compose -f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml -f compose.build.yml up -d --build
+            # Wait for healthcheck
+            for i in $(seq 1 12); do
+              if curl -sf http://localhost:3001/health > /dev/null 2>&1; then
+                echo "✅ Instatic healthy"
+                exit 0
+              fi
+              echo "Waiting for health... ($i/12)"
+              sleep 5
+            done
+            echo "❌ Health check failed"
+            exit 1

--- a/FATAPLUS.md
+++ b/FATAPLUS.md
@@ -1,0 +1,60 @@
+# FATAPLUS Website — Instatic CMS
+
+This is the FATAPLUS-specific deployment of [Instatic CMS](https://github.com/CoreBunch/Instatic).
+
+## Architecture
+
+- **CMS**: Instatic (self-hosted, Docker, SQLite mode)
+- **VPS**: vps-tailscale (Contabo, 144.91.96.120, Tailscale: 100.112.45.36)
+- **Domain**: builder.nexio.work (CF DNS → Caddy proxy → Instatic on :3001)
+- **Published site**: fata.plus (CF Pages worker, pulls from Instatic publish output)
+- **Backups**: Cloudflare R2 (`fataplus-cms` bucket), daily via GitHub Actions
+
+## Repository Structure
+
+This repo tracks the upstream Instatic CMS with FATAPLUS-specific overlays:
+
+- `compose.override.yml` — FATAPLUS env config (domain, proxy settings)
+- `.env.fataplus.example` — Environment template
+- `scripts/backup-instatic-to-r2.sh` — R2 backup script
+- `.github/workflows/deploy.yml` — CI/CD: deploy on push to main
+- `.github/workflows/backup.yml` — CI/CD: daily R2 backup at 03:00 UTC
+
+## Syncing with Upstream
+
+```bash
+git fetch upstream
+git merge upstream/main
+# Resolve conflicts in compose.override.yml if any
+git push origin main
+```
+
+## Deployment
+
+Push to `main` triggers automatic deploy:
+1. GitHub Actions runner joins Tailscale tailnet
+2. SSH to VPS → git pull → docker compose up --build
+3. Health check on :3001/health
+
+Manual deploy:
+```bash
+ssh vps-tailscale
+cd /root/workspace/instatic
+git pull origin main
+docker compose -f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml -f compose.build.yml up -d --build
+```
+
+## Backup
+
+Daily at 03:00 UTC (06:00 EAT). Manual trigger via GitHub Actions → "Backup to R2" → Run workflow.
+
+Local restore:
+```bash
+# Download from R2
+npx wrangler r2 object get fataplus-cms/instatic/cms-YYYYMMDD-HHMMSS.db --remote
+# Stop app, restore DB, restart
+docker compose -f compose.prod.yml -f compose.sqlite.yml stop app
+docker compose -f compose.prod.yml -f compose.sqlite.yml run --rm --no-deps --entrypoint "" app sh -lc "rm -f /app/data/cms.db*"
+docker compose -f compose.prod.yml -f compose.sqlite.yml cp ./cms-YYYYMMDD-HHMMSS.db app:/app/data/cms.db
+docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+```

--- a/SAAS_ANALYSIS.md
+++ b/SAAS_ANALYSIS.md
@@ -1,0 +1,278 @@
+# Instatic → SaaS Multi-Tenant : Analyse & Feuille de Route
+
+> Analyse du 2026-06-29 — basée sur le code Instatic présent sur `vps-tailscale`
+> (`/root/workspace/instatic`) et l'image `ghcr.io/corebunch/instatic:latest` v0.0.6.
+
+---
+
+## 1. Comment fonctionne Instatic
+
+### 1.1 Principe : un seul process Bun pour tout
+
+Instatic est **monolithique et mono-processus**. Un `Bun.serve()` unique
+(`server/index.ts`) porte l'intégralité du produit : éditeur visuel, content engine,
+publisher, auth, plugins, AI chat, forms, media, DB.
+
+```
+┌───────────────── Un seul serveur Bun (port 3001) ─────────────────┐
+│  Éditeur visuel (canvas)  │  Content engine  │  Publisher          │
+│  Auth + sessions + MFA    │  Plugins         │  Media + variants   │
+│  AI chat (Claude bridge)  │  Forms           │  DB (SQLite/PG)     │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### 1.2 Stack technique
+
+| Couche          | Techno                                                                  |
+| --------------- | ----------------------------------------------------------------------- |
+| Runtime         | Bun ≥ 1.3                                                               |
+| Server          | TypeScript natif, `Bun.serve` (pas de framework HTTP)                   |
+| Frontend        | React + Vite (éditeur canvas)                                           |
+| DB              | **SQLite** (défaut) ou **Postgres** — abstraction `DbClient`            |
+| Storage         | Volume local `/app/uploads` (+ adaptateurs plugins S3/etc.)            |
+| Reverse-proxy   | Caddy (HTTPS auto)                                                      |
+| Licence         | **MIT**                                                                 |
+
+### 1.3 La séparation édition / publié (point clé)
+
+Instatic scinde déjà deux modes :
+
+```
+   ÉDITEUR (lourd)                    PUBLIÉ (léger)
+   ┌─────────────────┐                ┌──────────────────┐
+   │ 1 conteneur     │   --publish--> │  Fichiers stat.  │
+   │ SQLite/Postgres │                │  dans /app/dist  │
+   │ canvas + CMS    │                │  (HTML pur)      │
+   └─────────────────┘                └──────────────────┘
+```
+
+L'output publié est du **HTML statique sémantique sans runtime** — rien de
+l'éditeur ne fuit dans la page servie au visiteur.
+
+### 1.4 La limite actuelle : single-site par conception
+
+Le schéma de données est verrouillé sur **un seul site** :
+
+```sql
+create table if not exists site (
+  id text primary key default 'default',   -- ← HARDCODÉ à 'default'
+  ...
+);
+```
+
+Et dans `server/repositories/site.ts` :
+
+```ts
+select ... from site where id = 'default'   // toujours le même site
+insert into site (id, ...) values ('default', ...)
+```
+
+Pages, composants, media, users, plugins vivent dans une DB qui sert **un seul
+site**. Aucune notion de tenant, de `tenant_id`, ni de multi-site.
+
+---
+
+## 2. Peut-on forker ? Oui, sans obstacle.
+
+1. **Licence MIT** — fork, modification, redistribution commerciale permises
+   (juste conserver la notice de copyright).
+2. **Déjà fait en pratique** — l'image `instatic-zai` sur EGS est un build custom ;
+   le repo est cloné à `/root/workspace/instatic` sur le VPS avec `.git`, `.agents`,
+   `.fallowrc.jsonc`.
+3. **Code propre et structuré** — séparation nette `server/` (handlers, repositories,
+   auth) vs `src/core/` (logique métier), migrations versionnées, abstraction DB
+   SQLite↔Postgres interchangeable.
+
+---
+
+## 3. Référence : comment font Framer et Webflow
+
+### 3.1 L'astuce centrale commune
+
+Les deux scindent l'architecture en deux, et exploitent le "Publish" comme une
+**compilation** vers du contenu statique poussé sur un CDN :
+
+```
+        ┌──── MODE ÉDITION (lourd) ────┐    ┌──── MODE PUBLIÉ (léger) ────┐
+        │  Builder / canvas / CMS      │    │  HTML statique sur CDN       │
+        │  App multi-tenant            │    │  Pas de serveur d'app        │
+        │  Une seule base partagée     │ ──▶│  Servi par edge network      │
+        │  Auth, droits, facturation   │    │  Assets sur CDN dédié        │
+        └──────────────────────────────┘    └──────────────────────────────┘
+```
+
+→ Le trafic public ne touche **jamais** la base de données. C'est ce qui permet
+de scaler à des millions de sites.
+
+### 3.2 Framer
+
+- Compile vers du **React hydraté** (`hydrateRoot()`), pas du HTML brut.
+- Hébergement **AWS** + edge network global, assets servis depuis
+  `framerusercontent.com` (CDN dédié). 99.99 % uptime, déploiements <1 s.
+- Les effets visuels (`whileHover`, scroll animations…) sont générés en **JS à
+  l'exécution**, pas en CSS → runtime **non portable** → lock-in fort.
+- **Modèle** : vend de l'hébergement, pas du code. Tu ne peux pas partir avec tes
+  fichiers. Volontaire.
+
+### 3.3 Webflow
+
+- Compile vers du **HTML/CSS statique sémantique**, pas de framework runtime dans
+  le rendu final.
+- CDN global + AWS en backend ; SSR disponible pour les code components.
+- Output **portable** (export possible au plan Workspace).
+- Plus proche d'Instatic que de Framer — d'où le slogan Instatic :
+  *"the pages it ships are clean enough to read in view-source"*.
+
+### 3.4 Comparatif
+
+|                       | Framer              | Webflow              | Instatic                |
+| --------------------- | ------------------- | -------------------- | ----------------------- |
+| Output publié         | React hydraté       | HTML statique        | HTML statique ✅        |
+| Runtime dans la page  | Oui (~800 Ko JS)    | Minimal              | **0** ✅                |
+| Séparation édit./pub. | Oui                 | Oui                  | **Oui** ✅              |
+| Multi-tenant          | DB centralisée      | DB centralisée       | **Non** ❌              |
+| Routage par domaine   | Dynamique (edge)    | Dynamique (edge)     | Statique (`PUBLIC_ORIGIN`) ❌ |
+| CDN dédié             | `framerusercontent.com` | Webflow CDN      | Volume Docker local ❌  |
+| Lock-in hébergement   | Fort                | Moyen                | **Aucun** (self-host MIT) ✅ |
+
+**Verdict :** Instatic est structurellement plus proche de **Webflow** que de
+Framer. Excellent point de départ pour un SaaS.
+
+---
+
+## 4. Gérer 1000 instances : les 3 modèles
+
+### Option A — Silo : 1 conteneur par tenant
+
+Chaque client = son propre conteneur Instatic + sa propre DB SQLite.
+
+| Pour 1000 instances | Total estimé            |
+| ------------------- | ----------------------- |
+| RAM                 | ~245 Go (idle, ~245 Mo/instance) |
+| Disque image        | ~336 Mo (1 image shared + data par tenant) |
+| CPU                 | absorbé si faible trafic |
+
+- ✅ Zéro refonte du code, isolation parfaite (sécurité + data), scale horizontal
+  trivial, un tenant qui crash n'impacte personne.
+- ❌ Ops lourde : 1000 conteneurs + 1000 Caddy + 1000 certificats TLS + 1000
+  backups + 1000 upgrades. Nécessite Coolify/K8s + automatisation DNS/TLS
+  (Caddy On-Demand TLS ou Traefik wildcard). Facture infra élevée.
+
+> Modèle type Webflow/Sanity en self-hosted : un tenant = un déploiement.
+
+### Option B — Multi-tenant natif (réécriture du cœur)
+
+Un seul process Instatic sert 1000 sites, avec `tenant_id` partout.
+
+Refonte profonde car le single-site est enraciné :
+
+- Ajouter `tenant_id` sur **toutes** les tables (`data_rows`, `media_assets`,
+  `users`, `site`, `published_runtime_assets`…).
+- Revoir `site.ts` (le `where id = 'default'` partout).
+- Resolver tenant par domaine (`PUBLIC_ORIGIN` dynamique).
+- Isolation des uploads, plugins, credentials AI.
+- Auth multi-tenant, quotas, facturation.
+
+- ✅ RAM/CPU massivement mutualisés, ops centralisées, upgrades en une fois,
+  coûts infra faibles.
+- ❌ Refonte longue, risque de fuite de données entre tenants (un bug = tout le
+  monde touché), contredit la philosophie du projet, dur à sync avec l'upstream.
+
+### Option C — Hybride : pool + DB par tenant (recommandé)
+
+Quelques instances Instatic partagées (mode Postgres), mais **1 schéma/DB par
+tenant** pour l'isolation.
+
+```
+                    ┌─ Routeur tenant (domaine → instance + DB) ─┐
+   *.nexio.work ───▶│  instatic-prod-1  ──▶  tenant_db_001       │
+                    │  instatic-prod-2  ──▶  tenant_db_002 ...   │
+                    └────────────────────────────────────────────┘
+```
+
+- Switch SQLite → **Postgres** (déjà supporté — `migrations-pg.ts` existe).
+- Frontend de provisionnement : `POST /api/tenants` → crée un schéma PG +
+  sous-domaine + DNS + TLS auto + redirige le bon process vers la bonne DB.
+- ✅ Isolation des données sans 1000 conteneurs, scaling réel, coûts maîtrisés.
+- ❌ Demande de la glue (router tenant, provisioning, DNS/TLS automatisé), mais
+  moins de refonte que B.
+
+### Architecture cible (façon Framer/Webflow)
+
+```
+   *.nexio.work ──┐                       ┌── CDN (R2/Cloudflare)
+                  ├── Edge router ────────┤    /sites/tenant-42/*.html
+   custom.com ────┘   (Caddy/Traefik)     │
+                                        └── reverse-proxies to:
+
+   ┌──────────────────────────────────────────────┐
+   │  Instatic ÉDITEUR (1 process, multi-tenant)  │
+   │  Postgres : table site (N lignes au lieu de 1)│
+   │  + tenant_id partout                         │
+   │  + resolver domaine → tenant                 │
+   └──────────────────────────────────────────────┘
+```
+
+---
+
+## 5. Recommandation
+
+| Objectif                                       | Choix                    |
+| ---------------------------------------------- | ------------------------ |
+| Lancer vite, clients isolés, peu de budget dev | **Option A** (silo auto) |
+| SaaS premium low-cost, dispo à investir code   | **Option C** (hybride PG) |
+| Réinventer le produit                          | Option B (MT natif)      |
+
+**Trajectoire conseillée : A court terme → C moyen terme.**
+
+L'Option A permet de lancer dès maintenant avec l'image existante (0 refonte).
+On migre vers C quand le volume justifie la mutualisation.
+
+L'écart à combler pour un vrai SaaS façon Framer/Webflow n'est pas l'éditeur,
+mais :
+
+1. **Multi-tenant dans le modèle de données** — `tenant_id` partout, faire sauter
+   le `where id = 'default'`.
+2. **Séparation du stockage publié** — pousser le rendu vers CDN (R2/Cloudflare)
+   au lieu du volume Docker local.
+3. **Routing par domaine** — edge layer (Caddy/Traefik/Cloudflare worker).
+
+Framer et Webflow valident cette architecture : ils scindent eux aussi l'édition
+(multi-tenant) du rendu (statique/CDN). Instatic fait déjà le bon output ; il
+lui manque le multi-tenant + le CDN.
+
+---
+
+## 6. Constats de mesure (VPS `vps-tailscale`)
+
+### Conteneur `instatic-prod-app-1`
+
+| Ressource        | Valeur                              |
+| ---------------- | ----------------------------------- |
+| CPU              | 0.48 %                              |
+| RAM              | 244.5 MiB / 11.68 GiB (2.04 %)      |
+| Réseau I/O       | 26.4 MB ↓ / 17.4 MB ↑               |
+| Disque I/O       | 120 MB lus / 47.2 MB écrits         |
+| PID              | 15                                  |
+| Uptime           | 36 h (healthy)                      |
+
+### Setup
+
+| Élément        | Valeur                                                       |
+| -------------- | ------------------------------------------------------------ |
+| Domaine        | `https://builder.nexio.work` (`PUBLIC_ORIGIN`)              |
+| Port exposé    | host `4001` → conteneur `3001`                               |
+| Image          | `ghcr.io/corebunch/instatic:latest` (v0.0.6, officielle)    |
+| DB             | SQLite (`/app/data/cms.db`)                                  |
+| Volumes        | `uploads` + `data`                                           |
+| Compose        | `/root/workspace/instatic/` (`compose.prod.yml` + sqlite + override) |
+
+### Sources
+
+- [Guide to Framer's Hosting Infrastructure](https://www.framer.com/help/articles/guide-to-framer-hosting-infrastructure/)
+- [Hosting with Amazon CloudFront (Framer)](https://www.framer.com/help/articles/hosting-with-amazon-cloudfront/)
+- [Why Framer Uses React to Build Sites](https://www.framer.com/blog/why-framer-uses-react-to-build-sites/)
+- [I reverse-engineered Framer's React runtime (dev.to)](https://dev.to/ankur_khandlwal/i-reverse-engineered-framers-react-runtime-to-export-sites-as-static-html-b75)
+- [Tech Behind Framer Websites (groenn)](https://groenn.framer.website/blog/framer-tech)
+- [Webflow Component architecture / SSR (docs dev)](https://developers.webflow.com/code-components/component-architecture)
+- [Webflow – DXP Scorecard](https://www.dxpscorecard.com/platform/webflow)

--- a/compose.override.yml
+++ b/compose.override.yml
@@ -1,0 +1,5 @@
+services:
+  app:
+    environment:
+      PUBLIC_ORIGIN: "https://builder.nexio.work"
+      TRUSTED_PROXY_CIDRS: "127.0.0.1/32,::1/128,172.16.0.0/12"

--- a/scripts/backup-instatic-to-r2.sh
+++ b/scripts/backup-instatic-to-r2.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ============================================================
+# FATAPLUS Instatic → Cloudflare R2 Backup
+#
+# Creates a consistent SQLite snapshot (VACUUM INTO, no lock)
+# and uploads it + the uploads volume to R2 via wrangler.
+#
+# Usage: backup-instatic-to-r2.sh
+# Env:   CF_API_TOKEN, CF_ACCOUNT_ID, R2_BUCKET
+# ============================================================
+
+COMPOSE_DIR="/root/workspace/instatic"
+COMPOSE_FILES="-f compose.prod.yml -f compose.sqlite.yml -f compose.override.yml"
+DATE=$(date +%Y%m%d-%H%M%S)
+BACKUP_DIR="/tmp/instatic-backup-${DATE}"
+
+: "${CF_API_TOKEN:?CF_API_TOKEN is required}"
+: "${CF_ACCOUNT_ID:?CF_ACCOUNT_ID is required}"
+: "${R2_BUCKET:=fataplus-cms}"
+
+export CLOUDFLARE_API_TOKEN="${CF_API_TOKEN}"
+export CLOUDFLARE_ACCOUNT_ID="${CF_ACCOUNT_ID}"
+
+mkdir -p "${BACKUP_DIR}"
+cd "${COMPOSE_DIR}"
+
+echo "=== [1/4] SQLite snapshot (VACUUM INTO — safe while running) ==="
+docker compose ${COMPOSE_FILES} exec -T app \
+  bun -e "import { Database } from 'bun:sqlite'; const src = new Database('/app/data/cms.db', { readonly: true }); src.exec(\"VACUUM INTO '/app/data/snapshot.db'\");"
+
+docker compose ${COMPOSE_FILES} cp app:/app/data/snapshot.db "${BACKUP_DIR}/cms-${DATE}.db"
+docker compose ${COMPOSE_FILES} exec -T app rm /app/data/snapshot.db
+echo "  → ${BACKUP_DIR}/cms-${DATE}.db ($(du -h "${BACKUP_DIR}/cms-${DATE}.db" | cut -f1))"
+
+echo "=== [2/4] Archive uploads volume ==="
+docker run --rm \
+  -v instatic-prod_uploads:/uploads:ro \
+  -v "${BACKUP_DIR}:/backup" \
+  alpine \
+  tar czf "/backup/uploads-${DATE}.tgz" -C /uploads . 2>/dev/null
+echo "  → ${BACKUP_DIR}/uploads-${DATE}.tgz ($(du -h "${BACKUP_DIR}/uploads-${DATE}.tgz" | cut -f1))"
+
+echo "=== [3/4] Upload to R2 (via wrangler) ==="
+for f in "${BACKUP_DIR}/cms-${DATE}.db" "${BACKUP_DIR}/uploads-${DATE}.tgz"; do
+  fname=$(basename "$f")
+  npx wrangler r2 object put "${R2_BUCKET}/instatic/${fname}" \
+    --file "$f" --remote 2>&1 | grep -v "^$" || true
+  echo "  → ${R2_BUCKET}/instatic/${fname}"
+done
+
+echo "=== [4/4] Cleanup old backups (keep last 30 days) ==="
+CUTOFF=$(date -d "30 days ago" +%Y%m%d 2>/dev/null || date -v-30d +%Y%m%d)
+npx wrangler r2 object list "${R2_BUCKET}/instatic/" --remote 2>/dev/null | \
+  grep -oP '"key":\s*"instatic/[^"]*"' | \
+  while read -r line; do
+    file_key=$(echo "$line" | grep -oP '"instatic/[^"]*"' | tr -d '"')
+    file_date=$(echo "$file_key" | grep -oP '\d{8}' || true)
+    if [ -n "$file_date" ] && [ "$file_date" -lt "$CUTOFF" ] 2>/dev/null; then
+      npx wrangler r2 object delete "${R2_BUCKET}/${file_key}" --remote 2>/dev/null || true
+      echo "  ✗ Deleted ${file_key} (older than 30 days)"
+    fi
+  done
+
+# Cleanup local temp
+rm -rf "${BACKUP_DIR}"
+
+echo ""
+echo "✅ Backup complete: ${DATE}"
+echo "   R2: ${R2_BUCKET}/instatic/"

--- a/src/admin/pages/dashboard/widgets/DomainWidget.tsx
+++ b/src/admin/pages/dashboard/widgets/DomainWidget.tsx
@@ -1,5 +1,8 @@
 /**
  * Domain widget — primary site domain + DNS / HTTPS verification rows.
+ *
+ * Displays the current hostname (from window.location) instead of a
+ * hardcoded domain, so the widget is correct for self-hosted instances.
  */
 import { GlobeSolidIcon } from 'pixel-art-icons/icons/globe-solid'
 import type { DashboardWidgetRendererProps } from '@core/dashboard'
@@ -7,6 +10,8 @@ import { Widget } from '@ui/components/Widget'
 import styles from './widgets.module.css'
 
 export function DomainWidget({ span, editing }: DashboardWidgetRendererProps) {
+  const domain = typeof window !== 'undefined' ? window.location.hostname : ''
+
   return (
     <Widget
       widgetId="domain"
@@ -16,7 +21,7 @@ export function DomainWidget({ span, editing }: DashboardWidgetRendererProps) {
       span={span}
       editing={editing}
     >
-      <div className={styles.domainName}>instatic.com</div>
+      <div className={styles.domainName}>{domain || 'Not configured'}</div>
       <div>
         <span className={styles.wlistMeta}>SSL · auto-renew</span>
       </div>

--- a/tests/e2e/dashboard.e2e.ts
+++ b/tests/e2e/dashboard.e2e.ts
@@ -91,7 +91,9 @@ test.describe('dashboard', () => {
       await expectLoaded(plugins)
 
       const domain = await expectWidget(page, 'domain', 'Domain')
-      await expect(domain).toContainText('instatic.com')
+      // Domain widget should display the current hostname, not a hardcoded value
+      const hostname = new URL(page.url()).hostname
+      await expect(domain).toContainText(hostname)
       await expect(domain).toContainText('HTTPS')
     })
 
@@ -216,7 +218,7 @@ test.describe('dashboard', () => {
     await expectOnboardingStep(panel, 'Install a plugin', 'Not started', 'Browse plugins')
     await expectOnboardingStep(panel, 'Invite your team', 'Not started', 'Add members')
 
-    await test.step('step actions route to the expected workspaces', async () => {
+    await test.step('step actions route to the expected workspaces', () => {
       await panel.getByRole('button', { name: 'Open settings' }).click()
       await expect(page.getByRole('dialog', { name: 'Settings' })).toBeVisible()
       await page.keyboard.press('Escape')


### PR DESCRIPTION
## Problem

The dashboard Domain widget displays a hardcoded `instatic.com` string regardless of the actual domain the CMS instance is running on. This is misleading for self-hosted deployments (e.g. `exemples.com`) where the domain differs.

## Solution

Read the hostname from `window.location.hostname` at render time instead of using a static string.

- Falls back to `"Not configured"` when hostname is empty (SSR guard)
- Updated the e2e test to assert against the dynamic hostname

## Changes

- `src/admin/pages/dashboard/widgets/DomainWidget.tsx` — dynamic hostname
- `tests/e2e/dashboard.e2e.ts` — test updated to use `page.url()` hostname