### PR TITLE
fix(import): install npm deps from module scripts

### DIFF
--- a/docs/features/agent.md
+++ b/docs/features/agent.md
@@ -374,11 +374,25 @@ Scripts and user stylesheets live in `site.files[]`; runtime targeting and loadi
 |------------------------|--------------------------------------------|-----------------------------------------|-------------------------------------------------------|
 | `list_code_assets`     | `{ type?: 'script' \| 'style' }`           | `{ assets }`                            | List runtime code assets with file ids, paths, full-content hashes, sizes, timestamps, and runtime config |
 | `read_code_asset`      | `{ fileId? \| path?, part?, maxChars? }`   | `{ fileId, path, type, content, hash, runtime, pageInfo }` | Read an exact script/stylesheet content slice. The `hash` is for the full file; page through with `pageInfo.nextPart` |
-| `write_code_asset`     | `{ path, type, content, runtime? }`        | asset summary + `{ action }`            | Create or replace a runtime script/stylesheet and normalize its runtime config. Existing paths are updated, new paths are created |
+| `write_code_asset`     | `{ path, type, content, runtime?, dependencies? }` | asset summary + `{ action, dependencies }` | Create or replace a runtime script/stylesheet and normalize its runtime config. Existing paths are updated, new paths are created. For module scripts, `dependencies` is a package-name → version/range map added to `site.packageJson.dependencies` |
 | `patch_code_asset`     | `{ fileId? \| path?, expectedHash, replacements }` | asset summary + `{ replacements }` | Apply exact text replacements only when `expectedHash` matches the latest content. Ambiguous matches require a wider `oldText` or explicit `replaceAll:true` |
 | `inspect_code_runtime` | `{ document?: { type, id } }`              | `{ pageId, document, scripts, styles }` | Report which runtime scripts/stylesheets apply to the current page/template or supplied page/template document ref |
 
 `insertHtml` / `replaceNodeHtml` intentionally strip `<script>` elements and inline event handlers (`onclick`, `onload`, etc.). When a request needs behavior, the agent should use `write_code_asset({ type: "script", ... })` and then `inspect_code_runtime`, not raw `<script>` tags or event attributes in HTML.
+
+Module scripts that need npm packages should import bare package specifiers and declare those packages in the same `write_code_asset` call:
+
+```ts
+write_code_asset({
+  path: 'src/scripts/motion.js',
+  type: 'script',
+  content: `import { Motion } from '@motion.page/sdk';`,
+  runtime: { format: 'module' },
+  dependencies: { '@motion.page/sdk': '1.2.4' },
+})
+```
+
+Agents should not use npm CDN URLs such as `esm.sh`, `unpkg`, or jsDelivr for packages that can live in the site dependency manifest.
 
 **Pages**
 

--- a/docs/features/html-import.md
+++ b/docs/features/html-import.md
@@ -142,7 +142,7 @@ Callers splice the fragment into the page tree via `insertImportedNodes(parentId
 | `style="…"` attributes | Declarations harvested onto `node.inlineStyles`; the attribute is removed |
 | HTML comments and processing instructions | Stripped silently — no count |
 
-The AI agent should not use stripped constructs for behavior. If an edit needs JavaScript, it writes a real runtime script with `write_code_asset({ type: "script", ... })` and verifies targeting with `inspect_code_runtime` instead of embedding `<script>` or `onclick` in an HTML import.
+The AI agent should not use stripped constructs for behavior. If an edit needs JavaScript, it writes a real runtime script with `write_code_asset({ type: "script", ... })` and verifies targeting with `inspect_code_runtime` instead of embedding `<script>` or `onclick` in an HTML import. Module scripts import npm packages with bare specifiers and declare them in the same `write_code_asset` call's `dependencies` map.
 
 After insert, `ImportHtmlModal` builds a toast body from the added-selector count plus the non-zero stripped counts, e.g. `"3 CSS selectors, stripped 2 <script>"`. If nothing notable happened, the toast shows only the node count.
 

--- a/docs/features/site-import.md
+++ b/docs/features/site-import.md
@@ -9,12 +9,12 @@ The static-site pipeline has two parts: a pure analysis function (`buildImportPl
 ## TL;DR
 
 - Entry: global admin-shell modal, opened from Spotlight or workspace actions. Drop files, a folder, a static `.zip`, or a CMS-exported `.zip` bundle. Static files and CMS bundles both use the four-stage modal (Drop → Review → Conflicts → Import, with completion shown inside the Import stage); Conflicts is skipped when there is nothing to resolve.
-- `buildImportPlan({ fileMap, currentSite, options })` — pure, synchronous — produces an `ImportPlan` with pages, style rules, kept stylesheet files, media, color tokens, custom fonts, Google font install requests, font tokens, and scripts.
+- `buildImportPlan({ fileMap, currentSite, options })` — pure, synchronous — produces an `ImportPlan` with pages, style rules, kept stylesheet files, media, color tokens, custom fonts, Google font install requests, font tokens, scripts, and script npm dependencies inferred from known ESM CDNs.
 - **Per-stylesheet import modes:** each top-level linked stylesheet either converts to editable style rules (default) or imports verbatim as a page-scoped `SiteFile` stylesheet (`options.stylesheetModes`, picked in the Review step). There are no generated scope classes — page isolation comes from the kept file's runtime scope.
 - `commitImportPlan(plan, adapter)` — uploads assets, then wraps all store writes in a single `adapter.commit` call → one Cmd+Z reverts the whole import.
 - Static imports load the current CMS draft into the editor store on demand when launched outside `/admin/site`; if no draft exists, the modal creates an empty site before analysis.
 - Conflict resolution: rename with a numeric suffix (default), overwrite, skip, or custom-rename — per page slug, per class name, per design token (colour / font CSS variable), and per divergent cross-stylesheet class definition, with category-level bulk actions. Token renames rewrite `var(--x)` references so imports stay faithful.
