### PR TITLE
fix(editor): refresh framework state after onboarding changes

### DIFF
--- a/src/__tests__/editor-hooks/siteEditorDataDeepLink.test.tsx
+++ b/src/__tests__/editor-hooks/siteEditorDataDeepLink.test.tsx
@@ -8,6 +8,7 @@ import { makeNode, makePage, makeSite } from '../fixtures'
 import type { SiteDocument } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
 import type { IPersistenceAdapter } from '@core/persistence/types'
+import { buildCoreFrameworkSettings } from '@core/framework'
 
 afterEach(cleanup)
 
@@ -66,6 +67,25 @@ function makeAdapter(site: SiteDocument): IPersistenceAdapter & { loadCount: () 
     },
     async saveSite() {},
     loadCount: () => loads,
+  }
+}
+
+function makeControlledAdapter(
+  site: SiteDocument,
+): IPersistenceAdapter & { loadCount: () => number; resolveNextLoad: () => void } {
+  let loads = 0
+  const resolvers: Array<() => void> = []
+  return {
+    async loadSite() {
+      loads += 1
+      await new Promise<void>((resolve) => resolvers.push(resolve))
+      return site
+    },
+    async saveSite() {},
+    loadCount: () => loads,
+    resolveNextLoad: () => {
+      resolvers.shift()?.()
+    },
   }
 }
 
@@ -134,6 +154,43 @@ describe('Site editor Data workspace deep links', () => {
           (component) => component.id === 'component-pending-reload',
         ),
       ).toBe(true)
+    })
+  })
+
+  it('retains a pending CMS site reload when a mount is cancelled before the fresh site hydrates', async () => {
+    const staleSite = makeEditorSite([])
+    const freshSite = makeEditorSite([])
+    freshSite.settings.framework = buildCoreFrameworkSettings({ includeUtilities: true })
+    const adapter = makeControlledAdapter(freshSite)
+
+    useEditorStore.setState({
+      site: staleSite,
+      activePageId: 'page-home',
+      hasUnsavedChanges: false,
+    } as Parameters<typeof useEditorStore.setState>[0])
+    requestCmsSiteReload()
+
+    const firstMount = renderHook(() => usePersistence('default', adapter, { enabled: true }))
+    await waitFor(() => {
+      expect(adapter.loadCount()).toBe(1)
+    })
+    firstMount.unmount()
+    adapter.resolveNextLoad()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().site?.settings.framework).toBeUndefined()
+    })
+
+    renderHook(() => usePersistence('default', adapter, { enabled: true }))
+
+    await waitFor(() => {
+      expect(adapter.loadCount()).toBe(2)
+    })
+    adapter.resolveNextLoad()
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().site?.settings.framework).toBeDefined()
     })
   })
 })

--- a/src/admin/modals/Settings/useSiteSettingsController.ts
+++ b/src/admin/modals/Settings/useSiteSettingsController.ts
@@ -44,7 +44,7 @@ import type { SiteDocument, SiteSettings } from '@core/page-tree'
 import type { FrameworkPreferencesSettings } from '@core/framework-schema'
 import { useEditorStore } from '@site/store/store'
 import { useAdminUi } from '@admin/state/adminUi'
-import { CMS_SITE_RELOAD_EVENT } from '@admin/state/adminEvents'
+import { requestCmsSiteReload } from '@admin/state/adminEvents'
 import { getErrorMessage } from '@core/utils/errorMessage'
 
 const SITE_ID = 'default'
@@ -97,7 +97,7 @@ const useSettingsDraftStore = create<SettingsDraftState>((set, get) => {
           name: next.name,
           faviconUrl: next.settings.faviconUrl ?? null,
         })
