### PR TITLE
fix(editor): apply empty-folder explorer ops without the "0 paths" dialog

### DIFF
--- a/docs/features/site-shell.md
+++ b/docs/features/site-shell.md
@@ -208,7 +208,7 @@ Generated files (e.g. `package.json`, `vite.config.ts`) are hidden in the Site E
 
 Site Explorer organization is split by whether a section owns URL/file paths.
 
-Pages, styles, and scripts are structural sections: folders are derived from page slugs or file paths, and changing a folder or item path rewrites those slugs/paths after a confirmation dialog lists the exact changes. Deleting a structural folder deletes every page or file under that path. Templates and Visual Components stay decorative: folders only organize rows in the editor and do not change template routing or component identity.
+Pages, styles, and scripts are structural sections: folders are derived from page slugs or file paths, and changing a folder or item path rewrites those slugs/paths. The confirmation dialog only appears when there is something to review — actual slug/path rewrites, or a blocker to explain. Renaming, moving, or deleting an *empty* folder rewrites no content paths, so it applies directly (its new/removed path is still persisted in the section's `emptyFolders`/`expandedFolders`/`rowOrder` bookkeeping via the plan commit). Deleting a non-empty structural folder deletes every page or file under that path. Templates and Visual Components stay decorative: folders only organize rows in the editor and do not change template routing or component identity.
 
 ```ts
 type SiteExplorerSectionId =

--- a/src/__tests__/site-explorer/siteExplorerOrganizationStore.test.ts
+++ b/src/__tests__/site-explorer/siteExplorerOrganizationStore.test.ts
@@ -123,6 +123,52 @@ describe('Site Explorer organization store actions', () => {
     expect(site.explorer.pages).toEqual({ expandedFolders: [], emptyFolders: [], rowOrder: [] })
   })
 
+  it('renames a freshly created empty structural folder end-to-end without touching pages', () => {
+    // A freshly created folder is collapsed — tracked in emptyFolders only,
+    // which is exactly the "rewrite 0 paths" case that used to no-op on commit.
+    loadExplorerSite({
+      pages: [makePage({ id: 'home', slug: 'index', title: 'Home' })],
+      explorer: {
+        ...createDefaultSiteExplorerOrganization(),
+        pages: {
+          expandedFolders: [],
+          emptyFolders: ['new-folder'],
+          rowOrder: [{ kind: 'folder', id: 'new-folder', order: 0 }],
+        },
+      },
+    })
+
+    const plan = useEditorStore.getState().previewRenameExplorerFolder('pages', 'new-folder', 'link')
+    useEditorStore.getState().commitExplorerPathChange(plan)
+
+    const section = useEditorStore.getState().site!.explorer.pages
+    expect(section.emptyFolders).toEqual(['link'])
+    expect(section.rowOrder).toEqual([{ kind: 'folder', id: 'link', order: 0 }])
+  })
+
+  it('deletes a freshly created empty structural folder end-to-end', () => {
+    loadExplorerSite({
+      pages: [makePage({ id: 'home', slug: 'index', title: 'Home' })],
+      explorer: {
+        ...createDefaultSiteExplorerOrganization(),
+        pages: {
+          expandedFolders: [],
+          emptyFolders: ['scratch'],
+          rowOrder: [{ kind: 'folder', id: 'scratch', order: 0 }],
+        },
+      },
+    })
+
+    const plan = useEditorStore.getState().previewDeleteExplorerFolder('pages', 'scratch')
+    useEditorStore.getState().commitExplorerPathChange(plan)
+
+    expect(useEditorStore.getState().site!.explorer.pages).toEqual({
+      expandedFolders: [],
+      emptyFolders: [],
+      rowOrder: [],
+    })
+  })
+
   it('commits a structural scripts folder delete and removes runtime config', () => {
     loadExplorerSite({
       files: [

--- a/src/__tests__/site-explorer/siteExplorerPathPlans.test.ts
+++ b/src/__tests__/site-explorer/siteExplorerPathPlans.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'bun:test'
 import {
   buildDeleteExplorerPathPlan,
+  buildMoveExplorerFolderPlan,
   buildMoveExplorerItemPlan,
   buildRenameExplorerFolderPlan,
   commitExplorerPathPlan,
+  createDefaultSiteExplorerOrganization,
 } from '@core/page-tree'
 import { DEFAULT_SCRIPT_RUNTIME_CONFIG, DEFAULT_STYLE_RUNTIME_CONFIG } from '@core/site-runtime'
 import { makePage, makeSite } from '../fixtures'
@@ -145,5 +147,115 @@ describe('site explorer path plans', () => {
     expect(liveRuntime.styles.theme).toBeUndefined()
     expect(liveRuntime.scripts.main).toBeUndefined()
     expect(liveRuntime.scripts.keep).toEqual(DEFAULT_SCRIPT_RUNTIME_CONFIG)
+  })
+
+  it('carries a folder-path change and rewrites bookkeeping for an empty folder rename', () => {
+    const site = makeSite({
+      pages: [makePage({ id: 'home', slug: 'index' })],
+      explorer: {
+        ...createDefaultSiteExplorerOrganization(),
+        pages: {
+          expandedFolders: ['new-folder'],
+          emptyFolders: ['new-folder', 'new-folder/inner'],
+          rowOrder: [{ kind: 'folder', id: 'new-folder', order: 0 }],
+        },
+      },
+    })
+
+    const plan = buildRenameExplorerFolderPlan(site, {
+      sectionId: 'pages',
+      folderPath: 'new-folder',
+      nextFolderPath: 'link',
+    })
+
+    expect(plan.changes).toEqual([])
+    expect(plan.folderPathChange).toEqual({ from: 'new-folder', to: 'link' })
+
+    commitExplorerPathPlan(site, undefined, plan)
+
+    expect(site.explorer.pages.emptyFolders).toEqual(['link', 'link/inner'])
+    expect(site.explorer.pages.expandedFolders).toEqual(['link'])
+    expect(site.explorer.pages.rowOrder).toEqual([{ kind: 'folder', id: 'link', order: 0 }])
+  })
+
+  it('rewrites bookkeeping when moving an empty folder under a new parent', () => {
+    const site = makeSite({
+      pages: [makePage({ id: 'home', slug: 'index' })],
+      explorer: {
+        ...createDefaultSiteExplorerOrganization(),
+        pages: {
+          expandedFolders: ['scratch'],
+          emptyFolders: ['scratch'],
+          rowOrder: [{ kind: 'folder', id: 'scratch', order: 0 }],
+        },
+      },
+    })
+
+    const plan = buildMoveExplorerFolderPlan(site, {
+      sectionId: 'pages',
+      folderPath: 'scratch',
+      nextParentPath: 'docs',
+    })
+
+    expect(plan.blockers).toEqual([])
+    expect(plan.folderPathChange).toEqual({ from: 'scratch', to: 'docs/scratch' })
+
+    commitExplorerPathPlan(site, undefined, plan)
+
+    expect(site.explorer.pages.emptyFolders).toEqual(['docs/scratch'])
+    expect(site.explorer.pages.rowOrder).toEqual([{ kind: 'folder', id: 'docs/scratch', order: 0 }])
+  })
+
+  it('preserves folder expansion and order when renaming a non-empty folder', () => {
+    const site = makeSite({
+      pages: [
+        makePage({ id: 'home', slug: 'index' }),
+        makePage({ id: 'docs', slug: 'documentation' }),
+        makePage({ id: 'setup', slug: 'documentation/setup' }),
+      ],
+      explorer: {
+        ...createDefaultSiteExplorerOrganization(),
+        pages: {
+          expandedFolders: ['documentation'],
+          emptyFolders: [],
+          rowOrder: [{ kind: 'folder', id: 'documentation', order: 3 }],
+        },
+      },
+    })
+
+    const plan = buildRenameExplorerFolderPlan(site, {
+      sectionId: 'pages',
+      folderPath: 'documentation',
+      nextFolderPath: 'docs',
+    })
+
+    commitExplorerPathPlan(site, undefined, plan)
+
+    expect(site.pages.find((page) => page.id === 'docs')?.slug).toBe('docs')
+    expect(site.explorer.pages.expandedFolders).toEqual(['docs'])
+    expect(site.explorer.pages.rowOrder).toEqual([{ kind: 'folder', id: 'docs', order: 3 }])
+  })
+
+  it('removes empty-folder bookkeeping on delete even with no descendant items', () => {
+    const site = makeSite({
+      pages: [makePage({ id: 'home', slug: 'index' })],
+      explorer: {
+        ...createDefaultSiteExplorerOrganization(),
+        pages: {
+          expandedFolders: ['scratch'],
+          emptyFolders: ['scratch', 'scratch/inner'],
+          rowOrder: [{ kind: 'folder', id: 'scratch', order: 0 }],
+        },
+      },
+    })
+
+    const plan = buildDeleteExplorerPathPlan(site, { sectionId: 'pages', folderPath: 'scratch' })
+
+    expect(plan.deletedItems).toEqual([])
+    expect(plan.folderPath).toBe('scratch')
+
+    commitExplorerPathPlan(site, undefined, plan)
+
+    expect(site.explorer.pages).toEqual({ expandedFolders: [], emptyFolders: [], rowOrder: [] })
   })
 })

--- a/src/admin/pages/site/panels/SiteExplorerPanel/SiteExplorerPanel.tsx
+++ b/src/admin/pages/site/panels/SiteExplorerPanel/SiteExplorerPanel.tsx
@@ -76,6 +76,16 @@ function renamedFolderPath(
   return parentPath ? `${parentPath}/${segment}` : segment
 }
 
+/**
+ * A structural path plan warrants the confirm dialog only when it has a blocker
+ * to explain or actually rewrites/removes page/file paths. Empty-folder
+ * operations touch no content paths, so they skip the dialog and apply directly.
+ */
+function planNeedsConfirmation(plan: ExplorerPathChangePlan): boolean {
+  if (plan.blockers.length > 0) return true
+  return plan.kind === 'rewrite' ? plan.changes.length > 0 : plan.deletedItems.length > 0
+}
+
 export function SiteExplorerPanel({
   sectionGroup,
   organizationDndEnabled = false,
@@ -213,6 +223,26 @@ export function SiteExplorerPanel({
     setContextMenu(null)
   }
 
+  function commitStructuralPathPlan(plan: ExplorerPathChangePlan) {
+    try {
+      commitExplorerPathChange(plan)
+    } catch (err) {
+      console.error('[SiteExplorerPanel] commit explorer path change error:', err)
+    }
+  }
+
+  // A structural plan only needs the confirm dialog when there is something to
+  // review — real page/file path rewrites (raw URLs in content won't follow) or
+  // a blocker to explain. Empty-folder rename/move/delete rewrite nothing, so
+  // they apply straight away instead of surfacing a "0 paths" dialog.
+  function presentStructuralPathPlan(plan: ExplorerPathChangePlan) {
+    if (planNeedsConfirmation(plan)) {
+      setPathConfirmPlan(plan)
+    } else {
+      commitStructuralPathPlan(plan)
+    }
+  }
+
   function handleInlineRename(value: string) {
     if (!inlineRenameTarget) return
 
@@ -224,7 +254,7 @@ export function SiteExplorerPanel({
       } else if (inlineRenameTarget.kind === 'folder') {
         if (isStructuralSection(inlineRenameTarget.sectionId)) {
           const nextFolderPath = renamedFolderPath(inlineRenameTarget.sectionId, inlineRenameTarget.id, value)
-          setPathConfirmPlan(previewRenameExplorerFolder(inlineRenameTarget.sectionId, inlineRenameTarget.id, nextFolderPath))
+          presentStructuralPathPlan(previewRenameExplorerFolder(inlineRenameTarget.sectionId, inlineRenameTarget.id, nextFolderPath))
         } else {
           renameExplorerFolder(inlineRenameTarget.sectionId, inlineRenameTarget.id, value)
         }
@@ -258,7 +288,7 @@ export function SiteExplorerPanel({
       })
     } else if (target.kind === 'folder') {
       if (isStructuralSection(target.sectionId)) {
-        setPathConfirmPlan(previewDeleteExplorerFolder(target.sectionId, target.id))
+        presentStructuralPathPlan(previewDeleteExplorerFolder(target.sectionId, target.id))
       } else {
         deleteExplorerFolder(target.sectionId, target.id)
       }
@@ -270,12 +300,8 @@ export function SiteExplorerPanel({
 
   function handleConfirmPathChange() {
     if (!pathConfirmPlan) return
-    try {
-      commitExplorerPathChange(pathConfirmPlan)
-      setPathConfirmPlan(null)
-    } catch (err) {
-      console.error('[SiteExplorerPanel] commit explorer path change error:', err)
-    }
+    commitStructuralPathPlan(pathConfirmPlan)
+    setPathConfirmPlan(null)
   }
 
   function handleDeleteContext(menu: ContextMenuState) {
@@ -648,7 +674,7 @@ export function SiteExplorerPanel({
   return (
     <SiteExplorerDndScope
       enabled={organizationDndEnabled}
-      onStructuralPathPlan={setPathConfirmPlan}
+      onStructuralPathPlan={presentStructuralPathPlan}
     >
       {renderPanel}
     </SiteExplorerDndScope>

--- a/src/core/page-tree/explorerPathPlans.ts
+++ b/src/core/page-tree/explorerPathPlans.ts
@@ -5,7 +5,7 @@ import {
 } from '@core/site-runtime'
 import type { SiteRuntimeConfig } from '@core/site-runtime-schema'
 import type { SiteDocument } from './siteDocument'
-import type { StructuralSiteExplorerSectionId } from './siteExplorer'
+import type { StructuralExplorerSection, StructuralSiteExplorerSectionId } from './siteExplorer'
 import { isHomePage, pageSlugError } from './slugs'
 
 interface ExplorerPathChangeBlocker {
@@ -40,6 +40,14 @@ interface ExplorerPathDeletedItem {
   path: string
 }
 
+/** A structural folder that moves as a whole (rename or reparent). Drives the
+ *  bookkeeping rewrite so empty folders — which have no page/file rows — still
+ *  follow their new path across emptyFolders/expandedFolders/rowOrder. */
+interface ExplorerFolderPathChange {
+  from: string
+  to: string
+}
+
 interface ExplorerPathRewritePlan {
   kind: 'rewrite'
   sectionId: StructuralSiteExplorerSectionId
@@ -47,6 +55,8 @@ interface ExplorerPathRewritePlan {
   changes: ExplorerPathRewriteChange[]
   blockers: ExplorerPathChangeBlocker[]
   warnings: ExplorerPathChangeWarning[]
+  /** Set for folder rename/move; absent for single-item moves. */
+  folderPathChange?: ExplorerFolderPathChange
 }
 
 interface ExplorerPathDeletePlan {
@@ -56,6 +66,8 @@ interface ExplorerPathDeletePlan {
   deletedItems: ExplorerPathDeletedItem[]
   blockers: ExplorerPathChangeBlocker[]
   warnings: ExplorerPathChangeWarning[]
+  /** The folder subtree being removed, including empty folders with no rows. */
+  folderPath: string
 }
 
 export type ExplorerPathChangePlan = ExplorerPathRewritePlan | ExplorerPathDeletePlan
@@ -85,6 +97,7 @@ export function buildRenameExplorerFolderPlan(
     input.sectionId,
     `Rename ${input.folderPath} to ${input.nextFolderPath}`,
     changes,
+    { from: input.folderPath, to: input.nextFolderPath },
   )
 }
 
@@ -106,6 +119,7 @@ export function buildMoveExplorerFolderPlan(
     input.sectionId,
     `Move ${input.folderPath} to ${nextFolderPath}`,
     changes,
+    { from: input.folderPath, to: nextFolderPath },
   )
 
   if (input.nextParentPath && isDescendantPath(input.nextParentPath, input.folderPath)) {
@@ -151,6 +165,7 @@ export function buildDeleteExplorerPathPlan(
     deletedItems,
     blockers,
     warnings: [{ code: 'raw-url-not-rewritten', message: 'Raw URLs in authored content are not rewritten.' }],
+    folderPath: input.folderPath,
   }
 }
 
@@ -176,6 +191,7 @@ function rewritePlan(
   sectionId: StructuralSiteExplorerSectionId,
   operationLabel: string,
   changes: ExplorerPathRewriteChange[],
+  folderPathChange?: ExplorerFolderPathChange,
 ): ExplorerPathRewritePlan {
   return {
     kind: 'rewrite',
@@ -184,6 +200,9 @@ function rewritePlan(
     changes,
     blockers: blockersForRewrite(site, sectionId, changes),
     warnings: warningsForRewrite(site, sectionId, changes),
+    ...(folderPathChange && folderPathChange.from !== folderPathChange.to
+      ? { folderPathChange }
+      : {}),
   }
 }
 
@@ -342,7 +361,16 @@ function commitRewritePlan(site: SiteDocument, plan: ExplorerPathRewritePlan): v
       }
     }
   }
-  if (plan.changes.length > 0) site.updatedAt = now
+
+  // Empty folders have no page/file rows, so their new path is only reflected in
+  // the section bookkeeping. Non-empty folder renames route through here too,
+  // which keeps their expansion + ordering intact instead of losing it to the
+  // stale-entry pruning in reconcileSiteExplorerInPlace.
+  if (plan.folderPathChange) {
+    rewriteStructuralFolderPaths(site.explorer[plan.sectionId], plan.folderPathChange.from, plan.folderPathChange.to)
+  }
+
+  if (plan.changes.length > 0 || plan.folderPathChange) site.updatedAt = now
 }
 
 function commitDeletePlan(
@@ -351,23 +379,68 @@ function commitDeletePlan(
   plan: ExplorerPathDeletePlan,
 ): void {
   const deletedIds = new Set(plan.deletedItems.map((item) => item.id))
-  if (deletedIds.size === 0) return
 
-  if (plan.sectionId === 'pages') {
-    site.pages = site.pages.filter((page) => !deletedIds.has(page.id))
-  } else {
-    site.files = site.files.filter((file) => !deletedIds.has(file.id))
-    for (const id of deletedIds) {
-      if (plan.sectionId === 'scripts') {
-        if (site.runtime?.scripts) delete site.runtime.scripts[id]
-        if (liveRuntime?.scripts) delete liveRuntime.scripts[id]
-      } else {
-        if (site.runtime?.styles) delete site.runtime.styles[id]
-        if (liveRuntime?.styles) delete liveRuntime.styles[id]
+  if (deletedIds.size > 0) {
+    if (plan.sectionId === 'pages') {
+      site.pages = site.pages.filter((page) => !deletedIds.has(page.id))
+    } else {
+      site.files = site.files.filter((file) => !deletedIds.has(file.id))
+      for (const id of deletedIds) {
+        if (plan.sectionId === 'scripts') {
+          if (site.runtime?.scripts) delete site.runtime.scripts[id]
+          if (liveRuntime?.scripts) delete liveRuntime.scripts[id]
+        } else {
+          if (site.runtime?.styles) delete site.runtime.styles[id]
+          if (liveRuntime?.styles) delete liveRuntime.styles[id]
+        }
       }
     }
   }
-  site.updatedAt = Date.now()
+
+  // Remove the folder subtree from the section bookkeeping. Empty folders live
+  // only here, so without this an empty-folder delete would leave the folder
+  // standing after commit.
+  const removed = removeStructuralFolderPaths(site.explorer[plan.sectionId], plan.folderPath)
+
+  if (deletedIds.size > 0 || removed) site.updatedAt = Date.now()
+}
+
+/** Move every bookkeeping reference to `from` (and its descendants) onto `to`. */
+function rewriteStructuralFolderPaths(section: StructuralExplorerSection, from: string, to: string): void {
+  section.emptyFolders = dedupePaths(section.emptyFolders.map((path) => rewriteFolderPath(path, from, to)))
+  section.expandedFolders = dedupePaths(section.expandedFolders.map((path) => rewriteFolderPath(path, from, to)))
+  section.rowOrder = section.rowOrder.map((entry) => ({
+    ...entry,
+    ...(entry.kind === 'folder' ? { id: rewriteFolderPath(entry.id, from, to) } : {}),
+    ...(entry.parentPath !== undefined ? { parentPath: rewriteFolderPath(entry.parentPath, from, to) } : {}),
+  }))
+}
+
+/** Drop every bookkeeping reference at or under `folderPath`. Returns whether anything changed. */
+function removeStructuralFolderPaths(section: StructuralExplorerSection, folderPath: string): boolean {
+  const emptyFolders = section.emptyFolders.filter((path) => !isDescendantPath(path, folderPath))
+  const expandedFolders = section.expandedFolders.filter((path) => !isDescendantPath(path, folderPath))
+  const rowOrder = section.rowOrder.filter(
+    (entry) => !(entry.kind === 'folder' && isDescendantPath(entry.id, folderPath)),
+  )
+  const changed =
+    emptyFolders.length !== section.emptyFolders.length
+    || expandedFolders.length !== section.expandedFolders.length
+    || rowOrder.length !== section.rowOrder.length
+  section.emptyFolders = emptyFolders
+  section.expandedFolders = expandedFolders
+  section.rowOrder = rowOrder
+  return changed
+}
+
+function rewriteFolderPath(path: string, from: string, to: string): string {
+  if (path === from) return to
+  if (path.startsWith(`${from}/`)) return `${to}${path.slice(from.length)}`
+  return path
+}
+
+function dedupePaths(paths: readonly string[]): string[] {
+  return [...new Set(paths)]
 }
 
 function structuralItems(site: SiteDocument, sectionId: StructuralSiteExplorerSectionId): StructuralItem[] {


### PR DESCRIPTION
## What changed

Renaming, moving, or deleting an **empty** structural folder (pages / styles / scripts) in the Site Explorer no longer pops the "This will rewrite 0 paths" confirmation dialog. Those operations rewrite no page slugs or file paths, so they now apply directly. The dialog still appears whenever there is something to review — real slug/path rewrites, or a blocker to explain.

## Why

Two problems, one screenshot:

1. **Pointless dialog.** Renaming an empty folder showed a confirm dialog reading *"This will rewrite 0 paths in Pages"* with a generic "Raw URLs in authored content are not rewritten" warning — friction with nothing to confirm.
2. **Silent no-op underneath.** The confirm-plan commit only rewrote `pages[].slug` / `files[].path`. An empty folder's path lives in the section bookkeeping (`emptyFolders` / `expandedFolders` / `rowOrder`), which the commit never touched. So even after clicking **Apply**, the empty folder was *not* renamed/deleted — the operation did nothing.

Fixing only the UI (hiding the dialog) would have made the silent no-op worse, so both are fixed at the source.

## How

- **Core — `src/core/page-tree/explorerPathPlans.ts`**
  - Rewrite plans now carry a `folderPathChange { from, to }`; delete plans carry the removed `folderPath`.
  - `commit` rewrites/removes the `emptyFolders` / `expandedFolders` / `rowOrder` references so empty-folder rename/move/delete actually persist. Non-empty folder renames route through the same rewrite, which also preserves their expansion + ordering (previously lost to the reconcile pruning pass).

- **UI — `src/admin/pages/site/panels/SiteExplorerPanel/SiteExplorerPanel.tsx`**
  - A single `presentStructuralPathPlan` interception applies a plan directly when it has no blockers and rewrites 0 content paths; otherwise it opens the dialog. Covers inline rename, context-menu delete, and drag-drop moves through one code path.

## Tests

- Core unit tests: empty-folder rename (with nested descendant), empty-folder move under a new parent, non-empty rename preserves expansion/order, empty-folder delete removes bookkeeping with no descendant items.
- End-to-end store tests (preview → commit → reconcile) for a freshly-created (collapsed) empty folder rename and delete.

## Verification

- `bun run build` ✓
- `bun run lint` ✓
- `bun test src/__tests__/site-explorer/ src/__tests__/panels/` ✓ (all pass)

Pre-existing `icon-catalog-integrity` architecture failures are environmental (the vendored `pixel-art-icons/dist` is not built in this worktree) and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)