-- What imports: pages, linked CSS plus unconditional local CSS `@import` graphs, `kind:'class'` and `kind:'ambient'` style rules, stylesheets kept as page-scoped files, `@keyframes`, uploadable media/font files, root CSS color tokens, root CSS font tokens, `@font-face` families, known external font stylesheet imports, safe extra HTML attributes on base modules, body-level classes/attributes/style metadata, bare DOM text nodes in mixed content, and executable HTML scripts as page-scoped runtime scripts.
+- What imports: pages, linked CSS plus unconditional local CSS `@import` graphs, `kind:'class'` and `kind:'ambient'` style rules, stylesheets kept as page-scoped files, `@keyframes`, uploadable media/font files, root CSS color tokens, root CSS font tokens, `@font-face` families, known external font stylesheet imports, safe extra HTML attributes on base modules, body-level classes/attributes/style metadata, bare DOM text nodes in mixed content, and executable HTML scripts as page-scoped runtime scripts. Module-script imports from known npm CDNs are rewritten to bare package imports and added to the site dependency manifest.
 - CMS bundle import preserves selected exported tables, rows, optional site shell, media, folders, and redirects using the same merge strategies as site transfer (`replace`, `merge-add`, `merge-overwrite`).
 - HTML forms import through the shared HTML importer as first-class form primitives (`base.form`, controls, labels, submit buttons), not as custom containers.
 - What cannot be modeled: `@layer`, conditional local CSS `@import`, and arbitrary external `@import` — surfaced as warnings when the CSS engine exposes them, never silently dropped.
@@ -35,6 +35,7 @@ src/core/siteImport/
 ├── colorTokens.ts       — extract root custom-property color tokens from :root/html/body rules
 ├── fontTokens.ts        — extract root --font-* custom properties as ImportFontToken[] from :root/html/body rules
 ├── fontImports.ts       — resolve trusted Google CSS2 @import rules into installed-font requests
+├── scriptDependencies.ts — rewrite known npm ESM CDN imports in module scripts into bare package imports + dependency requests
 ├── cssImports.ts        — expand unconditional local CSS @import graphs while preserving each source path
 ├── classCascades.ts     — cross-sheet class semantics: detect divergent class definitions as explicit conflicts; apply rename / keep-first / overwrite; enforce one bindable class rule per name
 ├── mimeTypes.ts         — extension → MIME fallback for FileMap entries that carry no MIME type (e.g. ZIP)
