### PR TITLE
feat(agent): render tool calls as compact labeled rows in the agent panel

### DIFF
--- a/docs/features/agent.md
+++ b/docs/features/agent.md
@@ -95,6 +95,8 @@ src/admin/pages/content/agent/
 
 src/admin/pages/site/panels/AgentPanel/
 ├── AgentPanel.tsx          — main panel; resolves active model's contextWindow from the models endpoint
+├── ToolCallRow.tsx         — tool-call row UI: icon rendering, status text, failed-call error copy
+├── toolCallDisplay.ts      — raw tool name + params → human-readable action row copy, icon key, and tone
 ├── ModelPicker.tsx         — credential + model selector used in the input bar
 ├── ConversationHistory.tsx — history popover (browse, restore, delete past threads)
 ├── ContextMeter.tsx        — "context used / window" progress indicator (display only)
@@ -114,6 +116,8 @@ src/admin/pages/ai/
 ```
 
 The Agent Panel owns the credential list load for its header, lock-state empty states, and model picker. The header always contains a `ConversationHistory` popover (browse and restore past threads), a "New chat" button (`startNewAgentConversation`), a conditional "Clear conversation" button (visible when `agentMessages.length > 0`), a streaming badge, and an "AI settings" shortcut that routes to `/admin/ai`. The AI settings button is always visible in the header, independent of credential state.
+
+Tool-call blocks render as action rows instead of raw tool names. `toolCallDisplay.ts` maps each streamed `toolName` plus its params to human copy, detail text, icon key, and semantic tone; `ToolCallRow.tsx` owns the pixel-art icon rendering and status/error states. The same renderer is shared by the site and content AI panels because both mount the same `AgentPanel` component.
 
 The composer has two distinct lock states, expressed as `lockReason: 'setup' | 'chooseModel' | null`:
 
@@ -548,7 +552,7 @@ Conversations and their message history are persisted server-side in `ai_convers
 
 **Content blocks are one schema.** Every message body is an `AiContentBlock[]` — a discriminated union of `text` / `image` / `toolCall` / `toolResult` kinds defined once as a TypeBox schema in `@core/ai` (`src/core/ai/contentBlock.ts`). The server runtime type (`AiContentBlock`), the read boundary (`ContentBlocksSchema` in `conversations/store.ts`, which validates every block out of `content_json`), and the client wire schema (`MessageViewSchema` in `src/admin/ai/api.ts`) all derive from it. Add a kind there and every reader/writer sees it.
 
-**Tool outcomes are first-class.** A `role:'tool'` row records its result as a `{ kind: 'toolResult', ok, error? }` block — `ok` is an explicit boolean, never inferred from the emptiness of a text block. The persister writes it (`appendToolResult`), `buildMessageHistory` reads `ok`/`error` straight off the block to reconstruct the replay `AiToolOutput`, and the client folds it back into the matching tool-call badge (`rehydrateMessages`). The heavy successful `data` an `AiToolOutput` may carry is intentionally **not** persisted: the model already consumed it in the round that produced the result, so replay only needs `{ ok, error }` — re-feeding large tool payloads every turn would bloat the context for no benefit.
+**Tool outcomes are first-class.** A `role:'tool'` row records its result as a `{ kind: 'toolResult', ok, error? }` block — `ok` is an explicit boolean, never inferred from the emptiness of a text block. The persister writes it (`appendToolResult`), `buildMessageHistory` reads `ok`/`error` straight off the block to reconstruct the replay `AiToolOutput`, and the client folds it back into the matching tool-call row (`rehydrateMessages`). The heavy successful `data` an `AiToolOutput` may carry is intentionally **not** persisted: the model already consumed it in the round that produced the result, so replay only needs `{ ok, error }` — re-feeding large tool payloads every turn would bloat the context for no benefit.
 
 ---
 

--- a/src/__tests__/panels/agentPanel.test.tsx
+++ b/src/__tests__/panels/agentPanel.test.tsx
@@ -3,7 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { createStore } from 'zustand/vanilla'
 import { AgentStoreProvider } from '@admin/ai/AgentStoreContext'
 import { MemoryRouter, useLocation } from '@admin/lib/routing'
-import type { AgentSlice } from '@site/agent'
+import type { AgentMessage, AgentSlice } from '@site/agent'
 import { AgentPanel } from '@site/panels/AgentPanel'
 
 const originalFetch = globalThis.fetch
@@ -230,5 +230,112 @@ describe('AgentPanel', () => {
     expect(screen.queryByText('Connect an AI provider')).toBeNull()
     const textarea = screen.getByLabelText('Message to AI assistant') as HTMLTextAreaElement
     expect(textarea.disabled).toBe(false)
+  })
+
+  it('renders tool calls as human-readable action rows', async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/admin/api/ai/credentials')) {
+        return jsonResponse({
+          credentials: [{
+            id: 'cred_1',
+            providerId: 'openai',
+            authMode: 'apiKey',
+            displayLabel: 'OpenAI',
+            baseUrl: null,
+            keyFingerprintCurrent: true,
+            createdAt: '2026-06-01T10:00:00.000Z',
+            lastUsedAt: null,
+          }],
+        })
+      }
+      if (url.includes('/admin/api/ai/providers/')) {
+        return jsonResponse({ models: [] })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    const assistantMessage: AgentMessage = {
+      id: 'assistant-1',
+      role: 'assistant',
+      timestamp: Date.now(),
+      blocks: [{
+        kind: 'toolCall',
+        toolCall: {
+          id: 'tool-1',
+          externalId: 'toolu_1',
+          actionType: 'applyCss',
+          params: { css: '.hero { color: red; } .cta:hover { color: blue; }' },
+          result: null,
+          status: 'pending',
+        },
+      }],
+    }
+
+    renderAgentPanel({
+      agentActiveCredentialId: 'cred_1',
+      agentActiveModelId: 'gpt-4o',
+      agentMessages: [assistantMessage],
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('Updating CSS')).toBeTruthy()
+    })
+
+    expect(screen.getByText('.hero, .cta:hover')).toBeTruthy()
+    expect(screen.queryByText('applyCss')).toBeNull()
+    expect(screen.getByRole('status', { name: 'Running Updating CSS - .hero, .cta:hover' })).toBeTruthy()
+  })
+
+  it('stacks consecutive same-role messages under one role marker', async () => {
+    globalThis.fetch = mock(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url.endsWith('/admin/api/ai/credentials')) {
+        return jsonResponse({
+          credentials: [{
+            id: 'cred_1',
+            providerId: 'openai',
+            authMode: 'apiKey',
+            displayLabel: 'OpenAI',
+            baseUrl: null,
+            keyFingerprintCurrent: true,
+            createdAt: '2026-06-01T10:00:00.000Z',
+            lastUsedAt: null,
+          }],
+        })
+      }
+      if (url.includes('/admin/api/ai/providers/')) {
+        return jsonResponse({ models: [] })
+      }
+      throw new Error(`Unexpected fetch: ${url}`)
+    }) as typeof fetch
+
+    const assistantMessages: AgentMessage[] = [
+      {
+        id: 'assistant-1',
+        role: 'assistant',
+        timestamp: Date.now(),
+        blocks: [{ kind: 'text', text: 'First assistant note.' }],
+      },
+      {
+        id: 'assistant-2',
+        role: 'assistant',
+        timestamp: Date.now() + 1,
+        blocks: [{ kind: 'text', text: 'Second assistant note.' }],
+      },
+    ]
+
+    renderAgentPanel({
+      agentActiveCredentialId: 'cred_1',
+      agentActiveModelId: 'gpt-4o',
+      agentMessages: assistantMessages,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText('First assistant note.')).toBeTruthy()
+    })
+
+    expect(screen.getByText('Second assistant note.')).toBeTruthy()
+    expect(screen.getAllByText('Assistant')).toHaveLength(1)
   })
 })

