### PR TITLE
chore(release): prepare 0.0.10

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.9 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.10 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.9
+docker pull ghcr.io/corebunch/instatic:0.0.10
 ```
 
-The v0.0.9 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.10 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.9
+ghcr.io/corebunch/instatic:0.0.10
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.9` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.10` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.9
+Image=ghcr.io/corebunch/instatic:0.0.10
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.9
+ghcr.io/corebunch/instatic:0.0.10
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.9` |
+| Image | `ghcr.io/corebunch/instatic:0.0.10` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.9` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.10` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.9",
+  "version": "0.0.10",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },


### PR DESCRIPTION
## What changed

- Bumped the app package version to `0.0.10`.
- Updated checked-in deployment docs that pin the GHCR semver image tag to `ghcr.io/corebunch/instatic:0.0.10`.

## Release highlights since 0.0.9

- Added OpenAI-compatible AI providers with custom base URL support.
- Improved imported module scripts by rewriting known CDN ESM imports to npm package imports and recording dependencies.
- Aligned canvas and Layers tree shortcuts for copy, cut, paste, duplicate, and delete.
- Fixed published YouTube embeds by allowing modules to declare CSP sources.
- Fixed empty Site Explorer structural folder rename/move/delete handling.

No database migrations are included.

## Verification

- `bun test` — 5909 pass, 0 fail
- `bun run build`
- `bun run lint`
- `bun run release:bundle -- 0.0.10`