### PR TITLE
fix(db): hydrate Postgres JSON text columns

### DIFF
--- a/docs/reference/database-dialects.md
+++ b/docs/reference/database-dialects.md
@@ -10,7 +10,7 @@ The CMS supports **Postgres** (production, multi-author teams, horizontal scale)
 
 - **One `DbClient` interface** (`server/db/client.ts`). Two adapters: `postgres.ts` (via `Bun.sql`) and `sqlite.ts` (via `bun:sqlite`).
 - **Repositories are dialect-naive.** They use ANSI-standard SQL only. The five Postgres-isms are banned. Gated by `db-postgres-isms.test.ts`.
-- **JSON columns end in `_json`.** The SQLite adapter auto-parses on read and auto-stringifies on write. Gated by `db-json-column-naming.test.ts`.
+- **JSON columns end in `_json`.** Adapters hydrate string-valued JSON on read; SQLite also stringifies objects on write. Gated by `db-json-column-naming.test.ts`.
 - **Migrations are split per dialect.** `migrations-pg.ts` and `migrations-sqlite.ts` carry identical migration IDs in the same order. Parity gated by `migration-parity.test.ts`.
 - **Adding a migration** means editing both files. **Adding a JSON column** means naming it `<something>_json`.
 
@@ -38,10 +38,10 @@ The two migration files (`migrations-pg.ts`, `migrations-sqlite.ts`) are explici
 
 Every column intended to store JSON has a name ending in `_json`. This is a hard convention, not a suggestion.
 
-The SQLite adapter (`server/db/sqlite.ts`) exploits it:
+The adapters exploit it:
 
-- **On read** — any column whose name ends in `_json` and whose value is a non-empty string is auto-`JSON.parse`d. Repositories receive a `Record<string, unknown>`, not a string.
-- **On write** — any plain object or array passed via tagged-template interpolation is auto-`JSON.stringify`d.
+- **On read** — any column whose name ends in `_json` and whose value is a non-empty string is auto-`JSON.parse`d. Repositories receive a `Record<string, unknown>`, not a string. Postgres `jsonb` values already arrive parsed; this read normalizer covers `_json` columns backed by text.
+- **On write** — the SQLite adapter auto-`JSON.stringify`s any plain object or array passed via tagged-template interpolation. Postgres relies on `Bun.sql` parameter binding and native `jsonb` handling where the backing column is `jsonb`.
 
 Result: repository code is identical across dialects:
 
@@ -135,7 +135,7 @@ For SQLite, the parent directory of the DB file is created automatically.
 
 ### Adapter behaviors at the boundary
 
-**`server/db/sqlite.ts` does four things the Postgres adapter doesn't need to:**
+**`server/db/sqlite.ts` owns the SQLite-specific boundary work:**
 
 1. `toBindable(value)` converts JS values for SQLite parameter binding:
    - Plain object / array → `JSON.stringify` (stored as `TEXT`)
@@ -150,7 +150,7 @@ For SQLite, the parent directory of the DB file is created automatically.
 
 The Postgres adapter relies on `Bun.sql`'s native handling of `jsonb` columns and parameter binding — JS objects sent to `jsonb` columns are stored as JSONB and read back as `Record<string, unknown>` automatically.
 
-**`server/db/postgres.ts`** additionally resolves `rowCount` from `result.count` (Bun's per-command row count from PostgreSQL's CommandComplete tag) rather than `result.length`. For non-RETURNING writes (UPDATE / DELETE / INSERT), Postgres streams the affected-row count in its CommandComplete tag rather than returning data rows, so `result.length` is always 0 for those statements. `result.count` captures the CommandComplete count, giving `rowCount` the same semantics as the SQLite adapter's `info.changes`. Falls back to `result.length` if the property is absent.
+**`server/db/postgres.ts`** normalizes returned rows by converting `Date` instances to ISO strings and parsing string-valued `_json` columns. It also resolves `rowCount` from `result.count` (Bun's per-command row count from PostgreSQL's CommandComplete tag) rather than `result.length`. For non-RETURNING writes (UPDATE / DELETE / INSERT), Postgres streams the affected-row count in its CommandComplete tag rather than returning data rows, so `result.length` is always 0 for those statements. `result.count` captures the CommandComplete count, giving `rowCount` the same semantics as the SQLite adapter's `info.changes`. Falls back to `result.length` if the property is absent.
 
 ---
 