-        window.dispatchEvent(new Event(CMS_SITE_RELOAD_EVENT))
+        requestCmsSiteReload()
       })
       .catch((err: unknown) => {
         console.error('[useSiteSettingsController] failed to save site settings:', err)

--- a/src/admin/pages/site/hooks/usePersistence.ts
+++ b/src/admin/pages/site/hooks/usePersistence.ts
@@ -57,6 +57,7 @@ import {
   CMS_SITE_RELOAD_EVENT,
   EDITOR_SAVE_REQUEST_EVENT,
   consumePendingCmsSiteReload,
+  hasPendingCmsSiteReload,
 } from '@admin/state/adminEvents'
 
 export interface PersistenceSaveStatus {
@@ -183,8 +184,9 @@ export function usePersistence(
         setHasUnsavedChanges,
       } = useEditorStore.getState()
 
+      const pendingCmsSiteReload = hasPendingCmsSiteReload()
       const shouldReloadExistingSite = existingSite
-        ? consumePendingCmsSiteReload() || siteMissesEditorDataDeepLink(existingSite)
+        ? pendingCmsSiteReload || siteMissesEditorDataDeepLink(existingSite)
         : false
 
       if (existingSite && !shouldReloadExistingSite) {
@@ -205,6 +207,7 @@ export function usePersistence(
           // Constraint #230 is satisfied at the adapter boundary.
           const site = await adapterRef.current.loadSite(idToTry)
           if (site && !cancelled) {
+            if (pendingCmsSiteReload) consumePendingCmsSiteReload()
             syncedPageIdsRef.current = site.pages.map((p) => p.id)
             loadSite(site)
             applyDefaultBreakpointPreference(site.breakpoints)
@@ -226,6 +229,7 @@ export function usePersistence(
       }
 
       if (cancelled) return
+      if (pendingCmsSiteReload) consumePendingCmsSiteReload()
 
       if (existingSite) {
         loadedRef.current = true
@@ -272,10 +276,14 @@ export function usePersistence(
 
     async function reload() {
       const idToTry = requestedSiteId || 'default'
+      const pendingCmsSiteReload = hasPendingCmsSiteReload()
       try {
         // Adapter validates internally (Constraint #230).
         const site = await adapterRef.current.loadSite(idToTry)
-        if (!site) return
+        if (!site) {
+          if (pendingCmsSiteReload) consumePendingCmsSiteReload()
+          return
+        }
         const { loadSite, setHasUnsavedChanges } = useEditorStore.getState()
         syncedPageIdsRef.current = site.pages.map((p) => p.id)
         loadSite(site)
@@ -283,6 +291,7 @@ export function usePersistence(
         // The site doc on disk is now authoritative; clear the unsaved flag so
         // the auto-save loop doesn't immediately overwrite it back.
         setHasUnsavedChanges(false)
+        if (pendingCmsSiteReload) consumePendingCmsSiteReload()
         setSaveStatus({ state: 'saved', lastSavedAt: Date.now() })
       } catch (err) {
         console.error('[persistence] Reload after pack install failed:', err)
@@ -290,7 +299,6 @@ export function usePersistence(
     }
 
     function handleReload() {
-      consumePendingCmsSiteReload()
       void reload()
     }
 

--- a/src/admin/state/adminEvents.ts
+++ b/src/admin/state/adminEvents.ts
@@ -35,6 +35,10 @@ export function requestCmsSiteReload(): void {
   }
 }
 
+export function hasPendingCmsSiteReload(): boolean {
+  return cmsSiteReloadPending
+}
+
 export function consumePendingCmsSiteReload(): boolean {
   if (!cmsSiteReloadPending) return false
   cmsSiteReloadPending = false


### PR DESCRIPTION
## Summary

- Retain CMS site reload requests until the Site editor actually hydrates the fresh site document.
- Route framework/settings saves through the retained reload helper so dashboard and settings changes share the same behavior.
- Add regression coverage for a cancelled Site editor mount preserving the pending reload.

## Root Cause

The pending CMS site reload flag was consumed before the async Site load resolved. If the persistence hook unmounted before hydration, the next mount treated the stale editor store as authoritative and skipped the refetch, so onboarding framework changes only appeared after a hard refresh.

## Verification

- `bun run build`
- `bun test` (5863 pass, 0 fail)
- `bun run lint`
- Browser smoke: with a local SQLite dev server, Dashboard Core Framework remove/import reflected in the Site editor without a hard refresh.