--- a/src/__tests__/panels/agentToolCallDisplay.test.ts
+++ b/src/__tests__/panels/agentToolCallDisplay.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test'
+import { getToolCallDisplay } from '@site/panels/AgentPanel'
+
+describe('getToolCallDisplay', () => {
+  test('formats document reads as readable document actions', () => {
+    expect(getToolCallDisplay('read_document', {
+      document: { type: 'template', id: 'tpl_home' },
+    })).toEqual({
+      title: 'Reading document',
+      detail: 'Template tpl_home',
+      icon: 'document',
+      tone: 'read',
+    })
+  })
+
+  test('summarizes CSS selectors without exposing applyCss', () => {
+    expect(getToolCallDisplay('applyCss', {
+      css: '.hero { color: red; } .cta:hover { color: blue; }',
+    })).toEqual({
+      title: 'Updating CSS',
+      detail: '.hero, .cta:hover',
+      icon: 'style',
+      tone: 'style',
+    })
+  })
+
+  test('formats content workspace writes', () => {
+    expect(getToolCallDisplay('set_document_status', { status: 'published' })).toEqual({
+      title: 'Setting document status',
+      detail: 'Published',
+      icon: 'edit',
+      tone: 'write',
+    })
+  })
+
+  test('falls back to humanized unknown names', () => {
+    expect(getToolCallDisplay('custom_tool_name', {})).toEqual({
+      title: 'Running custom tool name',
+      detail: '',
+      icon: 'tool',
+      tone: 'neutral',
+    })
+  })
+})

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -129,133 +129,135 @@
   flex: 0 1 auto;
 }
 
