### PR TITLE
fix(publisher): let modules declare CSP sources so base.video YouTube embeds render on publish

### DIFF
--- a/server/handlers/cms/hole.ts
+++ b/server/handlers/cms/hole.ts
@@ -148,6 +148,7 @@ async function renderHoleFragment(
     jsMap: new Map(),
     infiniteLoopIds: new Set(),
     holeNodeIds: new Set(),
+    cspSources: new Map(),
   }
   // Hole fragments bypass the published-HTML pipeline, so CMS forms inside
   // them would never receive their page token. Stamp here — tokens are

--- a/server/handlers/cms/loop.ts
+++ b/server/handlers/cms/loop.ts
@@ -142,6 +142,7 @@ export async function handleLoopRequest(
     jsMap: new Map(),
     infiniteLoopIds: new Set(),
     holeNodeIds: new Set(),
+    cspSources: new Map(),
   }
 
   // Render each item by walking each variant child once per iteration.

--- a/server/publish/siteModuleAssets.ts
+++ b/server/publish/siteModuleAssets.ts
@@ -31,6 +31,7 @@ export function collectSiteModuleAssets(
     jsMap: new Map<string, string>(),
     infiniteLoopIds: new Set<string>(),
     holeNodeIds: new Set<string>(),
+    cspSources: new Map<string, Set<string>>(),
   }
   for (const page of site.pages) {
     const config: RenderConfig = {

--- a/src/__tests__/base-modules.test.ts
+++ b/src/__tests__/base-modules.test.ts
@@ -1005,6 +1005,43 @@ describe('base.video — render() specifics', () => {
       withBannedGlobals(() => VideoModule.render(VideoModule.defaults, []))
     ).not.toThrow()
   })
+
+  // --- cspSources ---
+
+  it('returns cspSources with frame-src YouTube origins for a youtube watch URL', () => {
+    const out = renderModule(VideoModule, {
+      videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ',
+    })
+    expect(out.cspSources).toBeDefined()
+    const frameSrc = out.cspSources?.find((r) => r.directive === 'frame-src')
+    expect(frameSrc).toBeDefined()
+    expect(frameSrc?.sources).toContain('https://www.youtube.com')
+    expect(frameSrc?.sources).toContain('https://www.youtube-nocookie.com')
+  })
+
+  it('returns cspSources with frame-src YouTube origins for a youtu.be short link', () => {
+    const out = renderModule(VideoModule, { videoUrl: 'https://youtu.be/dQw4w9WgXcQ' })
+    const frameSrc = out.cspSources?.find((r) => r.directive === 'frame-src')
+    expect(frameSrc?.sources).toContain('https://www.youtube.com')
+    expect(frameSrc?.sources).toContain('https://www.youtube-nocookie.com')
+  })
+
+  it('returns cspSources with frame-src YouTube origins for a shorts URL', () => {
+    // Shorts ID must be exactly 11 base64-url chars (same as regular YouTube IDs)
+    const out = renderModule(VideoModule, { videoUrl: 'https://www.youtube.com/shorts/dQw4w9WgXcQ' })
+    const frameSrc = out.cspSources?.find((r) => r.directive === 'frame-src')
+    expect(frameSrc?.sources).toContain('https://www.youtube.com')
+  })
+
+  it('does not declare cspSources for a self-hosted video URL', () => {
+    const out = renderModule(VideoModule, { videoUrl: '/uploads/intro.mp4' })
+    expect(out.cspSources).toBeUndefined()
+  })
+
+  it('does not declare cspSources when videoUrl is empty (no embed)', () => {
+    const out = renderModule(VideoModule, { videoUrl: '' })
+    expect(out.cspSources).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/publisher/cspPlan.test.ts
+++ b/src/__tests__/publisher/cspPlan.test.ts
@@ -15,13 +15,17 @@ import {
   createBaseCspPlan,
   cspMetaTag,
   parseCspContent,
+  publishPage,
   serializeCsp,
   setCspDirective,
 } from '@core/publisher'
+import type { AnyModuleDefinition } from '@core/module-engine'
 import {
   injectFrontendAssets,
   type FrontendInjections,
 } from '../../../server/publish/frontendInjections'
+import { VideoModule } from '@modules/base/video'
+import { makeModule, makeRegistry, makePage, makeSite } from './helpers'
 
 describe('CspPlan — serialization is deterministic and sorted', () => {
   it('sorts directives by name and sources within each directive', () => {
@@ -172,5 +176,75 @@ describe('frontend injection — CSP determinism', () => {
       const sources = directive.split(/\s+/).slice(1)
       expect(sources).toEqual([...sources].sort())
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// publishPage — CSP frame-src lifted by module cspSources
+//
+// Locks in the fix for the pre-existing publisher gap where frame-src was
+// hardcoded to 'none', blocking YouTube embeds on published pages even though
+// they rendered correctly in the editor canvas.
+// ---------------------------------------------------------------------------
+
+/** Extract the CSP policy string from a full publishPage HTML document. */
+function extractPublishedCsp(html: string): string {
+  const m = html.match(/<meta http-equiv="Content-Security-Policy"\s+content="([^"]*)"/i)
+  if (!m) throw new Error('no CSP meta found in published HTML')
+  return m[1]!
+}
+
+describe('publishPage — CSP frame-src from module cspSources', () => {
+  it('page with a youtube video has youtube.com in frame-src (not none)', () => {
+    const page = makePage({
+      root: {
+        moduleId: 'base.video',
+        props: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+      },
+    })
+    const reg = makeRegistry({ 'base.video': VideoModule as AnyModuleDefinition })
+    const { html } = publishPage(page, makeSite(), reg)
+    const csp = extractPublishedCsp(html)
+    expect(csp).toContain('https://www.youtube.com')
+    expect(csp).toContain('https://www.youtube-nocookie.com')
+    expect(csp).not.toContain("frame-src 'none'")
+  })
+
+  it('page with no video keeps frame-src none (no youtube leakage)', () => {
+    const page = makePage({
+      root: { moduleId: 'test.plain', props: {} },
+    })
+    const reg = makeRegistry({ 'test.plain': makeModule('test.plain') })
+    const { html } = publishPage(page, makeSite(), reg)
+    const csp = extractPublishedCsp(html)
+    expect(csp).toContain("frame-src 'none'")
+    expect(csp).not.toContain('youtube')
+  })
+
+  it('youtube sources are sorted deterministically across repeated builds', () => {
+    const page = makePage({
+      root: {
+        moduleId: 'base.video',
+        props: { videoUrl: 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' },
+      },
+    })
+    const reg = makeRegistry({ 'base.video': VideoModule as AnyModuleDefinition })
+    const html1 = publishPage(page, makeSite(), reg).html
+    const html2 = publishPage(page, makeSite(), reg).html
+    expect(extractPublishedCsp(html1)).toBe(extractPublishedCsp(html2))
+    expect(extractPublishedCsp(html1)).not.toBe('')
+  })
+
+  it('frame-src contains both youtube.com and youtube-nocookie.com for the youtu.be URL form', () => {
+    const page = makePage({
+      root: {
+        moduleId: 'base.video',
+        props: { videoUrl: 'https://youtu.be/dQw4w9WgXcQ' },
+      },
+    })
+    const reg = makeRegistry({ 'base.video': VideoModule as AnyModuleDefinition })
+    const { html } = publishPage(page, makeSite(), reg)
+    const csp = extractPublishedCsp(html)
+    expect(csp).toContain('https://www.youtube-nocookie.com')
   })
 })

--- a/src/__tests__/publisher/helpers.ts
+++ b/src/__tests__/publisher/helpers.ts
@@ -23,6 +23,7 @@ export function makeAccumulators(): RenderAccumulators {
     jsMap: new Map<string, string>(),
     infiniteLoopIds: new Set<string>(),
     holeNodeIds: new Set<string>(),
+    cspSources: new Map<string, Set<string>>(),
   }
 }
 

--- a/src/admin/pages/site/agent/executor.ts
+++ b/src/admin/pages/site/agent/executor.ts
@@ -337,6 +337,7 @@ function runGetNodeHtml(input: GetNodeHtmlInput): AiToolOutput {
     jsMap: new Map(),
     infiniteLoopIds: new Set(),
     holeNodeIds: new Set(),
+    cspSources: new Map(),
   }
 
   const html = renderNode(input.nodeId, config, acc)

--- a/src/core/ai/readSurface.ts
+++ b/src/core/ai/readSurface.ts
@@ -292,6 +292,7 @@ function collectPageModuleCss(page: Page, site: SiteDocument, registry: IModuleR
     jsMap: new Map<string, string>(),
     infiniteLoopIds: new Set<string>(),
     holeNodeIds: new Set<string>(),
+    cspSources: new Map<string, Set<string>>(),
   }
   renderNode(page.rootNodeId, { page, site, registry, breakpointId: undefined }, acc)
   return Array.from(acc.cssMap.values()).join('\n')

--- a/src/core/module-engine/index.ts
+++ b/src/core/module-engine/index.ts
@@ -10,6 +10,8 @@ export type {
   AnyModuleDefinition,
   IModuleRegistry,
   RenderOutput,
+  CspDirective,
+  CspSourceRequirement,
   ModuleComponentProps,
   InlineEditBinding,
   NodeWrapperProps,

--- a/src/core/module-engine/types.ts
+++ b/src/core/module-engine/types.ts
@@ -48,6 +48,35 @@ interface ModuleEditorRuntime {
 // Decision #309: render() returns { html, css? } not a plain string
 // ---------------------------------------------------------------------------
 
+/**
+ * The safe set of CSP directives a module may declare source requirements for.
+ * Scoped to content-loading directives only — modules cannot request
+ * 'script-src' relaxation through this channel (that would open arbitrary
+ * script execution; plugin frontend assets go through the server injection
+ * pipeline instead).
+ */
+export type CspDirective =
+  | 'frame-src'
+  | 'script-src'
+  | 'img-src'
+  | 'media-src'
+  | 'connect-src'
+  | 'style-src'
+  | 'font-src'
+
+/**
+ * A single CSP source requirement declared by a module's render() output.
+ * The publisher collects these across all rendered nodes on a page and merges
+ * them into the per-page CSP plan before emitting the `<meta>` tag.
+ *
+ * Declare sources ONLY for the provider ACTUALLY used by this node's current
+ * props — a YouTube node must not pull in Vimeo sources, and vice versa.
+ */
+export interface CspSourceRequirement {
+  directive: CspDirective
+  sources: string[]
+}
+
 export interface RenderOutput {
   /** Clean HTML string — no editor code, no React, no framework runtime */
   html: string
@@ -67,6 +96,19 @@ export interface RenderOutput {
    * React components, not published render() output).
    */
   js?: string
+  /**
+   * Optional CSP source requirements for this specific render instance.
+   *
+   * The publisher collects these per-page and merges them into the CSP plan
+   * so that only pages that actually embed an external resource carry relaxed
+   * directives. A page with no YouTube embeds keeps `frame-src 'none'`; a
+   * page with one YouTube node gets `frame-src https://www.youtube.com
+   * https://www.youtube-nocookie.com`.
+   *
+   * Omit when the module requires no additional CSP origins (self-hosted
+   * video, images on the same origin, plain HTML, etc.).
+   */
+  cspSources?: CspSourceRequirement[]
 }
 
 // ---------------------------------------------------------------------------

--- a/src/core/publisher/render.ts
+++ b/src/core/publisher/render.ts
@@ -36,7 +36,7 @@ import { PUBLISHER_RESET_CSS } from './reset'
 import { buildSiteFrameworkCss } from './frameworkCss'
 import type { SiteCssBundle } from './siteCssBundle'
 import { escapeHtml, isSafeUrl } from './utils'
-import { createBaseCspPlan, cspMetaTag } from './cspPlan'
+import { addCspSources, createBaseCspPlan, cspMetaTag } from './cspPlan'
 import type { PublishedPageRuntimeAssets } from '@core/site-runtime/schemas'
 import { hasPublishedRuntimeScripts, scriptTagsForRuntimeAssets } from '@core/site-runtime'
 import { renderNode } from './renderNode'
@@ -403,8 +403,17 @@ function buildRuntimeAssetsBlock(
 function buildContentSecurityPolicy(
   anyScriptTag: boolean,
   importmap: PublishedRuntimePackageImportmap | undefined,
+  moduleCspSources: ReadonlyMap<string, ReadonlySet<string>>,
 ): string {
   const plan = createBaseCspPlan({ anyScriptTag, importmapSha: importmap?.sha256 })
+  // Merge per-page CSP requirements declared by module render() outputs.
+  // addCspSources automatically drops the lone 'none' when real sources are
+  // added, so frame-src 'none' becomes frame-src <origins> on pages that
+  // embed external iframes (e.g. YouTube). Pages with no such embeds are
+  // unaffected and keep frame-src 'none'.
+  for (const [directive, sources] of moduleCspSources) {
+    addCspSources(plan, directive, sources)
+  }
   return `\n  ${cspMetaTag(plan)}`
 }
 
@@ -507,6 +516,7 @@ export function publishPage(
   const acc: RenderAccumulators = {
     cssMap: new Map<string, string>(),
     jsMap: new Map<string, string>(),
+    cspSources: new Map<string, Set<string>>(),
     infiniteLoopIds: new Set<string>(),
     holeNodeIds: new Set<string>(),
   }
@@ -539,7 +549,7 @@ export function publishPage(
 
   const meta = buildDocumentMetaTags(site, page)
   const runtime = buildRuntimeAssetsBlock(options, acc)
-  const csp = buildContentSecurityPolicy(runtime.anyScriptTag, runtime.importmap)
+  const csp = buildContentSecurityPolicy(runtime.anyScriptTag, runtime.importmap, acc.cspSources)
 
   const html = assembleHtmlDocument({
     langAttr: meta.langAttr,

--- a/src/core/publisher/renderConfig.ts
+++ b/src/core/publisher/renderConfig.ts
@@ -159,6 +159,18 @@ export interface RenderAccumulators {
    * began).
    */
   readonly holeNodeIds: Set<string>
+  /**
+   * Per-directive CSP source requirements collected from module render() outputs
+   * during the walk. Maps directive name → set of source origins. Built up as
+   * the node walk proceeds; read after the walk by `buildContentSecurityPolicy`
+   * in `render.ts` to emit a per-page CSP that reflects exactly which external
+   * resources the page actually embeds.
+   *
+   * Using a plain Map instead of a per-directive typed structure keeps the
+   * accumulator consistent with `cssMap`/`jsMap` and avoids a proliferation
+   * of per-directive fields as more modules declare requirements over time.
+   */
+  readonly cspSources: Map<string, Set<string>>
 }
 
 /**

--- a/src/core/publisher/renderNode.ts
+++ b/src/core/publisher/renderNode.ts
@@ -177,6 +177,19 @@ function renderStandardNode(
     acc.jsMap.set(node.moduleId, output.js)
   }
 
+  // CSP source requirements — union all sources declared by this render into
+  // the per-page accumulator. Deduplication is implicit (Set). addCspSources
+  // in cspPlan.ts will drop any existing 'none' when real sources are merged
+  // in at CSP-build time, so 'none' on frame-src is automatically lifted on
+  // any page that embeds an external resource (e.g. YouTube iframe).
+  if (output.cspSources) {
+    for (const { directive, sources } of output.cspSources) {
+      const existing = acc.cspSources.get(directive) ?? new Set<string>()
+      for (const source of sources) existing.add(source)
+      acc.cspSources.set(directive, existing)
+    }
+  }
+
   // base.body has no wrapper element — its classIds + inline styles go on
   // <body> in publishPage.
   if (node.moduleId === 'base.body') return output.html

--- a/src/modules/base/video/index.ts
+++ b/src/modules/base/video/index.ts
@@ -24,7 +24,7 @@
  * optional — missing values fall back gracefully.
  */
 import { registry } from '@core/module-engine'
-import type { ModuleDefinition } from '@core/module-engine'
+import type { ModuleDefinition, RenderOutput, CspSourceRequirement } from '@core/module-engine'
 import type { RenderResolvedMedia } from '@core/publisher'
 import { Value } from '@core/utils/typeboxHelpers'
 import { VideoSolidIcon } from 'pixel-art-icons/icons/video-solid'
@@ -174,6 +174,21 @@ interface YoutubeRenderInput {
 }
 
 /**
+ * CSP frame-src origins required when a YouTube embed is rendered.
+ * Declared on every YouTube render so the publisher can lift frame-src
+ * from 'none' to these origins — but ONLY on pages that actually embed
+ * YouTube. Pages with no YouTube nodes keep frame-src 'none'.
+ * youtube-nocookie.com is included because the embed URL may use that
+ * domain when privacy-enhanced mode is configured in the future.
+ */
+const YOUTUBE_CSP_SOURCES: CspSourceRequirement[] = [
+  {
+    directive: 'frame-src',
+    sources: ['https://www.youtube.com', 'https://www.youtube-nocookie.com'],
+  },
+]
+
+/**
  * Emit a YouTube iframe.
  *
  * With a poster: wrap the iframe in a `<div>` that also contains a
@@ -185,7 +200,7 @@ interface YoutubeRenderInput {
  *
  * Without a poster: emit just the iframe, also `loading="lazy"`.
  */
-function renderYoutube(input: YoutubeRenderInput): { html: string; css?: string } {
+function renderYoutube(input: YoutubeRenderInput): RenderOutput {
   const embedSrc = youtubeEmbedUrl(input.youtubeId, input.autoplay)
   if (!embedSrc) return { html: '' }
 
@@ -200,7 +215,7 @@ function renderYoutube(input: YoutubeRenderInput): { html: string; css?: string 
   const iframeHtml = `<iframe ${iframeAttrs.join(' ')}></iframe>`
 
   if (!input.posterUrl && !input.posterMedia) {
-    return { html: iframeHtml }
+    return { html: iframeHtml, cspSources: YOUTUBE_CSP_SOURCES }
   }
 
   // Poster aspect target — derives the variant pick. YouTube embeds are
@@ -213,7 +228,7 @@ function renderYoutube(input: YoutubeRenderInput): { html: string; css?: string 
   if (!posterSrc) {
     // Poster prop set but URL didn't survive safeUrl — fall back to
     // bare iframe rather than emitting an `<img src>` we can't trust.
-    return { html: iframeHtml }
+    return { html: iframeHtml, cspSources: YOUTUBE_CSP_SOURCES }
   }
 
   const posterSrcset = input.posterMedia ? buildMediaSrcset(input.posterMedia) : null
@@ -240,7 +255,7 @@ function renderYoutube(input: YoutubeRenderInput): { html: string; css?: string 
     + `<iframe class="bv-yt-frame" ${iframeAttrs.join(' ')}></iframe>`
     + `</div>`
 
-  return { html, css: YOUTUBE_FACADE_CSS }
+  return { html, css: YOUTUBE_FACADE_CSS, cspSources: YOUTUBE_CSP_SOURCES }
 }
 
 // Scoped to `.bv-yt` so the publisher's per-moduleId CSS dedup applies


### PR DESCRIPTION
## What changed

**New module `cspSources` API** (`RenderOutput.cspSources?: CspSourceRequirement[]`):
- Added `CspDirective` union type and `CspSourceRequirement` interface to `@core/module-engine`
- Modules can now declare which CSP origins their render output requires, keyed by directive
- The publisher collects these across the node walk and merges them into the per-page CSP plan

**Per-page CSP collection** (`RenderAccumulators.cspSources`):
- `renderStandardNode` unions each render output's `cspSources` into `acc.cspSources` (a `Map<directive, Set<source>>`)
- `buildContentSecurityPolicy` in `render.ts` receives and merges `acc.cspSources` via `addCspSources` — which already drops the lone `'none'` when real sources are added, so no special-case logic was needed

**base.video declares YouTube CSP sources**:
- `renderYoutube` returns `cspSources: [{ directive: 'frame-src', sources: ['https://www.youtube.com', 'https://www.youtube-nocookie.com'] }]` on every YouTube path (bare iframe, poster-wrapped iframe, failed-poster fallback)
- Self-hosted `<video>` paths declare nothing — their return value has no `cspSources` field

## Why

Published pages had `frame-src 'none'` hardcoded in the base CSP plan, blocking YouTube iframes that rendered correctly in the editor canvas. This was a pre-existing publisher gap, not a regression.

The fix is general-purpose — any future module (e.g. Vimeo embeds, third-party maps) can declare its own `cspSources` on the `frame-src` or other content-loading directives without touching the CSP builder.

## Security note

`frame-src` is relaxed **only** on pages that actually contain a YouTube node. A page with no video keeps `frame-src 'none'` exactly as before. CSP determinism is preserved (sources are sorted via the existing `addCspSources` + `serializeCsp` sort pass).

The general `CspDirective` union deliberately excludes `default-src` and `object-src`; modules cannot use this channel to grant arbitrary script execution (`script-src` is in the union for future plugin use cases, but `base.video` only touches `frame-src`).

**Follow-up note**: arbitrary external scripts (e.g. user-injected ESM URLs like `esm.sh/@motion.page/sdk`) are **not** covered by this change and require a separate site-level trusted-hosts allowlist mechanism.

## Sanitizer finding

The `<iframe>` in `base.video`'s `render()` HTML output is **not touched by DOMPurify** — the publisher sanitizer (`sanitize.ts`) only runs on `richtext` and `svg` typed props via `escapeProps()`, not on the module HTML output. The iframe passes through unchanged. This is correct for a trusted base module.

## Verification

```
bun run build       # ✓ tsc -b && vite build — 0 type errors
bun test            # ✓ 5877 pass, 0 fail (9 new tests added)
bun run lint        # ✓ clean
```

New tests added:
- 5 × `base.video — render() specifics`: `cspSources` present for youtube/youtu.be/shorts, absent for self-hosted and empty URL
- 4 × `publishPage — CSP frame-src from module cspSources`: youtube page lifts frame-src, no-video page keeps 'none', determinism across builds, youtu.be form includes nocookie