### PR TITLE
chore(repo): enable GitHub Sponsors button

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: corebunch


### PR DESCRIPTION
## What changed

Adds `.github/FUNDING.yml` with the GitHub Sponsors account set to `corebunch`.

## Why

GitHub uses this file on the default branch to show the Sponsor button for the repository.

## Impact

After merge, the repository can display the native GitHub Sponsor button linked to `https://github.com/sponsors/corebunch`.

## Verification

- `bun test`
- `bun run build`
- `bun run lint`