--- a/server/ai/conversations/store.ts
+++ b/server/ai/conversations/store.ts
@@ -54,8 +54,8 @@ interface MessageRow {
   conversation_id: string
   position: number
   role: string
-  // Both dialects auto-hydrate `_json` columns to JS values (SQLite via the
-  // adapter's parseJsonColumns; PG via jsonb). The row arrives already-parsed.
+  // Both dialect adapters auto-hydrate `_json` columns to JS values. The row
+  // arrives already parsed even when a backing column stores JSON as text.
   content_json: unknown
   tool_call_id: string | null
   tool_name: string | null
@@ -94,8 +94,8 @@ function conversationRowToRecord(row: ConversationRow): ConversationRecord {
 const ContentBlocksSchema = Type.Array(AiContentBlockSchema)
 
 function parseContentBlocks(raw: unknown): AiContentBlock[] {
-  // SQLite adapter + PG jsonb both deliver this column pre-parsed. This is the
-  // read boundary: every block is validated against the canonical
+  // The DB adapters deliver this column pre-parsed. This is the read boundary:
+  // every block is validated against the canonical
   // `AiContentBlockSchema`, so callers (e.g. `buildMessageHistory`) receive a
   // fully-typed `AiContentBlock[]` and never re-cast.
   const parsed = safeParseValue(ContentBlocksSchema, raw)
@@ -367,8 +367,8 @@ export async function appendMessage(
     const cacheReadTokens = input.cacheReadTokens ?? 0
     const cacheCreationTokens = input.cacheCreationTokens ?? 0
 
-    // Pass content as a plain array; both dialect adapters handle the JSON
-    // encoding (SQLite auto-stringify on bind for objects; PG jsonb native).
+    // Pass content as a plain array; the DB boundary handles JSON
+    // encoding/decoding for `_json` columns.
     const { rows: msgRows } = await tx<MessageRow>`
       insert into ai_messages (
         id, conversation_id, position, role, content_json,

--- a/server/db/__tests__/postgresRowNormalization.test.ts
+++ b/server/db/__tests__/postgresRowNormalization.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test'
+import { normalizePostgresRow } from '../postgres'
+
+describe('postgres row normalization', () => {
+  it('parses string-valued JSON columns and normalizes dates', () => {
+    const createdAt = new Date('2026-06-29T12:03:32.000Z')
+
+    const row = normalizePostgresRow({
+      id: 'message_1',
+      content_json: '[{"kind":"text","text":"hello"}]',
+      metadata_json: '{"scope":"site","nested":{"ok":true}}',
+      broken_json: '{not valid json',
+      settings_json: { already: 'parsed' },
+      created_at: createdAt,
+      title: 'Plain text',
+    })
+
+    expect(row.content_json).toEqual([{ kind: 'text', text: 'hello' }])
+    expect(row.metadata_json).toEqual({ scope: 'site', nested: { ok: true } })
+    expect(row.broken_json).toBe('{not valid json')
+    expect(row.settings_json).toEqual({ already: 'parsed' })
+    expect(row.created_at).toBe(createdAt.toISOString())
+    expect(row.title).toBe('Plain text')
+  })
+})

--- a/server/db/postgres.ts
+++ b/server/db/postgres.ts
@@ -7,16 +7,27 @@ export function createPostgresClient(connectionString: string): DbClient {
 }
 
 /**
- * Walk every column in a returned row and convert any Date instance to its
- * ISO 8601 string representation. This normalises the PG read path to match
- * the shape SQLite returns (ISO strings for all timestamps), so downstream
- * code can collapse `Date | string` unions to `string` over time.
+ * Walk every column in a returned row and normalize dialect-specific values:
+ *
+ * - Date instances become ISO 8601 strings, matching SQLite timestamp reads.
+ * - String-valued `*_json` columns are JSON.parsed, matching SQLite's TEXT
+ *   JSON hydration and covering PG columns that intentionally store JSON in
+ *   text rather than jsonb.
  */
-function normalizeRowDates<Row>(row: Row): Row {
+export function normalizePostgresRow<Row>(row: Row): Row {
   if (row === null || typeof row !== 'object' || Array.isArray(row)) return row
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(row as Record<string, unknown>)) {
-    result[key] = value instanceof Date ? value.toISOString() : value
+    const normalized = value instanceof Date ? value.toISOString() : value
+    if (key.endsWith('_json') && typeof normalized === 'string' && normalized.length > 0) {
+      try {
+        result[key] = JSON.parse(normalized)
+      } catch {
+        result[key] = normalized
+      }
+    } else {
+      result[key] = normalized
+    }
   }
   return result as Row
 }
@@ -43,7 +54,7 @@ function wrapSql(sql: SQL): DbClient {
     ...values: unknown[]
   ): Promise<DbResult<Row>> => {
     const rows = await sql<Row[]>(strings, ...values)
-    return { rows: rows.map(normalizeRowDates), rowCount: resultRowCount(rows) }
+    return { rows: rows.map(normalizePostgresRow), rowCount: resultRowCount(rows) }
   }) as DbClient
 
   fn.unsafe = async <Row = Record<string, unknown>>(
@@ -53,7 +64,7 @@ function wrapSql(sql: SQL): DbClient {
     const rows = params !== undefined
       ? await sql.unsafe<Row[]>(rawSql, params as unknown[])
       : await sql.unsafe<Row[]>(rawSql)
-    return { rows: rows.map(normalizeRowDates), rowCount: resultRowCount(rows) }
+    return { rows: rows.map(normalizePostgresRow), rowCount: resultRowCount(rows) }
   }
 
   fn.transaction = async <T>(cb: (tx: DbClient) => Promise<T>): Promise<T> => {

--- a/server/db/sqlite.ts
+++ b/server/db/sqlite.ts
@@ -47,9 +47,8 @@ function renderTemplate(
 
 /**
  * Walk every column in a returned row and JSON.parse any column whose name
- * ends in `_json` and whose value is a non-empty string. This mirrors the
- * automatic JSONB deserialization that Postgres does, so repository code does
- * not need to know which dialect it's talking to.
+ * ends in `_json` and whose value is a non-empty string. This keeps the
+ * DbClient `_json` read contract dialect-neutral for repository code.
  */
 function parseJsonColumns<Row>(row: Row): Row {
   if (row === null || typeof row !== 'object' || Array.isArray(row)) return row


### PR DESCRIPTION
## Summary

- Hydrate string-valued `*_json` columns in the Postgres adapter while preserving existing Date normalization and native `jsonb` objects.
- Add a regression test for a Postgres-style `content_json` string row.
- Update AI conversation comments and the database dialect docs to describe the adapter-level `_json` read contract.

## Root Cause

Fixes #96. `ai_messages.content_json` is backed by `text` in Postgres, so hosted Postgres reads returned the saved AI message content as a JSON string. The conversation store validates `content_json` as an array of content blocks; receiving a string failed validation and collapsed the message to `content: []`, which Anthropic then rejected with `messages.0: user messages must have non-empty content`.

## Impact

Postgres-backed installs, including Railway and Docker/self-hosted deployments, now read AI conversation message content in the same shape as SQLite. Existing valid `content_json` rows do not need a migration.

## Verification

- `bun test server/db/__tests__/postgresRowNormalization.test.ts src/__tests__/ai/conversationRoundtrip.test.ts server/db/__tests__/sqliteStatementCache.test.ts`
- `bun test`
- `bun run build`
- `bun run lint`