### PR TITLE
fix(editor): align canvas and layers shortcuts

### DIFF
--- a/docs/features/spotlight.md
+++ b/docs/features/spotlight.md
@@ -288,15 +288,19 @@ Used by destructive commands: delete user, sign out all devices, revoke session,
 | Key                  | Action                                                |
 |----------------------|-------------------------------------------------------|
 | ⌘K / Ctrl+K          | Open / close                                          |
+| ⌘I / Ctrl+I          | Open the AI assistant panel                           |
+| ⌘, / Ctrl+,          | Open Settings                                         |
 | Esc                  | Clear query (or close if empty)                       |
 | Arrow up / down      | Move selection                                        |
 | Enter                | Run selected (twice for `destructive` commands)       |
 | Tab                  | Cycle scope                                           |
 | Backspace (empty)    | Pop scope                                             |
-| ⌘?                   | Show all keybindings                                  |
+| ?                    | Show all keybindings                                  |
 | Custom command shortcuts | Per-command entry in `keybindings.ts`             |
 
-The keybindings registry is **the single source of truth** for shortcuts — gated by `keybindings-registry-single-source.test.ts`. Don't add raw `keydown` listeners in components; register a command with a shortcut in `keybindings.ts`.
+Selected-layer shortcuts are command shortcuts too. `⌘C` / `Ctrl+C`, `⌘X` / `Ctrl+X`, `⌘V` / `Ctrl+V`, and `⌘D` / `Ctrl+D` run when focus is on the canvas or the Layers tree. `⌘⌫` / `Ctrl+Backspace` deletes the selected layer from either surface through the normal delete confirmation flow; plain Delete / Backspace remains accepted by the canvas handler for selected canvas nodes.
+
+The keybindings registry is **the single source of truth** for shortcuts — gated by `keybindings-registry-single-source.test.ts`. Register each command shortcut in `keybindings.ts`; component-owned handlers may consume those registered bindings when a surface needs local selection or confirmation behavior, but they must not hard-code a second shortcut definition.
 
 ---
 

--- a/src/__tests__/spotlight/layersCommands.test.ts
+++ b/src/__tests__/spotlight/layersCommands.test.ts
@@ -62,6 +62,7 @@ async function runLayerCommand(commandId: string, selectedNodeIds: string[]): Pr
       canUndo: false,
       canRedo: false,
       activeBreakpointId: 'desktop',
+      activeInlineEdit: false,
     },
     args: {},
     navigate: () => {},

--- a/src/admin/pages/site/canvas/CanvasRoot.tsx
+++ b/src/admin/pages/site/canvas/CanvasRoot.tsx
@@ -22,12 +22,14 @@
  * - prefers-reduced-motion: CSS transitions are disabled for users who opt out
  */
 
-import { lazy, Suspense, useEffect, useRef } from 'react'
+import { lazy, Suspense, useContext, useEffect, useEffectEvent, useRef } from 'react'
 import { useEditorStore, selectActiveCanvasPage, selectRightSidebarExpanded } from '@site/store/store'
 import type { Breakpoint } from '@core/page-tree'
 import { registry } from '@core/module-engine'
 import { getNodeDisplayName } from '@core/page-tree'
 import { ErrorBoundary } from '@ui/components/ErrorBoundary'
+import { SpotlightContext } from '@admin/spotlight/spotlightContext'
+import { getKeybindingForCommand } from '@admin/spotlight/keybindings'
 import { useCanvas } from '@site/hooks/useCanvas'
 import { useEditorPermissions } from '@site/editorPermissionsContext'
 import { CanvasTransformLayer } from './CanvasTransformLayer'