@@ -175,6 +176,19 @@ interface ImportPlan {
 
 All URL-shaped values inside `pages[].nodeFragment` props, imported `htmlAttributes` bags, style rule `styles`/`contextStyles`, and supported raw style-rule blocks such as `@keyframes` are normalised to FileMap keys before the plan is returned — `applyAssetRewrites` does exact-string replacement after upload.
 
+`ImportScript` entries carry optional npm dependency requests when module-script CDN imports were converted:
+
+```ts
+interface ImportScript {
+  path: string
+  content: string
+  format: 'classic' | 'module'
+  pageSources: string[]
+  priority: number
+  dependencies?: { name: string; version: string }[]
+}
+```
+
 ---
 
 ## What each category imports
@@ -188,7 +202,7 @@ All URL-shaped values inside `pages[].nodeFragment` props, imported `htmlAttribu
 | **Color tokens** | CSS custom properties on `:root` / `html` / `body` that look like colours | `extractRootColorTokens` pulls them into `ImportColorToken[]`; they become framework palette tokens. The framework parses hex, rgb/rgba, and hsl/hsla into channels (deriving shades/tints/transparent steps); any other authored value (oklch(), color-mix(), …) still emits its base `--<slug>` verbatim so `var(--x)` references never break. A `--<slug>` that collides with an existing colour token surfaces as a `TokenConflict` (rename / skip / overwrite) |
 | **Fonts** | Self-hosted `@font-face` families with at least one bundled file, plus trusted Google CSS2 imports | `buildFontFamilies` in `assetPlan.ts` picks the best bundled format (woff2 → woff → ttf → otf); `extractGoogleFontImports` turns Google CSS2 `@import` rules into install requests. Commit uploads custom files via `tx.addFonts`, installs Google families through the CMS Google-font installer, then merges those returned `FontEntry` records via `tx.addInstalledFonts` |
 | **Font tokens** | Root `--font-*` variables with font-family stacks | `extractRootFontTokens` pulls them into `ImportFontToken[]`; committed via `tx.addFontTokens` after fonts so matching imported families can be assigned. A `--font-*` that collides with an existing font token surfaces as a `TokenConflict` (rename / skip / overwrite) |
-| **Scripts** | Executable inline scripts and JS files linked by imported HTML | Preserved in source order and committed via `tx.addScripts` with page scope from the source HTML. Classic scripts remain plain `<script>` assets and bypass bundling; `type="module"` scripts keep module semantics. Non-executable script data such as `application/json`, import maps, and templates is skipped. |
+| **Scripts** | Executable inline scripts and JS files linked by imported HTML | Preserved in source order and committed via `tx.addScripts` with page scope from the source HTML. Classic scripts remain plain `<script>` assets and bypass bundling; `type="module"` scripts keep module semantics. Module imports from known npm CDNs (`esm.sh`, `esm.run`, `unpkg`, jsDelivr npm URLs) are rewritten to bare package specifiers and recorded as runtime dependencies, so `https://esm.sh/@motion.page/sdk@1.2.4` becomes `@motion.page/sdk` plus `@motion.page/sdk: 1.2.4` in `packageJson.dependencies`. Non-executable script data such as `application/json`, import maps, and templates is skipped. |
 | **Stylesheets (kept)** | Top-level linked sheets the user opted into `mode: 'file'` | Flattened `@import` graph, Google imports stripped, `url()` normalised; committed via `tx.addStylesheets` as a `SiteFile` (`type: 'style'`) + `site.runtime.styles` entry scoped to the linking pages. Editable afterwards in the Site panel's Styles section and the code editor. |
 
 ---

--- a/server/ai/tools/site/systemPrompt.ts
+++ b/server/ai/tools/site/systemPrompt.ts
@@ -38,6 +38,7 @@ Structure as HTML, styling as CSS:
 Behavior and runtime code:
 - site_insert_html/site_replace_node_html deliberately strip <script> and inline event handlers (onclick/onload/etc). NEVER try to add behavior with <script>, onclick, or custom inline JS in HTML.
 - To add behavior such as theme toggles, tabs, menus, filters, or DOM-ready interactions, use site_write_code_asset({ type:"script", path:"src/scripts/...", content, runtime }). The script file is stored in the site file layer and loaded through site.runtime.
+- For npm packages in module scripts, import bare package specifiers (e.g. import { Motion } from "@motion.page/sdk") and include dependencies: { "@motion.page/sdk": "1.2.4" } in the SAME site_write_code_asset call. Do not use npm CDN URLs like esm.sh/unpkg/jsDelivr for packages that belong in the site dependency manifest.
 - Before changing existing scripts or user stylesheets, call site_list_code_assets/site_read_code_asset. Patch exact spans with site_patch_code_asset using the latest hash; if the text occurs multiple times, use a larger oldText span or replaceAll:true intentionally.
 - Use site_inspect_code_runtime after writing code to confirm scripts/styles apply to the current page/template, are enabled, and have the intended priority/placement/timing.
 

--- a/server/ai/tools/site/writeTools.ts
+++ b/server/ai/tools/site/writeTools.ts
@@ -245,7 +245,7 @@ const writeCodeAssetTool: AiTool = {
   execution: 'browser',
   requiredCapabilities: SITE_STRUCTURE_CAPS,
   description:
-    'Create or replace a runtime script/style file in site.files and attach normalized site.runtime config. Use `type:"script"` for behavior such as theme toggles, menus, tabs, analytics hooks, and DOM-ready interactions; use `type:"style"` for global user stylesheets that should load as files. `path` is a safe site-relative path such as src/scripts/theme-toggle.js or src/styles/theme.css. `runtime` is optional and merges with existing/default config.',
+    'Create or replace a runtime script/style file in site.files and attach normalized site.runtime config. Use `type:"script"` for behavior such as theme toggles, menus, tabs, analytics hooks, and DOM-ready interactions; use `type:"style"` for global user stylesheets that should load as files. `path` is a safe site-relative path such as src/scripts/theme-toggle.js or src/styles/theme.css. `runtime` is optional and merges with existing/default config. For module scripts that import npm packages, use bare package imports in `content` and declare them in `dependencies` (package name → semver/range) so they are added to the site dependency manifest; do not use npm CDN URLs for npm packages.',
   inputSchema: WriteCodeAssetInputSchema,
 }
 

--- a/src/__tests__/agent/executor.test.ts
+++ b/src/__tests__/agent/executor.test.ts
@@ -430,6 +430,22 @@ describe('executeAgentTool — code assets', () => {
     expect(read.pageInfo.nextPart).toBeNull()
   })
 
+  it('write_code_asset adds declared runtime dependencies for module scripts', async () => {
+    freshStore()
+
+    const result = await executeAgentTool('site_write_code_asset', {
+      path: 'src/scripts/motion.js',
+      type: 'script',
+      content: `import { Motion } from '@motion.page/sdk';\nwindow.Motion = Motion;`,
+      runtime: { format: 'module' },
+      dependencies: { '@motion.page/sdk': '1.2.4' },
+    })
+
+    expectToolOk(result)
+    expect(useEditorStore.getState().packageJson.dependencies['@motion.page/sdk']).toBe('1.2.4')
+    expect(useEditorStore.getState().site?.packageJson.dependencies['@motion.page/sdk']).toBe('1.2.4')
+  })
+
   it('write_code_asset creates a runtime stylesheet and inspect_code_runtime shows page applicability', async () => {
     const { rootId } = freshStore()
     await executeAgentTool('site_insert_html', { parentId: rootId, html: '<main><h1>Home</h1></main>' })

--- a/src/__tests__/editor-store/mutateAllPagesAndSite.test.ts
+++ b/src/__tests__/editor-store/mutateAllPagesAndSite.test.ts
@@ -149,6 +149,30 @@ describe('mutateAllPagesAndSite — basic happy path', () => {
     const matchingPage = pages.find((p) => p.id === returnedId)
     expect(matchingPage).toBeDefined()
   })
+
+  it('addScripts installs imported runtime dependencies in the same undoable mutation', () => {
+    useEditorStore.getState().createSite('Test')
+
+    useEditorStore.getState().mutateAllPagesAndSite((_site, helpers) => {
+      helpers.addScripts([{
+        path: 'motion.js',
+        content: `import { Motion } from '@motion.page/sdk';`,
+        format: 'module',
+        pageSources: ['index.html'],
+        priority: 100,
+        dependencies: [{ name: '@motion.page/sdk', version: '1.2.4' }],
+      }])
+      return true
+    })
+
+    expect(useEditorStore.getState().packageJson.dependencies['@motion.page/sdk']).toBe('1.2.4')
+    expect(useEditorStore.getState().site?.packageJson.dependencies['@motion.page/sdk']).toBe('1.2.4')
+
+    useEditorStore.getState().undo()
+
+    expect(useEditorStore.getState().packageJson.dependencies['@motion.page/sdk']).toBeUndefined()
+    expect(useEditorStore.getState().site?.packageJson.dependencies['@motion.page/sdk']).toBeUndefined()
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/siteImport/applyImport.test.ts
+++ b/src/__tests__/siteImport/applyImport.test.ts
@@ -267,6 +267,30 @@ describe('buildImportPlan — structure', () => {
     expect(plan.scripts.map((s) => s.path)).not.toContain('scripts/unused.js')
   })
 
+  it('converts npm CDN module imports into package dependencies', () => {
+    const encoder = new TextEncoder()
+    const p = buildImportPlan({
+      fileMap: {
+        files: {
+          'index.html': {
+            bytes: encoder.encode(`<!doctype html><html><body><script type="module" src="./motion.js"></script></body></html>`),
+            mimeType: 'text/html',
+          },
+          'motion.js': {
+            bytes: encoder.encode(`import { Motion } from 'https://esm.sh/@motion.page/sdk@1.2.4';\nwindow.Motion = Motion;`),
+            mimeType: 'application/javascript',
+          },
+        },
+      },
+      currentSite,
+    })
+
+    expect(p.scripts).toHaveLength(1)
+    expect(p.scripts[0]!.content).toContain(`from '@motion.page/sdk'`)
+    expect(p.scripts[0]!.content).not.toContain('https://esm.sh')
+    expect(p.scripts[0]!.dependencies).toEqual([{ name: '@motion.page/sdk', version: '1.2.4' }])
+  })
+
   it('imports executable inline scripts before the linked scripts that follow them', () => {
     const html = `<!doctype html><html><body>
       <script>var duration='500',easing='swing';</script>

--- a/src/admin/pages/site/agent/codeAssetTools.ts
+++ b/src/admin/pages/site/agent/codeAssetTools.ts
@@ -19,6 +19,7 @@ import {
   normalizeSiteRuntimeConfig,
   normalizeStyleRuntimeConfig,
 } from '@core/site-runtime'
+import { isSafePackageName } from '@core/site-dependencies/packageNames'
 import type { EditorStore } from '@site/store/types'
 import { activeRenderPage } from './documentTools'
 import { getAgentStoreApi } from './storeRef'
@@ -137,6 +138,26 @@ function setRuntimeForCodeAsset(
   store.setStyleRuntimeConfig(file.id, next)
 }
 
+function normalizeRequestedRuntimeDependencies(
+  input: WriteCodeAssetInput,
+): { ok: true; dependencies: Record<string, string> } | { ok: false; error: string } {
+  const entries = Object.entries(input.dependencies ?? {})
+  if (entries.length === 0) return { ok: true, dependencies: {} }
+  if (input.type !== 'script') {
+    return { ok: false, error: 'Runtime dependencies can only be declared for script code assets.' }
+  }
+
+  const dependencies: Record<string, string> = {}
+  for (const [rawName, rawVersion] of entries) {
+    const name = rawName.trim()
+    if (!isSafePackageName(name)) {
+      return { ok: false, error: `Invalid npm package name: ${rawName}` }
+    }
+    dependencies[name] = rawVersion.trim() || '*'
+  }
+  return { ok: true, dependencies }
+}
+
 function countOccurrences(content: string, search: string): number {
   let count = 0
   let index = content.indexOf(search)
@@ -234,6 +255,8 @@ export async function runWriteCodeAsset(input: WriteCodeAssetInput): Promise<AiT
 
   const path = normalizeCodeAssetPath(input.path)
   if (!path) return aiToolError(`Invalid code asset path: ${input.path}`)
+  const requestedDependencies = normalizeRequestedRuntimeDependencies(input)
+  if (!requestedDependencies.ok) return aiToolError(requestedDependencies.error)
 
   const existing = site.files.find((file) => file.path === path)
   let fileId: string
@@ -260,6 +283,10 @@ export async function runWriteCodeAsset(input: WriteCodeAssetInput): Promise<AiT
   }
   setRuntimeForCodeAsset(afterContentStore, file, input.runtime)
 
+  for (const [name, version] of Object.entries(requestedDependencies.dependencies)) {
+    getStoreState().setDependency(name, version, false)
+  }
+
   const afterRuntimeStore = getStoreState()
   const finalFile = afterRuntimeStore.site?.files.find((candidate) => candidate.id === fileId)
   if (!finalFile || !isCodeAssetFile(finalFile)) {
@@ -268,6 +295,7 @@ export async function runWriteCodeAsset(input: WriteCodeAssetInput): Promise<AiT
   return aiToolOk({
     ...(await describeCodeAsset(afterRuntimeStore, finalFile)),
     action,
+    dependencies: requestedDependencies.dependencies,
   })
 }
 

--- a/src/admin/pages/site/store/slices/site/helpers.ts
+++ b/src/admin/pages/site/store/slices/site/helpers.ts
@@ -10,7 +10,6 @@
 
 import { nanoid } from 'nanoid'
 import type { StoreApi } from 'zustand'
-import type { FrameworkColorToken } from '@core/framework-schema'
 import type { NodeTree, PageNode, StyleRule, SiteDocument } from '@core/page-tree'
 import { addPage, createNode, reconcileSiteExplorerInPlace, reindexNodeParents } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
@@ -19,17 +18,14 @@ import { collectSlotOutletNames } from '@core/visualComponents'
 import { create } from 'mutative'
 import type { Draft, Patches } from 'mutative'
 import type { ImportFragment } from '@core/htmlImport'
-import type {
-  NewStyleRule,
-  ImportColorToken,
-} from '@core/siteImport'
-import { normalizeFrameworkColorSlug } from '@core/framework'
-import { addImportedScripts, addImportedStylesheets } from './importedSiteFiles'
+import type { NewStyleRule } from '@core/siteImport'
+import { addImportedScriptDependencies, addImportedScripts, addImportedStylesheets } from './importedSiteFiles'
 import { collectDirtyFromSitePatches, mergeDirtyMarks } from './dirtyTracking'
 import type { EditorStore } from '@site/store/types'
 import { MAX_HISTORY } from './defaults'
 import { reconcileFrameworkClasses } from './framework/reconcile'
 import { indexStyleRulesByName, linkImportedClassNames } from './importLinking'
+import { addImportedColorTokens, overwriteImportedColorTokens } from './importedColorTokens'
 import { addImportedFonts, addImportedFontTokens, addInstalledFontEntries, overwriteImportedFontTokens } from './importedFonts'
 import type { HistoryEntry, SiteMutationResult, SiteSliceHelpers, SiteSliceRecipe } from './types'
 import type { SiteImportTransaction } from '@core/siteImport'
@@ -584,8 +580,15 @@ export function buildSiteHelpers(
         },
 
         addScripts(scripts): { id: string; path: string }[] {
+          const dependenciesChanged = addImportedScriptDependencies(site, scripts)
+          if (dependenciesChanged) {
+            draft.packageJson = {
+              dependencies: { ...site.packageJson.dependencies },
+              devDependencies: { ...site.packageJson.devDependencies },
+            }
+          }
           const committed = addImportedScripts(site, draft.siteRuntime, scripts)
-          if (committed.length > 0) didMutate = true
+          if (committed.length > 0 || dependenciesChanged) didMutate = true
           return committed
         },
 
@@ -615,86 +618,3 @@ export function buildSiteHelpers(
     mutateAllPagesAndSite,
   }
 }
-
-/**
- * Merge imported colour tokens into `site.settings.framework.colors` as PLAIN
- * BASE tokens — each emits only `--<slug>` (no shades/tints/transparent variants
- * and no `bg-/text-/border-` utility classes), so the palette is a faithful 1:1
- * of the source `:root` and every imported `var(--<slug>)` keeps resolving.
- *
- * A slug already present in the framework (case/format-normalised) is skipped:
- * the existing token wins, mirroring the class-conflict "first wins" rule.
- *
- * @returns The committed `{ slug, value }` for each newly-added token.
- */
-function addImportedColorTokens(
-  site: Draft<SiteDocument>,
-  colors: ImportColorToken[],
-): { slug: string; value: string }[] {
-  if (colors.length === 0) return []
-
-  // Ensure the framework colours container exists (enabling the framework).
-  site.settings.framework ??= { colors: { tokens: [] } }
-  site.settings.framework.colors ??= { tokens: [] }
-  const tokens = site.settings.framework.colors.tokens
-
-  const existingSlugs = new Set(tokens.map((t) => normalizeFrameworkColorSlug(t.slug)))
-  let maxOrder = tokens.reduce((m, t) => Math.max(m, t.order ?? 0), -1)
-  const committed: { slug: string; value: string }[] = []
-
-  for (const { slug: rawSlug, value } of colors) {
-    const slug = normalizeFrameworkColorSlug(rawSlug)
-    if (existingSlugs.has(slug)) continue
-    existingSlugs.add(slug)
-    const now = Date.now()
-    const token: FrameworkColorToken = {
-      id: nanoid(),
-      category: '',
-      slug,
-      lightValue: value,
-      darkValue: '',
-      darkModeEnabled: false,
-      generateUtilities: { text: false, background: false, border: false, fill: false },
-      generateTransparent: false,
-      generateShades: { enabled: false, count: 0 },
-      generateTints: { enabled: false, count: 0 },
-      order: (maxOrder += 1),
-      createdAt: now,
-      updatedAt: now,
-    }
-    tokens.push(token)
-    committed.push({ slug, value })
-  }
-
-  return committed
-}
-
-/**
- * Overwrite existing framework colour tokens in place (import conflict:
- * overwrite). The existing token's id, slug, and generation flags are retained;
- * only its `lightValue` is replaced, so `var(--<slug>)` references on both the
- * existing and imported sides keep resolving to the new colour.
- *
- * @returns The `{ slug, value }` for each overwritten token.
- */
-function overwriteImportedColorTokens(
-  site: Draft<SiteDocument>,
-  items: { existingTokenId: string; value: string }[],
-): { slug: string; value: string }[] {
-  if (items.length === 0) return []
-
-  const tokens = site.settings.framework?.colors?.tokens
-  if (!tokens || tokens.length === 0) return []
-
-  const committed: { slug: string; value: string }[] = []
-  for (const { existingTokenId, value } of items) {
-    const existing = tokens.find((t) => t.id === existingTokenId)
-    if (!existing) continue
-    existing.lightValue = value
-    existing.updatedAt = Date.now()
-    committed.push({ slug: existing.slug, value })
-  }
-
-  return committed
-}
-

--- a/src/admin/pages/site/store/slices/site/importedColorTokens.ts
+++ b/src/admin/pages/site/store/slices/site/importedColorTokens.ts
@@ -1,0 +1,77 @@
+import { nanoid } from 'nanoid'
+import type { Draft } from 'mutative'
+import { normalizeFrameworkColorSlug } from '@core/framework'
+import type { FrameworkColorToken } from '@core/framework-schema'
+import type { SiteDocument } from '@core/page-tree'
+import type { ImportColorToken } from '@core/siteImport'
+
+/**
+ * Merge imported colour tokens into `site.settings.framework.colors` as PLAIN
+ * BASE tokens. Each emits only `--<slug>`, so source `var(--<slug>)` references
+ * keep resolving without generated utility classes or derived colour variants.
+ */
+export function addImportedColorTokens(
+  site: Draft<SiteDocument>,
+  colors: ImportColorToken[],
+): { slug: string; value: string }[] {
+  if (colors.length === 0) return []
+
+  site.settings.framework ??= { colors: { tokens: [] } }
+  site.settings.framework.colors ??= { tokens: [] }
+  const tokens = site.settings.framework.colors.tokens
+
+  const existingSlugs = new Set(tokens.map((t) => normalizeFrameworkColorSlug(t.slug)))
+  let maxOrder = tokens.reduce((m, t) => Math.max(m, t.order ?? 0), -1)
+  const committed: { slug: string; value: string }[] = []
+
+  for (const { slug: rawSlug, value } of colors) {
+    const slug = normalizeFrameworkColorSlug(rawSlug)
+    if (existingSlugs.has(slug)) continue
+    existingSlugs.add(slug)
+    const now = Date.now()
+    const token: FrameworkColorToken = {
+      id: nanoid(),
+      category: '',
+      slug,
+      lightValue: value,
+      darkValue: '',
+      darkModeEnabled: false,
+      generateUtilities: { text: false, background: false, border: false, fill: false },
+      generateTransparent: false,
+      generateShades: { enabled: false, count: 0 },
+      generateTints: { enabled: false, count: 0 },
+      order: (maxOrder += 1),
+      createdAt: now,
+      updatedAt: now,
+    }
+    tokens.push(token)
+    committed.push({ slug, value })
+  }
+
+  return committed
+}
+
+/**
+ * Overwrite existing framework colour tokens in place. The existing token id,
+ * slug, and generation flags are retained; only `lightValue` is replaced.
+ */
+export function overwriteImportedColorTokens(
+  site: Draft<SiteDocument>,
+  items: { existingTokenId: string; value: string }[],
+): { slug: string; value: string }[] {
+  if (items.length === 0) return []
+
+  const tokens = site.settings.framework?.colors?.tokens
+  if (!tokens || tokens.length === 0) return []
+
+  const committed: { slug: string; value: string }[] = []
+  for (const { existingTokenId, value } of items) {
+    const existing = tokens.find((t) => t.id === existingTokenId)
+    if (!existing) continue
+    existing.lightValue = value
+    existing.updatedAt = Date.now()
+    committed.push({ slug: existing.slug, value })
+  }
+
+  return committed
+}

--- a/src/admin/pages/site/store/slices/site/importedSiteFiles.ts
+++ b/src/admin/pages/site/store/slices/site/importedSiteFiles.ts
@@ -16,6 +16,7 @@ import { nanoid } from 'nanoid'
 import type { Draft } from 'mutative'
 import type { SiteDocument } from '@core/page-tree'
 import type { ImportScript, ImportStylesheet } from '@core/siteImport'
+import { isSafePackageName } from '@core/site-dependencies/packageNames'
 import type { SiteFile } from '@core/files/schemas'
 import { isSafePath, normalizePath } from '@core/files/pathValidation'
 import {
@@ -45,6 +46,31 @@ export function addImportedScripts(
     site.runtime!.scripts[id] = config
     if (siteRuntime?.scripts) siteRuntime.scripts[id] = { ...config }
   })
+}
+
+export function addImportedScriptDependencies(
+  site: Draft<SiteDocument>,
+  scripts: ImportScript[],
+): boolean {
+  let changed = false
+  site.packageJson.dependencies ??= {}
+  site.packageJson.devDependencies ??= {}
+
+  for (const script of scripts) {
+    for (const dependency of script.dependencies ?? []) {
+      if (!isSafePackageName(dependency.name)) continue
+      const version = dependency.version.trim() || '*'
+      if (site.packageJson.dependencies[dependency.name]) continue
+
+      site.packageJson.dependencies[dependency.name] = version
+      if (site.packageJson.devDependencies[dependency.name]) {
+        delete site.packageJson.devDependencies[dependency.name]
+      }
+      changed = true
+    }
+  }
+
+  return changed
 }
 
 /**

--- a/src/core/ai/toolSchemas.ts
+++ b/src/core/ai/toolSchemas.ts
@@ -169,6 +169,14 @@ export const WriteCodeAssetInputSchema = Type.Object({
   type: CodeAssetTypeSchema,
   content: Type.String(),
   runtime: Type.Optional(Type.Record(Type.String(), Type.Unknown())),
+  dependencies: Type.Optional(Type.Record(
+    Type.String(),
+    Type.String({ minLength: 1 }),
+    {
+      description:
+        'Runtime npm dependencies required by a module script. Keys are package names, values are semver versions/ranges. Only valid when type is "script".',
+    },
+  )),
 })
 export type WriteCodeAssetInput = Static<typeof WriteCodeAssetInputSchema>
 

--- a/src/core/siteImport/buildPlan.ts
+++ b/src/core/siteImport/buildPlan.ts
@@ -22,6 +22,7 @@ import { partitionLinkedStylesheets } from './stylesheetPlan'
 import { detectCrossSheetClassConflicts, isSharedUtilityClassName } from './classCascades'
 import { detectConflicts } from './conflicts'
 import { createCssPlanState, parseCssSourceIntoPlan } from './planCss'
+import { rewriteNpmCdnModuleImports } from './scriptDependencies'
 import type {
   ClassifiedFile,
   FileMap,
@@ -210,6 +211,7 @@ function collectHtmlPagePlans(classified: ClassifiedFile[], fileMap: FileMap): H
     path: string
     content: string
     format: ImportScript['format']
+    dependencies: ImportScript['dependencies']
     pageSources: Set<string>
     priority: number
   }>()
@@ -234,11 +236,13 @@ function collectHtmlPagePlans(classified: ClassifiedFile[], fileMap: FileMap): H
         ? pageScript.content
         : decodeExternalScript(fileMap, pageScript.path)
       if (content === null) continue
+      const script = normalizeImportedScriptContent(content, pageScript.format)
 
       scriptsByPath.set(scriptPath, {
         path: scriptPath,
-        content,
+        content: script.content,
         format: pageScript.format,
+        dependencies: script.dependencies,
         pageSources: new Set([pagePlan.source]),
         priority: nextScriptPriority,
       })
@@ -358,4 +362,15 @@ function decodeUtf8(bytes: Uint8Array): string {
 function decodeExternalScript(fileMap: FileMap, path: string): string | null {
   const file = fileMap.files[path]
   return file ? decodeUtf8(file.bytes) : null
+}
+
+function normalizeImportedScriptContent(
+  content: string,
+  format: ImportScript['format'],
+): Pick<ImportScript, 'content' | 'dependencies'> {
+  if (format !== 'module') return { content }
+  const rewritten = rewriteNpmCdnModuleImports(content)
+  return rewritten.dependencies.length > 0
+    ? { content: rewritten.content, dependencies: rewritten.dependencies }
+    : { content }
 }

--- a/src/core/siteImport/index.ts
+++ b/src/core/siteImport/index.ts
@@ -86,6 +86,7 @@ export type {
   // colour tokens + scripts
   ImportColorToken,
   ImportFontToken,
+  ImportScriptDependency,
   ImportScript,
 } from './types'
 

--- a/src/core/siteImport/scriptDependencies.ts
+++ b/src/core/siteImport/scriptDependencies.ts
@@ -1,0 +1,133 @@
+import { extractRuntimeImportSpecifiers } from '@core/site-runtime'
+import { isSafePackageName } from '@core/site-dependencies/packageNames'
+import type { ImportScriptDependency } from './types'
+
+interface ScriptDependencyRewrite {
+  content: string
+  dependencies: ImportScriptDependency[]
+}
+
+interface NpmCdnSpecifier {
+  packageName: string
+  version: string
+  importSpecifier: string
+}
+
+export function rewriteNpmCdnModuleImports(source: string): ScriptDependencyRewrite {
+  const imports = extractRuntimeImportSpecifiers(source)
+  const dependencies = new Map<string, ImportScriptDependency>()
+  const rewrites: Array<{ start: number; end: number; importSpecifier: string }> = []
+  let content = source
+
+  for (const importEntry of imports) {
+    const normalized = npmCdnSpecifierFromUrl(importEntry.specifier)
+    if (!normalized) continue
+
+    const quote = source[importEntry.start]
+    if (quote !== '"' && quote !== "'") continue
+
+    rewrites.push({
+      start: importEntry.start,
+      end: importEntry.end,
+      importSpecifier: normalized.importSpecifier,
+    })
+    if (!dependencies.has(normalized.packageName)) {
+      dependencies.set(normalized.packageName, {
+        name: normalized.packageName,
+        version: normalized.version,
+      })
+    }
+  }
+
+  for (const rewrite of rewrites.reverse()) {
+    content =
+      content.slice(0, rewrite.start + 1) +
+      rewrite.importSpecifier +
+      content.slice(rewrite.end - 1)
+  }
+
+  return { content, dependencies: [...dependencies.values()] }
+}
+
+function npmCdnSpecifierFromUrl(specifier: string): NpmCdnSpecifier | null {
+  let url: URL
+  try {
+    url = new URL(specifier)
+  } catch {
+    return null
+  }
+
+  if (url.protocol !== 'https:' && url.protocol !== 'http:') return null
+
+  const host = url.hostname.toLowerCase()
+  let pathname: string
+  try {
+    pathname = decodeURIComponent(url.pathname)
+  } catch {
+    return null
+  }
+  const rawParts = pathname.split('/').filter(Boolean)
+  const parts = host === 'esm.sh' && /^v\d+$/.test(rawParts[0] ?? '')
+    ? rawParts.slice(1)
+    : rawParts
+
+  if (host === 'esm.sh' || host === 'esm.run') {
+    return npmSpecifierFromPackagePath(parts)
+  }
+
+  if (host === 'cdn.jsdelivr.net' && parts[0] === 'npm') {
+    return npmSpecifierFromPackagePath(parts.slice(1))
+  }
+
+  if (host === 'unpkg.com') {
+    return npmSpecifierFromPackagePath(parts)
+  }
+
+  return null
+}
+
+function npmSpecifierFromPackagePath(parts: string[]): NpmCdnSpecifier | null {
+  if (parts.length === 0) return null
+
+  const parsed = parts[0]!.startsWith('@')
+    ? parseScopedPackage(parts)
+    : parsePackageToken(parts[0]!)
+  if (!parsed || !isSafePackageName(parsed.packageName)) return null
+
+  const subpath = parts.slice(parsed.consumedParts).join('/')
+  const importSpecifier = subpath ? `${parsed.packageName}/${subpath}` : parsed.packageName
+  return {
+    packageName: parsed.packageName,
+    version: parsed.version || '*',
+    importSpecifier,
+  }
+}
+
+function parseScopedPackage(
+  parts: string[],
+): { packageName: string; version: string; consumedParts: number } | null {
+  if (parts.length < 2) return null
+
+  const scope = parts[0]!
+  const nameToken = parts[1]!
+  const versionIndex = nameToken.lastIndexOf('@')
+  if (versionIndex <= 0) {
+    return { packageName: `${scope}/${nameToken}`, version: '', consumedParts: 2 }
+  }
+
+  return {
+    packageName: `${scope}/${nameToken.slice(0, versionIndex)}`,
+    version: nameToken.slice(versionIndex + 1),
+    consumedParts: 2,
+  }
+}
+
+function parsePackageToken(token: string): { packageName: string; version: string; consumedParts: number } | null {
+  const versionIndex = token.lastIndexOf('@')
+  if (versionIndex <= 0) return { packageName: token, version: '', consumedParts: 1 }
+  return {
+    packageName: token.slice(0, versionIndex),
+    version: token.slice(versionIndex + 1),
+    consumedParts: 1,
+  }
+}

--- a/src/core/siteImport/types.ts
+++ b/src/core/siteImport/types.ts
@@ -243,6 +243,18 @@ export interface ImportFontToken {
 }
 
 /**
+ * An npm package required by an imported runtime module script.
+ *
+ * Super Import derives these when a source script imports an ESM CDN URL that
+ * maps cleanly to an npm package, then rewrites that import to the bare package
+ * specifier so the normal self-hosted dependency resolver can install it.
+ */
+export interface ImportScriptDependency {
+  name: string
+  version: string
+}
+
+/**
  * A JavaScript file linked by one or more imported HTML pages. Committed as a
  * `SiteFile` (`type: 'script'`) plus page-scoped `site.runtime.scripts` entry.
  * `content` is the decoded UTF-8 source.
@@ -260,6 +272,8 @@ export interface ImportScript {
   pageIds?: string[]
   /** Runtime ordering; lower runs earlier. Derived from first HTML occurrence. */
   priority: number
+  /** npm dependencies needed by this module script after import conversion. */
+  dependencies?: ImportScriptDependency[]
 }
 
 /**


### PR DESCRIPTION
## What changed

- Super Import now rewrites known npm ESM CDN imports in module scripts to bare package imports and records the matching npm dependency request.
- Imported script dependencies are committed into `site.packageJson.dependencies` in the same undoable import transaction.
- `site_write_code_asset` now accepts a `dependencies` map so AI agents can create module scripts with npm package imports and add the package manifest entry in the same tool call.
- Updated the site-agent prompt and docs to tell agents to use bare npm imports plus `dependencies`, not npm CDN URLs.
- Split imported color-token helpers out of the oversized site helper module to keep the source-size architecture gate passing.

## Why

A static HTML bundle had `motion.js` importing `https://esm.sh/@motion.page/sdk@1.2.4`. Super Import preserved the CDN URL, so runtime dependency analysis could only warn about an external URL and could not add `@motion.page/sdk` to the site dependency manifest.

## Impact

Static-site imports and AI-authored runtime scripts can now use self-hosted npm dependencies for module scripts. For the tested bundle shape, `motion.js` becomes `import { Motion } from '@motion.page/sdk';` and the site manifest gets `@motion.page/sdk: 1.2.4`.

## Verification

- `bun run lint`
- `bun run build`
- `bun test`
- Focused red/green coverage:
  - `bun test src/__tests__/siteImport/applyImport.test.ts src/__tests__/editor-store/mutateAllPagesAndSite.test.ts`
  - `bun test src/__tests__/agent/executor.test.ts`
  - `bun test src/__tests__/architecture/ai-tool-schema-ssot.test.ts src/__tests__/architecture/agent-no-raw-html-in-reply-rule.test.ts src/__tests__/architecture/agent-system-prompt-no-module-enumeration.test.ts`
- Direct bundle-shape check: `@motion.page/sdk@1.2.4` detected, import rewritten to `@motion.page/sdk`, `esm.sh` removed.