### PR TITLE
refactor(loops): collapse data.rows page-slice SQL into one whitelisted query

### DIFF
--- a/src/__tests__/architecture/module-size-budgets.test.ts
+++ b/src/__tests__/architecture/module-size-budgets.test.ts
@@ -96,7 +96,10 @@ const GRANDFATHERED: Record<string, number> = {
   // extracted into server/repositories/mediaAssetMapping.ts, dropping media.ts
   // to 583 lines — under CEILING, so it's now held by the normal ceiling rule.
   'server/handlers/cms/auth.ts': 854,
-  'src/core/loops/sources/dataRows.ts': 903,
+  // src/core/loops/sources/dataRows.ts graduated: the 12 per-order-branch SQL
+  // copies collapsed into one query + a whitelisted ORDER BY column map,
+  // dropping the file to 540 lines — under CEILING, so it's now held by the
+  // normal ceiling rule.
   // The O(1) parentId pointer is a denormalised cache that every
   // parentage-changing primitive (insert/move/duplicate/wrap/paste) maintains
   // inline. The node deep-clone primitive lives in its own module

--- a/src/__tests__/loops/dataRowsFetch.test.ts
+++ b/src/__tests__/loops/dataRowsFetch.test.ts
@@ -1,0 +1,429 @@
+/**
+ * Behavior tests for `fetchPublishedDataRowItems` — the `data.rows` loop
+ * source's page-slice query — against a real migrated SQLite database.
+ *
+ * Locks in, for BOTH table kinds (post-type published-version join and
+ * data-kind direct read):
+ *   - every orderBy × direction combination's row order,
+ *   - the publishedAt → createdAt mapping on data-kind tables,
+ *   - status / soft-delete filtering,
+ *   - pagination (limit/offset) with a stable totalItems,
+ *   - the LoopItem fields projection (identity, people, media aliases,
+ *     dates, permalink),
+ *   - fallback behavior for unknown orderBy / direction / tableId.
+ *
+ * Written alongside the refactor that collapsed the per-order-branch SQL
+ * into one query + a whitelisted ORDER BY map, to pin the query semantics
+ * independent of how the SQL text is assembled.
+ */
+
+import { describe, expect, it, beforeAll, afterAll } from 'bun:test'
+import { createTestDb, type TestDb } from '../helpers/createTestDb'
+import { createUser } from '../../../server/repositories/users'
+import { fetchPublishedDataRowItems } from '@core/loops/sources/dataRows'
+
+type Db = TestDb['db']
+
+// ---------------------------------------------------------------------------
+// Seeding helpers
+// ---------------------------------------------------------------------------
+
+interface PostSeed {
+  rowId: string
+  slug: string
+  cells: Record<string, unknown>
+  status?: 'draft' | 'published'
+  deletedAt?: string | null
+  authorUserId?: string | null
+  publishedByUserId?: string | null
+  versionPublishedAt: string
+  versionCreatedAt: string
+  rowUpdatedAt: string
+}
+
+/**
+ * Insert a `posts` row + version pair. `data_rows.active_version_id` and
+ * `data_row_versions.row_id` form a circular FK, so: row first (no active
+ * version), then the version, then point the row at it.
+ */
+async function seedPost(db: Db, seed: PostSeed): Promise<void> {
+  const versionId = `${seed.rowId}-v1`
+  await db`
+    insert into data_rows
+      (id, table_id, cells_json, slug, status, author_user_id, updated_at, deleted_at)
+    values
+      (${seed.rowId}, ${'posts'}, ${JSON.stringify(seed.cells)}, ${seed.slug},
+       ${seed.status ?? 'published'}, ${seed.authorUserId ?? null},
+       ${seed.rowUpdatedAt}, ${seed.deletedAt ?? null})
+  `
+  await db`
+    insert into data_row_versions
+      (id, row_id, version_number, cells_json, slug, published_by_user_id, published_at, created_at)
+    values
+      (${versionId}, ${seed.rowId}, ${1}, ${JSON.stringify(seed.cells)}, ${seed.slug},
+       ${seed.publishedByUserId ?? null}, ${seed.versionPublishedAt}, ${seed.versionCreatedAt})
+  `
+  await db`update data_rows set active_version_id = ${versionId} where id = ${seed.rowId}`
+}
+
+interface DataRowSeed {
+  rowId: string
+  slug: string
+  cells: Record<string, unknown>
+  createdAt: string
+  updatedAt: string
+  deletedAt?: string | null
+}
+
+/** Insert a data-kind row — no version workflow, live on creation. */
+async function seedDataRow(db: Db, tableId: string, seed: DataRowSeed): Promise<void> {
+  await db`
+    insert into data_rows
+      (id, table_id, cells_json, slug, status, created_at, updated_at, deleted_at)
+    values
+      (${seed.rowId}, ${tableId}, ${JSON.stringify(seed.cells)}, ${seed.slug},
+       ${'draft'}, ${seed.createdAt}, ${seed.updatedAt}, ${seed.deletedAt ?? null})
+  `
+}
+
+async function fetchSlugs(
+  db: Db,
+  tableId: string,
+  orderBy: string,
+  direction: 'asc' | 'desc',
+): Promise<string[]> {
+  const { items } = await fetchPublishedDataRowItems(db, {
+    tableId,
+    orderBy,
+    direction,
+    limit: 50,
+    offset: 0,
+  })
+  return items.map((item) => String(item.fields['slug']))
+}
+
+// ---------------------------------------------------------------------------
+// Shared fixture — one DB for the whole suite (read-only after seeding)
+// ---------------------------------------------------------------------------
+
+let testDb: TestDb
+let db: Db
+let authorId: string
+let publisherId: string
+
+beforeAll(async () => {
+  testDb = await createTestDb()
+  db = testDb.db
+
+  const author = await createUser(db, {
+    email: 'author@example.com',
+    displayName: 'Ada Author',
+    passwordHash: 'h-author',
+    roleId: 'admin',
+  })
+  const publisher = await createUser(db, {
+    email: 'publisher@example.com',
+    displayName: 'Percy Publisher',
+    passwordHash: 'h-publisher',
+    roleId: 'client',
+  })
+  authorId = author.id
+  publisherId = publisher.id
+
+  // Featured-media asset referenced by the 'alpha' post's cells.
+  await db`
+    insert into media_assets
+      (id, filename, mime_type, size_bytes, storage_path, public_path,
+       storage_adapter_id, externally_hosted)
+    values ('m1', 'hero.png', 'image/png', 100, 'hero.png', '/uploads/hero.png', '', 0)
+  `
+
+  // Post-type rows: distinct publishedAt / createdAt / updatedAt / slug
+  // orderings so each orderBy option produces a different sequence.
+  await seedPost(db, {
+    rowId: 'row-alpha',
+    slug: 'alpha',
+    cells: {
+      title: 'Alpha',
+      body: 'Intro\n\n![inline](/uploads/inline.png)\n',
+      featuredMedia: 'm1',
+    },
+    authorUserId: authorId,
+    publishedByUserId: publisherId,
+    versionPublishedAt: '2026-01-03T00:00:00.000Z',
+    versionCreatedAt: '2026-01-01T00:00:00.000Z',
+    rowUpdatedAt: '2026-01-02T00:00:00.000Z',
+  })
+  await seedPost(db, {
+    rowId: 'row-bravo',
+    slug: 'bravo',
+    cells: { title: 'Bravo' },
+    versionPublishedAt: '2026-01-01T00:00:00.000Z',
+    versionCreatedAt: '2026-01-03T00:00:00.000Z',
+    rowUpdatedAt: '2026-01-01T00:00:00.000Z',
+  })
+  await seedPost(db, {
+    rowId: 'row-charlie',
+    slug: 'charlie',
+    cells: { title: 'Charlie' },
+    versionPublishedAt: '2026-01-02T00:00:00.000Z',
+    versionCreatedAt: '2026-01-02T00:00:00.000Z',
+    rowUpdatedAt: '2026-01-03T00:00:00.000Z',
+  })
+  // Excluded: draft status (has an active version — proves the status filter,
+  // not just the join, excludes it).
+  await seedPost(db, {
+    rowId: 'row-delta',
+    slug: 'delta',
+    cells: { title: 'Delta' },
+    status: 'draft',
+    versionPublishedAt: '2026-01-04T00:00:00.000Z',
+    versionCreatedAt: '2026-01-04T00:00:00.000Z',
+    rowUpdatedAt: '2026-01-04T00:00:00.000Z',
+  })
+  // Excluded: soft-deleted despite published status.
+  await seedPost(db, {
+    rowId: 'row-echo',
+    slug: 'echo',
+    cells: { title: 'Echo' },
+    deletedAt: '2026-01-05T00:00:00.000Z',
+    versionPublishedAt: '2026-01-05T00:00:00.000Z',
+    versionCreatedAt: '2026-01-05T00:00:00.000Z',
+    rowUpdatedAt: '2026-01-05T00:00:00.000Z',
+  })
+
+  // Data-kind table + rows. Status stays 'draft' (the default) on every row —
+  // data-kind iteration ignores the publish lifecycle entirely.
+  await db`
+    insert into data_tables (id, name, slug, kind, route_base, singular_label, plural_label)
+    values ('things', 'Things', 'things', 'data', '/things', 'Thing', 'Things')
+  `
+  await seedDataRow(db, 'things', {
+    rowId: 'thing-x',
+    slug: 'x',
+    cells: { name: 'X' },
+    createdAt: '2026-02-01T00:00:00.000Z',
+    updatedAt: '2026-02-03T00:00:00.000Z',
+  })
+  await seedDataRow(db, 'things', {
+    rowId: 'thing-y',
+    slug: 'y',
+    cells: { name: 'Y' },
+    createdAt: '2026-02-03T00:00:00.000Z',
+    updatedAt: '2026-02-01T00:00:00.000Z',
+  })
+  await seedDataRow(db, 'things', {
+    rowId: 'thing-z',
+    slug: 'z',
+    cells: { name: 'Z' },
+    createdAt: '2026-02-02T00:00:00.000Z',
+    updatedAt: '2026-02-02T00:00:00.000Z',
+  })
+  await seedDataRow(db, 'things', {
+    rowId: 'thing-w',
+    slug: 'w',
+    cells: { name: 'W' },
+    createdAt: '2026-02-04T00:00:00.000Z',
+    updatedAt: '2026-02-04T00:00:00.000Z',
+    deletedAt: '2026-02-05T00:00:00.000Z',
+  })
+})
+
+afterAll(async () => {
+  await testDb.cleanup()
+})
+
+// ---------------------------------------------------------------------------
+// Post-type tables — published-version join
+// ---------------------------------------------------------------------------
+
+describe('fetchPublishedDataRowItems — post-type ordering', () => {
+  it('orders by publishedAt in both directions (version published_at)', async () => {
+    expect(await fetchSlugs(db, 'posts', 'publishedAt', 'asc')).toEqual(['bravo', 'charlie', 'alpha'])
+    expect(await fetchSlugs(db, 'posts', 'publishedAt', 'desc')).toEqual(['alpha', 'charlie', 'bravo'])
+  })
+
+  it('orders by createdAt in both directions (version created_at)', async () => {
+    expect(await fetchSlugs(db, 'posts', 'createdAt', 'asc')).toEqual(['alpha', 'charlie', 'bravo'])
+    expect(await fetchSlugs(db, 'posts', 'createdAt', 'desc')).toEqual(['bravo', 'charlie', 'alpha'])
+  })
+
+  it('orders by updatedAt in both directions (row updated_at)', async () => {
+    expect(await fetchSlugs(db, 'posts', 'updatedAt', 'asc')).toEqual(['bravo', 'alpha', 'charlie'])
+    expect(await fetchSlugs(db, 'posts', 'updatedAt', 'desc')).toEqual(['charlie', 'alpha', 'bravo'])
+  })
+
+  it('orders by slug in both directions (version slug)', async () => {
+    expect(await fetchSlugs(db, 'posts', 'slug', 'asc')).toEqual(['alpha', 'bravo', 'charlie'])
+    expect(await fetchSlugs(db, 'posts', 'slug', 'desc')).toEqual(['charlie', 'bravo', 'alpha'])
+  })
+
+  it('falls back to publishedAt / desc for unknown orderBy and direction', async () => {
+    const { items } = await fetchPublishedDataRowItems(db, {
+      tableId: 'posts',
+      orderBy: 'title', // not a whitelisted order column
+      direction: 'sideways' as never,
+      limit: 50,
+      offset: 0,
+    })
+    expect(items.map((i) => i.fields['slug'])).toEqual(['alpha', 'charlie', 'bravo'])
+  })
+
+  it('excludes draft and soft-deleted rows from items and totalItems', async () => {
+    const { items, totalItems } = await fetchPublishedDataRowItems(db, {
+      tableId: 'posts',
+      orderBy: 'slug',
+      direction: 'asc',
+      limit: 50,
+      offset: 0,
+    })
+    const slugs = items.map((i) => i.fields['slug'])
+    expect(slugs).not.toContain('delta')
+    expect(slugs).not.toContain('echo')
+    expect(totalItems).toBe(3)
+  })
+
+  it('paginates with limit/offset while totalItems stays the full count', async () => {
+    const first = await fetchPublishedDataRowItems(db, {
+      tableId: 'posts',
+      orderBy: 'publishedAt',
+      direction: 'desc',
+      limit: 2,
+      offset: 0,
+    })
+    expect(first.items.map((i) => i.fields['slug'])).toEqual(['alpha', 'charlie'])
+    expect(first.totalItems).toBe(3)
+
+    const rest = await fetchPublishedDataRowItems(db, {
+      tableId: 'posts',
+      orderBy: 'publishedAt',
+      direction: 'desc',
+      limit: 2,
+      offset: 2,
+    })
+    expect(rest.items.map((i) => i.fields['slug'])).toEqual(['bravo'])
+    expect(rest.totalItems).toBe(3)
+  })
+
+  it('projects the full LoopItem field surface', async () => {
+    const { items } = await fetchPublishedDataRowItems(db, {
+      tableId: 'posts',
+      orderBy: 'slug',
+      direction: 'asc',
+      limit: 1,
+      offset: 0,
+    })
+    const alpha = items[0]!
+    expect(alpha.id).toBe('row-alpha')
+
+    const f = alpha.fields
+    // Identity + cells
+    expect(f['id']).toBe('row-alpha')
+    expect(f['rowId']).toBe('row-alpha')
+    expect(f['versionId']).toBe('row-alpha-v1')
+    expect(f['versionNumber']).toBe(1)
+    expect(f['tableId']).toBe('posts')
+    expect(f['tableSlug']).toBe('posts')
+    expect(f['title']).toBe('Alpha')
+    // People
+    expect(f['authorName']).toBe('Ada Author')
+    expect(f['authorRoleSlug']).toBe('admin')
+    expect(f['publishedByName']).toBe('Percy Publisher')
+    expect(f['publishedByRoleSlug']).toBe('client')
+    // Media aliases — featured resolves through media_assets, first image
+    // comes from the body markdown.
+    expect(f['featuredMediaId']).toBe('m1')
+    expect(f['featuredMedia']).toBe('/uploads/hero.png')
+    expect(f['featuredMediaPath']).toBe('/uploads/hero.png')
+    expect(f['featuredMediaUrl']).toBe('/uploads/hero.png')
+    expect(f['firstImage']).toBe('/uploads/inline.png')
+    // Dates + routing
+    expect(f['slug']).toBe('alpha')
+    expect(f['publishedAt']).toBe('2026-01-03T00:00:00.000Z')
+    expect(f['createdAt']).toBe('2026-01-01T00:00:00.000Z')
+    expect(f['updatedAt']).toBe('2026-01-02T00:00:00.000Z')
+    expect(f['permalink']).toBe('/posts/alpha')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Data-kind tables — direct data_rows read
+// ---------------------------------------------------------------------------
+
+describe('fetchPublishedDataRowItems — data-kind ordering', () => {
+  it('maps publishedAt to createdAt (no publish lifecycle)', async () => {
+    expect(await fetchSlugs(db, 'things', 'publishedAt', 'asc')).toEqual(['x', 'z', 'y'])
+    expect(await fetchSlugs(db, 'things', 'publishedAt', 'desc')).toEqual(['y', 'z', 'x'])
+  })
+
+  it('orders by createdAt / updatedAt / slug in both directions', async () => {
+    expect(await fetchSlugs(db, 'things', 'createdAt', 'asc')).toEqual(['x', 'z', 'y'])
+    expect(await fetchSlugs(db, 'things', 'createdAt', 'desc')).toEqual(['y', 'z', 'x'])
+    expect(await fetchSlugs(db, 'things', 'updatedAt', 'asc')).toEqual(['y', 'z', 'x'])
+    expect(await fetchSlugs(db, 'things', 'updatedAt', 'desc')).toEqual(['x', 'z', 'y'])
+    expect(await fetchSlugs(db, 'things', 'slug', 'asc')).toEqual(['x', 'y', 'z'])
+    expect(await fetchSlugs(db, 'things', 'slug', 'desc')).toEqual(['z', 'y', 'x'])
+  })
+
+  it('includes draft-status rows but excludes soft-deleted rows', async () => {
+    const { items, totalItems } = await fetchPublishedDataRowItems(db, {
+      tableId: 'things',
+      orderBy: 'slug',
+      direction: 'asc',
+      limit: 50,
+      offset: 0,
+    })
+    // All seeded rows have status 'draft' — they still iterate.
+    expect(items).toHaveLength(3)
+    expect(items.map((i) => i.fields['slug'])).not.toContain('w')
+    expect(totalItems).toBe(3)
+  })
+
+  it('projects data-kind fields: permalink base, createdAt-as-publishedAt, null publisher', async () => {
+    const { items } = await fetchPublishedDataRowItems(db, {
+      tableId: 'things',
+      orderBy: 'slug',
+      direction: 'asc',
+      limit: 1,
+      offset: 0,
+    })
+    const x = items[0]!
+    expect(x.id).toBe('thing-x')
+    const f = x.fields
+    expect(f['name']).toBe('X')
+    expect(f['permalink']).toBe('/things/x')
+    expect(f['publishedAt']).toBe('2026-02-01T00:00:00.000Z')
+    expect(f['createdAt']).toBe('2026-02-01T00:00:00.000Z')
+    expect(f['updatedAt']).toBe('2026-02-03T00:00:00.000Z')
+    expect(f['publishedBy']).toBeNull()
+    expect(f['publishedByName']).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Degenerate inputs
+// ---------------------------------------------------------------------------
+
+describe('fetchPublishedDataRowItems — degenerate inputs', () => {
+  it('returns empty for an empty tableId', async () => {
+    const result = await fetchPublishedDataRowItems(db, {
+      tableId: '',
+      orderBy: 'publishedAt',
+      direction: 'desc',
+      limit: 50,
+      offset: 0,
+    })
+    expect(result).toEqual({ items: [], totalItems: 0 })
+  })
+
+  it('returns empty for a tableId that does not exist', async () => {
+    const result = await fetchPublishedDataRowItems(db, {
+      tableId: 'nope',
+      orderBy: 'publishedAt',
+      direction: 'desc',
+      limit: 50,
+      offset: 0,
+    })
+    expect(result).toEqual({ items: [], totalItems: 0 })
+  })
+})

--- a/src/core/loops/sources/dataRows.ts
+++ b/src/core/loops/sources/dataRows.ts
@@ -69,6 +69,18 @@ const ALLOWED_ORDER_BY: ReadonlySet<OrderColumn> = new Set([
 ])
 
 // ---------------------------------------------------------------------------
+// SQL helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Dialect-appropriate positional placeholder for `db.unsafe`:
+ * `$<index>` on Postgres, `?` on SQLite. `index` is 1-based.
+ */
+function positionalParam(db: LoopSourceDb, index: number): string {
+  return db.dialect === 'postgres' ? `$${index}` : '?'
+}
+
+// ---------------------------------------------------------------------------
 // Media path resolution
 //
 // Featured media lives inside cells_json, not as a SQL column. We extract
@@ -90,9 +102,7 @@ export async function resolveMediaIdsToPaths(
   const idList = [...new Set(ids)]
   const pathMap = new Map<string, string>()
   if (idList.length === 0) return pathMap
-  const placeholders = idList.map((_, i) =>
-    db.dialect === 'postgres' ? `$${i + 1}` : '?'
-  ).join(', ')
+  const placeholders = idList.map((_, i) => positionalParam(db, i + 1)).join(', ')
   const { rows } = await db.unsafe<MediaAssetRow>(
     `select id, public_path from media_assets where id in (${placeholders})`,
     idList,
@@ -182,12 +192,24 @@ function rowToLoopItem(
 }
 
 // ---------------------------------------------------------------------------
-// Page-slice queries
+// Page-slice query — post-type tables (published-version join)
 //
-// Each branch hard-codes its ORDER BY column so the tagged template never
-// concatenates column names from variables — keeps the SQL parameterised
-// and satisfies db-postgres-isms.test.ts.
+// One SELECT; the ORDER BY clause is composed from the closed, compile-time
+// column map below, so no runtime input ever reaches the SQL text:
+// `orderBy` is whitelisted against ALLOWED_ORDER_BY and `direction` is
+// narrowed to 'asc' | 'desc' in `fetchPublishedDataRowItems` before either
+// value gets here. All runtime VALUES (tableId, limit, offset) ride as
+// positional parameters via `db.unsafe` — the same dialect-aware pattern as
+// `resolveMediaIdsToPaths`.
 // ---------------------------------------------------------------------------
+
+/** Order column expressions for the post-type published-version query. */
+const POST_TYPE_ORDER_COLUMN: Record<OrderColumn, string> = {
+  publishedAt: 'data_row_versions.published_at',
+  createdAt: 'data_row_versions.created_at',
+  updatedAt: 'data_rows.updated_at',
+  slug: 'data_row_versions.slug',
+}
 
 async function fetchPage(
   db: LoopSourceDb,
@@ -197,314 +219,48 @@ async function fetchPage(
   limit: number,
   offset: number,
 ): Promise<PublishedDataRowSqlRow[]> {
-  if (orderBy === 'publishedAt' && direction === 'asc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_row_versions.published_at asc, data_row_versions.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (orderBy === 'publishedAt' && direction === 'desc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_row_versions.published_at desc, data_row_versions.id desc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (orderBy === 'createdAt' && direction === 'asc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_row_versions.created_at asc, data_row_versions.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (orderBy === 'createdAt' && direction === 'desc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_row_versions.created_at desc, data_row_versions.id desc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (orderBy === 'updatedAt' && direction === 'asc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.updated_at asc, data_row_versions.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (orderBy === 'updatedAt' && direction === 'desc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.updated_at desc, data_row_versions.id desc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  // slug asc
-  if (direction === 'asc') {
-    const { rows } = await db<PublishedDataRowSqlRow>`
-      select data_row_versions.id as version_id,
-             data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.kind as table_kind,
-             data_tables.route_base as table_route_base,
-             data_row_versions.version_number,
-             data_row_versions.cells_json,
-             data_row_versions.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_row_versions.published_by_user_id,
-             publisher_users.display_name as published_by_display_name,
-             publisher_roles.slug as published_by_role_slug,
-             publisher_roles.name as published_by_role_name,
-             data_row_versions.published_at,
-             data_row_versions.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      join data_row_versions on data_row_versions.id = data_rows.active_version_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-      left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.status = 'published'
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_row_versions.slug asc, data_row_versions.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  // slug desc
-  const { rows } = await db<PublishedDataRowSqlRow>`
-    select data_row_versions.id as version_id,
-           data_rows.id as row_id,
-           data_rows.table_id,
-           data_tables.slug as table_slug,
-           data_tables.kind as table_kind,
-           data_tables.route_base as table_route_base,
-           data_row_versions.version_number,
-           data_row_versions.cells_json,
-           data_row_versions.slug,
-           data_rows.author_user_id,
-           author_users.display_name as author_display_name,
-           author_roles.slug as author_role_slug,
-           author_roles.name as author_role_name,
-           data_row_versions.published_by_user_id,
-           publisher_users.display_name as published_by_display_name,
-           publisher_roles.slug as published_by_role_slug,
-           publisher_roles.name as published_by_role_name,
-           data_row_versions.published_at,
-           data_row_versions.created_at,
-           data_rows.updated_at
-    from data_rows
-    join data_tables on data_tables.id = data_rows.table_id
-    join data_row_versions on data_row_versions.id = data_rows.active_version_id
-    left join users author_users on author_users.id = data_rows.author_user_id
-    left join roles author_roles on author_roles.id = author_users.role_id
-    left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
-    left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
-    where data_rows.table_id = ${tableId}
-      and data_rows.status = 'published'
-      and data_rows.deleted_at is null
-      and data_tables.deleted_at is null
-    order by data_row_versions.slug desc, data_row_versions.id desc
-    limit ${limit} offset ${offset}
-  `
+  const orderColumn = POST_TYPE_ORDER_COLUMN[orderBy]
+  const { rows } = await db.unsafe<PublishedDataRowSqlRow>(
+    `select data_row_versions.id as version_id,
+            data_rows.id as row_id,
+            data_rows.table_id,
+            data_tables.slug as table_slug,
+            data_tables.kind as table_kind,
+            data_tables.route_base as table_route_base,
+            data_row_versions.version_number,
+            data_row_versions.cells_json,
+            data_row_versions.slug,
+            data_rows.author_user_id,
+            author_users.display_name as author_display_name,
+            author_roles.slug as author_role_slug,
+            author_roles.name as author_role_name,
+            data_row_versions.published_by_user_id,
+            publisher_users.display_name as published_by_display_name,
+            publisher_roles.slug as published_by_role_slug,
+            publisher_roles.name as published_by_role_name,
+            data_row_versions.published_at,
+            data_row_versions.created_at,
+            data_rows.updated_at
+     from data_rows
+     join data_tables on data_tables.id = data_rows.table_id
+     join data_row_versions on data_row_versions.id = data_rows.active_version_id
+     left join users author_users on author_users.id = data_rows.author_user_id
+     left join roles author_roles on author_roles.id = author_users.role_id
+     left join users publisher_users on publisher_users.id = data_row_versions.published_by_user_id
+     left join roles publisher_roles on publisher_roles.id = publisher_users.role_id
+     where data_rows.table_id = ${positionalParam(db, 1)}
+       and data_rows.status = 'published'
+       and data_rows.deleted_at is null
+       and data_tables.deleted_at is null
+     order by ${orderColumn} ${direction}, data_row_versions.id ${direction}
+     limit ${positionalParam(db, 2)} offset ${positionalParam(db, 3)}`,
+    [tableId, limit, offset],
+  )
   return rows
 }
 
 // ---------------------------------------------------------------------------
-// Data-kind page-slice query
+// Page-slice query — data-kind tables (direct data_rows read)
 //
 // Data-kind tables (`kind: 'data'`) have no publish lifecycle and no
 // `data_row_versions` rows. They are authored directly via the Data
@@ -582,6 +338,18 @@ function dataKindRowToLoopItem(
   }
 }
 
+/**
+ * Order column expressions for the data-kind query. There is no
+ * `published_at` on this path — `fetchDataKindPage` maps a `publishedAt`
+ * request to `createdAt` so "order by published date" still produces a
+ * sensible newest-first ordering.
+ */
+const DATA_KIND_ORDER_COLUMN: Record<'createdAt' | 'updatedAt' | 'slug', string> = {
+  createdAt: 'data_rows.created_at',
+  updatedAt: 'data_rows.updated_at',
+  slug: 'data_rows.slug',
+}
+
 async function fetchDataKindPage(
   db: LoopSourceDb,
   tableId: string,
@@ -590,167 +358,36 @@ async function fetchDataKindPage(
   limit: number,
   offset: number,
 ): Promise<DataKindRowSqlRow[]> {
-  // Data-kind tables have no `published_at`. Map publishedAt → createdAt
-  // so the loop's "order by published date" still produces a sensible
-  // newest-first ordering. `slug` is selected from data_rows directly.
   const sortKey: 'createdAt' | 'updatedAt' | 'slug' =
     orderBy === 'updatedAt' ? 'updatedAt' : orderBy === 'slug' ? 'slug' : 'createdAt'
+  const orderColumn = DATA_KIND_ORDER_COLUMN[sortKey]
 
-  // Hard-coded ORDER BY branches keep the tagged template free of
-  // variable-substituted column names (db-postgres-isms.test.ts).
-  if (sortKey === 'createdAt' && direction === 'asc') {
-    const { rows } = await db<DataKindRowSqlRow>`
-      select data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.route_base as table_route_base,
-             data_rows.cells_json,
-             data_rows.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_rows.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.created_at asc, data_rows.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (sortKey === 'createdAt' && direction === 'desc') {
-    const { rows } = await db<DataKindRowSqlRow>`
-      select data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.route_base as table_route_base,
-             data_rows.cells_json,
-             data_rows.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_rows.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.created_at desc, data_rows.id desc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (sortKey === 'updatedAt' && direction === 'asc') {
-    const { rows } = await db<DataKindRowSqlRow>`
-      select data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.route_base as table_route_base,
-             data_rows.cells_json,
-             data_rows.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_rows.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.updated_at asc, data_rows.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (sortKey === 'updatedAt' && direction === 'desc') {
-    const { rows } = await db<DataKindRowSqlRow>`
-      select data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.route_base as table_route_base,
-             data_rows.cells_json,
-             data_rows.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_rows.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.updated_at desc, data_rows.id desc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  if (direction === 'asc') {
-    const { rows } = await db<DataKindRowSqlRow>`
-      select data_rows.id as row_id,
-             data_rows.table_id,
-             data_tables.slug as table_slug,
-             data_tables.route_base as table_route_base,
-             data_rows.cells_json,
-             data_rows.slug,
-             data_rows.author_user_id,
-             author_users.display_name as author_display_name,
-             author_roles.slug as author_role_slug,
-             author_roles.name as author_role_name,
-             data_rows.created_at,
-             data_rows.updated_at
-      from data_rows
-      join data_tables on data_tables.id = data_rows.table_id
-      left join users author_users on author_users.id = data_rows.author_user_id
-      left join roles author_roles on author_roles.id = author_users.role_id
-      where data_rows.table_id = ${tableId}
-        and data_rows.deleted_at is null
-        and data_tables.deleted_at is null
-      order by data_rows.slug asc, data_rows.id asc
-      limit ${limit} offset ${offset}
-    `
-    return rows
-  }
-  const { rows } = await db<DataKindRowSqlRow>`
-    select data_rows.id as row_id,
-           data_rows.table_id,
-           data_tables.slug as table_slug,
-           data_tables.route_base as table_route_base,
-           data_rows.cells_json,
-           data_rows.slug,
-           data_rows.author_user_id,
-           author_users.display_name as author_display_name,
-           author_roles.slug as author_role_slug,
-           author_roles.name as author_role_name,
-           data_rows.created_at,
-           data_rows.updated_at
-    from data_rows
-    join data_tables on data_tables.id = data_rows.table_id
-    left join users author_users on author_users.id = data_rows.author_user_id
-    left join roles author_roles on author_roles.id = author_users.role_id
-    where data_rows.table_id = ${tableId}
-      and data_rows.deleted_at is null
-      and data_tables.deleted_at is null
-    order by data_rows.slug desc, data_rows.id desc
-    limit ${limit} offset ${offset}
-  `
+  // Same safety contract as `fetchPage`: the ORDER BY text comes only from
+  // the closed map above; every runtime value is a positional parameter.
+  const { rows } = await db.unsafe<DataKindRowSqlRow>(
+    `select data_rows.id as row_id,
+            data_rows.table_id,
+            data_tables.slug as table_slug,
+            data_tables.route_base as table_route_base,
+            data_rows.cells_json,
+            data_rows.slug,
+            data_rows.author_user_id,
+            author_users.display_name as author_display_name,
+            author_roles.slug as author_role_slug,
+            author_roles.name as author_role_name,
+            data_rows.created_at,
+            data_rows.updated_at
+     from data_rows
+     join data_tables on data_tables.id = data_rows.table_id
+     left join users author_users on author_users.id = data_rows.author_user_id
+     left join roles author_roles on author_roles.id = author_users.role_id
+     where data_rows.table_id = ${positionalParam(db, 1)}
+       and data_rows.deleted_at is null
+       and data_tables.deleted_at is null
+     order by ${orderColumn} ${direction}, data_rows.id ${direction}
+     limit ${positionalParam(db, 2)} offset ${positionalParam(db, 3)}`,
+    [tableId, limit, offset],
+  )
   return rows
 }
 


### PR DESCRIPTION
## What changed

`src/core/loops/sources/dataRows.ts` repeated the same ~35-line SELECT **twelve times** (6 orderBy/direction branches × 2 table kinds), with only the `ORDER BY` line differing — 903 lines, of which ~560 were literal duplication.

Each table kind now has **one query**:

- The `ORDER BY` clause is composed from a closed, compile-time column map (`POST_TYPE_ORDER_COLUMN` / `DATA_KIND_ORDER_COLUMN`). `orderBy` is whitelisted against `ALLOWED_ORDER_BY` and `direction` is narrowed to `'asc' | 'desc'` in `fetchPublishedDataRowItems` before either value reaches the SQL text, so no runtime input is ever interpolated.
- Every runtime **value** (`tableId`, `limit`, `offset`) rides as a positional parameter via `db.unsafe` with dialect-appropriate placeholders — the same pattern `resolveMediaIdsToPaths` in this file already used (now shared via a small `positionalParam` helper).
- Both DB adapters run identical row normalization (`*_json` hydration, `Date` → ISO) on the `unsafe` path as on the tagged-template path, so read semantics are unchanged.

`dataRows.ts` drops **903 → 540 lines** and graduates from the module-size grandfathered ledger (`module-size-budgets.test.ts` entry removed — the gate demanded it).

## Why

Adding one column to the projection previously meant editing twelve SQL copies; forgetting one branch would produce an ordering-dependent bug that only shows for a specific sort. This was #2 on the codebase-quality review's refactor list (best effort-to-payoff ratio).

## Behavior lock

New `src/__tests__/loops/dataRowsFetch.test.ts` runs against a real migrated SQLite DB and pins:

- every orderBy × direction row ordering for **both** table kinds,
- the `publishedAt → createdAt` mapping on data-kind tables,
- status / soft-delete filtering (draft + deleted rows excluded on the post-type path; data-kind ignores status but honors soft-delete),
- pagination with stable `totalItems`,
- the full `LoopItem` fields projection (identity, author/publisher, featured-media + first-image resolution, dates, permalink),
- unknown orderBy/direction/tableId fallbacks.

The suite **passed against the old branchy implementation before the swap** and passes unchanged after it.

## Impact

No user-facing or API changes. `fetchPublishedDataRowItems` signature, projection, ordering, and filtering are byte-identical.

## Verification

```sh
bun test          # 5924 pass (incl. 14 new dataRowsFetch tests)
bun run build     # tsc -b && vite build — clean
bun run lint      # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)