### PR TITLE
fix(editor): darken explorer tabs and fade layers scroll

### DIFF
--- a/src/__tests__/ui/segmentedControlChrome.test.tsx
+++ b/src/__tests__/ui/segmentedControlChrome.test.tsx
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { cleanup, render, screen } from '@testing-library/react'
+import { SegmentedControl } from '@ui/components/SegmentedControl'
+
+afterEach(cleanup)
+
+describe('SegmentedControl editor chrome variants', () => {
+  it('exposes a recessed active surface for dark panel tab strips', () => {
+    render(
+      <SegmentedControl
+        value="layers"
+        options={[
+          { value: 'layers', label: 'Layers' },
+          { value: 'site', label: 'Site' },
+        ]}
+        onChange={() => {}}
+        activeSurface="recessed"
+        data-testid="segmented-control"
+      />,
+    )
+
+    const group = screen.getByTestId('segmented-control')
+    expect(group.getAttribute('data-active-surface')).toBe('recessed')
+    expect(screen.getByRole('button', { name: 'Layers' }).getAttribute('aria-pressed')).toBe('true')
+  })
+
+  it('uses the recessed tab surface and top fade in Explorer Layers chrome', () => {
+    const explorerSource = readFileSync('src/admin/pages/site/panels/ExplorerPanel/ExplorerPanel.tsx', 'utf8')
+    const domPanelCss = readFileSync('src/admin/pages/site/panels/DomPanel/DomPanel.module.css', 'utf8')
+
+    expect(explorerSource).toContain('activeSurface="recessed"')
+    expect(domPanelCss).toContain('.searchRow::after')
+    expect(domPanelCss).toContain('linear-gradient(180deg, var(--bg-body) 0%, transparent)')
+  })
+})

--- a/src/admin/pages/site/panels/DomPanel/DomPanel.module.css
+++ b/src/admin/pages/site/panels/DomPanel/DomPanel.module.css
@@ -25,10 +25,22 @@
  * row owns the outer spacing; the SearchBar fills, the button keeps its
  * intrinsic size. */
 .searchRow {
+    position: relative;
+    z-index: 1;
     display: flex;
     align-items: center;
     gap: var(--space-xs);
     margin: var(--space-s) var(--space-s) 0;
+}
+
+.searchRow::after {
+    content: "";
+    position: absolute;
+    inset-inline: calc(-1 * var(--space-s));
+    top: 100%;
+    height: var(--space-2xl);
+    pointer-events: none;
+    background: linear-gradient(180deg, var(--bg-body) 0%, transparent);
 }
 
 .searchFill {

--- a/src/admin/pages/site/panels/ExplorerPanel/ExplorerPanel.tsx
+++ b/src/admin/pages/site/panels/ExplorerPanel/ExplorerPanel.tsx
@@ -52,6 +52,7 @@ export function ExplorerPanel({ editable = true }: ExplorerPanelProps) {
           options={TABS}
           onChange={setTab}
           size="sm"
+          activeSurface="recessed"
           fullWidth
         />
       </div>

--- a/src/ui/components/SegmentedControl/SegmentedControl.module.css
+++ b/src/ui/components/SegmentedControl/SegmentedControl.module.css
@@ -45,6 +45,10 @@
     color: var(--text);
 }
 
+.group[data-active-surface="recessed"] .segment.segment[aria-pressed="true"] {
+    background: var(--bg-surface);
+}
+
 /* Trailing modifier — used by the render-prop's `trailingClassName`. Switches
  * the segment from "stretch to fill" to "fixed-square icon button" so a
  * chevron-down dropdown trigger never absorbs flex slack and reads as a

--- a/src/ui/components/SegmentedControl/SegmentedControl.tsx
+++ b/src/ui/components/SegmentedControl/SegmentedControl.tsx
@@ -54,6 +54,8 @@ interface SegmentedControlProps<T extends string> {
    */
   onClear?: () => void
   size?: ButtonProps['size']
+  /** Darker active fill for tab strips embedded in black editor panel chrome. */
+  activeSurface?: 'recessed'
   /** Render-prop for an extra trailing segment (e.g. dropdown chevron). */
   trailing?: (args: { segmentClassName: string; trailingClassName: string }) => ReactNode
   className?: string
@@ -70,6 +72,7 @@ export function SegmentedControl<T extends string>({
   onChange,
   onClear,
   size = 'sm',
+  activeSurface,
   trailing,
   className,
   fullWidth = false,
@@ -84,6 +87,7 @@ export function SegmentedControl<T extends string>({
       role="group"
       aria-label={ariaLabel}
       data-testid={dataTestId}
+      data-active-surface={activeSurface}
       data-clearable={clearable ? 'true' : undefined}
       className={cn(styles.group, fullWidth && styles.fullWidth, className)}
     >


### PR DESCRIPTION
## What changed

- Added a recessed active surface option to `SegmentedControl` for dark panel tab strips.
- Applied that darker active state to the Explorer panel tab switcher.
- Added a top fade under the Layers search row so scrolled layer rows blend under the fixed chrome.
- Added a focused regression test for the Explorer tab surface and Layers search fade hooks.

## Why

The newly consolidated Explorer mode switcher rendered the active tab with a lighter gray fill, but the intended editor chrome treatment is the darker/black active surface. The Layers list also met the fixed search row with a hard edge while scrolling.

## Impact

The Explorer panel active mode now reads as the darker selected state, while other segmented controls keep their existing default active surface unless they opt into the recessed variant.

## Verification

- `bun test ./src/__tests__/ui/segmentedControlChrome.test.tsx`
- `bun run lint`
- `bun run build`
- `bun test`
- `bunx react-doctor@latest --verbose --scope changed --base origin/main`
- Browser smoke with disposable SQLite data: active Layers background computed as `rgb(27, 27, 27)` and Layers search fade rendered as black-to-transparent.