### PR TITLE
fix(scripts): Windows dev server port probing with cmd timeout fallback

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -265,7 +265,9 @@ function stopChildren(signal: NodeJS.Signals = 'SIGTERM'): void {
 }
 
 for (const cfg of processes) {
-  const child = Bun.spawn(cfg.command.split(' '), {
+  const args = cfg.command.split(' ')
+  if (args[0] === 'bun') args[0] = process.execPath
+  const child = Bun.spawn(args, {
     env: { ...process.env, ...cfg.env },
     stdin: 'inherit',
     stdout: 'inherit',

--- a/scripts/lib/freePort.ts
+++ b/scripts/lib/freePort.ts
@@ -22,6 +22,7 @@ interface PortHolder {
  * holding process's `comm` name. Empty array when the port is free.
  */
 function findPortHolders(port: number): PortHolder[] {
+  if (process.platform === 'win32') return []
   const lsof = Bun.spawnSync(
     ['lsof', '-nP', `-iTCP:${port}`, '-sTCP:LISTEN', '-t'],
     { stdout: 'pipe', stderr: 'ignore' },
@@ -107,8 +108,14 @@ export async function ensurePortFree(
 
   const holders = findPortHolders(port)
   if (holders.length === 0) {
-    // Port is busy but we couldn't enumerate the holder (rare — usually
-    // a permissions issue on lsof). Fall through to the manual message.
+    if (process.platform === 'win32') {
+      // On Windows we can't enumerate holders easily; just wait a bit
+      // and re-probe in case a previous dev server is shutting down.
+      for (let i = 0; i < 30; i++) {
+        if (probePort(port) === 'free') return
+        Bun.spawnSync(['cmd', '/c', 'timeout', '/t', '1', '/nobreak', '>nul', '2>&1'])
+      }
+    }
     log(`Port ${port} (${name}) is in use, but the holding process could not be identified.`)
     log(`Run \`lsof -i :${port} -P -n\` to inspect it manually.`)
     process.exit(1)


### PR DESCRIPTION
## Summary

Fixes a false-positive port-in-use error on Windows when starting the dev server. The port probing helper could not identify the holding process on Windows (no `lsof` equivalent), causing `bun run dev` to bail even when the port was about to free up from a recently-stopped previous server.

## Why

On Windows, rapid restart of the dev server (e.g. after a crash or file watcher trigger) frequently hit this race condition:

1. Old server starts shutting down
2. New server process spins up
3. Port probe says "in use" but `lsof` fails to find the holder
4. Script exits with `process.exit(1)`

The retry loop gives the old process time to fully release the socket before we declare failure.

## Testing

- Run `bun run dev` twice in quick succession on Windows — second invocation should wait and succeed instead of crashing
- Verify `lsof` path on macOS/Linux is unaffected (retry loop only runs when `lsof` is unavailable)