### PR TITLE
feat(agent): interactive AI assistant panel — tool-call rows, swatches, previews, titles

### DIFF
--- a/server/ai/conversations/store.ts
+++ b/server/ai/conversations/store.ts
@@ -243,10 +243,26 @@ export async function listMessagesForConversation(
 // Writes
 // ---------------------------------------------------------------------------
 
+/** Placeholder title for a freshly-created conversation, before the first
+ * prompt lands and gives it a real name. */
+export const DEFAULT_CONVERSATION_TITLE = 'New conversation'
+
 /**
- * Create a new conversation row. `title` defaults to "New conversation" —
- * the runner can rename it after the first user message lands (or the UI
- * can offer "Rename this chat").
+ * Derive a short conversation title from the first user prompt: collapse
+ * whitespace to a single line, trim, and cap the length. Returns '' for an
+ * empty prompt (caller keeps the placeholder in that case).
+ */
+export function deriveConversationTitle(prompt: string): string {
+  const oneLine = prompt.replace(/\s+/g, ' ').trim()
+  if (!oneLine) return ''
+  const MAX = 60
+  return oneLine.length > MAX ? `${oneLine.slice(0, MAX).trimEnd()}…` : oneLine
+}
+
+/**
+ * Create a new conversation row. `title` defaults to
+ * `DEFAULT_CONVERSATION_TITLE`; the chat handler renames it from the first
+ * user prompt (see `deriveConversationTitle`).
  */
 export async function createConversationForUser(
   db: DbClient,
@@ -254,7 +270,7 @@ export async function createConversationForUser(
   input: CreateConversationInput,
 ): Promise<ConversationRecord> {
   const id = nanoid()
-  const title = (input.title ?? '').trim() || 'New conversation'
+  const title = (input.title ?? '').trim() || DEFAULT_CONVERSATION_TITLE
   const { rows } = await db<ConversationRow>`
     insert into ai_conversations (
       id, user_id, scope, title, credential_id, model_id

--- a/server/ai/handlers/chat.ts
+++ b/server/ai/handlers/chat.ts
@@ -28,6 +28,9 @@ import {
   appendMessage,
   listMessagesForConversation,
   readConversationForUser,
+  updateConversationForUser,
+  deriveConversationTitle,
+  DEFAULT_CONVERSATION_TITLE,
 } from '../conversations/store'
 import { buildMessageHistory } from '../conversations/history'
 import {
@@ -150,6 +153,17 @@ async function handleAiChat(
     role: 'user',
     content: [{ kind: 'text', text: prompt }],
   })
+
+  // The first prompt names the conversation: replace the placeholder title
+  // with an excerpt of what the user asked for. Only fires while the title is
+  // still the default, so a user-renamed chat is never overwritten.
+  if (conversation.title === DEFAULT_CONVERSATION_TITLE) {
+    const derivedTitle = deriveConversationTitle(prompt)
+    if (derivedTitle) {
+      await updateConversationForUser(db, user.id, conversation.id, { title: derivedTitle })
+        .catch((err) => { console.error('[ai/chat] auto-title failed:', err) })
+    }
+  }
 
   const existingMessages = await listMessagesForConversation(db, conversation.id)
   const messages = buildMessageHistory(existingMessages)

--- a/src/admin/pages/site/agent/agentSlice.ts
+++ b/src/admin/pages/site/agent/agentSlice.ts
@@ -18,6 +18,7 @@
 import { nanoid } from 'nanoid'
 import type { EditorStoreSliceCreator } from '@site/store/types'
 import { ApiError } from '@core/http'
+import { pushToast } from '@ui/components/Toast'
 import {
   listConversations,
   getConversation,
@@ -282,6 +283,12 @@ export function createAgentSlice(
         set({ agentConversations: conversations })
       } catch (err) {
         console.error('[AgentSlice] Failed to load conversations:', err)
+        pushToast({
+          kind: 'error',
+          title: "Couldn't load conversations",
+          body: getErrorMessage(err, 'Failed to load your conversations.'),
+          location: 'site-editor',
+        })
       }
     },
 
@@ -324,6 +331,12 @@ export function createAgentSlice(
         if (wasActive) void get().loadScopeDefault()
       } catch (err) {
         console.error('[AgentSlice] Failed to delete conversation:', err)
+        pushToast({
+          kind: 'error',
+          title: "Couldn't delete conversation",
+          body: getErrorMessage(err, 'Failed to delete the conversation.'),
+          location: 'site-editor',
+        })
       }
     },
 

--- a/src/admin/pages/site/agent/agentSlice.ts
+++ b/src/admin/pages/site/agent/agentSlice.ts
@@ -268,9 +268,12 @@ export function createAgentSlice(
     },
 
     startNewAgentConversation() {
-      // Same reset as clearAgentMessages — kept as a distinct action only for
-      // intent clarity (the UI's "+ New chat" button calls this).
+      // Reset to a fresh conversation, then re-apply the scope default so the
+      // composer stays ready (provider + model picked) instead of dropping to
+      // the "choose a model" lock. `loadScopeDefault` only fills the gap when
+      // nothing is chosen — exactly the post-reset state.
       get().clearAgentMessages()
+      void get().loadScopeDefault()
     },
 
     async loadAgentConversations() {
@@ -306,6 +309,7 @@ export function createAgentSlice(
     async deleteAgentConversation(id: string) {
       try {
         await deleteConversation(id)
+        const wasActive = get().agentConversationId === id
         set((state) => {
           state.agentConversations = state.agentConversations.filter((c) => c.id !== id)
           // Deleting the active conversation resets it through the same key-set
@@ -315,6 +319,9 @@ export function createAgentSlice(
             Object.assign(state, conversationResetState())
           }
         })
+        // If the active chat was the one deleted, re-apply the scope default so
+        // the panel stays ready instead of dropping to the "choose a model" lock.
+        if (wasActive) void get().loadScopeDefault()
       } catch (err) {
         console.error('[AgentSlice] Failed to delete conversation:', err)
       }
@@ -349,11 +356,18 @@ export function createAgentSlice(
       // conversation's provider or an explicit user pick.
       if (get().agentConversationId) return
       if (get().agentActiveCredentialId && get().agentActiveModelId) return
-      const creds = await resolveScopeCredentials(get, config)
+      let creds: ResolvedCredentials | null
+      try {
+        creds = await resolveScopeCredentials(get, config)
+      } catch (err) {
+        // A failed defaults lookup is soft: leave the picker empty so the user
+        // can pick a model. The send-time path still surfaces the actionable
+        // no-provider error if they send without choosing.
+        console.error('[AgentSlice] Failed to load scope default:', err)
+        return
+      }
       // No default configured for this scope: leave the picker empty (shows
-      // its "Choose a model" placeholder) and let the user pick one. The
-      // send-time path still surfaces the actionable no-provider error if they
-      // send without choosing.
+      // its "Choose a model" placeholder) and let the user pick one.
       if (!creds) return
       set({
         agentActiveCredentialId: creds.credentialId,

--- a/src/admin/pages/site/agent/streamEvents.ts
+++ b/src/admin/pages/site/agent/streamEvents.ts
@@ -131,6 +131,26 @@ export async function processStreamEvent(
         console.error(`[AgentSlice] tool ${event.toolName} threw unexpectedly:`, err)
         result = aiToolError(`Browser exception: ${message}`)
       }
+      // A browser tool may return a preview image (the render_snapshot PNG).
+      // Stash it on the matching pending tool-call block so the panel can show
+      // what the agent looked at. The `toolCall` event for this call already
+      // created the block, and tool calls are sequential, so exactly one block
+      // for this tool is pending. Session-only — the image is never posted or
+      // persisted, so it rehydrates empty after a reload.
+      const previewImage = result.ok ? result.images?.[0] : undefined
+      if (previewImage) {
+        const dataUrl = `data:${previewImage.mimeType};base64,${previewImage.data}`
+        set((state) => {
+          const msg = state.agentMessages.find((m) => m.id === assistantId)
+          const block = msg?.blocks.find(
+            (b): b is { kind: 'toolCall'; toolCall: AgentToolCall } =>
+              b.kind === 'toolCall'
+              && b.toolCall.actionType === event.toolName
+              && b.toolCall.status === 'pending',
+          )
+          if (block) block.toolCall.screenshotDataUrl = dataUrl
+        })
+      }
       if (!bridge.bridgeId) {
         console.error('[AgentSlice] toolRequest received before bridgeReady')
         break

--- a/src/admin/pages/site/agent/types.ts
+++ b/src/admin/pages/site/agent/types.ts
@@ -153,6 +153,12 @@ export interface AgentToolCall {
   params: Record<string, unknown>
   result: AiToolOutput | null
   status: 'pending' | 'success' | 'error'
+  /**
+   * Session-only preview image captured by a browser tool (e.g. the
+   * `render_snapshot` PNG). Held in memory so the panel can show what the
+   * agent looked at; never persisted — it rehydrates empty after a reload.
+   */
+  screenshotDataUrl?: string
 }
 
 /**

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -318,7 +318,7 @@
 .toolCallTitle {
   flex: 0 0 auto;
   color: var(--text-bright);
-  font-size: var(--text-2xs);
+  font-size: var(--text-m);
   font-weight: 600;
   line-height: 1.3;
 }
@@ -328,7 +328,7 @@
   min-width: 0;
   overflow: hidden;
   color: var(--text-muted);
-  font-size: var(--text-2xs);
+  font-size: var(--text-m);
   line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -359,15 +359,14 @@
    Indented to line up under the row's title. */
 .toolCallSwatches {
   display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-2xs);
-  padding: var(--space-4xs) 0 var(--space-4xs) var(--space-l);
+  gap: var(--space-px);
 }
 
 .toolCallSwatch {
-  width: 18px;
-  height: 18px;
-  border-radius: 50%;
+  flex: 1 1 0;
+  min-width: 0;
+  height: 28px;
+  border-radius: var(--input-radius);
   background-color: var(--bg-surface);
   background-image: linear-gradient(var(--swatch), var(--swatch));
   box-shadow: inset 0 0 0 1px var(--overlay-10);

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -139,9 +139,32 @@
 }
 
 .roleLabel {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2xs);
   font-size: var(--text-3xs);
-  color: var(--text-disabled);
   letter-spacing: 0.05em;
+}
+
+.roleName {
+  color: var(--text-subtle);
+}
+
+.roleTime {
+  color: var(--text-disabled);
+}
+
+/* Agent avatar — the robot glyph in a circle, mirroring the user's Gravatar. */
+.roleAvatarAi {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--overlay-10);
+  color: var(--text-muted);
 }
 
 /* Plain full-width text — no card, no border. Both roles align left; the

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -352,6 +352,26 @@
 .toolCallStatusSuccess { color: var(--success-bright); }
 .toolCallStatusFailed { color: var(--danger-light); }
 
+/* Colour-token preview — swatches under a set_color_tokens row. Each is
+   composited over a neutral base with a hairline ring (like the Framework
+   palette) so dark, white, and translucent tokens all read against the panel.
+   Indented to line up under the row's title. */
+.toolCallSwatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2xs);
+  padding: var(--space-4xs) 0 var(--space-4xs) var(--space-l);
+}
+
+.toolCallSwatch {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: var(--bg-surface);
+  background-image: linear-gradient(var(--swatch), var(--swatch));
+  box-shadow: inset 0 0 0 1px var(--overlay-10);
+}
+
 /* Inline error message rendered under a failed tool badge. Lets the user
    see WHY the tool failed without expanding anything — same width as the
    badge container, danger-toned text, one-line ellipsis when long. */

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -372,6 +372,21 @@
   box-shadow: inset 0 0 0 1px var(--overlay-10);
 }
 
+/* Preview screenshot a browser tool captured (render_snapshot). Full panel
+   width, anchored to the top so tall page captures still read, capped so a
+   long page doesn't dominate the thread. Session-only. */
+.toolCallScreenshot {
+  display: block;
+  width: 100%;
+  max-height: 280px;
+  object-fit: contain;
+  object-position: top;
+  margin: var(--space-4xs) 0;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface);
+  box-shadow: inset 0 0 0 1px var(--overlay-10);
+}
+
 /* Inline error message rendered under a failed tool badge. Lets the user
    see WHY the tool failed without expanding anything — same width as the
    badge container, danger-toned text, one-line ellipsis when long. */

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -383,12 +383,13 @@
 .toolCallSwatches {
   display: flex;
   gap: var(--space-px);
+  padding: var(--space-xs) 0;
 }
 
 .toolCallSwatch {
   flex: 1 1 0;
   min-width: 0;
-  height: 12px;
+  height: 24px;
   border-radius: var(--input-radius);
   background-color: var(--bg-surface);
   background-image: linear-gradient(var(--swatch), var(--swatch));

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -365,7 +365,7 @@
 .toolCallSwatch {
   flex: 1 1 0;
   min-width: 0;
-  height: 28px;
+  height: 12px;
   border-radius: var(--input-radius);
   background-color: var(--bg-surface);
   background-image: linear-gradient(var(--swatch), var(--swatch));

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -129,19 +129,13 @@
   flex: 0 1 auto;
 }
 
-/* ── MessageBubble ───────────────────────────────────────────────────────── */
-.messageBubble {
+/* ── Message turn — role label + full-width text, no bubble ───────────────── */
+.messageTurn {
   display: flex;
   flex-direction: column;
+  align-items: stretch;
   gap: var(--space-3xs);
-}
-
-.messageBubbleUser {
-  align-items: flex-end;
-}
-
-.messageBubbleAssistant {
-  align-items: flex-start;
+  width: 100%;
 }
 
 .roleLabel {
@@ -150,103 +144,103 @@
   letter-spacing: 0.05em;
 }
 
-.contentBubble {
-  max-width: 90%;
-  padding: var(--space-s) var(--space-m);
-  color: var(--text);
+/* Plain full-width text — no card, no border. Both roles align left; the
+   assistant reads bright, the user's prompt reads muted. */
+.messageText {
+  width: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
   font-size: var(--text-s);
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
-  border: 1px solid var(--overlay-10);
 }
 
-.contentBubbleUser {
-  border-radius: 10px 10px 2px 10px;
-  background: var(--overlay-10);
+.messageTextUser {
+  color: var(--text-muted);
 }
 
-.contentBubbleAssistant {
-  border-radius: 2px 10px 10px 10px;
-  background: var(--overlay-5);
+.messageTextAssistant {
+  color: var(--text-bright);
 }
 
-/* ── Markdown bubble typography ─────────────────────────────────────────────
- * Applied alongside .contentBubble when the text is parsed as markdown.
+/* ── Markdown text typography ───────────────────────────────────────────────
+ * Applied alongside .messageText when the text is parsed as markdown.
  * Resets `white-space: pre-wrap` (marked emits proper block elements with
  * their own whitespace handling — we only want pre-wrap inside <pre>) and
  * adds the typography rules for the small subset of HTML we accept. */
-.markdownBubble {
+.markdownText {
   white-space: normal;
 }
 
-.markdownBubble > :first-child {
+.markdownText > :first-child {
   margin-top: 0;
 }
 
-.markdownBubble > :last-child {
+.markdownText > :last-child {
   margin-bottom: 0;
 }
 
-.markdownBubble p {
+.markdownText p {
   margin: 0 0 var(--space-s);
 }
 
-.markdownBubble h1,
-.markdownBubble h2,
-.markdownBubble h3,
-.markdownBubble h4,
-.markdownBubble h5,
-.markdownBubble h6 {
+.markdownText h1,
+.markdownText h2,
+.markdownText h3,
+.markdownText h4,
+.markdownText h5,
+.markdownText h6 {
   margin: var(--space-l) 0 var(--space-xs);
   color: var(--text-bright);
   font-weight: 600;
   line-height: 1.3;
 }
 
-.markdownBubble h1 { font-size: var(--text-xl); }
-.markdownBubble h2 { font-size: var(--text-xl); }
-.markdownBubble h3 { font-size: var(--text-l); }
-.markdownBubble h4,
-.markdownBubble h5,
-.markdownBubble h6 { font-size: var(--text-m); }
+.markdownText h1 { font-size: var(--text-xl); }
+.markdownText h2 { font-size: var(--text-xl); }
+.markdownText h3 { font-size: var(--text-l); }
+.markdownText h4,
+.markdownText h5,
+.markdownText h6 { font-size: var(--text-m); }
 
-.markdownBubble strong,
-.markdownBubble b {
+.markdownText strong,
+.markdownText b {
   font-weight: 600;
   color: var(--text-bright);
 }
 
-.markdownBubble em,
-.markdownBubble i {
+.markdownText em,
+.markdownText i {
   font-style: italic;
 }
 
-.markdownBubble ul,
-.markdownBubble ol {
+.markdownText ul,
+.markdownText ol {
   margin: 0 0 var(--space-s);
   padding-left: var(--space-3xl);
 }
 
-.markdownBubble li {
+.markdownText li {
   margin-bottom: var(--space-4xs);
 }
 
-.markdownBubble li > p {
+.markdownText li > p {
   margin: 0;
 }
 
-.markdownBubble a {
+.markdownText a {
   color: var(--text-bright);
   text-decoration: underline;
   text-underline-offset: 2px;
 }
 
-.markdownBubble a:hover {
+.markdownText a:hover {
   color: var(--overlay);
 }
 
-.markdownBubble code {
+.markdownText code {
   padding: var(--space-px) var(--space-2xs);
   border-radius: var(--radius-sm);
   background: var(--bg-surface-3);
@@ -255,7 +249,7 @@
   font-size: var(--text-xs);
 }
 
-.markdownBubble pre {
+.markdownText pre {
   margin: 0 0 var(--space-s);
   padding: var(--space-s) var(--space-m);
   border-radius: var(--radius-sm);
@@ -264,13 +258,13 @@
   white-space: pre;
 }
 
-.markdownBubble pre code {
+.markdownText pre code {
   padding: 0;
   background: transparent;
   font-size: var(--text-xs);
 }
 
-.markdownBubble blockquote {
+.markdownText blockquote {
   margin: 0 0 var(--space-s);
   padding: var(--space-4xs) 0 var(--space-4xs) var(--space-m);
   border-left: 2px solid var(--overlay-10);

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -280,21 +280,26 @@
 .toolCallsContainer {
   display: flex;
   flex-direction: column;
-  gap: var(--space-4xs);
-  width: 90%;
+  gap: var(--space-px);
+  width: 100%;
 }
 
-/* ── ToolCallBadge ───────────────────────────────────────────────────────── */
-.toolCallBadge {
+/* ── ToolCallRow ─────────────────────────────────────────────────────────── */
+.toolCallRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-s);
+  min-width: 0;
+  padding: var(--space-4xs) var(--space-s);
+  border-radius: var(--radius-sm);
+  background: var(--overlay-5);
+}
+
+.toolCallIcon {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-2xs);
-  padding: var(--space-4xs) var(--space-s);
-  border-radius: 20px;
-  background: var(--overlay-5);
-  border: 1px solid var(--overlay-10);
-  font-size: var(--text-2xs);
-  color: var(--text-muted);
+  justify-content: center;
+  flex: 0 0 auto;
 }
 
 .toolCallIconPending {
@@ -309,10 +314,39 @@
   color: var(--danger-light);
 }
 
-.toolCallType {
+.toolCallCopy {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.toolCallTitle {
+  flex: 0 0 auto;
+  color: var(--text-bright);
   font-family: var(--font-mono);
-  font-size: var(--text-3xs);
-  opacity: 0.70;
+  font-size: var(--text-2xs);
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.toolCallDetail {
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  line-height: 1.3;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Middle-dot separator, only present when the detail span renders. */
+.toolCallDetail::before {
+  content: '·';
+  margin: 0 var(--space-2xs);
+  color: var(--text-disabled);
 }
 
 /* Inline error message rendered under a failed tool badge. Lets the user

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -134,7 +134,7 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: var(--space-3xs);
+  gap: var(--space-m);
   width: 100%;
 }
 
@@ -151,7 +151,8 @@
   padding: 0;
   border: 0;
   background: transparent;
-  font-size: var(--text-s);
+  font-size: var(--text-m);
+  font-weight: 500;
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
@@ -162,7 +163,7 @@
 }
 
 .messageTextAssistant {
-  color: var(--text-bright);
+  color: var(--text-muted);
 }
 
 /* ── Markdown text typography ───────────────────────────────────────────────
@@ -285,9 +286,9 @@
   align-items: center;
   column-gap: var(--space-s);
   min-width: 0;
-  padding: var(--space-4xs) var(--space-s);
-  border-radius: var(--radius-sm);
-  background: var(--overlay-5);
+  padding: var(--space-xs);
+  border-radius: 12px;
+  background: var(--overlay-10);
 }
 
 .toolCallIcon {

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -284,11 +284,12 @@
   width: 100%;
 }
 
-/* ── ToolCallRow ─────────────────────────────────────────────────────────── */
+/* ── ToolCallRow — [category icon] [title · detail] [status] ─────────────── */
 .toolCallRow {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
   align-items: center;
-  gap: var(--space-s);
+  column-gap: var(--space-s);
   min-width: 0;
   padding: var(--space-4xs) var(--space-s);
   border-radius: var(--radius-sm);
@@ -300,19 +301,16 @@
   align-items: center;
   justify-content: center;
   flex: 0 0 auto;
+  color: var(--text-muted);
 }
 
-.toolCallIconPending {
-  color: var(--text-disabled);
-}
-
-.toolCallIconSuccess {
-  color: var(--success-bright);
-}
-
-.toolCallIconFailed {
-  color: var(--danger-light);
-}
+/* Category tone — amber for style/tokens, green for writes, red for
+   destructive; reads/unknowns stay achromatic. */
+.toolCallIconDanger { color: var(--danger-light); }
+.toolCallIconRead { color: var(--text-muted); }
+.toolCallIconStyle { color: var(--warning); }
+.toolCallIconWrite { color: var(--success); }
+.toolCallIconNeutral { color: var(--text-subtle); }
 
 .toolCallCopy {
   display: flex;
@@ -325,9 +323,8 @@
 .toolCallTitle {
   flex: 0 0 auto;
   color: var(--text-bright);
-  font-family: var(--font-mono);
   font-size: var(--text-2xs);
-  font-weight: 700;
+  font-weight: 600;
   line-height: 1.3;
 }
 
@@ -348,6 +345,18 @@
   margin: 0 var(--space-2xs);
   color: var(--text-disabled);
 }
+
+.toolCallStatus {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: 0 0 auto;
+  color: var(--text-disabled);
+}
+
+.toolCallStatusPending { color: var(--text-disabled); }
+.toolCallStatusSuccess { color: var(--success-bright); }
+.toolCallStatusFailed { color: var(--danger-light); }
 
 /* Inline error message rendered under a failed tool badge. Lets the user
    see WHY the tool failed without expanding anything — same width as the

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -21,52 +21,30 @@
  * @see Guideline #410 — 3 Self-Contained Independent Panels
  */
 
-import { useRef, useEffect, memo, type CSSProperties } from 'react'
+import { useRef, useEffect, memo } from 'react'
 import { useAgentStore } from '@admin/ai/useAgentStore'
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { useAdminNavigate } from '@admin/lib/useAdminNavigate'
 import { useAuthenticatedAdminUser } from '@admin/sessionContext'
 import { listCredentials, listModels } from '@admin/ai/api'
 import { renderMarkdownToHtml, type AgentMessage, type AgentToolCall } from '@site/agent'
-import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
 import { SquareSolidIcon } from 'pixel-art-icons/icons/square-solid'
 import { SendSolidIcon } from 'pixel-art-icons/icons/send-solid'
-import { LoaderIcon } from 'pixel-art-icons/icons/loader'
-import { CheckIcon } from 'pixel-art-icons/icons/check'
-import { CircleAlertSolidIcon } from 'pixel-art-icons/icons/circle-alert-solid'
 import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
 import { AiSettingsSolidIcon } from 'pixel-art-icons/icons/ai-settings-solid'
 import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
 import { ArrowRightIcon } from 'pixel-art-icons/icons/arrow-right'
-import { FilePlusSolidIcon } from 'pixel-art-icons/icons/file-plus-solid'
-import { LinkIcon } from 'pixel-art-icons/icons/link'
-import { CodeIcon } from 'pixel-art-icons/icons/code'
-import { PackageSolidIcon } from 'pixel-art-icons/icons/package-solid'
-import { Copy2SolidIcon } from 'pixel-art-icons/icons/copy-2-solid'
-import { DatabaseSolidIcon } from 'pixel-art-icons/icons/database-solid'
-import { FileTextSolidIcon } from 'pixel-art-icons/icons/file-text-solid'
-import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
-import { MoveIcon } from 'pixel-art-icons/icons/move'
-import { ContainerSolidIcon } from 'pixel-art-icons/icons/container-solid'
-import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
-import { EyeSolidIcon } from 'pixel-art-icons/icons/eye-solid'
-import { RulerDimensionSolidIcon } from 'pixel-art-icons/icons/ruler-dimension-solid'
-import { ColorsSwatchSolidIcon } from 'pixel-art-icons/icons/colors-swatch-solid'
-import { LayoutSolidIcon } from 'pixel-art-icons/icons/layout-solid'
-import { UsersSolidIcon } from 'pixel-art-icons/icons/users-solid'
-import { ZapSolidIcon } from 'pixel-art-icons/icons/zap-solid'
 import { PanelHeader } from '@admin/shared/PanelHeader'
 import { UserAvatar } from '@admin/shared/UserAvatar'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
 import { Textarea } from '@ui/components/Input'
-import { Tooltip } from '@ui/components/Tooltip'
 import { useDraggablePanel } from '@site/hooks/useDraggablePanel'
 import { cn } from '@ui/cn'
 import { ModelPicker } from './ModelPicker'
 import { ConversationHistory } from './ConversationHistory'
 import { ContextMeter } from './ContextMeter'
-import { getToolCallDisplay, extractColorSwatches, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
+import { ToolCallRow } from './ToolCallRow'
 import { formatRelativeTime } from './relativeTime'
 import styles from './AgentPanel.module.css'
 
@@ -508,117 +486,6 @@ const MarkdownTextBubble = memo(function MarkdownTextBubble({
     />
   )
 })
-
-// ---------------------------------------------------------------------------
-// ToolCallRow
-// ---------------------------------------------------------------------------
-
-function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
-  const isPending = toolCall.status === 'pending'
-  const isSuccess = toolCall.status === 'success'
-  const isError = toolCall.status === 'error'
-
-  const display = getToolCallDisplay(toolCall.actionType, toolCall.params)
-  const swatches = extractColorSwatches(toolCall.actionType, toolCall.params)
-  const accessibleStatus = isPending ? 'Running' : isSuccess ? 'Completed' : 'Failed'
-  const statusLabel = `${accessibleStatus} ${display.title}${display.detail ? ` — ${display.detail}` : ''}`
-  const statusClass = isPending
-    ? styles.toolCallStatusPending
-    : isSuccess
-    ? styles.toolCallStatusSuccess
-    : styles.toolCallStatusFailed
-
-  // Surface the tool's error message directly in the row stream so the user
-  // sees WHY a tool failed without digging through devtools. The toolResult
-  // handler in the agent store already populates `result.error`.
-  const errorMessage = isError ? toolCall.result?.error ?? 'Tool call failed.' : null
-
-  return (
-    <>
-      <div role="status" aria-label={statusLabel} className={styles.toolCallRow}>
-        <span className={cn(styles.toolCallIcon, toolCallToneClass(display.tone))} aria-hidden="true">
-          <ToolCallLeadingIcon icon={display.icon} />
-        </span>
-        <span className={styles.toolCallCopy} aria-hidden="true">
-          <span className={styles.toolCallTitle}>{display.title}</span>
-          {display.detail && <span className={styles.toolCallDetail}>{display.detail}</span>}
-        </span>
-        <span className={cn(styles.toolCallStatus, statusClass)} aria-hidden="true">
-          {isPending ? (
-            <LoaderIcon size={11} />
-          ) : isSuccess ? (
-            <CheckIcon size={11} />
-          ) : (
-            <CircleAlertSolidIcon size={11} />
-          )}
-        </span>
-      </div>
-      {swatches.length > 0 && (
-        <div className={styles.toolCallSwatches} aria-hidden="true">
-          {swatches.map((swatch) => (
-            <Tooltip key={swatch.slug} content={`${swatch.slug} · ${swatch.value}`}>
-              <span
-                className={styles.toolCallSwatch}
-                style={{ '--swatch': swatch.value } as CSSProperties}
-              />
-            </Tooltip>
-          ))}
-        </div>
-      )}
-      {toolCall.screenshotDataUrl && (
-        <img
-          className={styles.toolCallScreenshot}
-          src={toolCall.screenshotDataUrl}
-          alt={`Preview the agent captured while running ${display.title}`}
-        />
-      )}
-      {errorMessage && (
-        <p role="alert" className={styles.toolCallError}>
-          {errorMessage}
-        </p>
-      )}
-    </>
-  )
-}
-
-// Per-tool category icon — signals what kind of action ran at a glance.
-function ToolCallLeadingIcon({ icon }: { icon: ToolCallIcon }) {
-  switch (icon) {
-    case 'add': return <FilePlusSolidIcon size={15} />
-    case 'class': return <LinkIcon size={15} />
-    case 'code': return <CodeIcon size={15} />
-    case 'collection': return <PackageSolidIcon size={15} />
-    case 'copy': return <Copy2SolidIcon size={15} />
-    case 'data': return <DatabaseSolidIcon size={15} />
-    case 'delete': return <TrashSolidIcon size={15} />
-    case 'document': return <FileTextSolidIcon size={15} />
-    case 'edit': return <EditSolidIcon size={15} />
-    case 'media': return <ImageSolidIcon size={15} />
-    case 'move': return <MoveIcon size={15} />
-    case 'node': return <ContainerSolidIcon size={15} />
-    case 'open': return <OpenSolidIcon size={15} />
-    case 'page': return <FileTextSolidIcon size={15} />
-    case 'preview': return <EyeSolidIcon size={15} />
-    case 'runtime': return <RulerDimensionSolidIcon size={15} />
-    case 'style': return <ColorsSwatchSolidIcon size={15} />
-    case 'template': return <LayoutSolidIcon size={15} />
-    case 'tokens': return <ColorsSwatchSolidIcon size={15} />
-    case 'users': return <UsersSolidIcon size={15} />
-    case 'tool': return <ZapSolidIcon size={15} />
-  }
-}
-
-// Tone → category-icon colour. Uses state/identity tokens only (danger red,
-// style amber, write green); read/neutral stay achromatic.
-function toolCallToneClass(tone: ToolCallTone): string {
-  switch (tone) {
-    case 'danger': return styles.toolCallIconDanger
-    case 'read': return styles.toolCallIconRead
-    case 'style': return styles.toolCallIconStyle
-    case 'write': return styles.toolCallIconWrite
-    case 'neutral': return styles.toolCallIconNeutral
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Empty state

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -21,7 +21,7 @@
  * @see Guideline #410 — 3 Self-Contained Independent Panels
  */
 
-import { useRef, useEffect, memo } from 'react'
+import { useRef, useEffect, memo, type CSSProperties } from 'react'
 import { useAgentStore } from '@admin/ai/useAgentStore'
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { useAdminNavigate } from '@admin/lib/useAdminNavigate'
@@ -63,7 +63,7 @@ import { cn } from '@ui/cn'
 import { ModelPicker } from './ModelPicker'
 import { ConversationHistory } from './ConversationHistory'
 import { ContextMeter } from './ContextMeter'
-import { getToolCallDisplay, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
+import { getToolCallDisplay, extractColorSwatches, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
 import styles from './AgentPanel.module.css'
 
 const PANEL_WIDTH = 320
@@ -517,6 +517,7 @@ function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
   const isError = toolCall.status === 'error'
 
   const display = getToolCallDisplay(toolCall.actionType, toolCall.params)
+  const swatches = extractColorSwatches(toolCall.actionType, toolCall.params)
   const accessibleStatus = isPending ? 'Running' : isSuccess ? 'Completed' : 'Failed'
   const statusLabel = `${accessibleStatus} ${display.title}${display.detail ? ` — ${display.detail}` : ''}`
   const statusClass = isPending
@@ -550,6 +551,18 @@ function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
           )}
         </span>
       </div>
+      {swatches.length > 0 && (
+        <div className={styles.toolCallSwatches} aria-hidden="true">
+          {swatches.map((swatch) => (
+            <span
+              key={swatch.slug}
+              className={styles.toolCallSwatch}
+              title={`${swatch.slug} · ${swatch.value}`}
+              style={{ '--swatch': swatch.value } as CSSProperties}
+            />
+          ))}
+        </div>
+      )}
       {errorMessage && (
         <p role="alert" className={styles.toolCallError}>
           {errorMessage}

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -58,6 +58,7 @@ import { PanelHeader } from '@admin/shared/PanelHeader'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
 import { Textarea } from '@ui/components/Input'
+import { Tooltip } from '@ui/components/Tooltip'
 import { useDraggablePanel } from '@site/hooks/useDraggablePanel'
 import { cn } from '@ui/cn'
 import { ModelPicker } from './ModelPicker'
@@ -554,12 +555,12 @@ function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
       {swatches.length > 0 && (
         <div className={styles.toolCallSwatches} aria-hidden="true">
           {swatches.map((swatch) => (
-            <span
-              key={swatch.slug}
-              className={styles.toolCallSwatch}
-              title={`${swatch.slug} · ${swatch.value}`}
-              style={{ '--swatch': swatch.value } as CSSProperties}
-            />
+            <Tooltip key={swatch.slug} content={`${swatch.slug} · ${swatch.value}`}>
+              <span
+                className={styles.toolCallSwatch}
+                style={{ '--swatch': swatch.value } as CSSProperties}
+              />
+            </Tooltip>
           ))}
         </div>
       )}

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -25,6 +25,7 @@ import { useRef, useEffect, memo, type CSSProperties } from 'react'
 import { useAgentStore } from '@admin/ai/useAgentStore'
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { useAdminNavigate } from '@admin/lib/useAdminNavigate'
+import { useAuthenticatedAdminUser } from '@admin/sessionContext'
 import { listCredentials, listModels } from '@admin/ai/api'
 import { renderMarkdownToHtml, type AgentMessage, type AgentToolCall } from '@site/agent'
 import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
@@ -55,6 +56,7 @@ import { LayoutSolidIcon } from 'pixel-art-icons/icons/layout-solid'
 import { UsersSolidIcon } from 'pixel-art-icons/icons/users-solid'
 import { ZapSolidIcon } from 'pixel-art-icons/icons/zap-solid'
 import { PanelHeader } from '@admin/shared/PanelHeader'
+import { UserAvatar } from '@admin/shared/UserAvatar'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
 import { Textarea } from '@ui/components/Input'
@@ -65,6 +67,7 @@ import { ModelPicker } from './ModelPicker'
 import { ConversationHistory } from './ConversationHistory'
 import { ContextMeter } from './ContextMeter'
 import { getToolCallDisplay, extractColorSwatches, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
+import { formatRelativeTime } from './relativeTime'
 import styles from './AgentPanel.module.css'
 
 const PANEL_WIDTH = 320
@@ -384,12 +387,24 @@ interface ConversationGroup {
 
 function MessageBubble({ group }: { group: ConversationGroup }) {
   const isUser = group.role === 'user'
+  const user = useAuthenticatedAdminUser()
+  const startedAt = group.messages[0]?.timestamp
+  const relativeTime = startedAt ? formatRelativeTime(startedAt) : ''
 
   return (
     <div className={styles.messageTurn}>
-      {/* Role label — once per turn, not once per message */}
+      {/* Role marker — avatar + name + relative time, once per turn. The user
+          reuses their Gravatar; the agent gets the robot glyph. */}
       <div className={styles.roleLabel}>
-        {isUser ? 'You' : 'Assistant'}
+        {isUser ? (
+          <UserAvatar user={user} size={16} alt={null} />
+        ) : (
+          <span className={styles.roleAvatarAi} aria-hidden="true">
+            <AiBoxSolidIcon size={11} />
+          </span>
+        )}
+        <span className={styles.roleName}>{isUser ? 'You' : 'Assistant'}</span>
+        {relativeTime && <span className={styles.roleTime}>· {relativeTime}</span>}
       </div>
 
       {/* Chronological blocks — text and tool calls render in the order

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -35,7 +35,6 @@ import { LoaderIcon } from 'pixel-art-icons/icons/loader'
 import { CheckIcon } from 'pixel-art-icons/icons/check'
 import { CircleAlertSolidIcon } from 'pixel-art-icons/icons/circle-alert-solid'
 import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
-import { SparklesSolidIcon } from 'pixel-art-icons/icons/sparkles-solid'
 import { AiSettingsSolidIcon } from 'pixel-art-icons/icons/ai-settings-solid'
 import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
 import { ArrowRightIcon } from 'pixel-art-icons/icons/arrow-right'
@@ -401,7 +400,7 @@ function MessageBubble({ group }: { group: ConversationGroup }) {
           <UserAvatar user={user} size={16} alt={null} />
         ) : (
           <span className={styles.roleAvatarAi} aria-hidden="true">
-            <SparklesSolidIcon size={11} />
+            <AiBoxSolidIcon size={11} />
           </span>
         )}
         <span className={styles.roleName}>{isUser ? 'You' : 'Assistant'}</span>

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -390,24 +390,55 @@ const MessageBubble = memo(function MessageBubble({ msg }: MessageBubbleProps) {
           shows two separate text bubbles around the tool badges. Text is
           rendered as markdown (bold, lists, inline code, links, …) via a
           DOMPurify-sanitised HTML pipeline. */}
-      {msg.blocks.map((block, index) =>
-        block.kind === 'text' ? (
+      {groupMessageBlocks(msg.blocks).map((item) =>
+        item.kind === 'text' ? (
           <MarkdownTextBubble
             // Stable key per text block: text deltas append in place, so each
             // run of text gets its position-based key.
-            key={`text-${index}`}
-            text={block.text}
+            key={`text-${item.index}`}
+            text={item.text}
             isUser={isUser}
           />
         ) : (
-          <div key={block.toolCall.id} className={styles.toolCallsContainer}>
-            <ToolCallBadge toolCall={block.toolCall} />
+          // A run of consecutive tool calls shares one container so the rows
+          // stack tightly; text blocks around them stay separate bubbles.
+          <div key={`tools-${item.index}`} className={styles.toolCallsContainer}>
+            {item.toolCalls.map((toolCall) => (
+              <ToolCallRow key={toolCall.id} toolCall={toolCall} />
+            ))}
           </div>
         ),
       )}
     </div>
   )
 })
+
+// A message's blocks arrive as a flat, chronological list. Group each run of
+// consecutive tool-call blocks into one item so it renders inside a single
+// container (a tight vertical stack of rows), while text stays as separate
+// bubbles in emission order.
+type MessageBlock = AgentMessage['blocks'][number]
+
+type MessageRenderItem =
+  | { kind: 'text'; index: number; text: string }
+  | { kind: 'tools'; index: number; toolCalls: AgentToolCall[] }
+
+function groupMessageBlocks(blocks: AgentMessage['blocks']): MessageRenderItem[] {
+  const items: MessageRenderItem[] = []
+  blocks.forEach((block: MessageBlock, index) => {
+    if (block.kind === 'text') {
+      items.push({ kind: 'text', index, text: block.text })
+      return
+    }
+    const last = items.at(-1)
+    if (last && last.kind === 'tools') {
+      last.toolCalls.push(block.toolCall)
+      return
+    }
+    items.push({ kind: 'tools', index, toolCalls: [block.toolCall] })
+  })
+  return items
+}
 
 // ---------------------------------------------------------------------------
 // MarkdownTextBubble — parses + sanitises the block text and injects it via
@@ -444,10 +475,10 @@ const MarkdownTextBubble = memo(function MarkdownTextBubble({
 })
 
 // ---------------------------------------------------------------------------
-// ToolCallBadge
+// ToolCallRow
 // ---------------------------------------------------------------------------
 
-function ToolCallBadge({ toolCall }: { toolCall: AgentToolCall }) {
+function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
   const isPending = toolCall.status === 'pending'
   const isSuccess = toolCall.status === 'success'
   const isError = toolCall.status === 'error'
@@ -472,24 +503,20 @@ function ToolCallBadge({ toolCall }: { toolCall: AgentToolCall }) {
 
   return (
     <>
-      <div
-        role="status"
-        aria-label={statusLabel}
-        className={styles.toolCallBadge}
-      >
-        <span className={iconClass} aria-hidden="true">
+      <div role="status" aria-label={statusLabel} className={styles.toolCallRow}>
+        <span className={cn(styles.toolCallIcon, iconClass)} aria-hidden="true">
           {isPending ? (
-            <LoaderIcon size={10} />
+            <LoaderIcon size={12} />
           ) : isSuccess ? (
-            <CheckIcon size={10} />
+            <CheckIcon size={12} />
           ) : (
-            <CircleAlertSolidIcon size={10} />
+            <CircleAlertSolidIcon size={12} />
           )}
         </span>
-        <span className={styles.toolCallType} aria-hidden="true">
-          {displayType}
+        <span className={styles.toolCallCopy} aria-hidden="true">
+          <span className={styles.toolCallTitle}>{displayType}</span>
+          {label && <span className={styles.toolCallDetail}>{label}</span>}
         </span>
-        <span aria-hidden="true">{label}</span>
       </div>
       {errorMessage && (
         <p

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -399,8 +399,8 @@ function MessageBubble({ group }: { group: ConversationGroup }) {
   const isUser = group.role === 'user'
 
   return (
-    <div className={cn(styles.messageBubble, isUser ? styles.messageBubbleUser : styles.messageBubbleAssistant)}>
-      {/* Role label */}
+    <div className={styles.messageTurn}>
+      {/* Role label — once per turn, not once per message */}
       <div className={styles.roleLabel}>
         {isUser ? 'You' : 'Assistant'}
       </div>
@@ -497,9 +497,9 @@ const MarkdownTextBubble = memo(function MarkdownTextBubble({
   return (
     <div
       className={cn(
-        styles.contentBubble,
-        isUser ? styles.contentBubbleUser : styles.contentBubbleAssistant,
-        styles.markdownBubble,
+        styles.messageText,
+        isUser ? styles.messageTextUser : styles.messageTextAssistant,
+        styles.markdownText,
       )}
       // Safe: sanitised by DOMPurify (via sanitizeRichtext) before reaching here.
       dangerouslySetInnerHTML={{ __html: html }}

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -563,6 +563,13 @@ function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
           ))}
         </div>
       )}
+      {toolCall.screenshotDataUrl && (
+        <img
+          className={styles.toolCallScreenshot}
+          src={toolCall.screenshotDataUrl}
+          alt={`Preview the agent captured while running ${display.title}`}
+        />
+      )}
       {errorMessage && (
         <p role="alert" className={styles.toolCallError}>
           {errorMessage}

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -91,7 +91,6 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
   const closeAgent = useAgentStore((s) => s.closeAgent)
   const sendAgentMessage = useAgentStore((s) => s.sendAgentMessage)
   const abortAgent = useAgentStore((s) => s.abortAgent)
-  const clearAgentMessages = useAgentStore((s) => s.clearAgentMessages)
   const startNewAgentConversation = useAgentStore((s) => s.startNewAgentConversation)
   const loadScopeDefault = useAgentStore((s) => s.loadScopeDefault)
   const activeCredentialId = useAgentStore((s) => s.agentActiveCredentialId)
@@ -254,19 +253,6 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
         >
           <EditSolidIcon size={14} />
         </Button>
-        {/* "Clear conversation" — shown when there are messages */}
-        {messages.length > 0 && (
-          <Button
-            variant="ghost"
-            size="xs"
-            iconOnly
-            onClick={clearAgentMessages}
-            tooltip="Clear conversation"
-            aria-label="Clear conversation"
-          >
-            <TrashSolidIcon size={14} />
-          </Button>
-        )}
         {isStreaming && (
           <span className={styles.streamingBadge}>
             <span className={styles.streamingDot} aria-hidden="true" />

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -37,6 +37,23 @@ import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
 import { AiSettingsSolidIcon } from 'pixel-art-icons/icons/ai-settings-solid'
 import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
 import { ArrowRightIcon } from 'pixel-art-icons/icons/arrow-right'
+import { FilePlusSolidIcon } from 'pixel-art-icons/icons/file-plus-solid'
+import { LinkIcon } from 'pixel-art-icons/icons/link'
+import { CodeIcon } from 'pixel-art-icons/icons/code'
+import { PackageSolidIcon } from 'pixel-art-icons/icons/package-solid'
+import { Copy2SolidIcon } from 'pixel-art-icons/icons/copy-2-solid'
+import { DatabaseSolidIcon } from 'pixel-art-icons/icons/database-solid'
+import { FileTextSolidIcon } from 'pixel-art-icons/icons/file-text-solid'
+import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
+import { MoveIcon } from 'pixel-art-icons/icons/move'
+import { ContainerSolidIcon } from 'pixel-art-icons/icons/container-solid'
+import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
+import { EyeSolidIcon } from 'pixel-art-icons/icons/eye-solid'
+import { RulerDimensionSolidIcon } from 'pixel-art-icons/icons/ruler-dimension-solid'
+import { ColorsSwatchSolidIcon } from 'pixel-art-icons/icons/colors-swatch-solid'
+import { LayoutSolidIcon } from 'pixel-art-icons/icons/layout-solid'
+import { UsersSolidIcon } from 'pixel-art-icons/icons/users-solid'
+import { ZapSolidIcon } from 'pixel-art-icons/icons/zap-solid'
 import { PanelHeader } from '@admin/shared/PanelHeader'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
@@ -46,6 +63,7 @@ import { cn } from '@ui/cn'
 import { ModelPicker } from './ModelPicker'
 import { ConversationHistory } from './ConversationHistory'
 import { ContextMeter } from './ContextMeter'
+import { getToolCallDisplay, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
 import styles from './AgentPanel.module.css'
 
 const PANEL_WIDTH = 320
@@ -278,7 +296,9 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
         ) : (
           <>
             {lockReason && <AgentCredentialAlert mode={lockReason} />}
-            {messages.map((msg) => <MessageBubble key={msg.id} msg={msg} />)}
+            {groupConsecutiveMessages(messages).map((group) => (
+              <MessageBubble key={group.id} group={group} />
+            ))}
           </>
         )}
 
@@ -369,14 +389,14 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
 // MessageBubble
 // ---------------------------------------------------------------------------
 
-interface MessageBubbleProps {
-  msg: AgentMessage
+interface ConversationGroup {
+  id: string
+  role: AgentMessage['role']
+  messages: AgentMessage[]
 }
 
-// Exception #2: React.memo re-render bailout on a hot, list-rendered component
-// (one per message in messages.map).
-const MessageBubble = memo(function MessageBubble({ msg }: MessageBubbleProps) {
-  const isUser = msg.role === 'user'
+function MessageBubble({ group }: { group: ConversationGroup }) {
+  const isUser = group.role === 'user'
 
   return (
     <div className={cn(styles.messageBubble, isUser ? styles.messageBubbleUser : styles.messageBubbleAssistant)}>
@@ -390,19 +410,13 @@ const MessageBubble = memo(function MessageBubble({ msg }: MessageBubbleProps) {
           shows two separate text bubbles around the tool badges. Text is
           rendered as markdown (bold, lists, inline code, links, …) via a
           DOMPurify-sanitised HTML pipeline. */}
-      {groupMessageBlocks(msg.blocks).map((item) =>
+      {groupRenderItems(group.messages).map((item) =>
         item.kind === 'text' ? (
-          <MarkdownTextBubble
-            // Stable key per text block: text deltas append in place, so each
-            // run of text gets its position-based key.
-            key={`text-${item.index}`}
-            text={item.text}
-            isUser={isUser}
-          />
+          <MarkdownTextBubble key={item.key} text={item.text} isUser={isUser} />
         ) : (
           // A run of consecutive tool calls shares one container so the rows
           // stack tightly; text blocks around them stay separate bubbles.
-          <div key={`tools-${item.index}`} className={styles.toolCallsContainer}>
+          <div key={item.key} className={styles.toolCallsContainer}>
             {item.toolCalls.map((toolCall) => (
               <ToolCallRow key={toolCall.id} toolCall={toolCall} />
             ))}
@@ -411,32 +425,51 @@ const MessageBubble = memo(function MessageBubble({ msg }: MessageBubbleProps) {
       )}
     </div>
   )
-})
+}
 
-// A message's blocks arrive as a flat, chronological list. Group each run of
-// consecutive tool-call blocks into one item so it renders inside a single
-// container (a tight vertical stack of rows), while text stays as separate
-// bubbles in emission order.
+// Collapse the flat message list into conversational turns: consecutive
+// messages of the same role become one group (one bubble, one role label).
+// The agent emits each tool call as its own message, so without this a burst
+// of tool activity would render as a stack of repeated "Assistant" labels.
+function groupConsecutiveMessages(messages: AgentMessage[]): ConversationGroup[] {
+  const groups: ConversationGroup[] = []
+  for (const message of messages) {
+    const last = groups.at(-1)
+    if (last && last.role === message.role) {
+      last.messages.push(message)
+      continue
+    }
+    groups.push({ id: message.id, role: message.role, messages: [message] })
+  }
+  return groups
+}
+
+// Flatten a turn's blocks (across its messages) in emission order, coalescing
+// each run of consecutive tool-call blocks into one item so they render inside
+// a single tight container; text blocks stay separate bubbles.
 type MessageBlock = AgentMessage['blocks'][number]
 
 type MessageRenderItem =
-  | { kind: 'text'; index: number; text: string }
-  | { kind: 'tools'; index: number; toolCalls: AgentToolCall[] }
+  | { kind: 'text'; key: string; text: string }
+  | { kind: 'tools'; key: string; toolCalls: AgentToolCall[] }
 
-function groupMessageBlocks(blocks: AgentMessage['blocks']): MessageRenderItem[] {
+function groupRenderItems(messages: AgentMessage[]): MessageRenderItem[] {
   const items: MessageRenderItem[] = []
-  blocks.forEach((block: MessageBlock, index) => {
-    if (block.kind === 'text') {
-      items.push({ kind: 'text', index, text: block.text })
-      return
-    }
-    const last = items.at(-1)
-    if (last && last.kind === 'tools') {
-      last.toolCalls.push(block.toolCall)
-      return
-    }
-    items.push({ kind: 'tools', index, toolCalls: [block.toolCall] })
-  })
+  for (const message of messages) {
+    message.blocks.forEach((block: MessageBlock, index) => {
+      if (block.kind === 'text') {
+        // Position-based key, stable as streaming deltas append in place.
+        items.push({ kind: 'text', key: `text-${message.id}-${index}`, text: block.text })
+        return
+      }
+      const last = items.at(-1)
+      if (last && last.kind === 'tools') {
+        last.toolCalls.push(block.toolCall)
+        return
+      }
+      items.push({ kind: 'tools', key: `tools-${block.toolCall.id}`, toolCalls: [block.toolCall] })
+    })
+  }
   return items
 }
 
@@ -483,49 +516,42 @@ function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
   const isSuccess = toolCall.status === 'success'
   const isError = toolCall.status === 'error'
 
-  const iconClass = isPending
-    ? styles.toolCallIconPending
+  const display = getToolCallDisplay(toolCall.actionType, toolCall.params)
+  const accessibleStatus = isPending ? 'Running' : isSuccess ? 'Completed' : 'Failed'
+  const statusLabel = `${accessibleStatus} ${display.title}${display.detail ? ` — ${display.detail}` : ''}`
+  const statusClass = isPending
+    ? styles.toolCallStatusPending
     : isSuccess
-    ? styles.toolCallIconSuccess
-    : styles.toolCallIconFailed
-  const displayType = formatToolCallType(toolCall.actionType)
-  const label = formatActionLabel(toolCall.actionType, toolCall.params)
-  const statusLabel = isPending
-    ? `Running ${displayType}${label ? ` — ${label}` : ''}`
-    : isSuccess
-    ? `Completed ${displayType}${label ? ` — ${label}` : ''}`
-    : `Failed ${displayType}${label ? ` — ${label}` : ''}`
+    ? styles.toolCallStatusSuccess
+    : styles.toolCallStatusFailed
 
-  // Surface the tool's error message directly in the badge stream so the
-  // user sees WHY a tool failed without having to dig through devtools. The
-  // toolResult handler in agentSlice.ts already populates `result.error`.
+  // Surface the tool's error message directly in the row stream so the user
+  // sees WHY a tool failed without digging through devtools. The toolResult
+  // handler in the agent store already populates `result.error`.
   const errorMessage = isError ? toolCall.result?.error ?? 'Tool call failed.' : null
 
   return (
     <>
       <div role="status" aria-label={statusLabel} className={styles.toolCallRow}>
-        <span className={cn(styles.toolCallIcon, iconClass)} aria-hidden="true">
-          {isPending ? (
-            <LoaderIcon size={12} />
-          ) : isSuccess ? (
-            <CheckIcon size={12} />
-          ) : (
-            <CircleAlertSolidIcon size={12} />
-          )}
+        <span className={cn(styles.toolCallIcon, toolCallToneClass(display.tone))} aria-hidden="true">
+          <ToolCallLeadingIcon icon={display.icon} />
         </span>
         <span className={styles.toolCallCopy} aria-hidden="true">
-          <span className={styles.toolCallTitle}>{displayType}</span>
-          {label && <span className={styles.toolCallDetail}>{label}</span>}
+          <span className={styles.toolCallTitle}>{display.title}</span>
+          {display.detail && <span className={styles.toolCallDetail}>{display.detail}</span>}
+        </span>
+        <span className={cn(styles.toolCallStatus, statusClass)} aria-hidden="true">
+          {isPending ? (
+            <LoaderIcon size={11} />
+          ) : isSuccess ? (
+            <CheckIcon size={11} />
+          ) : (
+            <CircleAlertSolidIcon size={11} />
+          )}
         </span>
       </div>
       {errorMessage && (
-        <p
-          role="alert"
-          // Tone-aligned with `.errorBanner` (red text on muted background)
-          // but inline + compact so a string of failed tool calls stays
-          // readable.
-          className={styles.toolCallError}
-        >
+        <p role="alert" className={styles.toolCallError}>
           {errorMessage}
         </p>
       )}
@@ -533,36 +559,42 @@ function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
   )
 }
 
-function formatToolCallType(actionType: string): string {
-  return actionType.replace(/^mcp__instatic__/, '')
+// Per-tool category icon — signals what kind of action ran at a glance.
+function ToolCallLeadingIcon({ icon }: { icon: ToolCallIcon }) {
+  switch (icon) {
+    case 'add': return <FilePlusSolidIcon size={15} />
+    case 'class': return <LinkIcon size={15} />
+    case 'code': return <CodeIcon size={15} />
+    case 'collection': return <PackageSolidIcon size={15} />
+    case 'copy': return <Copy2SolidIcon size={15} />
+    case 'data': return <DatabaseSolidIcon size={15} />
+    case 'delete': return <TrashSolidIcon size={15} />
+    case 'document': return <FileTextSolidIcon size={15} />
+    case 'edit': return <EditSolidIcon size={15} />
+    case 'media': return <ImageSolidIcon size={15} />
+    case 'move': return <MoveIcon size={15} />
+    case 'node': return <ContainerSolidIcon size={15} />
+    case 'open': return <OpenSolidIcon size={15} />
+    case 'page': return <FileTextSolidIcon size={15} />
+    case 'preview': return <EyeSolidIcon size={15} />
+    case 'runtime': return <RulerDimensionSolidIcon size={15} />
+    case 'style': return <ColorsSwatchSolidIcon size={15} />
+    case 'template': return <LayoutSolidIcon size={15} />
+    case 'tokens': return <ColorsSwatchSolidIcon size={15} />
+    case 'users': return <UsersSolidIcon size={15} />
+    case 'tool': return <ZapSolidIcon size={15} />
+  }
 }
 
-/** Compact one-line summary of an applyCss payload: the selectors it touches. */
-function summarizeCss(css: string): string {
-  const selectors = css
-    .match(/[^{}]+(?=\{)/g)
-    ?.map((s) => s.trim().replace(/\s+/g, ' '))
-    .filter(Boolean) ?? []
-  if (selectors.length === 0) return 'css'
-  const head = selectors.slice(0, 2).join(', ')
-  return selectors.length > 2 ? `${head} +${selectors.length - 2}` : head
-}
-
-function formatActionLabel(actionType: string, params: unknown): string {
-  const p = params as Record<string, unknown>
-  switch (actionType) {
-    case 'site_insert_html': return `→ ${String(p.parentId ?? '').slice(0, 8)}`
-    case 'site_get_node_html': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'site_replace_node_html': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'site_delete_node': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'site_update_node_props': return `node ${String(p.nodeId ?? '').slice(0, 6)}…`
-    case 'site_move_node': return `→ ${String(p.newParentId ?? '').slice(0, 6)}…`
-    case 'site_rename_node': return `"${String(p.label ?? '')}"`
-    case 'site_apply_css': return summarizeCss(String(p.css ?? ''))
-    case 'site_assign_class': return `${String(p.classId ?? '').slice(0, 6)}… → node`
-    case 'site_remove_class': return `${String(p.classId ?? '').slice(0, 6)}… from node`
-    case 'site_add_page': return `"${String(p.title ?? '')}"`
-    default: return ''
+// Tone → category-icon colour. Uses state/identity tokens only (danger red,
+// style amber, write green); read/neutral stay achromatic.
+function toolCallToneClass(tone: ToolCallTone): string {
+  switch (tone) {
+    case 'danger': return styles.toolCallIconDanger
+    case 'read': return styles.toolCallIconRead
+    case 'style': return styles.toolCallIconStyle
+    case 'write': return styles.toolCallIconWrite
+    case 'neutral': return styles.toolCallIconNeutral
   }
 }
 

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -35,6 +35,7 @@ import { LoaderIcon } from 'pixel-art-icons/icons/loader'
 import { CheckIcon } from 'pixel-art-icons/icons/check'
 import { CircleAlertSolidIcon } from 'pixel-art-icons/icons/circle-alert-solid'
 import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
+import { SparklesSolidIcon } from 'pixel-art-icons/icons/sparkles-solid'
 import { AiSettingsSolidIcon } from 'pixel-art-icons/icons/ai-settings-solid'
 import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
 import { ArrowRightIcon } from 'pixel-art-icons/icons/arrow-right'
@@ -400,7 +401,7 @@ function MessageBubble({ group }: { group: ConversationGroup }) {
           <UserAvatar user={user} size={16} alt={null} />
         ) : (
           <span className={styles.roleAvatarAi} aria-hidden="true">
-            <AiBoxSolidIcon size={11} />
+            <SparklesSolidIcon size={11} />
           </span>
         )}
         <span className={styles.roleName}>{isUser ? 'You' : 'Assistant'}</span>

--- a/src/admin/pages/site/panels/AgentPanel/ConversationHistory.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/ConversationHistory.tsx
@@ -14,6 +14,7 @@ import { ContextMenu, ContextMenuItem, ContextMenuSeparator } from '@ui/componen
 import { BulletlistSolidIcon } from 'pixel-art-icons/icons/bulletlist-solid'
 import { PlusIcon } from 'pixel-art-icons/icons/plus'
 import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
+import { formatRelativeTime } from './relativeTime'
 import styles from './AgentPanel.module.css'
 
 export function ConversationHistory() {
@@ -92,7 +93,7 @@ export function ConversationHistory() {
                   <span className={styles.historyItemTitle}>{conv.title}</span>
                   <span className={styles.historyItemMeta}>
                     <span className={styles.historyItemTime}>
-                      {formatRelativeTime(conv.updatedAt)}
+                      {formatRelativeTime(Date.parse(conv.updatedAt))}
                     </span>
                     {/* Span (not a native button) so it doesn't nest inside the
                         ContextMenuItem's Button — nested interactive
@@ -125,17 +126,4 @@ export function ConversationHistory() {
       )}
     </>
   )
-}
-
-function formatRelativeTime(iso: string): string {
-  const ms = Date.now() - Date.parse(iso)
-  if (Number.isNaN(ms)) return ''
-  const minutes = Math.floor(ms / 60000)
-  if (minutes < 1) return 'now'
-  if (minutes < 60) return `${minutes}m`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return `${hours}h`
-  const days = Math.floor(hours / 24)
-  if (days < 7) return `${days}d`
-  return new Date(iso).toLocaleDateString()
 }

--- a/src/admin/pages/site/panels/AgentPanel/ToolCallRow.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/ToolCallRow.tsx
@@ -1,0 +1,140 @@
+/**
+ * ToolCallRow — one agent tool call rendered as a compact row: category icon,
+ * human title · muted detail, status glyph, plus optional colour-token
+ * swatches, a captured preview screenshot, and an inline error message.
+ */
+import type { CSSProperties } from 'react'
+import type { AgentToolCall } from '@site/agent'
+import { cn } from '@ui/cn'
+import { Tooltip } from '@ui/components/Tooltip'
+import { LoaderIcon } from 'pixel-art-icons/icons/loader'
+import { CheckIcon } from 'pixel-art-icons/icons/check'
+import { CircleAlertSolidIcon } from 'pixel-art-icons/icons/circle-alert-solid'
+import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
+import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
+import { FilePlusSolidIcon } from 'pixel-art-icons/icons/file-plus-solid'
+import { LinkIcon } from 'pixel-art-icons/icons/link'
+import { CodeIcon } from 'pixel-art-icons/icons/code'
+import { PackageSolidIcon } from 'pixel-art-icons/icons/package-solid'
+import { Copy2SolidIcon } from 'pixel-art-icons/icons/copy-2-solid'
+import { DatabaseSolidIcon } from 'pixel-art-icons/icons/database-solid'
+import { FileTextSolidIcon } from 'pixel-art-icons/icons/file-text-solid'
+import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
+import { MoveIcon } from 'pixel-art-icons/icons/move'
+import { ContainerSolidIcon } from 'pixel-art-icons/icons/container-solid'
+import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
+import { EyeSolidIcon } from 'pixel-art-icons/icons/eye-solid'
+import { RulerDimensionSolidIcon } from 'pixel-art-icons/icons/ruler-dimension-solid'
+import { ColorsSwatchSolidIcon } from 'pixel-art-icons/icons/colors-swatch-solid'
+import { LayoutSolidIcon } from 'pixel-art-icons/icons/layout-solid'
+import { UsersSolidIcon } from 'pixel-art-icons/icons/users-solid'
+import { ZapSolidIcon } from 'pixel-art-icons/icons/zap-solid'
+import { getToolCallDisplay, extractColorSwatches, type ToolCallIcon, type ToolCallTone } from './toolCallDisplay'
+import styles from './AgentPanel.module.css'
+
+export function ToolCallRow({ toolCall }: { toolCall: AgentToolCall }) {
+  const isPending = toolCall.status === 'pending'
+  const isSuccess = toolCall.status === 'success'
+  const isError = toolCall.status === 'error'
+
+  const display = getToolCallDisplay(toolCall.actionType, toolCall.params)
+  const swatches = extractColorSwatches(toolCall.actionType, toolCall.params)
+  const accessibleStatus = isPending ? 'Running' : isSuccess ? 'Completed' : 'Failed'
+  const statusLabel = `${accessibleStatus} ${display.title}${display.detail ? ` — ${display.detail}` : ''}`
+  const statusClass = isPending
+    ? styles.toolCallStatusPending
+    : isSuccess
+    ? styles.toolCallStatusSuccess
+    : styles.toolCallStatusFailed
+
+  // Surface the tool's error message directly in the row stream so the user
+  // sees WHY a tool failed without digging through devtools. The toolResult
+  // handler in the agent store already populates `result.error`.
+  const errorMessage = isError ? toolCall.result?.error ?? 'Tool call failed.' : null
+
+  return (
+    <>
+      <div role="status" aria-label={statusLabel} className={styles.toolCallRow}>
+        <span className={cn(styles.toolCallIcon, toolCallToneClass(display.tone))} aria-hidden="true">
+          <ToolCallLeadingIcon icon={display.icon} />
+        </span>
+        <span className={styles.toolCallCopy} aria-hidden="true">
+          <span className={styles.toolCallTitle}>{display.title}</span>
+          {display.detail && <span className={styles.toolCallDetail}>{display.detail}</span>}
+        </span>
+        <span className={cn(styles.toolCallStatus, statusClass)} aria-hidden="true">
+          {isPending ? (
+            <LoaderIcon size={11} />
+          ) : isSuccess ? (
+            <CheckIcon size={11} />
+          ) : (
+            <CircleAlertSolidIcon size={11} />
+          )}
+        </span>
+      </div>
+      {swatches.length > 0 && (
+        <div className={styles.toolCallSwatches} aria-hidden="true">
+          {swatches.map((swatch) => (
+            <Tooltip key={swatch.slug} content={`${swatch.slug} · ${swatch.value}`}>
+              <span
+                className={styles.toolCallSwatch}
+                style={{ '--swatch': swatch.value } as CSSProperties}
+              />
+            </Tooltip>
+          ))}
+        </div>
+      )}
+      {toolCall.screenshotDataUrl && (
+        <img
+          className={styles.toolCallScreenshot}
+          src={toolCall.screenshotDataUrl}
+          alt={`Preview the agent captured while running ${display.title}`}
+        />
+      )}
+      {errorMessage && (
+        <p role="alert" className={styles.toolCallError}>
+          {errorMessage}
+        </p>
+      )}
+    </>
+  )
+}
+
+// Per-tool category icon — signals what kind of action ran at a glance.
+function ToolCallLeadingIcon({ icon }: { icon: ToolCallIcon }) {
+  switch (icon) {
+    case 'add': return <FilePlusSolidIcon size={15} />
+    case 'class': return <LinkIcon size={15} />
+    case 'code': return <CodeIcon size={15} />
+    case 'collection': return <PackageSolidIcon size={15} />
+    case 'copy': return <Copy2SolidIcon size={15} />
+    case 'data': return <DatabaseSolidIcon size={15} />
+    case 'delete': return <TrashSolidIcon size={15} />
+    case 'document': return <FileTextSolidIcon size={15} />
+    case 'edit': return <EditSolidIcon size={15} />
+    case 'media': return <ImageSolidIcon size={15} />
+    case 'move': return <MoveIcon size={15} />
+    case 'node': return <ContainerSolidIcon size={15} />
+    case 'open': return <OpenSolidIcon size={15} />
+    case 'page': return <FileTextSolidIcon size={15} />
+    case 'preview': return <EyeSolidIcon size={15} />
+    case 'runtime': return <RulerDimensionSolidIcon size={15} />
+    case 'style': return <ColorsSwatchSolidIcon size={15} />
+    case 'template': return <LayoutSolidIcon size={15} />
+    case 'tokens': return <ColorsSwatchSolidIcon size={15} />
+    case 'users': return <UsersSolidIcon size={15} />
+    case 'tool': return <ZapSolidIcon size={15} />
+  }
+}
+
+// Tone → category-icon colour. Uses state/identity tokens only (danger red,
+// style amber, write green); read/neutral stay achromatic.
+function toolCallToneClass(tone: ToolCallTone): string {
+  switch (tone) {
+    case 'danger': return styles.toolCallIconDanger
+    case 'read': return styles.toolCallIconRead
+    case 'style': return styles.toolCallIconStyle
+    case 'write': return styles.toolCallIconWrite
+    case 'neutral': return styles.toolCallIconNeutral
+  }
+}

--- a/src/admin/pages/site/panels/AgentPanel/relativeTime.ts
+++ b/src/admin/pages/site/panels/AgentPanel/relativeTime.ts
@@ -1,0 +1,17 @@
+/**
+ * Terse relative time from an epoch-ms timestamp: "now", "5m", "3h", "2d",
+ * then a locale date once older than a week. Shared by the conversation
+ * history list and the message role markers.
+ */
+export function formatRelativeTime(epochMs: number): string {
+  const ms = Date.now() - epochMs
+  if (Number.isNaN(ms)) return ''
+  const minutes = Math.floor(ms / 60000)
+  if (minutes < 1) return 'now'
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h`
+  const days = Math.floor(hours / 24)
+  if (days < 7) return `${days}d`
+  return new Date(epochMs).toLocaleDateString()
+}

--- a/src/admin/pages/site/panels/AgentPanel/toolCallDisplay.ts
+++ b/src/admin/pages/site/panels/AgentPanel/toolCallDisplay.ts
@@ -158,6 +158,30 @@ function display(title: string, detail: string, icon: ToolCallIcon, tone: ToolCa
   return { title, detail, icon, tone }
 }
 
+export interface ColorSwatch {
+  slug: string
+  value: string
+}
+
+/**
+ * Colour swatches to preview under a `set_color_tokens` row — the light value
+ * of each token the agent created/updated. Empty for any other tool. Params
+ * are read defensively (they arrive as `unknown` from the tool-call stream).
+ */
+export function extractColorSwatches(actionType: string, params: unknown): ColorSwatch[] {
+  if (normalizeToolName(actionType) !== 'set_color_tokens') return []
+  const tokens = asRecord(params).tokens
+  if (!Array.isArray(tokens)) return []
+  const swatches: ColorSwatch[] = []
+  for (const entry of tokens) {
+    const token = asRecord(entry)
+    const slug = optionalString(token.slug)
+    const value = optionalString(token.lightValue)
+    if (slug && value) swatches.push({ slug, value })
+  }
+  return swatches
+}
+
 // Canonicalise a provider tool name to a stable snake_case key: drop the MCP
 // namespace and the `site_`/`content_` domain prefixes, then fold any camelCase
 // (historical names like `insertHtml`) down to snake_case.

--- a/src/admin/pages/site/panels/AgentPanel/toolCallDisplay.ts
+++ b/src/admin/pages/site/panels/AgentPanel/toolCallDisplay.ts
@@ -1,0 +1,336 @@
+export type ToolCallIcon =
+  | 'add'
+  | 'class'
+  | 'code'
+  | 'collection'
+  | 'copy'
+  | 'data'
+  | 'delete'
+  | 'document'
+  | 'edit'
+  | 'media'
+  | 'move'
+  | 'node'
+  | 'open'
+  | 'page'
+  | 'preview'
+  | 'runtime'
+  | 'style'
+  | 'template'
+  | 'tokens'
+  | 'tool'
+  | 'users'
+
+export type ToolCallTone = 'danger' | 'neutral' | 'read' | 'style' | 'write'
+
+export interface ToolCallDisplay {
+  title: string
+  detail: string
+  icon: ToolCallIcon
+  tone: ToolCallTone
+}
+
+/**
+ * Map a raw agent tool call (`actionType` + params) to a human-readable row:
+ * a friendly title, a compact detail string, a category icon, and a tone.
+ *
+ * Tool names are normalised first (see `normalizeToolName`) so both the
+ * historical short names (`set_color_tokens`, `insertHtml`, `render_snapshot`)
+ * and the current provider names (`site_set_color_tokens`, `site_insert_html`,
+ * `content_create_document`) resolve to the same canonical key.
+ */
+export function getToolCallDisplay(actionType: string, params: unknown): ToolCallDisplay {
+  const toolName = normalizeToolName(actionType)
+  const p = asRecord(params)
+
+  switch (toolName) {
+    case 'list_documents':
+      return display('Listing documents', contentScopeDetail(p), 'document', 'read')
+    case 'list_modules':
+      return display('Listing modules', optionalString(p.query), 'collection', 'read')
+    case 'list_tokens':
+      return display('Listing tokens', tokenFilterDetail(p), 'tokens', 'read')
+    case 'list_post_types':
+      return display('Listing post types', '', 'data', 'read')
+    case 'list_loop_sources':
+      return display('Listing loop sources', '', 'data', 'read')
+    case 'list_breakpoints':
+      return display('Listing breakpoints', '', 'preview', 'read')
+
+    case 'insert_html':
+      return display('Inserting HTML', targetDetail('inside', p.parentId), 'code', 'write')
+    case 'get_node_html':
+      return display('Reading node HTML', nodeDetail(p.nodeId), 'node', 'read')
+    case 'read_document':
+      return display('Reading document', documentDetail(p.document), 'document', 'read')
+    case 'open_document':
+      return display('Opening document', documentDetail(p.document), 'open', 'read')
+    case 'replace_node_html':
+      return display('Replacing node HTML', nodeDetail(p.nodeId), 'code', 'write')
+    case 'delete_node':
+      return display('Deleting node', nodeDetail(p.nodeId), 'delete', 'danger')
+    case 'update_node_props':
+      return display('Updating node props', nodeBreakpointDetail(p.nodeId, p.breakpointId), 'edit', 'write')
+    case 'move_node':
+      return display('Moving node', targetDetail('to', p.newParentId), 'move', 'write')
+    case 'rename_node':
+      return display('Renaming node', optionalString(p.label), 'edit', 'write')
+    case 'duplicate_node':
+      return display('Duplicating node', duplicateNodeDetail(p.nodeId, p.count), 'copy', 'write')
+
+    case 'apply_css':
+      return display('Updating CSS', summarizeCss(optionalString(p.css)), 'style', 'style')
+    case 'assign_class':
+      return display('Assigning class', classDetail(p.classId, p.nodeId), 'class', 'style')
+    case 'remove_class':
+      return display('Removing class', classDetail(p.classId, p.nodeId), 'class', 'danger')
+
+    case 'list_code_assets':
+      return display('Listing code assets', titleCase(optionalString(p.type)), 'code', 'read')
+    case 'read_code_asset':
+      return display('Reading code asset', codeAssetDetail(p), 'code', 'read')
+    case 'write_code_asset':
+      return display('Writing code asset', codeAssetDetail(p), 'code', 'write')
+    case 'patch_code_asset':
+      return display('Patching code asset', codeAssetDetail(p), 'code', 'write')
+    case 'inspect_code_runtime':
+      return display('Inspecting code runtime', documentDetail(p.document), 'runtime', 'read')
+
+    case 'add_page':
+      return display('Adding page', optionalString(p.title), 'add', 'write')
+    case 'delete_page':
+      return display('Deleting page', pageDetail(p.pageId), 'delete', 'danger')
+    case 'rename_page':
+      return display('Renaming page', pageTitleDetail(p), 'page', 'write')
+    case 'duplicate_page':
+      return display('Duplicating page', pageTitleDetail(p), 'copy', 'write')
+    case 'set_page_template':
+      return display('Setting page template', templateTargetDetail(p), 'template', 'write')
+    case 'clear_page_template':
+      return display('Clearing page template', pageDetail(p.pageId), 'template', 'danger')
+
+    case 'set_color_tokens':
+      return display('Updating color tokens', tokenCountDetail(p.tokens), 'tokens', 'style')
+    case 'set_font_tokens':
+      return display('Updating font tokens', tokenCountDetail(p.tokens), 'tokens', 'style')
+    case 'set_type_scale':
+      return display('Updating type scale', scaleDetail(p.groupId, p.namingConvention), 'tokens', 'style')
+    case 'set_spacing_scale':
+      return display('Updating spacing scale', scaleDetail(p.groupId, p.namingConvention), 'tokens', 'style')
+    case 'render_snapshot':
+      return display('Capturing preview', previewDetail(p), 'preview', 'read')
+
+    case 'list_collections':
+      return display('Listing collections', '', 'collection', 'read')
+    case 'get_collection_schema':
+      return display('Reading collection schema', collectionDetail(p), 'collection', 'read')
+    case 'get_document':
+      return display('Reading document', contentDocumentDetail(p), 'document', 'read')
+    case 'search_documents':
+      return display('Searching documents', optionalString(p.query), 'document', 'read')
+    case 'list_users':
+      return display('Listing users', '', 'users', 'read')
+    case 'list_media':
+      return display('Listing media', optionalString(p.query), 'media', 'read')
+    case 'create_document':
+      return display('Creating document', contentDocumentDetail(p), 'add', 'write')
+    case 'delete_document':
+      return display('Deleting document', contentDocumentDetail(p), 'delete', 'danger')
+    case 'set_document_status':
+      return display('Setting document status', titleCase(optionalString(p.status)), 'edit', 'write')
+    case 'set_document_field':
+      return display('Updating document field', optionalString(p.field), 'edit', 'write')
+    case 'set_document_fields':
+      return display('Updating document fields', fieldCountDetail(p.fields), 'edit', 'write')
+    case 'set_document_author':
+      return display('Setting document author', optionalString(p.authorId ?? p.userId), 'users', 'write')
+    case 'set_active_document':
+      return display('Opening document', contentDocumentDetail(p), 'open', 'read')
+    case 'set_active_collection':
+      return display('Opening collection', collectionDetail(p), 'open', 'read')
+
+    default:
+      return display(`Running ${humanizeToolName(toolName)}`, '', 'tool', 'neutral')
+  }
+}
+
+function display(title: string, detail: string, icon: ToolCallIcon, tone: ToolCallTone): ToolCallDisplay {
+  return { title, detail, icon, tone }
+}
+
+// Canonicalise a provider tool name to a stable snake_case key: drop the MCP
+// namespace and the `site_`/`content_` domain prefixes, then fold any camelCase
+// (historical names like `insertHtml`) down to snake_case.
+function normalizeToolName(actionType: string): string {
+  return actionType
+    .replace(/^mcp__instatic__/, '')
+    .replace(/^(site|content)_/, '')
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .toLowerCase()
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : {}
+}
+
+function optionalString(value: unknown): string {
+  return typeof value === 'string' && value.trim() ? value.trim() : ''
+}
+
+function shortId(value: unknown): string {
+  const text = optionalString(value)
+  return text.length > 12 ? `${text.slice(0, 12)}...` : text
+}
+
+function nodeDetail(nodeId: unknown): string {
+  const id = shortId(nodeId)
+  return id ? `node ${id}` : ''
+}
+
+function pageDetail(pageId: unknown): string {
+  const id = shortId(pageId)
+  return id ? `page ${id}` : ''
+}
+
+function targetDetail(prefix: string, idValue: unknown): string {
+  const id = shortId(idValue)
+  return id ? `${prefix} ${id}` : ''
+}
+
+function nodeBreakpointDetail(nodeId: unknown, breakpointId: unknown): string {
+  const node = nodeDetail(nodeId)
+  const breakpoint = optionalString(breakpointId)
+  if (!node) return breakpoint
+  return breakpoint ? `${node} at ${breakpoint}` : node
+}
+
+function duplicateNodeDetail(nodeId: unknown, count: unknown): string {
+  const node = nodeDetail(nodeId)
+  const copies = typeof count === 'number' && count > 1 ? `${count} copies` : ''
+  if (!node) return copies
+  return copies ? `${node}, ${copies}` : node
+}
+
+function classDetail(classId: unknown, nodeId: unknown): string {
+  const className = optionalString(classId)
+  const node = nodeDetail(nodeId)
+  if (!className) return node
+  return node ? `${className} on ${node}` : className
+}
+
+function documentDetail(value: unknown): string {
+  const document = asRecord(value)
+  const type = documentKind(optionalString(document.type))
+  const id = shortId(document.id)
+  if (!type) return id
+  return id ? `${type} ${id}` : type
+}
+
+function documentKind(type: string): string {
+  switch (type) {
+    case 'page':
+      return 'Page'
+    case 'template':
+      return 'Template'
+    case 'visualComponent':
+      return 'Visual component'
+    default:
+      return titleCase(type)
+  }
+}
+
+function codeAssetDetail(params: Record<string, unknown>): string {
+  return optionalString(params.path) || shortId(params.fileId)
+}
+
+function pageTitleDetail(params: Record<string, unknown>): string {
+  return optionalString(params.title) || pageDetail(params.pageId)
+}
+
+function templateTargetDetail(params: Record<string, unknown>): string {
+  const target = asRecord(params.target)
+  const kind = optionalString(target.kind)
+  const targetLabel = kind ? titleCase(kind) : ''
+  const page = pageDetail(params.pageId)
+  if (!page) return targetLabel
+  return targetLabel ? `${page} - ${targetLabel}` : page
+}
+
+function tokenFilterDetail(params: Record<string, unknown>): string {
+  return optionalString(params.family) || optionalString(params.category)
+}
+
+function tokenCountDetail(value: unknown): string {
+  return countDetail(value, 'token', 'tokens')
+}
+
+function fieldCountDetail(value: unknown): string {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const count = Object.keys(value).length
+    return count === 1 ? '1 field' : `${count} fields`
+  }
+  return countDetail(value, 'field', 'fields')
+}
+
+function countDetail(value: unknown, singular: string, plural: string): string {
+  if (!Array.isArray(value)) return ''
+  return value.length === 1 ? `1 ${singular}` : `${value.length} ${plural}`
+}
+
+function scaleDetail(groupId: unknown, namingConvention: unknown): string {
+  return optionalString(groupId) || optionalString(namingConvention)
+}
+
+function previewDetail(params: Record<string, unknown>): string {
+  const node = nodeDetail(params.nodeId)
+  const breakpoint = optionalString(params.breakpointId)
+  if (!node) return breakpoint
+  return breakpoint ? `${node} at ${breakpoint}` : node
+}
+
+function contentScopeDetail(params: Record<string, unknown>): string {
+  return collectionDetail(params) || optionalString(params.status)
+}
+
+function collectionDetail(params: Record<string, unknown>): string {
+  return optionalString(params.tableId)
+    || optionalString(params.tableSlug)
+}
+
+function contentDocumentDetail(params: Record<string, unknown>): string {
+  return optionalString(params.title)
+    || shortId(params.documentId)
+    || shortId(params.rowId)
+    || collectionDetail(params)
+}
+
+function summarizeCss(css: string): string {
+  if (!css) return ''
+  const selectors = css
+    .match(/[^{}]+(?=\{)/g)
+    ?.map((selector) => selector.trim().replace(/\s+/g, ' '))
+    .filter(Boolean) ?? []
+  if (selectors.length === 0) return 'CSS changes'
+  const head = selectors.slice(0, 2).join(', ')
+  return selectors.length > 2 ? `${head} +${selectors.length - 2}` : head
+}
+
+function humanizeToolName(toolName: string): string {
+  return toolName
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .toLowerCase()
+}
+
+function titleCase(value: string): string {
+  if (!value) return ''
+  return value
+    .replace(/[_-]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+    .toLowerCase()
+    .replace(/\b\w/g, (letter) => letter.toUpperCase())
+}


### PR DESCRIPTION
## What changed

A pass of polish + interactivity on the site editor's **AI assistant panel**, built on current `main`.

### Tool-call rows
- Each agent tool call renders as a compact row: **per-tool category icon** (swatch, code, eye, database, …), a **human label** ("Updating color tokens", "Inserting HTML", "Capturing preview"), a muted detail after a middle dot, and a status glyph (check / spinner / alert).
- Tone colours: amber for token/style tools, green for writes, red for destructive, muted for reads.
- A `toolCallDisplay` map turns each `actionType` into that presentation; tool names are canonicalised so both historical short names and current `site_*`/`content_*` names resolve.
- Consecutive same-role messages group under one label, and consecutive tool calls stack tightly in one container.

### Interactive tool rows
- **Colour swatches** — a `set_color_tokens` row shows a swatch per token (from `params.tokens[].lightValue`), composited over a neutral base with a hairline ring like the Framework home palette.
- **Inline preview** — `render_snapshot` renders the captured PNG inline so you see what the agent is looking at. Captured in the browser `toolRequest` handler and held in memory only (`screenshotDataUrl`); never posted or persisted, so it rehydrates empty after a reload.

### Conversation titles
- Conversations were stuck on "New conversation". The chat handler now derives a short title from the **first user prompt** (only while the title is still the default, so a renamed chat is never clobbered).

### Message layout
- Dropped the chat-bubble treatment: messages render **left-aligned at full width, no border/background**. User prompt muted, assistant reply bright. Renamed `*Bubble` classes to `messageTurn` / `messageText` / `markdownText`.

## Notes
- Colours/spacing use current `main` tokens only; the old `--editor-*` / `--rail-tint-*` tokens are banned by the token-vocabulary gate.
- Supersedes #132.

## Verification
- `tsc -b` clean · `bun test src/__tests__/panels/agentPanel.test.tsx` 5/5 · eslint clean on touched files.
