### PR TITLE
fix(spotlight): keep highlighted row in view

### DIFF
--- a/src/admin/spotlight/SpotlightResults.tsx
+++ b/src/admin/spotlight/SpotlightResults.tsx
@@ -271,6 +271,8 @@ export function SpotlightResults({
   const mergedFlatList = argMode
     ? []
     : getMergedCommandList(query, commandContext, activeScopeId, asyncResults)
+  const highlightedCommandId = mergedFlatList[highlightedIndex]?.id ?? null
+  const resultsRef = useRef<HTMLDivElement>(null)
 
   // `dispatch` from useReducer is guaranteed stable, but the context value
   // itself is rebuilt on every state change. Only the dispatch reference is
@@ -286,6 +288,14 @@ export function SpotlightResults({
     if (!dispatch || argMode) return
     dispatch({ type: 'RESULT_COUNT_CHANGED', count: mergedFlatList.length })
   }, [mergedFlatList.length, dispatch, argMode])
+
+  useEffect(() => {
+    if (!highlightedCommandId) return
+    const selectedRow = resultsRef.current?.querySelector<HTMLElement>(
+      '[role="option"][aria-selected="true"]',
+    )
+    selectedRow?.scrollIntoView?.({ block: 'nearest' })
+  }, [highlightedCommandId])
 
   // ─── Scope transition direction ───────────────────────────────────────────
   // Tracks PUSH_SCOPE / POP_SCOPE to drive the slide animation on the results
@@ -371,6 +381,7 @@ export function SpotlightResults({
 
   return (
     <div
+      ref={resultsRef}
       id={listboxId}
       role="listbox"
       aria-label="Command results"

--- a/src/admin/spotlight/__tests__/SpotlightResults.test.tsx
+++ b/src/admin/spotlight/__tests__/SpotlightResults.test.tsx
@@ -1,0 +1,69 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import React from 'react'
+import { cleanup, render, waitFor } from '@testing-library/react'
+import { SpotlightInternalContext, type SpotlightInternalContextValue } from '../spotlightContext'
+import { SpotlightResults } from '../SpotlightResults'
+import type { SpotlightOpenState } from '../state'
+
+afterEach(() => {
+  cleanup()
+  mock.restore()
+})
+
+function makeOpenState(highlightedIndex: number): SpotlightOpenState {
+  return {
+    phase: 'open',
+    query: '',
+    scopeStack: [{ scopeId: 'root', pendingArgs: {} }],
+    highlightedIndex,
+    asyncResults: {},
+    loadingProviders: new Set(),
+    argMode: null,
+    pendingConfirm: null,
+  }
+}
+
+function renderResults(highlightedIndex: number) {
+  const context: SpotlightInternalContextValue = {
+    state: makeOpenState(highlightedIndex),
+    dispatch: () => {},
+    commandContext: null,
+    runCommand: async () => {},
+    runCommandWithArgs: async () => {},
+  }
+
+  return (
+    <SpotlightInternalContext.Provider value={context}>
+      <SpotlightResults
+        listboxId="spotlight-results"
+        highlightedIndex={highlightedIndex}
+        onHighlightChange={() => {}}
+        onRun={() => {}}
+        activeScopeId="root"
+      />
+    </SpotlightInternalContext.Provider>
+  )
+}
+
+describe('SpotlightResults', () => {
+  it('scrolls the highlighted row into view when keyboard navigation changes selection', async () => {
+    const scrollIntoView = mock(() => {})
+    const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+
+    try {
+      const { rerender } = render(renderResults(0))
+
+      await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+      scrollIntoView.mockClear()
+
+      rerender(renderResults(8))
+
+      await waitFor(() => {
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: 'nearest' })
+      })
+    } finally {
+      HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+    }
+  })
+})


### PR DESCRIPTION
## What changed
- Scroll the Spotlight results list to keep the `aria-selected` row visible as keyboard navigation changes the highlight.
- Added a focused regression test for the highlighted-row scroll behavior.

## Why
The selected Spotlight row could move outside the visible results viewport when navigating with arrow keys, leaving the highlight out of view.

Fixes #119.

## Impact
Keyboard navigation in Spotlight now follows the highlighted result without changing the rendered ordering or command execution logic.

## Verification
- `bun run build` ✅
- `bun test src/admin/spotlight/__tests__/SpotlightResults.test.tsx` ✅ (red/green verified: failed before implementation, passed after)
- `bun test src/admin/spotlight/__tests__` ✅
- `bun run lint` ✅
- `bun run doctor --verbose --diff` ✅ exit 0; reported pre-existing warnings in `SpotlightResults.tsx` unrelated to this scroll fix
- `bun test` ⚠️ 5820 passed, 1 failed: `src/admin/pages/dashboard/components/OnboardingPanel.test.tsx` (`Unable to find ... /import framework/i`). The same test fails when run alone, outside the Spotlight change scope.