-/* ── MessageBubble ───────────────────────────────────────────────────────── */
-.messageBubble {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
+/* ── Message entries ─────────────────────────────────────────────────────── */
+.messageEntry {
+  display: grid;
+  align-items: stretch;
+  gap: 8px;
+  width: 100%;
 }
 
-.messageBubbleUser {
-  align-items: flex-end;
-}
-
-.messageBubbleAssistant {
-  align-items: flex-start;
+.messageEntryUser,
+.messageEntryAssistant {
+  justify-items: stretch;
 }
 
 .roleLabel {
-  font-size: 9px;
   color: var(--editor-text-subtle);
+  font-size: 12px;
+  font-weight: 650;
+  line-height: 1.2;
   letter-spacing: 0.05em;
 }
 
-.contentBubble {
-  max-width: 90%;
-  padding: 7px 10px;
+.textBlock {
+  width: 100%;
+  max-width: none;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
   color: var(--editor-text);
   font-size: 12px;
-  line-height: 1.6;
+  font-weight: 500;
+  line-height: 1.55;
   white-space: pre-wrap;
   word-break: break-word;
-  border: 1px solid var(--panel-border);
 }
 
-.contentBubbleUser {
-  border-radius: 10px 10px 2px 10px;
-  background: var(--editor-overlay-white-08);
+.textBlockUser {
+  color: var(--editor-text-secondary);
 }
 
-.contentBubbleAssistant {
-  border-radius: 2px 10px 10px 10px;
-  background: var(--editor-overlay-white-04);
+.textBlockAssistant {
+  color: var(--editor-text);
 }
 
-/* ── Markdown bubble typography ─────────────────────────────────────────────
- * Applied alongside .contentBubble when the text is parsed as markdown.
+/* ── Markdown text typography ───────────────────────────────────────────────
+ * Applied alongside .textBlock when the text is parsed as markdown.
  * Resets `white-space: pre-wrap` (marked emits proper block elements with
  * their own whitespace handling — we only want pre-wrap inside <pre>) and
  * adds the typography rules for the small subset of HTML we accept. */
-.markdownBubble {
+.markdownText {
   white-space: normal;
 }
 
-.markdownBubble > :first-child {
+.markdownText > :first-child {
   margin-top: 0;
 }
 
-.markdownBubble > :last-child {
+.markdownText > :last-child {
   margin-bottom: 0;
 }
 
-.markdownBubble p {
+.markdownText p {
   margin: 0 0 8px;
 }
 
-.markdownBubble h1,
-.markdownBubble h2,
-.markdownBubble h3,
-.markdownBubble h4,
-.markdownBubble h5,
-.markdownBubble h6 {
+.markdownText h1,
+.markdownText h2,
+.markdownText h3,
+.markdownText h4,
+.markdownText h5,
+.markdownText h6 {
   margin: 12px 0 6px;
   color: var(--editor-text-bright);
   font-weight: 600;
   line-height: 1.3;
 }
 
-.markdownBubble h1 { font-size: 16px; }
-.markdownBubble h2 { font-size: 15px; }
-.markdownBubble h3 { font-size: 14px; }
-.markdownBubble h4,
-.markdownBubble h5,
-.markdownBubble h6 { font-size: 13px; }
+.markdownText h1 { font-size: 16px; }
+.markdownText h2 { font-size: 15px; }
+.markdownText h3 { font-size: 14px; }
+.markdownText h4,
+.markdownText h5,
+.markdownText h6 { font-size: 13px; }
 
-.markdownBubble strong,
-.markdownBubble b {
+.markdownText strong,
+.markdownText b {
   font-weight: 600;
   color: var(--editor-text-bright);
 }
 
-.markdownBubble em,
-.markdownBubble i {
+.markdownText em,
+.markdownText i {
   font-style: italic;
 }
 
-.markdownBubble ul,
-.markdownBubble ol {
+.markdownText ul,
+.markdownText ol {
   margin: 0 0 8px;
   padding-left: 18px;
 }
 
-.markdownBubble li {
+.markdownText li {
   margin-bottom: 2px;
 }
 
-.markdownBubble li > p {
+.markdownText li > p {
   margin: 0;
 }
 
-.markdownBubble a {
+.markdownText a {
   color: var(--editor-text-bright);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.markdownBubble a:hover {
+.markdownText a:hover {
   color: var(--editor-accent);
 }
 
-.markdownBubble code {
+.markdownText code {
   padding: 1px 5px;
   border-radius: var(--editor-radius-sm);
   background: var(--editor-surface-3);
   color: var(--editor-text-bright);
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
-  font-size: 11px;
+  font-size: 12px;
 }
 
-.markdownBubble pre {
+.markdownText pre {
   margin: 0 0 8px;
   padding: 8px 10px;
   border-radius: var(--editor-radius-sm);
@@ -264,13 +266,13 @@
   white-space: pre;
 }
 
-.markdownBubble pre code {
+.markdownText pre code {
   padding: 0;
   background: transparent;
-  font-size: 11px;
+  font-size: 12px;
 }
 
-.markdownBubble blockquote {
+.markdownText blockquote {
   margin: 0 0 8px;
   padding: 2px 0 2px 10px;
   border-left: 2px solid var(--panel-border);
@@ -280,47 +282,126 @@
 .toolCallsContainer {
   display: flex;
   flex-direction: column;
-  gap: 3px;
-  width: 90%;
+  gap: 2px;
+  width: 100%;
+  padding: 4px 0;
 }
 
-/* ── ToolCallBadge ───────────────────────────────────────────────────────── */
-.toolCallBadge {
-  display: inline-flex;
+/* ── ToolCallRow ─────────────────────────────────────────────────────────── */
+.toolCallRow {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) auto;
   align-items: center;
-  gap: 5px;
-  padding: 3px 8px;
-  border-radius: 20px;
-  background: var(--editor-overlay-white-04);
-  border: 1px solid var(--editor-overlay-white-08);
-  font-size: 10px;
+  column-gap: 10px;
+  width: 100%;
+  padding: 4px 8px 4px 4px;
+  border-radius: var(--editor-radius);
+  background: var(--editor-surface);
+  border: 0;
+  color: var(--editor-text);
+}
+
+.toolCallRowPending {
+  background: var(--editor-surface);
+}
+
+.toolCallRowFailed {
+  background: var(--editor-danger-bg);
+}
+
+.toolCallIcon {
+  display: inline-grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  background: transparent;
   color: var(--editor-text-secondary);
 }
 
-.toolCallIconPending {
-  color: var(--editor-text-subtle);
-}
-
-.toolCallIconSuccess {
-  color: var(--editor-success-bright);
-}
-
-.toolCallIconFailed {
+.toolCallIconDanger {
   color: var(--editor-danger-light);
 }
 
-.toolCallType {
-  font-family: var(--font-mono);
-  font-size: 9px;
-  opacity: 0.70;
+.toolCallIconNeutral {
+  color: var(--editor-text-secondary);
 }
 
-/* Inline error message rendered under a failed tool badge. Lets the user
+.toolCallIconRead {
+  color: var(--rail-tint-sky);
+}
+
+.toolCallIconStyle {
+  color: var(--rail-tint-gold);
+}
+
+.toolCallIconWrite {
+  color: var(--rail-tint-mint);
+}
+
+.toolCallCopy {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.toolCallTitle {
+  flex: 0 0 auto;
+  color: var(--editor-text);
+  font-size: 12px;
+  font-weight: 700;
+  line-height: 1.25;
+}
+
+.toolCallDetail {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--editor-text-muted);
+  font-size: 12px;
+  line-height: 1.25;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Middle-dot separator only renders when a detail value is present (the
+   span is conditionally rendered), keeping title + value on one row. */
+.toolCallDetail::before {
+  content: '·';
+  margin: 0 6px;
+  color: var(--editor-text-muted);
+}
+
+.toolCallStatus {
+  display: inline-flex;
+  align-items: center;
+  justify-self: end;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  color: var(--editor-text-muted);
+  line-height: 1;
+}
+
+.toolCallStatusPending {
+  color: var(--editor-text-secondary);
+}
+
+.toolCallStatusSuccess {
+  color: var(--editor-success-bright);
+}
+
+.toolCallStatusFailed {
+  color: var(--editor-danger-light);
+}
+
+/* Inline error message rendered under a failed tool row. Lets the user
    see WHY the tool failed without expanding anything — same width as the
-   badge container, danger-toned text, one-line ellipsis when long. */
+   row container, danger-toned text, one-line ellipsis when long. */
 .toolCallError {
   margin: 2px 0 0 12px;
-  font-size: 11px;
+  font-size: 12px;
   line-height: 1.4;
   color: var(--editor-danger-light);
   word-break: break-word;

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -15,24 +15,21 @@
  * - role="complementary" + aria-label="AI Assistant" on the panel landmark
  * - role="log" + aria-live="polite" on the message thread
  * - role="alert" for error messages
- * - role="status" for tool call status badges
+ * - role="status" for tool call status rows
  * - keyboard: Escape closes the panel
  *
  * @see Guideline #410 — 3 Self-Contained Independent Panels
  */
 
-import { useRef, useEffect, memo } from 'react'
+import { useRef, useEffect } from 'react'
 import { useAgentStore } from '@admin/ai/useAgentStore'
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { useAdminNavigate } from '@admin/lib/useAdminNavigate'
 import { listCredentials, listModels } from '@admin/ai/api'
-import { renderMarkdownToHtml, type AgentMessage, type AgentToolCall } from '@site/agent'
+import type { AgentMessage } from '@site/agent'
 import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
 import { SquareSolidIcon } from 'pixel-art-icons/icons/square-solid'
 import { SendSolidIcon } from 'pixel-art-icons/icons/send-solid'
-import { LoaderIcon } from 'pixel-art-icons/icons/loader'
-import { CheckIcon } from 'pixel-art-icons/icons/check'
-import { CircleAlertSolidIcon } from 'pixel-art-icons/icons/circle-alert-solid'
 import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
 import { AiSettingsSolidIcon } from 'pixel-art-icons/icons/ai-settings-solid'
 import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
@@ -46,6 +43,7 @@ import { cn } from '@ui/cn'
 import { ModelPicker } from './ModelPicker'
 import { ConversationHistory } from './ConversationHistory'
 import { ContextMeter } from './ContextMeter'
+import { MessageGroups } from './MessageGroup'
 import styles from './AgentPanel.module.css'
 
 const PANEL_WIDTH = 320
@@ -262,34 +260,14 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
         />
       </PanelHeader>
 
-      {/* ── Message thread ──────────────────────────────────────────────────── */}
-      <div
-        ref={threadRef}
-        role="log"
-        aria-live="polite"
-        aria-atomic="false"
-        aria-relevant="additions text"
-        aria-label="Conversation"
-        aria-busy={isStreaming}
-        className={styles.thread}
-      >
-        {messages.length === 0 ? (
-          <AgentEmptyState mode={lockReason ?? 'prompt'} />
-        ) : (
-          <>
-            {lockReason && <AgentCredentialAlert mode={lockReason} />}
-            {messages.map((msg) => <MessageBubble key={msg.id} msg={msg} />)}
-          </>
-        )}
-
-        {/* Generic error banner — only show when it's NOT the dedicated
-            no-credential message (which renders via the setup empty state). */}
-        {agentError && !noProviderError && (
-          <div role="alert" className={styles.errorBanner}>
-            {agentError}
-          </div>
-        )}
-      </div>
+      <AgentThread
+        threadRef={threadRef}
+        messages={messages}
+        lockReason={lockReason}
+        agentError={agentError}
+        noProviderError={noProviderError}
+        isStreaming={isStreaming}
+      />
 
       {/* ── Input bar ───────────────────────────────────────────────────────── */}
       <div className={styles.inputBar}>
@@ -365,178 +343,50 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
   )
 }
 
-// ---------------------------------------------------------------------------
-// MessageBubble
-// ---------------------------------------------------------------------------
-
-interface MessageBubbleProps {
-  msg: AgentMessage
+interface AgentThreadProps {
+  threadRef: React.RefObject<HTMLDivElement | null>
+  messages: AgentMessage[]
+  lockReason: ComposerLockReason | null
+  agentError: string | null
+  noProviderError: boolean
+  isStreaming: boolean
 }
 
-// Exception #2: React.memo re-render bailout on a hot, list-rendered component
-// (one per message in messages.map).
-const MessageBubble = memo(function MessageBubble({ msg }: MessageBubbleProps) {
-  const isUser = msg.role === 'user'
-
+function AgentThread({
+  threadRef,
+  messages,
+  lockReason,
+  agentError,
+  noProviderError,
+  isStreaming,
+}: AgentThreadProps) {
   return (
-    <div className={cn(styles.messageBubble, isUser ? styles.messageBubbleUser : styles.messageBubbleAssistant)}>
-      {/* Role label */}
-      <div className={styles.roleLabel}>
-        {isUser ? 'You' : 'Assistant'}
-      </div>
+    <div
+      ref={threadRef}
+      role="log"
+      aria-live="polite"
+      aria-atomic="false"
+      aria-relevant="additions text"
+      aria-label="Conversation"
+      aria-busy={isStreaming}
+      className={styles.thread}
+    >
+      {messages.length === 0 ? (
+        <AgentEmptyState mode={lockReason ?? 'prompt'} />
+      ) : (
+        <>
+          {lockReason && <AgentCredentialAlert mode={lockReason} />}
+          <MessageGroups messages={messages} />
+        </>
+      )}
 
-      {/* Chronological blocks — text and tool calls render in the order
-          Claude actually emitted them, so a "text → tool → text" sequence
-          shows two separate text bubbles around the tool badges. Text is
-          rendered as markdown (bold, lists, inline code, links, …) via a
-          DOMPurify-sanitised HTML pipeline. */}
-      {msg.blocks.map((block, index) =>
-        block.kind === 'text' ? (
-          <MarkdownTextBubble
-            // Stable key per text block: text deltas append in place, so each
-            // run of text gets its position-based key.
-            key={`text-${index}`}
-            text={block.text}
-            isUser={isUser}
-          />
-        ) : (
-          <div key={block.toolCall.id} className={styles.toolCallsContainer}>
-            <ToolCallBadge toolCall={block.toolCall} />
-          </div>
-        ),
+      {agentError && !noProviderError && (
+        <div role="alert" className={styles.errorBanner}>
+          {agentError}
+        </div>
       )}
     </div>
   )
-})
-
-// ---------------------------------------------------------------------------
-// MarkdownTextBubble — parses + sanitises the block text and injects it via
-// dangerouslySetInnerHTML. Memoised render so streaming deltas don't re-parse
-// markdown for unchanged blocks.
-// ---------------------------------------------------------------------------
-
-interface MarkdownTextBubbleProps {
-  text: string
-  isUser: boolean
-}
-
-// Exception #2: React.memo re-render bailout on a hot, list-rendered component
-// (one per text block, re-rendered on every streaming delta).
-const MarkdownTextBubble = memo(function MarkdownTextBubble({
-  text,
-  isUser,
-}: MarkdownTextBubbleProps) {
-  const html = renderMarkdownToHtml(text)
-  // Empty/whitespace-only blocks don't render at all (avoids stray bubbles
-  // around stripped-out tool blocks during streaming).
-  if (!html) return null
-  return (
-    <div
-      className={cn(
-        styles.contentBubble,
-        isUser ? styles.contentBubbleUser : styles.contentBubbleAssistant,
-        styles.markdownBubble,
-      )}
-      // Safe: sanitised by DOMPurify (via sanitizeRichtext) before reaching here.
-      dangerouslySetInnerHTML={{ __html: html }}
-    />
-  )
-})
-
-// ---------------------------------------------------------------------------
-// ToolCallBadge
-// ---------------------------------------------------------------------------
-
-function ToolCallBadge({ toolCall }: { toolCall: AgentToolCall }) {
-  const isPending = toolCall.status === 'pending'
-  const isSuccess = toolCall.status === 'success'
-  const isError = toolCall.status === 'error'
-
-  const iconClass = isPending
-    ? styles.toolCallIconPending
-    : isSuccess
-    ? styles.toolCallIconSuccess
-    : styles.toolCallIconFailed
-  const displayType = formatToolCallType(toolCall.actionType)
-  const label = formatActionLabel(toolCall.actionType, toolCall.params)
-  const statusLabel = isPending
-    ? `Running ${displayType}${label ? ` — ${label}` : ''}`
-    : isSuccess
-    ? `Completed ${displayType}${label ? ` — ${label}` : ''}`
-    : `Failed ${displayType}${label ? ` — ${label}` : ''}`
-
-  // Surface the tool's error message directly in the badge stream so the
-  // user sees WHY a tool failed without having to dig through devtools. The
-  // toolResult handler in agentSlice.ts already populates `result.error`.
-  const errorMessage = isError ? toolCall.result?.error ?? 'Tool call failed.' : null
-
-  return (
-    <>
-      <div
-        role="status"
-        aria-label={statusLabel}
-        className={styles.toolCallBadge}
-      >
-        <span className={iconClass} aria-hidden="true">
-          {isPending ? (
-            <LoaderIcon size={10} />
-          ) : isSuccess ? (
-            <CheckIcon size={10} />
-          ) : (
-            <CircleAlertSolidIcon size={10} />
-          )}
-        </span>
-        <span className={styles.toolCallType} aria-hidden="true">
-          {displayType}
-        </span>
-        <span aria-hidden="true">{label}</span>
-      </div>
-      {errorMessage && (
-        <p
-          role="alert"
-          // Tone-aligned with `.errorBanner` (red text on muted background)
-          // but inline + compact so a string of failed tool calls stays
-          // readable.
-          className={styles.toolCallError}
-        >
-          {errorMessage}
-        </p>
-      )}
-    </>
-  )
-}
-
-function formatToolCallType(actionType: string): string {
-  return actionType.replace(/^mcp__instatic__/, '')
-}
-
-/** Compact one-line summary of an applyCss payload: the selectors it touches. */
-function summarizeCss(css: string): string {
-  const selectors = css
-    .match(/[^{}]+(?=\{)/g)
-    ?.map((s) => s.trim().replace(/\s+/g, ' '))
-    .filter(Boolean) ?? []
-  if (selectors.length === 0) return 'css'
-  const head = selectors.slice(0, 2).join(', ')
-  return selectors.length > 2 ? `${head} +${selectors.length - 2}` : head
-}
-
-function formatActionLabel(actionType: string, params: unknown): string {
-  const p = params as Record<string, unknown>
-  switch (actionType) {
-    case 'insertHtml': return `→ ${String(p.parentId ?? '').slice(0, 8)}`
-    case 'getNodeHtml': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'replaceNodeHtml': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'deleteNode': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'updateNodeProps': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'moveNode': return `→ ${String(p.newParentId ?? '').slice(0, 6)}…`
-    case 'renameNode': return `"${String(p.label ?? '')}"`
-    case 'applyCss': return summarizeCss(String(p.css ?? ''))
-    case 'assignClass': return `${String(p.classId ?? '').slice(0, 6)}… → node`
-    case 'removeClass': return `${String(p.classId ?? '').slice(0, 6)}… from node`
-    case 'addPage': return `"${String(p.title ?? '')}"`
-    default: return ''
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/admin/pages/site/panels/AgentPanel/MessageGroup.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/MessageGroup.tsx
@@ -1,0 +1,119 @@
+import { renderMarkdownToHtml, type AgentMessage, type AgentToolCall } from '@site/agent'
+import { cn } from '@ui/cn'
+import { ToolCallRow } from './ToolCallRow'
+import styles from './AgentPanel.module.css'
+
+interface ConversationMessageGroup {
+  role: AgentMessage['role']
+  messages: AgentMessage[]
+}
+
+export function MessageGroups({ messages }: { messages: AgentMessage[] }) {
+  const groups = groupConversationMessages(messages)
+
+  return (
+    <>
+      {groups.map((group) => (
+        <MessageGroup key={group.messages[0]?.id ?? group.role} group={group} />
+      ))}
+    </>
+  )
+}
+
+function groupConversationMessages(messages: AgentMessage[]): ConversationMessageGroup[] {
+  const groups: ConversationMessageGroup[] = []
+  for (const message of messages) {
+    const previousGroup = groups.at(-1)
+    if (previousGroup && previousGroup.role === message.role) {
+      previousGroup.messages.push(message)
+      continue
+    }
+    groups.push({ role: message.role, messages: [message] })
+  }
+  return groups
+}
+
+function MessageGroup({ group }: { group: ConversationMessageGroup }) {
+  const isUser = group.role === 'user'
+  const items = flattenGroupBlocks(group.messages)
+
+  return (
+    <div className={cn(styles.messageEntry, isUser ? styles.messageEntryUser : styles.messageEntryAssistant)}>
+      <div className={styles.roleLabel}>
+        {isUser ? 'You' : 'Assistant'}
+      </div>
+
+      {items.map((item) =>
+        item.kind === 'text' ? (
+          <MarkdownTextBlock key={item.key} text={item.text} isUser={isUser} />
+        ) : (
+          <div key={item.key} className={styles.toolCallsContainer}>
+            {item.toolCalls.map((toolCall) => (
+              <ToolCallRow key={toolCall.id} toolCall={toolCall} />
+            ))}
+          </div>
+        ),
+      )}
+    </div>
+  )
+}
+
+type RenderItem =
+  | { kind: 'text'; key: string; text: string }
+  | { kind: 'tools'; key: string; toolCalls: AgentToolCall[] }
+
+// Coalesce runs of consecutive tool-call blocks into a single container so
+// stacked tools sit tight (flex gap), while text blocks stay separate items
+// that the message grid spaces apart. Runs span across messages of the same
+// role, since the agent emits multiple tool calls as separate messages.
+function flattenGroupBlocks(messages: AgentMessage[]): RenderItem[] {
+  const items: RenderItem[] = []
+  for (const message of messages) {
+    for (const block of message.blocks) {
+      if (block.kind === 'text') {
+        items.push({ kind: 'text', key: textBlockRenderKey(message.id, block.text), text: block.text })
+        continue
+      }
+      const last = items.at(-1)
+      if (last && last.kind === 'tools') {
+        last.toolCalls.push(block.toolCall)
+        continue
+      }
+      items.push({ kind: 'tools', key: `${message.id}-${block.toolCall.id}`, toolCalls: [block.toolCall] })
+    }
+  }
+  return items
+}
+
+function textBlockRenderKey(messageId: string, text: string): string {
+  let hash = 2166136261
+  for (let index = 0; index < text.length; index += 1) {
+    hash ^= text.charCodeAt(index)
+    hash = Math.imul(hash, 16777619)
+  }
+  return `${messageId}-text-${(hash >>> 0).toString(36)}`
+}
+
+interface MarkdownTextBlockProps {
+  text: string
+  isUser: boolean
+}
+
+function MarkdownTextBlock({
+  text,
+  isUser,
+}: MarkdownTextBlockProps) {
+  const html = renderMarkdownToHtml(text)
+  if (!html) return null
+  return (
+    <div
+      className={cn(
+        styles.textBlock,
+        isUser ? styles.textBlockUser : styles.textBlockAssistant,
+        styles.markdownText,
+      )}
+      // Safe: sanitised by DOMPurify (via sanitizeRichtext) before reaching here.
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  )
+}

--- a/src/admin/pages/site/panels/AgentPanel/ToolCallRow.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/ToolCallRow.tsx
@@ -1,0 +1,148 @@
+import type { AgentToolCall } from '@site/agent'
+import { LoaderIcon } from 'pixel-art-icons/icons/loader'
+import { CheckIcon } from 'pixel-art-icons/icons/check'
+import { CircleAlertSolidIcon } from 'pixel-art-icons/icons/circle-alert-solid'
+import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
+import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
+import { FileTextSolidIcon } from 'pixel-art-icons/icons/file-text-solid'
+import { FilePlusSolidIcon } from 'pixel-art-icons/icons/file-plus-solid'
+import { CodeIcon } from 'pixel-art-icons/icons/code'
+import { ColorsSwatchSolidIcon } from 'pixel-art-icons/icons/colors-swatch-solid'
+import { ContainerSolidIcon } from 'pixel-art-icons/icons/container-solid'
+import { DatabaseSolidIcon } from 'pixel-art-icons/icons/database-solid'
+import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
+import { UsersSolidIcon } from 'pixel-art-icons/icons/users-solid'
+import { PackageSolidIcon } from 'pixel-art-icons/icons/package-solid'
+import { MoveIcon } from 'pixel-art-icons/icons/move'
+import { Copy2SolidIcon } from 'pixel-art-icons/icons/copy-2-solid'
+import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
+import { EyeSolidIcon } from 'pixel-art-icons/icons/eye-solid'
+import { LayoutSolidIcon } from 'pixel-art-icons/icons/layout-solid'
+import { LinkIcon } from 'pixel-art-icons/icons/link'
+import { RulerDimensionSolidIcon } from 'pixel-art-icons/icons/ruler-dimension-solid'
+import { ZapSolidIcon } from 'pixel-art-icons/icons/zap-solid'
+import { cn } from '@ui/cn'
+import { getToolCallDisplay, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
+import styles from './AgentPanel.module.css'
+
+export function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
+  const isPending = toolCall.status === 'pending'
+  const isSuccess = toolCall.status === 'success'
+  const isError = toolCall.status === 'error'
+
+  const display = getToolCallDisplay(toolCall.actionType, toolCall.params)
+  const accessibleStatus = isPending ? 'Running' : isSuccess ? 'Completed' : 'Failed'
+  const detailLabel = display.detail ? ` - ${display.detail}` : ''
+  const statusLabel = `${accessibleStatus} ${display.title}${detailLabel}`
+  const iconToneClass = toolCallIconToneClass(display.tone)
+  const statusClass = isPending
+    ? styles.toolCallStatusPending
+    : isSuccess
+      ? styles.toolCallStatusSuccess
+      : styles.toolCallStatusFailed
+
+  // Surface the tool's error message directly in the row stream so the
+  // user sees why a tool failed without opening devtools.
+  const errorMessage = isError ? toolCall.result?.error ?? 'Tool call failed.' : null
+
+  return (
+    <>
+      <div
+        role="status"
+        aria-label={statusLabel}
+        className={cn(
+          styles.toolCallRow,
+          isPending ? styles.toolCallRowPending : null,
+          isError ? styles.toolCallRowFailed : null,
+        )}
+      >
+        <span className={cn(styles.toolCallIcon, iconToneClass)} aria-hidden="true">
+          <ToolCallLeadingIcon icon={display.icon} />
+        </span>
+        <span className={styles.toolCallCopy} aria-hidden="true">
+          <span className={styles.toolCallTitle}>{display.title}</span>
+          {display.detail && <span className={styles.toolCallDetail}>{display.detail}</span>}
+        </span>
+        <span className={cn(styles.toolCallStatus, statusClass)} aria-hidden="true">
+          {isPending ? (
+            <LoaderIcon size={11} />
+          ) : isSuccess ? (
+            <CheckIcon size={11} />
+          ) : (
+            <CircleAlertSolidIcon size={11} />
+          )}
+        </span>
+      </div>
+      {errorMessage && (
+        <p
+          role="alert"
+          className={styles.toolCallError}
+        >
+          {errorMessage}
+        </p>
+      )}
+    </>
+  )
+}
+
+function ToolCallLeadingIcon({ icon }: { icon: ToolCallIcon }) {
+  switch (icon) {
+    case 'add':
+      return <FilePlusSolidIcon size={16} />
+    case 'class':
+      return <LinkIcon size={16} />
+    case 'code':
+      return <CodeIcon size={16} />
+    case 'collection':
+      return <PackageSolidIcon size={16} />
+    case 'copy':
+      return <Copy2SolidIcon size={16} />
+    case 'data':
+      return <DatabaseSolidIcon size={16} />
+    case 'delete':
+      return <TrashSolidIcon size={16} />
+    case 'document':
+      return <FileTextSolidIcon size={16} />
+    case 'edit':
+      return <EditSolidIcon size={16} />
+    case 'media':
+      return <ImageSolidIcon size={16} />
+    case 'move':
+      return <MoveIcon size={16} />
+    case 'node':
+      return <ContainerSolidIcon size={16} />
+    case 'open':
+      return <OpenSolidIcon size={16} />
+    case 'page':
+      return <FileTextSolidIcon size={16} />
+    case 'preview':
+      return <EyeSolidIcon size={16} />
+    case 'runtime':
+      return <RulerDimensionSolidIcon size={16} />
+    case 'style':
+      return <ColorsSwatchSolidIcon size={16} />
+    case 'template':
+      return <LayoutSolidIcon size={16} />
+    case 'tokens':
+      return <ColorsSwatchSolidIcon size={16} />
+    case 'users':
+      return <UsersSolidIcon size={16} />
+    case 'tool':
+      return <ZapSolidIcon size={16} />
+  }
+}
+
+function toolCallIconToneClass(tone: ToolCallTone): string {
+  switch (tone) {
+    case 'danger':
+      return styles.toolCallIconDanger
+    case 'read':
+      return styles.toolCallIconRead
+    case 'style':
+      return styles.toolCallIconStyle
+    case 'write':
+      return styles.toolCallIconWrite
+    case 'neutral':
+      return styles.toolCallIconNeutral
+  }
+}

--- a/src/admin/pages/site/panels/AgentPanel/index.ts
+++ b/src/admin/pages/site/panels/AgentPanel/index.ts
@@ -1,1 +1,3 @@
 export { AgentPanel } from './AgentPanel'
+export { getToolCallDisplay } from './toolCallDisplay'
+export type { ToolCallDisplay, ToolCallIcon, ToolCallTone } from './toolCallDisplay'

--- a/src/admin/pages/site/panels/AgentPanel/toolCallDisplay.ts
+++ b/src/admin/pages/site/panels/AgentPanel/toolCallDisplay.ts
@@ -1,0 +1,320 @@
+export type ToolCallIcon =
+  | 'add'
+  | 'class'
+  | 'code'
+  | 'collection'
+  | 'copy'
+  | 'data'
+  | 'delete'
+  | 'document'
+  | 'edit'
+  | 'media'
+  | 'move'
+  | 'node'
+  | 'open'
+  | 'page'
+  | 'preview'
+  | 'runtime'
+  | 'style'
+  | 'template'
+  | 'tokens'
+  | 'tool'
+  | 'users'
+
+export type ToolCallTone = 'danger' | 'neutral' | 'read' | 'style' | 'write'
+
+export interface ToolCallDisplay {
+  title: string
+  detail: string
+  icon: ToolCallIcon
+  tone: ToolCallTone
+}
+
+export function getToolCallDisplay(actionType: string, params: unknown): ToolCallDisplay {
+  const toolName = normalizeToolName(actionType)
+  const p = asRecord(params)
+
+  switch (toolName) {
+    case 'list_documents':
+      return display('Listing documents', contentScopeDetail(p), 'document', 'read')
+    case 'list_modules':
+      return display('Listing modules', optionalString(p.query), 'collection', 'read')
+    case 'list_tokens':
+      return display('Listing tokens', tokenFilterDetail(p), 'tokens', 'read')
+    case 'list_post_types':
+      return display('Listing post types', '', 'data', 'read')
+    case 'list_loop_sources':
+      return display('Listing loop sources', '', 'data', 'read')
+    case 'list_breakpoints':
+      return display('Listing breakpoints', '', 'preview', 'read')
+
+    case 'insertHtml':
+      return display('Inserting HTML', targetDetail('inside', p.parentId), 'code', 'write')
+    case 'getNodeHtml':
+      return display('Reading node HTML', nodeDetail(p.nodeId), 'node', 'read')
+    case 'read_document':
+      return display('Reading document', documentDetail(p.document), 'document', 'read')
+    case 'open_document':
+      return display('Opening document', documentDetail(p.document), 'open', 'read')
+    case 'replaceNodeHtml':
+      return display('Replacing node HTML', nodeDetail(p.nodeId), 'code', 'write')
+    case 'deleteNode':
+      return display('Deleting node', nodeDetail(p.nodeId), 'delete', 'danger')
+    case 'updateNodeProps':
+      return display('Updating node props', nodeBreakpointDetail(p.nodeId, p.breakpointId), 'edit', 'write')
+    case 'moveNode':
+      return display('Moving node', targetDetail('to', p.newParentId), 'move', 'write')
+    case 'renameNode':
+      return display('Renaming node', optionalString(p.label), 'edit', 'write')
+    case 'duplicateNode':
+      return display('Duplicating node', duplicateNodeDetail(p.nodeId, p.count), 'copy', 'write')
+
+    case 'applyCss':
+      return display('Updating CSS', summarizeCss(optionalString(p.css)), 'style', 'style')
+    case 'assignClass':
+      return display('Assigning class', classDetail(p.classId, p.nodeId), 'class', 'style')
+    case 'removeClass':
+      return display('Removing class', classDetail(p.classId, p.nodeId), 'class', 'danger')
+
+    case 'list_code_assets':
+      return display('Listing code assets', titleCase(optionalString(p.type)), 'code', 'read')
+    case 'read_code_asset':
+      return display('Reading code asset', codeAssetDetail(p), 'code', 'read')
+    case 'write_code_asset':
+      return display('Writing code asset', codeAssetDetail(p), 'code', 'write')
+    case 'patch_code_asset':
+      return display('Patching code asset', codeAssetDetail(p), 'code', 'write')
+    case 'inspect_code_runtime':
+      return display('Inspecting code runtime', documentDetail(p.document), 'runtime', 'read')
+
+    case 'addPage':
+      return display('Adding page', optionalString(p.title), 'add', 'write')
+    case 'deletePage':
+      return display('Deleting page', pageDetail(p.pageId), 'delete', 'danger')
+    case 'renamePage':
+      return display('Renaming page', pageTitleDetail(p), 'page', 'write')
+    case 'duplicatePage':
+      return display('Duplicating page', pageTitleDetail(p), 'copy', 'write')
+    case 'setPageTemplate':
+      return display('Setting page template', templateTargetDetail(p), 'template', 'write')
+    case 'clearPageTemplate':
+      return display('Clearing page template', pageDetail(p.pageId), 'template', 'danger')
+
+    case 'set_color_tokens':
+      return display('Updating color tokens', tokenCountDetail(p.tokens), 'tokens', 'style')
+    case 'set_font_tokens':
+      return display('Updating font tokens', tokenCountDetail(p.tokens), 'tokens', 'style')
+    case 'set_type_scale':
+      return display('Updating type scale', scaleDetail(p.groupId, p.namingConvention), 'tokens', 'style')
+    case 'set_spacing_scale':
+      return display('Updating spacing scale', scaleDetail(p.groupId, p.namingConvention), 'tokens', 'style')
+    case 'render_snapshot':
+      return display('Capturing preview', previewDetail(p), 'preview', 'read')
+
+    case 'list_collections':
+      return display('Listing collections', '', 'collection', 'read')
+    case 'get_collection_schema':
+      return display('Reading collection schema', collectionDetail(p), 'collection', 'read')
+    case 'get_document':
+      return display('Reading document', contentDocumentDetail(p), 'document', 'read')
+    case 'search_documents':
+      return display('Searching documents', optionalString(p.query), 'document', 'read')
+    case 'list_users':
+      return display('Listing users', '', 'users', 'read')
+    case 'list_media':
+      return display('Listing media', optionalString(p.query), 'media', 'read')
+    case 'create_document':
+      return display('Creating document', contentDocumentDetail(p), 'add', 'write')
+    case 'delete_document':
+      return display('Deleting document', contentDocumentDetail(p), 'delete', 'danger')
+    case 'set_document_status':
+      return display('Setting document status', titleCase(optionalString(p.status)), 'edit', 'write')
+    case 'set_document_field':
+      return display('Updating document field', optionalString(p.field), 'edit', 'write')
+    case 'set_document_fields':
+      return display('Updating document fields', fieldCountDetail(p.fields), 'edit', 'write')
+    case 'set_document_author':
+      return display('Setting document author', optionalString(p.authorId ?? p.userId), 'users', 'write')
+    case 'set_active_document':
+      return display('Opening document', contentDocumentDetail(p), 'open', 'read')
+    case 'set_active_collection':
+      return display('Opening collection', collectionDetail(p), 'open', 'read')
+
+    default:
+      return display(`Running ${humanizeToolName(toolName)}`, '', 'tool', 'neutral')
+  }
+}
+
+function display(title: string, detail: string, icon: ToolCallIcon, tone: ToolCallTone): ToolCallDisplay {
+  return { title, detail, icon, tone }
+}
+
+function normalizeToolName(actionType: string): string {
+  return actionType.replace(/^mcp__instatic__/, '')
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function optionalString(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : ''
+}
+
+function shortId(value: unknown): string {
+  const text = optionalString(value)
+  return text.length > 12 ? `${text.slice(0, 12)}...` : text
+}
+
+function nodeDetail(nodeId: unknown): string {
+  const id = shortId(nodeId)
+  return id ? `node ${id}` : ''
+}
+
+function pageDetail(pageId: unknown): string {
+  const id = shortId(pageId)
+  return id ? `page ${id}` : ''
+}
+
+function targetDetail(prefix: string, idValue: unknown): string {
+  const id = shortId(idValue)
+  return id ? `${prefix} ${id}` : ''
+}
+
+function nodeBreakpointDetail(nodeId: unknown, breakpointId: unknown): string {
+  const node = nodeDetail(nodeId)
+  const breakpoint = optionalString(breakpointId)
+  if (!node) return breakpoint
+  return breakpoint ? `${node} at ${breakpoint}` : node
+}
+
+function duplicateNodeDetail(nodeId: unknown, count: unknown): string {
+  const node = nodeDetail(nodeId)
+  const copies = typeof count === 'number' && count > 1 ? `${count} copies` : ''
+  if (!node) return copies
+  return copies ? `${node}, ${copies}` : node
+}
+
+function classDetail(classId: unknown, nodeId: unknown): string {
+  const className = optionalString(classId)
+  const node = nodeDetail(nodeId)
+  if (!className) return node
+  return node ? `${className} on ${node}` : className
+}
+
+function documentDetail(value: unknown): string {
+  const document = asRecord(value)
+  const type = documentKind(optionalString(document.type))
+  const id = shortId(document.id)
+  if (!type) return id
+  return id ? `${type} ${id}` : type
+}
+
+function documentKind(type: string): string {
+  switch (type) {
+    case 'page':
+      return 'Page'
+    case 'template':
+      return 'Template'
+    case 'visualComponent':
+      return 'Visual component'
+    default:
+      return titleCase(type)
+  }
+}
+
+function codeAssetDetail(params: Record<string, unknown>): string {
+  return optionalString(params.path) || shortId(params.fileId)
+}
+
+function pageTitleDetail(params: Record<string, unknown>): string {
+  return optionalString(params.title) || pageDetail(params.pageId)
+}
+
+function templateTargetDetail(params: Record<string, unknown>): string {
+  const target = asRecord(params.target)
+  const kind = optionalString(target.kind)
+  const targetLabel = kind ? titleCase(kind) : ''
+  const page = pageDetail(params.pageId)
+  if (!page) return targetLabel
+  return targetLabel ? `${page} - ${targetLabel}` : page
+}
+
+function tokenFilterDetail(params: Record<string, unknown>): string {
+  return optionalString(params.family) || optionalString(params.category)
+}
+
+function tokenCountDetail(value: unknown): string {
+  return countDetail(value, 'token', 'tokens')
+}
+
+function fieldCountDetail(value: unknown): string {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const count = Object.keys(value).length
+    return count === 1 ? '1 field' : `${count} fields`
+  }
+  return countDetail(value, 'field', 'fields')
+}
+
+function countDetail(value: unknown, singular: string, plural: string): string {
+  if (!Array.isArray(value)) return ''
+  return value.length === 1 ? `1 ${singular}` : `${value.length} ${plural}`
+}
+
+function scaleDetail(groupId: unknown, namingConvention: unknown): string {
+  return optionalString(groupId) || optionalString(namingConvention)
+}
+
+function previewDetail(params: Record<string, unknown>): string {
+  const node = nodeDetail(params.nodeId)
+  const breakpoint = optionalString(params.breakpointId)
+  if (!node) return breakpoint
+  return breakpoint ? `${node} at ${breakpoint}` : node
+}
+
+function contentScopeDetail(params: Record<string, unknown>): string {
+  return collectionDetail(params) || optionalString(params.status)
+}
+
+function collectionDetail(params: Record<string, unknown>): string {
+  return optionalString(params.tableId)
+    || optionalString(params.tableSlug)
+}
+
+function contentDocumentDetail(params: Record<string, unknown>): string {
+  return optionalString(params.title)
+    || shortId(params.documentId)
+    || shortId(params.rowId)
+    || collectionDetail(params)
+}
+
+function summarizeCss(css: string): string {
+  if (!css) return ''
+  const selectors = css
+    .match(/[^{}]+(?=\{)/g)
+    ?.map((selector) => selector.trim().replace(/\s+/g, ' '))
+    .filter(Boolean) ?? []
+  if (selectors.length === 0) return 'CSS changes'
+  const head = selectors.slice(0, 2).join(', ')
+  return selectors.length > 2 ? `${head} +${selectors.length - 2}` : head
+}
+
+function humanizeToolName(toolName: string): string {
+  return toolName
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+function titleCase(value: string): string {
+  if (!value) return ''
+  return value
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}


### PR DESCRIPTION
## What changed

Adds a compact, readable presentation of the agent's tool calls in the Agent panel.

- **`toolCallDisplay.ts`** — maps each tool `actionType` + params to a human-readable `{ title, detail, icon, tone }` (e.g. `set_color_tokens` → "Updating color tokens" · "6 tokens", style-toned swatch icon).
- **`ToolCallRow.tsx`** — renders one tool call as a single-line row: leading tone-coloured icon, **bold white title**, middle-dot separator, muted detail value, and a trailing status glyph (pending / success / failed). Failed calls surface their error message inline.
- **`MessageGroup.tsx`** — coalesces runs of consecutive tool-call blocks into a single container so a sequence of tools reads as one tight, grouped block, while text blocks stay spaced apart.
- **Styling** (`AgentPanel.module.css`) — tight 2px gap between stacked tool rows, generous icon→label spacing, one-line title·value layout, all from existing design tokens (no hex, no `var()` fallbacks).
- Tests + `docs/features/agent.md` updated to match.

## Why

The previous stream showed raw/verbose tool activity. This makes agent actions scannable — you can see at a glance what the agent did, grouped and status-tagged, without opening devtools.

## Impact

- User-facing: clearer agent activity feed in the site editor's Agent panel.
- No API/schema/DB changes. Row `role="status"` + aria-labels preserved for screen readers.

## Verification

- `tsc -b` — clean (exit 0)
- `bun test src/__tests__/panels/agentPanel.test.tsx src/__tests__/panels/agentToolCallDisplay.test.ts` — 11 pass, 0 fail
- `eslint` on touched files — clean
- Manual: verified live via dev server HMR in the editor Agent panel

## Notes

- Branch is currently behind `main`; happy to rebase before review.
- react-doctor flags a few pre-existing warning-tier items in the AgentPanel files (`no-danger` on the DOMPurify-sanitized markdown block, `prefer-tag-over-role` on the intentional `role="status"`); none introduced by this change and none are error-tier gates.
