### PR TITLE
test(canvas): scope breakpoint dimming query

### DIFF
--- a/src/__tests__/canvas/breakpointProps.test.tsx
+++ b/src/__tests__/canvas/breakpointProps.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from 'bun:test'
 import React from 'react'
-import { act, fireEvent, render, screen, cleanup, waitFor } from '@testing-library/react'
+import { act, fireEvent, render, cleanup, waitFor } from '@testing-library/react'
 import { readFileSync } from 'fs'
 import { useEditorStore } from '@site/store/store'
 import { BreakpointFrame } from '@site/canvas/BreakpointFrame'
@@ -144,31 +144,39 @@ describe('canvas breakpoint rendering', () => {
       propertiesPanelMode: 'docked',
     } as Parameters<typeof useEditorStore.setState>[0])
 
-    const { rerender } = render(<CanvasRoot />)
+    const strayBreakpointMarker = document.createElement('div')
+    strayBreakpointMarker.dataset.breakpointId = 'mobile'
+    document.body.prepend(strayBreakpointMarker)
 
-    const frameWrapper = (breakpointId: string) =>
-      document.querySelector(`[data-breakpoint-id="${breakpointId}"]`)?.parentElement
+    try {
+      const { container, rerender } = render(<CanvasRoot />)
 
-    await waitFor(() => {
-      expect(frameWrapper('tablet')?.getAttribute('data-breakpoint-dimmed')).toBeNull()
-      expect(frameWrapper('mobile')?.getAttribute('data-breakpoint-dimmed')).toBe('true')
-      expect(frameWrapper('desktop')?.getAttribute('data-breakpoint-dimmed')).toBe('true')
-    })
+      const frameWrapper = (breakpointId: string) =>
+        container.querySelector(`[data-breakpoint-id="${breakpointId}"]`)?.parentElement
 
-    act(() => {
-      useEditorStore.setState({
-        propertiesPanel: { collapsed: true, x: 0, y: 0, width: 360 },
-      } as Parameters<typeof useEditorStore.setState>[0])
-    })
-    rerender(<CanvasRoot />)
+      await waitFor(() => {
+        expect(frameWrapper('tablet')?.getAttribute('data-breakpoint-dimmed')).toBeNull()
+        expect(frameWrapper('mobile')?.getAttribute('data-breakpoint-dimmed')).toBe('true')
+        expect(frameWrapper('desktop')?.getAttribute('data-breakpoint-dimmed')).toBe('true')
+      })
 
-    await waitFor(() => {
-      expect(frameWrapper('mobile')?.getAttribute('data-breakpoint-dimmed')).toBeNull()
-      expect(frameWrapper('desktop')?.getAttribute('data-breakpoint-dimmed')).toBeNull()
-    })
+      act(() => {
+        useEditorStore.setState({
+          propertiesPanel: { collapsed: true, x: 0, y: 0, width: 360 },
+        } as Parameters<typeof useEditorStore.setState>[0])
+      })
+      rerender(<CanvasRoot />)
 
-    const css = readFileSync(BREAKPOINT_FRAME_CSS, 'utf-8')
-    expect(css).toContain('.frameWrapperDimmed')
-    expect(css).toContain('opacity: 0.42')
+      await waitFor(() => {
+        expect(frameWrapper('mobile')?.getAttribute('data-breakpoint-dimmed')).toBeNull()
+        expect(frameWrapper('desktop')?.getAttribute('data-breakpoint-dimmed')).toBeNull()
+      })
+
+      const css = readFileSync(BREAKPOINT_FRAME_CSS, 'utf-8')
+      expect(css).toContain('.frameWrapperDimmed')
+      expect(css).toContain('opacity: 0.42')
+    } finally {
+      strayBreakpointMarker.remove()
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Scope the breakpoint dimming test's frame lookup to the `render()` container instead of `document`.
- Add an explicit stray `data-breakpoint-id` marker outside the rendered canvas so the CI failure mode is covered by the test.
- Remove an unused `screen` import from the canvas breakpoint test file.

## Why
The `v0.0.8` release workflow still failed in the Verify test step after waiting for React state because the global breakpoint lookup could match a stray `data-breakpoint-id="mobile"` element outside this test's rendered canvas tree. The failure received `null` from that stray element's parent instead of reading the actual frame wrapper.

## Impact
This is a test-only stabilization for the release-blocking canvas breakpoint assertion. Product behavior is unchanged.

## Verification
- `bun test src/__tests__/canvas/breakpointProps.test.tsx`
- `bun run build`
- `bun test`
- `bun run lint`