### PR TITLE
fix(security): add base-uri 'self' + object-src 'none' to the admin CSP

### DIFF
--- a/server/securityHeaders.ts
+++ b/server/securityHeaders.ts
@@ -22,14 +22,23 @@ import { publicOriginIsHttps } from './auth/security'
  *
  * Admin-specific headers (pathname starts with /admin):
  *   - `X-Frame-Options: DENY` — blocks framing in legacy browsers.
- *   - `Content-Security-Policy: frame-ancestors 'none'` — blocks framing in
- *     modern browsers. Sent alongside X-Frame-Options because frame-ancestors
- *     takes precedence where supported.
+ *   - `Content-Security-Policy` — three directives that are safe today:
+ *       · `frame-ancestors 'none'` — blocks framing in modern browsers (sent
+ *         alongside X-Frame-Options, which it supersedes where supported).
+ *       · `base-uri 'self'` — blocks a `<base href>` injection from rewriting
+ *         the resolution of every relative URL on the page (the admin never
+ *         emits a `<base>` element).
+ *       · `object-src 'none'` — blocks `<object>` / `<embed>` plugin content
+ *         (the admin never embeds either).
  *
- *   A full admin CSP (default-src, script-src, etc.) is a follow-up task.
- *   The admin is a React SPA with a blob: canvas iframe and dynamically-loaded
- *   plugin module bundles; scoping beyond frame-ancestors requires auditing
- *   every source to avoid breaking the editor.
+ *   A `script-src` / `style-src` policy is deliberately NOT set here yet: the
+ *   admin ships an inline `<script type="importmap">` the plugin runtime needs,
+ *   the visual-editor canvas is `srcDoc` iframes (which inherit this policy)
+ *   that inject the site's runtime scripts as inline `<script>`, and the
+ *   editor relies on inline styles for dynamic custom properties. A safe
+ *   `script-src` therefore requires per-request nonce plumbing through the
+ *   served-HTML patcher and the canvas script injector plus a full editor
+ *   browser sweep — tracked as a dedicated follow-up, not bolted on here.
  *
  * @param res      The raw Response from the route handler.
  * @param pathname URL pathname of the incoming request.
@@ -57,7 +66,10 @@ export function applySecurityHeaders(res: Response, pathname: string): Response 
   // A framed CMS admin is a clickjacking vector for one-click publish/delete.
   if (pathname.startsWith('/admin')) {
     headers.set('x-frame-options', 'DENY')
-    headers.set('content-security-policy', "frame-ancestors 'none'")
+    headers.set(
+      'content-security-policy',
+      "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+    )
   }
 
   return new Response(res.body, {

--- a/src/__tests__/server/security-headers.test.ts
+++ b/src/__tests__/server/security-headers.test.ts
@@ -96,21 +96,37 @@ describe('applySecurityHeaders — admin framing protection', () => {
     expect(res.headers.get('x-frame-options')).toBe('DENY')
   })
 
-  it("sets CSP frame-ancestors 'none' on /admin HTML responses", () => {
+  it('sets the admin CSP (frame-ancestors + base-uri + object-src) on /admin HTML responses', () => {
     const res = applySecurityHeaders(makeResponse('<html>admin</html>'), '/admin')
-    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'")
+    expect(res.headers.get('content-security-policy')).toBe(
+      "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+    )
   })
 
-  it('applies framing protection to /admin/* subpaths (admin SPA routes)', () => {
+  it("locks base-uri to 'self' so a <base href> injection can't rewrite relative URLs", () => {
+    const res = applySecurityHeaders(makeResponse('<html>admin</html>'), '/admin')
+    expect(res.headers.get('content-security-policy')).toContain("base-uri 'self'")
+  })
+
+  it("blocks <object>/<embed> plugin content with object-src 'none'", () => {
+    const res = applySecurityHeaders(makeResponse('<html>admin</html>'), '/admin')
+    expect(res.headers.get('content-security-policy')).toContain("object-src 'none'")
+  })
+
+  it('applies the admin CSP to /admin/* subpaths (admin SPA routes)', () => {
     const res = applySecurityHeaders(makeResponse(), '/admin/site/123')
     expect(res.headers.get('x-frame-options')).toBe('DENY')
-    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'")
+    expect(res.headers.get('content-security-policy')).toBe(
+      "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+    )
   })
 
-  it('applies framing protection to /admin/api/* (admin API endpoints)', () => {
+  it('applies the admin CSP to /admin/api/* (admin API endpoints)', () => {
     const res = applySecurityHeaders(makeResponse('{}'), '/admin/api/cms/login')
     expect(res.headers.get('x-frame-options')).toBe('DENY')
-    expect(res.headers.get('content-security-policy')).toBe("frame-ancestors 'none'")
+    expect(res.headers.get('content-security-policy')).toBe(
+      "frame-ancestors 'none'; base-uri 'self'; object-src 'none'",
+    )
   })
 
   it('does NOT set X-Frame-Options on public page responses', () => {


### PR DESCRIPTION
## What & why

The admin CSP was `frame-ancestors 'none'` only. This adds two directives that are **safe to enforce today** and close two injection vectors as defense-in-depth behind the `htmlAttributes` / custom-tag hardening (PR for Fix #2):

- **`base-uri 'self'`** — a `<base href>` injection can otherwise rewrite how every relative URL on the page resolves (script/style/fetch targets). The admin never emits a `<base>` element.
- **`object-src 'none'`** — blocks `<object>`/`<embed>` plugin content. The admin never embeds either.

## Why NOT a full script-src here

Deliberately deferred — a naive `script-src` would break the admin:

1. The shell ships an inline `<script type="importmap">` the **plugin runtime depends on**.
2. The visual-editor canvas is `srcDoc` iframes that **inherit this policy** and inject the site's runtime scripts as **inline `<script>`** ("Run scripts").
3. The editor relies on **inline styles** for dynamic CSS custom properties.

A safe `script-src`/`style-src` needs per-request **nonce plumbing** through the served-HTML patcher and the canvas script injector, plus a full editor browser sweep. Tracked as a dedicated follow-up — not bolted on here.

## Verification

- `bun test src/__tests__/server/security-headers.test.ts` — 22 pass (three-directive policy asserted on `/admin`, `/admin/*`, `/admin/api/*`; absent on public/uploads/root).
- `bunx tsc -b` clean; `eslint` clean.
- `base-uri`/`object-src` cannot affect script/style/frame/font/XHR loading, and the admin uses no `<base>`/`<object>`/`<embed>` (grep-verified), so no editor regression is possible from these two directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)