### PR TITLE
fix(docker): exclude tests from release image build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,4 +14,8 @@ backups
 !.env.example
 !.env.production.example
 docs/superpowers
-src/__tests__
+
+# Test sources are verified in CI but are not needed in production images.
+**/__tests__
+**/*.test.ts
+**/*.test.tsx

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -34,5 +34,10 @@
       "@users/*": ["./src/admin/pages/users/*"]
     }
   },
-  "include": ["vite.config.ts", "server/**/*.ts", "src/core/plugin-sdk/cli/**/*.ts"]
+  "include": ["vite.config.ts", "server/**/*.ts", "src/core/plugin-sdk/cli/**/*.ts"],
+  "exclude": [
+    "server/**/__tests__",
+    "server/**/*.test.ts",
+    "server/**/*.test.tsx"
+  ]
 }


### PR DESCRIPTION
## Summary
- Exclude test sources from the Docker production build context.
- Exclude server test files from the node TypeScript build project so production builds typecheck production/server sources only.

## Why
The `v0.0.8` release workflow passed Verify, then failed in `Publish GHCR Image` while Docker ran `bun run build`. The Docker context excluded `src/__tests__` but still included server-side test files, so TypeScript saw `server/handlers/cms/__tests__/importArchiveMedia.test.ts` without its imported `src/__tests__/helpers/createTestDb` helper.

## Impact
Production images no longer copy or compile test files. Runtime behavior is unchanged.

## Verification
- `bun run build`
- `bun test`
- `bun run lint`

Local Docker CLI was present, but the Docker daemon was not running, so the exact image build will be verified by the release workflow after merge.