### PR TITLE
fix(onboarding): open framework import ready to import (pre-select Full)

### DIFF
--- a/src/admin/pages/dashboard/components/OnboardingPanel.tsx
+++ b/src/admin/pages/dashboard/components/OnboardingPanel.tsx
@@ -238,6 +238,10 @@ export function OnboardingPanel({ facts, onDismiss, onFrameworkImported }: Onboa
         onClose={() => setFrameworkImportOpen(false)}
         applier={onboardingApplier}
         currentState={facts.framework === 'done' ? 'full' : 'none'}
+        // The onboarding step's intent is "import the framework" — open with
+        // Full pre-selected so the primary button reads "Import framework" and
+        // one click imports, rather than landing on the no-op current state.
+        initialTarget="full"
         onApplied={onFrameworkImported}
       />
     </section>

--- a/src/admin/shared/dialogs/FrameworkManagerDialog/FrameworkManagerDialog.tsx
+++ b/src/admin/shared/dialogs/FrameworkManagerDialog/FrameworkManagerDialog.tsx
@@ -85,8 +85,16 @@ interface FrameworkManagerDialogProps {
   open: boolean
   onClose: () => void
   applier: FrameworkManagerApplier
-  /** The framework's current state — pre-selects a card and gates the button. */
+  /** The framework's current state — gates the button (sameState / nothingToDo). */
   currentState: FrameworkPreset
+  /**
+   * Target to pre-select when the dialog opens. Defaults to `currentState`
+   * (the in-editor "Manage framework" host wants the picker to reflect reality).
+   * The onboarding "Import framework" step passes `'full'` instead so the step
+   * opens ready to import — otherwise a no-framework site (`currentState:
+   * 'none'`) would land on "None" selected with an "Up to date" no-op button.
+   */
+  initialTarget?: FrameworkPreset
   /** Called after any successful apply. */
   onApplied?: () => void
 }
@@ -96,22 +104,23 @@ export function FrameworkManagerDialog({
   onClose,
   applier,
   currentState,
+  initialTarget = currentState,
   onApplied,
 }: FrameworkManagerDialogProps) {
-  // Preselect the framework's actual current state, not a fixed default.
-  const [target, setTarget] = useState<FrameworkPreset>(currentState)
+  // Preselect `initialTarget` (defaults to the current state, not a fixed value).
+  const [target, setTarget] = useState<FrameworkPreset>(initialTarget)
   const [busy, setBusy] = useState(false)
   const [wasOpen, setWasOpen] = useState(open)
   const applyButtonRef = useRef<HTMLButtonElement | null>(null)
   const confirmFrameworkChange = useFrameworkChangeConfirm()
 
-  // Re-sync the picker to the live state each time the dialog opens, so it
-  // always reflects reality rather than the last session's choice. Adjusting
-  // state during render (not in an effect) is the React-sanctioned pattern for
+  // Re-sync the picker each time the dialog opens, so it reflects the intended
+  // starting target rather than the last session's choice. Adjusting state
+  // during render (not in an effect) is the React-sanctioned pattern for
   // resetting state when a prop changes.
   if (open !== wasOpen) {
     setWasOpen(open)
-    if (open) setTarget(currentState)
+    if (open) setTarget(initialTarget)
   }
 
   function requestClose() {


### PR DESCRIPTION
## What

The onboarding **"Import framework"** step opens `FrameworkManagerDialog`, whose declarative state picker initializes its selection to the framework's *current* state. A new user has no framework (`currentState: 'none'`), so the dialog opened with **"None"** selected and the primary button read **"Up to date"** — a no-op dead-end for a step whose entire purpose is to import the framework.

This adds an optional `initialTarget` prop to the dialog (defaults to `currentState`, so the in-editor **"Manage framework"** host is unchanged) and has onboarding pass `'full'`. The step now opens with **Full** pre-selected, the button reads **"Import framework"**, and one click imports.

## Why

It's a real onboarding UX dead-end introduced when the Core Framework was unified into the declarative manager dialog (#123): the one-shot "import the full framework" action became a state picker that defaults to the no-op current state.

It also fixes the long-red `OnboardingPanel framework import › dispatches a CMS site reload after a successful import` test, which asserted the old flow's "Import framework" button — that test had been failing on `main` since #123.

## Impact

- Onboarding: the "Import framework" step opens ready to import (one click) instead of on a no-op "Up to date".
- In-editor "Manage framework": **unchanged** — it doesn't pass `initialTarget`, so the picker still reflects the live state.

## Verification

- `bun run build` ✓
- `bun run lint` ✓
- `bun test` → **5819 pass, 0 fail** (the previously-red onboarding test now passes; suite fully green)
- `react-doctor --scope changed --base main` → no issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)