@@ -78,6 +80,7 @@ interface CanvasRootProps {
 export function CanvasRoot({ editable = true }: CanvasRootProps) {
   const transformLayerRef = useRef<HTMLDivElement>(null)
   const canvasRef = useRef<HTMLDivElement>(null)
+  const spotlight = useContext(SpotlightContext)
 
   // Store subscriptions
   const canvasPage = useEditorStore(selectActiveCanvasPage)
@@ -330,7 +333,53 @@ export function CanvasRoot({ editable = true }: CanvasRootProps) {
     cutNode,
     cutNodes,
     pasteNode,
+    runShortcut: spotlight?.runShortcut,
   })
+
+  const requestDeleteSelectionFromShortcut = useEffectEvent((
+    currentSelectedNodeId: string,
+    currentIds: readonly string[],
+  ) => {
+    if (currentIds.length > 1) {
+      deleteNodes([...currentIds])
+      clearSelection()
+    } else {
+      requestDeleteNode(currentSelectedNodeId)
+    }
+  })
+
+  useEffect(() => {
+    if (isLive || !editable) return
+    const deleteBinding = getKeybindingForCommand('layers.delete')
+    if (!deleteBinding) return
+
+    const isCanvasEvent = (event: KeyboardEvent) => {
+      const target = event.target
+      if (target instanceof Element && canvasRef.current?.contains(target)) return true
+      const activeElement = document.activeElement
+      return activeElement instanceof Element && canvasRef.current?.contains(activeElement)
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return
+      if (useEditorStore.getState().activeInlineEdit) return
+      if (!deleteBinding.match(event)) return
+      if (!isCanvasEvent(event)) return
+
+      const state = useEditorStore.getState()
+      const currentIds = state.selectedNodeIds
+      const currentSelectedNodeId = state.selectedNodeId
+      if (!currentSelectedNodeId) return
+
+      event.preventDefault()
+      event.stopPropagation()
+
+      requestDeleteSelectionFromShortcut(currentSelectedNodeId, currentIds)
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [editable, isLive])
 
   // ─── Canvas background click → deselect ───────────────────────────────────
 
@@ -371,6 +420,7 @@ export function CanvasRoot({ editable = true }: CanvasRootProps) {
           aria-label="Canvas — infinite editing surface"
           tabIndex={0}
           data-testid="canvas-root"
+          data-instatic-canvas-root="true"
           data-canvas-state={canvasPage ? 'canvas-ready' : 'canvas-empty'}
           data-canvas-view={canvasView}
           data-vc-mode={activeDocument?.kind === 'visualComponent' ? 'true' : undefined}

--- a/src/admin/pages/site/canvas/IframeFrameSurface.tsx
+++ b/src/admin/pages/site/canvas/IframeFrameSurface.tsx
@@ -417,16 +417,9 @@ export const IframeFrameSurface = forwardRef<IframeFrameSurfaceHandle, IframeFra
       // and every `window`-level listener during capture/bubble.
       //
       // We deliberately dispatch on `document`, NOT on the iframe element. The
-      // canvas's own shortcut handler (delete / duplicate / clipboard / Escape)
-      // is a React `onKeyDown` on the canvas root, and React already delivers
-      // iframe-originated key events to it through the React fiber tree (see
-      // docs/features/canvas-iframe-per-frame.md). Dispatching the clone on the
-      // iframe element would bubble it through React's root container too and
-      // fire those handlers a SECOND time (duplicate twice, delete twice).
-      // `document` is above React's root container in the DOM, so the clone is
-      // seen only by the native window/document listeners — never re-entering
-      // React. The clone also lands in the parent document, so this
-      // iframe-document listener never sees it again (no loop).
+      // global shortcut dispatcher and canvas-level native bridge both listen
+      // in the parent document; dispatching here keeps the clone out of the
+      // iframe document so this listener never sees it again (no loop).
       const parentDocument = iframe.ownerDocument
       const forwardKeyboard = (e: KeyboardEvent) => {
         const forwarded = new KeyboardEvent('keydown', {

--- a/src/admin/pages/site/canvas/useCanvasKeyboardShortcuts.ts
+++ b/src/admin/pages/site/canvas/useCanvasKeyboardShortcuts.ts
@@ -40,6 +40,7 @@ interface CanvasKeyboardShortcutsDeps {
   cutNode: (nodeId: string) => void
   cutNodes: (nodeIds: string[]) => void
   pasteNode: (nodeId: string) => void
+  runShortcut?: (event: KeyboardEvent) => boolean
 }
 
 /** Inputs / textareas / contenteditable surfaces let the browser own the keystroke. */
@@ -140,6 +141,7 @@ export function useCanvasKeyboardShortcuts(
     cutNode,
     cutNodes,
     pasteNode,
+    runShortcut,
   } = deps
 
   return (event: CanvasKeyEvent) => {
@@ -153,6 +155,8 @@ export function useCanvasKeyboardShortcuts(
 
     // Zoom / pan keys always run, regardless of selection state.
     canvasKeyDown(event)
+
+    if (runShortcut?.(event.nativeEvent)) return
 
     // Escape exits VC mode regardless of selection (SF-1 / CR #666). This
     // must run before the selectedNodeId guard so pressing Escape while in

--- a/src/admin/pages/site/panels/DomPanel/DomPanel.tsx
+++ b/src/admin/pages/site/panels/DomPanel/DomPanel.tsx
@@ -445,6 +445,7 @@ function DomPanelInner({ editable = true }: { editable?: boolean }) {
             <TreeContainer
               ariaLabel="Page element tree"
               testId="dom-panel-tree"
+              data-instatic-layer-tree="true"
             >
               <SearchResults
                 rows={searchRows}
@@ -470,6 +471,7 @@ function DomPanelInner({ editable = true }: { editable?: boolean }) {
                   ariaLabel="Page element tree"
                   testId="dom-panel-tree"
                   containerRef={treeRef}
+                  data-instatic-layer-tree="true"
                 >
                   {/*
                     Page mode shows the `base.body` root because it represents

--- a/src/admin/pages/site/panels/DomPanel/TreeNode.tsx
+++ b/src/admin/pages/site/panels/DomPanel/TreeNode.tsx
@@ -39,6 +39,7 @@ import {
   TreeRow,
   treeDropStyles,
 } from '@site/ui/Tree'
+import { getKeybindingForCommand } from '@admin/spotlight/keybindings'
 import { useEditorPreference } from '@site/preferences/editorPreferences'
 import { useConfirmDelete } from '@admin/shared/dialogs/ConfirmDeleteDialog'
 import { LayerTreeNodeContent } from './LayerTreeNodeContent'
@@ -94,6 +95,7 @@ export const TreeNode = memo(function TreeNode({ nodeId, depth, editable = true 
   const selectNode = useEditorStore((s) => s.selectNode)
   const hoverNode = useEditorStore((s) => s.hoverNode)
   const deleteNode = useEditorStore((s) => s.deleteNode)
+  const deleteNodes = useEditorStore((s) => s.deleteNodes)
   const duplicateNode = useEditorStore((s) => s.duplicateNode)
   const renameNode = useEditorStore((s) => s.renameNode)
   const wrapNode = useEditorStore((s) => s.wrapNode)
@@ -163,11 +165,60 @@ export const TreeNode = memo(function TreeNode({ nodeId, depth, editable = true 
         ? 'inside'
         : undefined
 
+  const requestDeleteLayer = () => {
+    if (!editable || isRoot || node.locked) return
+    confirmDelete({
+      title: 'Delete layer?',
+      description: `${displayName} and any of its children will be removed. This can be undone with Ctrl/Cmd+Z.`,
+      commit: () => deleteNode(nodeId),
+    })
+  }
+
+  const requestDeleteSelection = () => {
+    if (!editable || isRoot || node.locked) return
+
+    const state = useEditorStore.getState()
+    const page = selectActiveCanvasPage(state)
+    if (!page) return
+
+    const selection = state.selectedNodeIds.includes(nodeId)
+      ? state.selectedNodeIds
+      : [nodeId]
+    const deletableIds = selection.filter((id) => {
+      const candidate = page.nodes[id]
+      return Boolean(candidate) && id !== page.rootNodeId && !candidate?.locked
+    })
+    if (deletableIds.length === 0) return
+
+    if (!state.selectedNodeIds.includes(nodeId)) {
+      selectLayerNode()
+    }
+
+    if (deletableIds.length === 1) {
+      requestDeleteLayer()
+      return
+    }
+
+    confirmDelete({
+      title: 'Delete layers?',
+      description: `${deletableIds.length} layers and any children will be removed. This can be undone with Ctrl/Cmd+Z.`,
+      commit: () => deleteNodes([...deletableIds]),
+    })
+  }
+
   // ── Keyboard navigation ───────────────────────────────────────────────────
   const handleKeyDown = (e: React.KeyboardEvent) => {
     // When the rename input is active, all key handling is delegated to
     // handleRenameKeyDown on the input itself — don't intercept here.
     if (isRenaming) return
+
+    if (getKeybindingForCommand('layers.delete')?.match(e)) {
+      e.preventDefault()
+      e.stopPropagation()
+      requestDeleteSelection()
+      return
+    }
+
     switch (e.key) {
       case 'Enter':
       case ' ':
@@ -374,11 +425,7 @@ export const TreeNode = memo(function TreeNode({ nodeId, depth, editable = true 
           onClose={() => setContextMenu(null)}
           onDelete={() => {
             setContextMenu(null)
-            confirmDelete({
-              title: 'Delete layer?',
-              description: `${displayName} and any of its children will be removed. This can be undone with Ctrl/Cmd+Z.`,
-              commit: () => deleteNode(nodeId),
-            })
+            requestDeleteLayer()
           }}
           onDuplicate={() => { duplicateNode(nodeId); setContextMenu(null) }}
           onRename={() => { setContextMenu(null); openRename() }}

--- a/src/admin/pages/site/ui/Tree/Tree.tsx
+++ b/src/admin/pages/site/ui/Tree/Tree.tsx
@@ -1,9 +1,8 @@
-import type { ReactNode, Ref } from 'react'
+import type { HTMLAttributes, ReactNode, Ref } from 'react'
 
-interface TreeContainerProps {
+interface TreeContainerProps extends HTMLAttributes<HTMLDivElement> {
   ariaLabel: string
   testId?: string
-  className?: string
   /** Forward a ref to the underlying div, e.g. for scroll-to-selected. */
   containerRef?: Ref<HTMLDivElement>
   children: ReactNode
@@ -15,6 +14,7 @@ export function TreeContainer({
   className,
   containerRef,
   children,
+  ...props
 }: TreeContainerProps) {
   return (
     <div
@@ -23,6 +23,7 @@ export function TreeContainer({
       aria-label={ariaLabel}
       data-testid={testId}
       className={className}
+      {...props}
     >
       {children}
     </div>

--- a/src/admin/spotlight/HelpKeybindingsList.tsx
+++ b/src/admin/spotlight/HelpKeybindingsList.tsx
@@ -27,7 +27,7 @@ const SCOPE_ORDER: ReadonlyArray<Scope> = ['global', 'editor', 'canvas', 'panels
 const SCOPE_LABELS: Record<Scope, string> = {
   global:  'Global',
   editor:  'Editor',
-  canvas:  'Canvas',
+  canvas:  'Canvas & Layers',
   panels:  'Panels',
 }
 

--- a/src/admin/spotlight/SpotlightRoot.tsx
+++ b/src/admin/spotlight/SpotlightRoot.tsx
@@ -32,6 +32,7 @@ import {
   lazy,
   Suspense,
   useEffect,
+  useEffectEvent,
   useReducer,
   useRef,
   useState,
@@ -51,6 +52,7 @@ import { recordRecentCommand } from './recentStore'
 import { SpotlightContext, SpotlightInternalContext } from './spotlightContext'
 import type { SpotlightInternalContextValue } from './spotlightContext'
 import { getKeybindingForCommand } from './keybindings'
+import { findMatchingShortcutCommand } from './shortcutDispatch'
 
 // ─── Lazy dialog chunk ────────────────────────────────────────────────────────
 // Defined at module level so React.lazy doesn't recreate the wrapper on each
@@ -164,15 +166,16 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
   }, []) // intentionally empty — run once on mount, clean up on unmount
 
   // ─── Editor context snapshot ──────────────────────────────────────────────
-  // Phase 2: subscribe to the editor store while the spotlight is open AND
-  // the active workspace is 'site'. The subscription is established lazily
-  // (dynamic import) so the editor store is never loaded on non-site workspaces.
+  // Subscribe to the editor store while the active workspace is 'site'. This
+  // feeds both Spotlight filtering and direct command-shortcut dispatch.
+  // The subscription is established lazily so the editor store is never loaded
+  // on non-site workspaces.
 
   const [editorCtx, setEditorCtx] = useState<EditorCtxSnapshot | null>(null)
 
   useEffect(() => {
-    // Not on site workspace or palette closed — subscribe nothing; cleanup resets ctx.
-    if (!isOpen || workspace !== 'site') {
+    // Not on site workspace — subscribe nothing; cleanup resets ctx.
+    if (workspace !== 'site') {
       return () => { setEditorCtx(null) }
     }
 
@@ -192,6 +195,7 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
           canUndo: s.canUndo,
           canRedo: s.canRedo,
           activeBreakpointId: s.activeBreakpointId,
+          activeInlineEdit: s.activeInlineEdit !== null,
         }
       }
 
@@ -216,7 +220,8 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
           next.activeDocument === last.activeDocument &&
           next.canUndo === last.canUndo &&
           next.canRedo === last.canRedo &&
-          next.activeBreakpointId === last.activeBreakpointId
+          next.activeBreakpointId === last.activeBreakpointId &&
+          next.activeInlineEdit === last.activeInlineEdit
         ) return
         last = next
         setEditorCtx(next)
@@ -228,7 +233,7 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
       unsubscribe?.()
       setEditorCtx(null)
     }
-  }, [isOpen, workspace])
+  }, [workspace])
 
   // ─── Build CommandContext ─────────────────────────────────────────────────
 
@@ -334,6 +339,19 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
     await runCommandWithArgs(command, {})
   }
 
+  const runShortcut = (event: KeyboardEvent): boolean => {
+    if (!commandContext) return false
+    const shortcutCommand = findMatchingShortcutCommand(event, commandContext)
+    if (!shortcutCommand) return false
+
+    event.preventDefault()
+    event.stopPropagation()
+    void runCommand(shortcutCommand)
+    return true
+  }
+
+  const runShortcutFromGlobalListener = useEffectEvent((event: KeyboardEvent) => runShortcut(event))
+
   // ─── Global Cmd+K / Ctrl+K listener ──────────────────────────────────────
   // Capture phase so the listener fires before editor keydown handlers.
   // The match predicate comes from the keybindings registry — single source of truth.
@@ -349,6 +367,8 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
         dispatch({ type: 'TOGGLE' })
         return
       }
+
+      if (runShortcutFromGlobalListener(event)) return
 
       if (currentPhase !== 'open') return
 
@@ -390,6 +410,7 @@ export function SpotlightRoot({ children }: { children: ReactNode }) {
     open: () => dispatch({ type: 'OPEN' }),
     close: () => dispatch({ type: 'CLOSE' }),
     toggle: () => dispatch({ type: 'TOGGLE' }),
+    runShortcut,
     pushScope: (scopeId, args) =>
       dispatch({ type: 'PUSH_SCOPE', scopeId, pendingArgs: args }),
     popScope: () => dispatch({ type: 'POP_SCOPE' }),

--- a/src/admin/spotlight/__tests__/commandRegistry.test.ts
+++ b/src/admin/spotlight/__tests__/commandRegistry.test.ts
@@ -202,6 +202,7 @@ describe('filterCommands — combined gates', () => {
         canUndo: false,
         canRedo: false,
         activeBreakpointId: 'desktop',
+        activeInlineEdit: false,
       },
     }
     expect(filterCommands([cmd], ctxWithEditor)).toEqual([cmd])

--- a/src/admin/spotlight/__tests__/shortcutDispatch.test.ts
+++ b/src/admin/spotlight/__tests__/shortcutDispatch.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'fs'
+import { getKeybindingForCommand } from '../keybindings'
+import { findMatchingShortcutCommand } from '../shortcutDispatch'
+import type { CommandContext } from '../types'
+
+const SPOTLIGHT_ROOT = new URL('../SpotlightRoot.tsx', import.meta.url)
+
+function eventLike(key: string, overrides: Partial<KeyboardEvent> = {}) {
+  return {
+    key,
+    metaKey: false,
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    ...overrides,
+  }
+}
+
+function context(capabilities: string[], editor?: CommandContext['editor']): CommandContext {
+  return {
+    workspace: 'site',
+    pathname: '/admin/site',
+    user: {
+      id: 'user-1',
+      email: 'owner@example.com',
+      name: 'Owner',
+      roleId: 'role-owner',
+      roleName: 'Owner',
+      capabilities,
+    },
+    editor,
+  } as CommandContext
+}
+
+function canvasTarget() {
+  return {
+    tagName: 'DIV',
+    isContentEditable: false,
+    closest: (selector: string) =>
+      selector === '[data-instatic-canvas-root="true"]' ? {} : null,
+  }
+}
+
+function layerTreeTarget() {
+  return {
+    tagName: 'DIV',
+    isContentEditable: false,
+    closest: (selector: string) =>
+      selector === '[data-instatic-layer-tree="true"]' ? {} : null,
+  }
+}
+
+describe('command shortcut dispatch', () => {
+  it('registers Cmd/Ctrl+I for opening the AI assistant panel', () => {
+    const binding = getKeybindingForCommand('ai.open')
+
+    expect(binding).toBeDefined()
+    expect(binding?.shortcut).toEqual({ mac: '⌘I', win: 'Ctrl+I' })
+    expect(binding?.scope).toBe('panels')
+    expect(binding?.match(eventLike('i', { metaKey: true }))).toBe(true)
+    expect(binding?.match(eventLike('i', { ctrlKey: true }))).toBe(true)
+  })
+
+  it('SpotlightRoot dispatches registered command shortcuts beyond Cmd+K', () => {
+    const src = readFileSync(SPOTLIGHT_ROOT, 'utf-8')
+
+    expect(src).toContain('findMatchingShortcutCommand')
+    expect(src).toContain('void runCommand(shortcutCommand)')
+  })
+
+  it('resolves Cmd/Ctrl+I to the AI command only when ai.chat is available', () => {
+    const allowed = findMatchingShortcutCommand(
+      eventLike('i', { metaKey: true }) as KeyboardEvent,
+      context(['site.read', 'ai.chat']),
+    )
+    const denied = findMatchingShortcutCommand(
+      eventLike('i', { metaKey: true }) as KeyboardEvent,
+      context(['site.read']),
+    )
+
+    expect(allowed?.id).toBe('ai.open')
+    expect(denied).toBeNull()
+  })
+
+  it('resolves canvas clipboard shortcuts only from the canvas focus surface', () => {
+    const ctx = context(['site.read'], {
+      selectedNodeIds: ['node-1'],
+      activePageId: 'page-1',
+      activeDocument: { kind: 'page', pageId: 'page-1' },
+      canUndo: false,
+      canRedo: false,
+      activeBreakpointId: 'desktop',
+      activeInlineEdit: false,
+    })
+    const fromCanvas = findMatchingShortcutCommand(
+      eventLike('c', { metaKey: true, target: canvasTarget() as EventTarget }) as KeyboardEvent,
+      ctx,
+    )
+    const outsideCanvas = findMatchingShortcutCommand(
+      eventLike('c', { metaKey: true }) as KeyboardEvent,
+      ctx,
+    )
+
+    expect(fromCanvas?.id).toBe('layers.copy')
+    expect(outsideCanvas).toBeNull()
+  })
+
+  it('resolves layer clipboard shortcuts from the Layers tree focus surface', () => {
+    const ctx = context(['site.read'], {
+      selectedNodeIds: ['node-1'],
+      activePageId: 'page-1',
+      activeDocument: { kind: 'page', pageId: 'page-1' },
+      canUndo: false,
+      canRedo: false,
+      activeBreakpointId: 'desktop',
+      activeInlineEdit: false,
+    })
+
+    const command = findMatchingShortcutCommand(
+      eventLike('c', { metaKey: true, target: layerTreeTarget() as EventTarget }) as KeyboardEvent,
+      ctx,
+    )
+
+    expect(command?.id).toBe('layers.copy')
+  })
+
+  it('registers Cmd/Ctrl+Backspace for deleting the selected layer', () => {
+    const binding = getKeybindingForCommand('layers.delete')
+
+    expect(binding).toBeDefined()
+    expect(binding?.shortcut).toEqual({ mac: '⌘⌫', win: 'Ctrl+Backspace' })
+    expect(binding?.match(eventLike('Backspace', { metaKey: true }))).toBe(true)
+    expect(binding?.match(eventLike('Backspace', { ctrlKey: true }))).toBe(true)
+  })
+
+  it('matches browser-uppercase canvas clipboard shortcut keys', () => {
+    const ctx = context(['site.read', 'site.structure.edit'], {
+      selectedNodeIds: ['node-1'],
+      activePageId: 'page-1',
+      activeDocument: { kind: 'page', pageId: 'page-1' },
+      canUndo: false,
+      canRedo: false,
+      activeBreakpointId: 'desktop',
+      activeInlineEdit: false,
+    })
+
+    expect(
+      findMatchingShortcutCommand(
+        eventLike('C', { metaKey: true, target: canvasTarget() as EventTarget }) as KeyboardEvent,
+        ctx,
+      )?.id,
+    ).toBe('layers.copy')
+    expect(
+      findMatchingShortcutCommand(
+        eventLike('X', { metaKey: true, target: canvasTarget() as EventTarget }) as KeyboardEvent,
+        ctx,
+      )?.id,
+    ).toBe('layers.cut')
+    expect(
+      findMatchingShortcutCommand(
+        eventLike('V', { metaKey: true, target: canvasTarget() as EventTarget }) as KeyboardEvent,
+        ctx,
+      )?.id,
+    ).toBe('layers.paste')
+  })
+
+  it('does not run canvas shortcuts during inline text editing', () => {
+    const ctx = context(['site.read', 'site.structure.edit'], {
+      selectedNodeIds: ['node-1'],
+      activePageId: 'page-1',
+      activeDocument: { kind: 'page', pageId: 'page-1' },
+      canUndo: false,
+      canRedo: false,
+      activeBreakpointId: 'desktop',
+      activeInlineEdit: true,
+    })
+
+    const command = findMatchingShortcutCommand(
+      eventLike('C', { metaKey: true, target: canvasTarget() as EventTarget }) as KeyboardEvent,
+      ctx,
+    )
+
+    expect(command).toBeNull()
+  })
+})

--- a/src/admin/spotlight/commands/aiAssistant.ts
+++ b/src/admin/spotlight/commands/aiAssistant.ts
@@ -22,9 +22,9 @@ export function getAiAssistantCommands(): Command[] {
         ctx.closeSpotlight()
         try {
           const { useEditorStore } = await import('@site/store/store')
-          useEditorStore.getState().openAgent()
+          useEditorStore.getState().setLeftSidebarPanel('agent')
         } catch (err) {
-          console.error('[spotlight] openAgent failed:', err)
+          console.error('[spotlight] open AI assistant panel failed:', err)
         }
       },
     },

--- a/src/admin/spotlight/commands/layers.ts
+++ b/src/admin/spotlight/commands/layers.ts
@@ -45,11 +45,16 @@ export function getLayersCommands(): Command[] {
       priorityBoost: 1.1,
       run: async (ctx) => {
         ctx.closeSpotlight()
-        const nodeId = ctx.editor?.selectedNodeIds[ctx.editor.selectedNodeIds.length - 1]
-        if (!nodeId) return
+        const ids = ctx.editor?.selectedNodeIds ?? []
+        if (ids.length === 0) return
         try {
           const { useEditorStore } = await import('@site/store/store')
-          useEditorStore.getState().duplicateNode(nodeId)
+          const store = useEditorStore.getState()
+          if (ids.length === 1) {
+            store.duplicateNode(ids[0]!)
+          } else {
+            store.duplicateNodes([...ids])
+          }
         } catch (err) {
           console.error('[spotlight] duplicateNode failed:', err)
         }

--- a/src/admin/spotlight/keybindings.ts
+++ b/src/admin/spotlight/keybindings.ts
@@ -16,7 +16,8 @@
  *   - scope      → where the binding is active:
  *                  'global'  = fires anywhere in the admin shell
  *                  'editor'  = fires within the editor workspace
- *                  'canvas'  = fires when the canvas element has focus
+ *                  'canvas'  = fires on layer-operation surfaces
+ *                              (canvas or Layers tree)
  *                  'panels'  = fires in the panel rail / sidebar region
  *   - ignoreInEditableField → advisory flag; handlers enforce this themselves.
  *
@@ -125,14 +126,6 @@ export const KEYBINDINGS: ReadonlyArray<KeybindingDefinition> = [
   },
 
   {
-    commandId: 'account.signOut',
-    shortcut: { mac: '⌘⇧Q', win: 'Ctrl+Shift+Q' },
-    match: (e) => (e.metaKey || e.ctrlKey) && e.shiftKey && e.key.toLowerCase() === 'q',
-    scope: 'global',
-    ignoreInEditableField: true,
-  },
-
-  {
     commandId: 'help.shortcuts',
     shortcut: { mac: '?', win: '?' },
     match: (e) => e.key === '?' && !e.metaKey && !e.ctrlKey,
@@ -170,40 +163,62 @@ export const KEYBINDINGS: ReadonlyArray<KeybindingDefinition> = [
     scope: 'panels',
   },
 
-  // ── Canvas (layer operations — fire when canvas has focus) ──────────────────
+  {
+    commandId: 'ai.open',
+    shortcut: { mac: '⌘I', win: 'Ctrl+I' },
+    ariaKeyshortcuts: isPlatformMac() ? 'Meta+I' : 'Control+I',
+    match: (e) =>
+      (e.metaKey || e.ctrlKey) &&
+      !e.shiftKey &&
+      !e.altKey &&
+      e.key.toLowerCase() === 'i',
+    scope: 'panels',
+    ignoreInEditableField: true,
+    capability: 'ai.chat',
+  },
+
+  // ── Canvas + Layers tree (layer operations) ─────────────────────────────────
 
   {
     commandId: 'layers.duplicate',
     shortcut: { mac: '⌘D', win: 'Ctrl+D' },
     match: (e) => (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'd',
     scope: 'canvas',
+    ignoreInEditableField: true,
   },
 
   {
     commandId: 'layers.copy',
     shortcut: { mac: '⌘C', win: 'Ctrl+C' },
-    match: (e) => (e.metaKey || e.ctrlKey) && e.key === 'c',
+    match: (e) => (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'c',
     scope: 'canvas',
+    ignoreInEditableField: true,
   },
 
   {
     commandId: 'layers.cut',
     shortcut: { mac: '⌘X', win: 'Ctrl+X' },
-    match: (e) => (e.metaKey || e.ctrlKey) && e.key === 'x',
+    match: (e) => (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'x',
     scope: 'canvas',
+    ignoreInEditableField: true,
   },
 
   {
     commandId: 'layers.paste',
     shortcut: { mac: '⌘V', win: 'Ctrl+V' },
-    match: (e) => (e.metaKey || e.ctrlKey) && e.key === 'v',
+    match: (e) => (e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'v',
     scope: 'canvas',
+    ignoreInEditableField: true,
   },
 
   {
     commandId: 'layers.delete',
-    shortcut: { mac: 'Delete', win: 'Delete' },
-    match: (e) => e.key === 'Delete' || e.key === 'Backspace',
+    shortcut: { mac: '⌘⌫', win: 'Ctrl+Backspace' },
+    ariaKeyshortcuts: isPlatformMac() ? 'Meta+Backspace' : 'Control+Backspace',
+    match: (e) =>
+      ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key === 'Backspace') ||
+      (!e.metaKey && !e.ctrlKey && !e.shiftKey && !e.altKey &&
+        (e.key === 'Delete' || e.key === 'Backspace')),
     scope: 'canvas',
     ignoreInEditableField: true,
   },

--- a/src/admin/spotlight/shortcutDispatch.ts
+++ b/src/admin/spotlight/shortcutDispatch.ts
@@ -1,0 +1,80 @@
+import { filterCommands, getAllCommands } from './commandRegistry'
+import { KEYBINDINGS, type KeyEventLike } from './keybindings'
+import type { Command, CommandContext } from './types'
+
+const CANVAS_ROOT_SELECTOR = '[data-instatic-canvas-root="true"]'
+const LAYER_TREE_SELECTOR = '[data-instatic-layer-tree="true"]'
+
+const COMPONENT_OWNED_SHORTCUTS = new Set([
+  'spotlight.open',
+  'editor.save',
+  'editor.undo',
+  'editor.redo',
+  'layers.delete',
+])
+
+function isElementLike(value: unknown): value is Element {
+  return typeof value === 'object' && value !== null && 'closest' in value
+}
+
+function elementFromTarget(target: EventTarget | null): Element | null {
+  return isElementLike(target) ? target : null
+}
+
+function isEditableShortcutTarget(target: EventTarget | null): boolean {
+  const element = elementFromTarget(target)
+  if (!element) return false
+
+  const htmlElement = element as HTMLElement
+  const tagName = htmlElement.tagName
+  if (tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT') return true
+  if (htmlElement.isContentEditable) return true
+
+  return Boolean(element.closest('input, textarea, select, [contenteditable="true"]'))
+}
+
+function eventDocument(event: KeyboardEvent): Document | null {
+  const element = elementFromTarget(event.target)
+  if (element?.ownerDocument) return element.ownerDocument
+  return typeof document === 'undefined' ? null : document
+}
+
+function isLayerShortcutSurface(event: KeyboardEvent): boolean {
+  const targetElement = elementFromTarget(event.target)
+  if (targetElement?.closest(CANVAS_ROOT_SELECTOR)) return true
+  if (targetElement?.closest(LAYER_TREE_SELECTOR)) return true
+
+  const activeElement = eventDocument(event)?.activeElement
+  return isElementLike(activeElement) &&
+    (Boolean(activeElement.closest(CANVAS_ROOT_SELECTOR)) ||
+      Boolean(activeElement.closest(LAYER_TREE_SELECTOR)))
+}
+
+function shouldIgnoreEditableTarget(commandId: string): boolean {
+  const binding = KEYBINDINGS.find((kb) => kb.commandId === commandId)
+  return binding?.ignoreInEditableField === true
+}
+
+export function findMatchingShortcutCommand(
+  event: KeyboardEvent,
+  context: CommandContext,
+): Command | null {
+  const commands = getAllCommands()
+
+  for (const binding of KEYBINDINGS) {
+    if (COMPONENT_OWNED_SHORTCUTS.has(binding.commandId)) continue
+    if (binding.scope === 'canvas' && context.editor?.activeInlineEdit) continue
+    if (binding.scope === 'canvas' && !isLayerShortcutSurface(event)) continue
+    if (shouldIgnoreEditableTarget(binding.commandId) && isEditableShortcutTarget(event.target)) continue
+    if (!binding.match(event as KeyEventLike)) continue
+
+    const command = commands.find((candidate) => candidate.id === binding.commandId)
+    if (!command) continue
+    if (command.args && command.args.length > 0) continue
+    if (command.destructive) continue
+    if (filterCommands([command], context).length === 0) continue
+    return command
+  }
+
+  return null
+}

--- a/src/admin/spotlight/spotlightControls.ts
+++ b/src/admin/spotlight/spotlightControls.ts
@@ -10,6 +10,7 @@ export interface SpotlightControls {
   open: () => void
   close: () => void
   toggle: () => void
+  runShortcut: (event: KeyboardEvent) => boolean
   pushScope: (scopeId: string, args?: Record<string, string>) => void
   popScope: () => void
 }

--- a/src/admin/spotlight/types.ts
+++ b/src/admin/spotlight/types.ts
@@ -73,6 +73,7 @@ export interface CommandContext {
     canUndo: boolean
     canRedo: boolean
     activeBreakpointId: string
+    activeInlineEdit: boolean
   }
 }
 

--- a/tests/e2e/helpers/editor.ts
+++ b/tests/e2e/helpers/editor.ts
@@ -81,7 +81,11 @@ export async function insertModuleViaPicker(
 export async function openLayersPanel(page: Page): Promise<void> {
   const tree = page.getByRole('tree', { name: 'Page element tree' })
   if (!(await tree.isVisible().catch(() => false))) {
-    await page.getByRole('button', { name: 'Open Layers panel' }).click()
+    const explorer = page.getByRole('complementary', { name: 'Explorer' })
+    if (!(await explorer.isVisible().catch(() => false))) {
+      await page.getByRole('button', { name: 'Open Explorer panel' }).click()
+    }
+    await explorer.getByRole('button', { name: 'Layers', exact: true }).click()
   }
   await expect(tree).toBeVisible()
 }
@@ -113,7 +117,11 @@ export async function setPropValue(
 export async function openSitePanel(page: Page): Promise<void> {
   const newPageButton = page.getByRole('button', { name: 'New page', exact: true })
   if (!(await newPageButton.isVisible().catch(() => false))) {
-    await page.getByRole('button', { name: 'Open Site panel' }).click()
+    const explorer = page.getByRole('complementary', { name: 'Explorer' })
+    if (!(await explorer.isVisible().catch(() => false))) {
+      await page.getByRole('button', { name: 'Open Explorer panel' }).click()
+    }
+    await explorer.getByRole('button', { name: 'Site', exact: true }).click()
   }
   await expect(newPageButton).toBeVisible()
 }

--- a/tests/e2e/visual-builder.e2e.ts
+++ b/tests/e2e/visual-builder.e2e.ts
@@ -190,7 +190,7 @@ test.describe('visual builder', () => {
     await expect(undoButton).not.toHaveAttribute('aria-disabled', 'true')
     await expect(redoButton).toHaveAttribute('aria-disabled', 'true')
 
-    await page.getByTestId('canvas-root').click()
+    await page.getByTestId('canvas-root').focus()
     await page.keyboard.press(`${shortcutModifier}+Z`)
     await expect(textNode).toHaveCount(0)
     await expect(undoButton).toHaveAttribute('aria-disabled', 'true')
@@ -220,6 +220,65 @@ test.describe('visual builder', () => {
     await expect(textNode).toHaveCount(0)
     await expect(undoButton).toHaveAttribute('aria-disabled', 'true')
     await expect(redoButton).toHaveAttribute('aria-disabled', 'true')
+  })
+
+  test('runs direct panel and canvas clipboard shortcuts (BUILDER-005)', async ({
+    page,
+  }) => {
+    await openBlankPage(page, 'Builder shortcuts')
+
+    const shortcutModifier = process.platform === 'darwin' ? 'Meta' : 'Control'
+
+    await page.getByTestId('canvas-root').focus()
+    await page.keyboard.press(`${shortcutModifier}+I`)
+    const assistantPanel = page.getByRole('complementary', { name: 'AI Assistant' })
+    await expect(assistantPanel).toBeVisible()
+
+    await page.getByTestId('panel-close-agent').click()
+    await expect(assistantPanel).toBeHidden()
+
+    const canvasShortcutText = `Canvas shortcut text ${Date.now().toString(36)}`
+    await insertNotchModule(page, 'text')
+    await setPropValue(page, 'text', canvasShortcutText)
+    await openLayersPanel(page)
+
+    const tree = page.getByRole('tree', { name: 'Page element tree' })
+    const textNodes = tree.getByRole('treeitem', { name: 'Text' })
+    await expect(textNodes).toHaveCount(1)
+    await textNodes.first().click()
+
+    await page.getByTestId('canvas-root').focus()
+    await page.keyboard.press(`${shortcutModifier}+C`)
+    await page.keyboard.press(`${shortcutModifier}+V`)
+
+    await expect(textNodes).toHaveCount(2)
+
+    await textNodes.first().click()
+    await expect(textNodes.first()).toBeFocused()
+    await page.keyboard.press(`${shortcutModifier}+C`)
+    await page.keyboard.press(`${shortcutModifier}+V`)
+    await expect(textNodes).toHaveCount(3)
+
+    await textNodes.first().click()
+    await expect(textNodes.first()).toBeFocused()
+    await page.keyboard.press(`${shortcutModifier}+Backspace`)
+    await confirmDeleteIfShown(page, 'Delete layer?')
+    await expect(textNodes).toHaveCount(2)
+
+    const canvasText = canvasFrame(page).getByText(canvasShortcutText, { exact: true }).first()
+    await canvasText.click()
+    await page.keyboard.press(`${shortcutModifier}+C`)
+    await page.keyboard.press(`${shortcutModifier}+V`)
+    await expect(textNodes).toHaveCount(3)
+
+    await canvasText.click()
+    await page.keyboard.press(`${shortcutModifier}+D`)
+    await expect(textNodes).toHaveCount(4)
+
+    await canvasText.click()
+    await page.keyboard.press(`${shortcutModifier}+Backspace`)
+    await confirmDeleteIfShown(page, 'Delete layer?')
+    await expect(textNodes).toHaveCount(3)
   })
 
   test('keeps generated slot layers locked while allowing slot content insertion (BUILDER-003 locked slots)', async ({


### PR DESCRIPTION
## What changed

- Routes registered command shortcuts from the canvas and Layers tree through the shared keybinding registry.
- Makes selected-layer copy, cut, paste, duplicate, and delete work consistently from both canvas selections and focused Layers rows.
- Adds `Cmd/Ctrl+I` for the AI assistant panel and updates the shortcut help/settings copy so the visible shortcuts match implemented behavior.
- Covers the canvas/Layers clipboard and delete paths with focused unit coverage and an E2E regression.

## Why

Layer operations are shared editor actions, but keyboard handling was split between canvas-only handlers, tree row handlers, and shortcut documentation. That meant shortcuts advertised in settings could fail depending on whether focus was in the canvas iframe or the Layers tree.

## Verification

- `bun run lint`
- `bun run build`
- `bun test`
- `E2E_REUSE_SERVER=1 bun run test:e2e -- --project=e2e tests/e2e/visual-builder.e2e.ts -g "direct panel and canvas clipboard"`