### PR TITLE
docs(readme): add InstaPods to the one-click deploy providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Railway is the fastest way to get Instatic live. Pick a template, hit the button
 |---|---|---|---|
 | **Railway** · *Recommended* | SQLite | A single site — blog, portfolio, small business | [Deploy →](https://railway.com/deploy/instatic-cms-sqlite?referralCode=Zm9bVJ&utm_medium=integration&utm_source=template&utm_campaign=generic) |
 | **Railway** | Postgres | Multiple authors, managed backups, room to grow | [Deploy →](https://railway.com/deploy/instatic-cms-postgres?referralCode=Zm9bVJ&utm_medium=integration&utm_source=template&utm_campaign=generic) |
+| **InstaPods** | SQLite | Self-hosted on your own server - $7/mo, unlimited sites, daily backups | [Deploy →](https://app.instapods.com/dashboard/pods/create?app=instatic) |
 | **Render** | — | — | *Coming soon* |
 | **Fly.io** | — | — | *Coming soon* |
 | **DigitalOcean** | — | — | *Coming soon* |


### PR DESCRIPTION
Hi! 👋 Adds **InstaPods** as a one-click deploy option in the "Deploy in one click" providers table, alongside Railway.

We (InstaPods) packaged Instatic as a verified 1-Click app - it deploys from a pre-baked image in ~60s with:
- A unique per-pod `INSTATIC_SECRET_KEY` (`openssl rand -base64 32`) + `INSTATIC_FORM_SECRET` generated on first boot
- `PUBLIC_ORIGIN` set to the pod's HTTPS domain automatically (so CSRF + Secure cookies work behind our TLS edge)
- The owner account pre-created (closes the open-claim window) with credentials emailed to the user
- The starter homepage auto-published, so `/` renders immediately
- Embedded SQLite, HTTPS, custom domains, daily backups - $7/mo, unlimited sites

One row added to the existing table:

```
| **InstaPods** | SQLite | Self-hosted on your own server - $7/mo, unlimited sites, daily backups | [Deploy →](https://app.instapods.com/dashboard/pods/create?app=instatic) |
```

There's also a landing page at https://instapods.com/apps/instatic if useful. Thanks for building Instatic - happy to tweak the wording or placement however you'd like. 🙌