### PR TITLE
docs(readme): add Trendshift badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,12 @@
 
 A self-hosted CMS where the visual editor, content engine, and publisher all live in one Bun server — and the pages it ships are clean enough to read in view-source.
 
+<p>
+  <a href="https://trendshift.io/repositories/66792?utm_source=repository-badge&utm_medium=badge&utm_campaign=badge-repository-66792" target="_blank" rel="noopener noreferrer">
+    <img src="https://trendshift.io/api/badge/repositories/66792" alt="CoreBunch/Instatic | Trendshift" width="250" height="55">
+  </a>
+</p>
+
 [![Release](https://img.shields.io/github/v/release/corebunch/instatic?color=black&labelColor=black)](https://github.com/corebunch/instatic/releases)
 [![License: MIT](https://img.shields.io/badge/license-MIT-black?labelColor=black&color=blue)](LICENSE)
 [![Runtime: Bun](https://img.shields.io/badge/runtime-Bun-black?labelColor=black&color=f9f1e1)](https://bun.sh)


### PR DESCRIPTION
## What changed

Added the Trendshift repository badge to the centered README header, positioned above the existing shields.

## Why

This makes the repository's Trendshift badge visible at the top of the GitHub README without disrupting the existing badge group.

## Impact

README-only presentation change. No runtime or product behavior impact.

## Verification

- `bun install --frozen-lockfile`
- `bun test` — 5893 pass, 1 skip, 0 fail
- `bun run build`
- `bun run lint`