### PR TITLE
fix(editor): hide empty container placeholder for inline styles

### DIFF
--- a/src/__tests__/base-modules-shared-render.editor.test.tsx
+++ b/src/__tests__/base-modules-shared-render.editor.test.tsx
@@ -15,6 +15,7 @@ import { render as renderReact } from '@testing-library/react'
 import { LinkModule } from '@modules/base/link'
 import { ButtonModule } from '@modules/base/button'
 import { ListModule } from '@modules/base/list'
+import { ContainerModule } from '@modules/base/container'
 import { anchorRel } from '@modules/base/shared/anchorTarget'
 import { parseItems } from '@modules/base/list/items'
 
@@ -86,5 +87,20 @@ describe('ListEditor canvas DOM matches parseItems', () => {
   it('renders <ol> for ordered, <ul> for unordered (== publisher tag)', () => {
     expect(renderEditor(ListModule, { listType: 'ordered', items: 'A' }).container.querySelector('ol')).not.toBeNull()
     expect(renderEditor(ListModule, { listType: 'unordered', items: 'A' }).container.querySelector('ul')).not.toBeNull()
+  })
+})
+
+describe('ContainerEditor empty-state placeholder', () => {
+  it('suppresses the empty-container affordance when inline styles make the element authored', () => {
+    const { container, queryByText } = renderEditor(
+      ContainerModule,
+      {},
+      { nodeWrapperProps: { style: { minHeight: 120 } } },
+    )
+
+    const root = container.querySelector('div')
+    expect(root?.getAttribute('style')).toContain('min-height: 120px')
+    expect(root?.getAttribute('data-canvas-empty-container')).toBeNull()
+    expect(queryByText('Empty container')).toBeNull()
   })
 })

--- a/src/modules/base/container/ContainerEditor.tsx
+++ b/src/modules/base/container/ContainerEditor.tsx
@@ -15,14 +15,14 @@
  * element so the canvas selection logic keeps treating the slot as a
  * pickable affordance.
  *
- * The empty-state affordance is suppressed once the container carries a
- * class (`mcClassName`). A class means the author has given the element
- * its own styling — decorative divs for background images, shapes, spacers
- * — where the "Empty container" icon + label would be visual noise that
- * fights the author's intended look. A class-bearing empty container is
- * already its own affordance via the styling it inherits, so it renders as
- * a bare element with no placeholder and no `data-canvas-empty-container`
- * marker.
+ * The empty-state affordance is suppressed once the container carries
+ * authored styling: either a class (`mcClassName`) or inline styles from the
+ * canvas node wrapper props. That means the author has given the element its
+ * own look — decorative divs for background images, shapes, spacers — where
+ * the "Empty container" icon + label would be visual noise that fights the
+ * author's intended result. A styled empty container is already its own
+ * affordance, so it renders as a bare element with no placeholder and no
+ * `data-canvas-empty-container` marker.
  *
  * Void elements (`<br>`, `<hr>`, `<input>`, etc.) must never receive
  * children — not even the empty-container placeholder — because React
@@ -60,9 +60,11 @@ export const ContainerEditor: React.FC<ModuleComponentProps<ContainerStoredProps
   }
 
   // Only show the empty-state affordance for a truly bare container — no
-  // children AND no author-applied class. A class supplies its own styling
-  // (background image, shape, spacer), so the placeholder would be noise.
-  const showPlaceholder = React.Children.count(children) === 0 && !mcClassName
+  // children AND no author-applied styling. Styling supplies its own visual
+  // affordance (background image, shape, spacer), so the placeholder would be
+  // noise.
+  const hasAuthoredStyling = !!mcClassName || Object.keys(nodeWrapperProps?.style ?? {}).length > 0
+  const showPlaceholder = React.Children.count(children) === 0 && !hasAuthoredStyling
 
   return React.createElement(
     Tag,


### PR DESCRIPTION
## What changed
- Treat a non-empty `nodeWrapperProps.style` as authored styling for empty `base.container` nodes in the editor canvas.
- Added a regression test proving an inline-styled empty container keeps its root style but does not render the `Empty container` affordance.

## Why
Class-styled empty containers already suppressed the placeholder, but inline-styled empty containers did not because `ContainerEditor` only checked `mcClassName`. That made the canvas behavior inconsistent between class and inline styling.

## Impact
Authors can style empty containers inline for spacer/background/positioning use cases without the canvas showing the empty-state label over the authored element.

## Verification
- `bun test src/__tests__/base-modules-shared-render.editor.test.tsx` (red before fix, green after)
- `bun test`
- `bun run build`
- `bun run lint`
- `npx react-doctor@latest --verbose --scope changed --base origin/main`