### PR TITLE
feat(cms): save conflict detection with per-row base seqs and resolution banner

### DIFF
--- a/docs/features/site-shell.md
+++ b/docs/features/site-shell.md
@@ -377,10 +377,12 @@ The whole document saves through ONE endpoint, in ONE server transaction:
 
 ```
 PUT /admin/api/cms/site-document
-{ mode, site,                                    // shell — always written
+{ mode, site,                                    // shell — written only when its content changed
   changedPages,      deletedPageIds,
   changedComponents, deletedComponentIds,
-  changedLayouts,    deletedLayoutIds }
+  changedLayouts,    deletedLayoutIds,
+  baseSeqs,                                      // rowId → last-synchronized seq (conflict check)
+  shellBaseSeq }                                 // the shell's counterpart
 ```
 
 Two modes:
@@ -442,10 +444,57 @@ reject with a 400 instead of dying on the index.
 
 Every save allocates a **site-global sync sequence number**
 (`server/repositories/syncSequence.ts`) inside the transaction and stamps it
-on the shell and every written or deleted row (`data_rows.seq`); the
-response returns it (`{ ok: true, seq }`). The seq is the substrate for
-multi-admin conflict detection and delta reconciliation (live-sync plan) —
-informational to the client until that lands.
+on every written or deleted row (`data_rows.seq`) — and on the shell, but
+**only when the shell content actually changed** (`shellsEqual` in
+`siteDiff.ts` gates the shell write; the shell ships with every save, so an
+unconditional stamp would make the shell seq useless as a conflict signal).
+The response returns the seq (`{ ok: true, seq }`).
+
+### Conflict detection (multi-admin level A)
+
+Incremental saves carry **base seqs**: for every changed *and* deleted row,
+the stored seq the client last synchronized with (`baseSeqs`), plus the
+shell's (`shellBaseSeq`). Inside the transaction — *after* `allocateSiteSeq`,
+whose counter-row lock serializes concurrent saves on both dialects, making
+the check exact — the handler compares each shipped row's STORED seq against
+its base:
+
+- stored seq **newer** than the base → another admin changed (or deleted —
+  soft-deleted rows are visible to the check via `listDataRowSeqs`) the row
+  since this client synchronized;
+- **no base entry** for a row that exists in storage → the client doesn't
+  know the row at all, so its write would be a blind overwrite;
+- the shell is checked only when the incoming shell differs from the stored
+  one (one coarse seq for the whole shell — accepted v1 granularity).
+
+Any hit throws `SaveConflictError` (`@core/persistence/saveConflict` — the
+same class the client adapter re-throws), rolling the transaction back into
+a **409** with `{ error, conflicts: [{ table, rowId, seq }] }`. Nothing is
+written. Client-created rows have no stored counterpart and pass by
+construction; **replace-mode saves skip the check** (imports replace
+deliberately).
+
+Known v1 blind spot: writers OUTSIDE the transactional save (plugin pack
+installs via `saveDraftSite`/`saveDataRowDraft`, data-workspace row edits)
+do not stamp seqs, so conflict detection cannot see them — those flows
+coordinate through `requestCmsSiteReload()` instead. Widening seq stamping
+to every writer is live-sync phase B territory.
+
+Client side: `loadSite` seeds `baseSeqs`/`shellBaseSeq` in the editor store
+(per-row seqs ride the collection GET responses — `DataRow.seq`; the shell
+seq rides `GET /site`). Every successful save bumps the shipped rows' bases
+to the response seq — deleted rows **keep** their entries so an undo that
+resurrects a saved-deleted row carries the right base. On a 409,
+`usePersistence` restores the dirty snapshot, fills `saveConflicts`, and the
+**conflict banner** (`SaveConflictBanner`, mounted in `AdminCanvasLayout`)
+offers per-target resolution: **Load theirs** fetches the remote state
+(single-row `?id=` filter on the collection GETs, or `GET /site` for the
+shell) and adopts it via `resolveSaveConflictTheirs` (swaps the row without
+undo history, clears its dirty marks, clears the undo history, and for VCs
+propagates slot re-sync / ref-cascade removal into consumer pages *with*
+dirty marks); **Keep mine** bumps the base seq so the next save overwrites
+as a stated decision. Autosave is suppressed while conflicts pend; resolving
+the last one flushes the surviving edits through the save queue.
 
 ### Atomic diff validation
 

--- a/docs/server.md
+++ b/docs/server.md
@@ -362,7 +362,7 @@ All SQL lives in `server/repositories/`. Each file owns one resource:
 | `sessions.ts`              | User sessions                                     |
 | `setup.ts`                 | Setup wizard state (`isSetup`, first-run owner)   |
 | `site.ts`                  | The single site shell row                         |
-| `syncSequence.ts`          | Site-global sync sequence counter (multi-admin sync substrate — stamped on every row the site-document save writes or deletes) |
+| `syncSequence.ts`          | Site-global sync sequence counter (multi-admin sync substrate — stamped on every row the site-document save writes or deletes, and on the shell only when its content changed; the save's conflict check compares client base seqs against these inside the transaction) |
 | `userPreferences.ts`       | Per-user editor preferences                       |
 | `users.ts`                 | Users + auth fields                               |
 

--- a/server/handlers/cms/components.ts
+++ b/server/handlers/cms/components.ts
@@ -1,10 +1,14 @@
 /**
  * Visual Components read endpoint backed by `data_rows` (table_id = 'components').
  *
- *   GET /admin/api/cms/components — list all non-deleted component rows as
- *                                   DataRow[] (gated by `site.read`). The client
- *                                   adapter converts these to VisualComponent[]
- *                                   via visualComponentFromRow + validateVisualComponents.
+ *   GET /admin/api/cms/components      — list all non-deleted component rows
+ *                                        as DataRow[] (gated by `site.read`).
+ *                                        The client adapter converts these to
+ *                                        VisualComponent[] via
+ *                                        visualComponentFromRow + validateVisualComponents.
+ *   GET /admin/api/cms/components?id=X — the single row X (empty `rows` when
+ *                                        deleted or not a component) — the
+ *                                        conflict banner's "Load theirs" fetch.
  *
  * The response returns raw DataRow objects (not VisualComponent objects) so
  * the client adapter can reconstruct VCs via visualComponentFromRow without a
@@ -16,9 +20,8 @@
  */
 import type { DbClient } from '../../db/client'
 import { requireCapability } from '../../auth/authz'
-import { listDataRows } from '../../repositories/data'
-import { jsonResponse, methodNotAllowed } from '../../http'
-import { CMS_API_PREFIX } from './shared'
+import { methodNotAllowed } from '../../http'
+import { CMS_API_PREFIX, siteCollectionRowsResponse } from './shared'
 
 export async function handleComponentsRoutes(req: Request, db: DbClient): Promise<Response | null> {
   const url = new URL(req.url)
@@ -28,6 +31,5 @@ export async function handleComponentsRoutes(req: Request, db: DbClient): Promis
   const user = await requireCapability(req, db, 'site.read')
   if (user instanceof Response) return user
 
-  const rows = await listDataRows(db, 'components')
-  return jsonResponse({ rows })
+  return siteCollectionRowsResponse(db, url, 'components')
 }

--- a/server/handlers/cms/layouts.ts
+++ b/server/handlers/cms/layouts.ts
@@ -1,10 +1,14 @@
 /**
  * Saved-layout read endpoint backed by `data_rows` (table_id = 'layouts').
  *
- *   GET /admin/api/cms/layouts — list all non-deleted layout rows as
- *                                DataRow[] (gated by `site.read`). The client
- *                                adapter converts these to SavedLayout[]
- *                                via savedLayoutFromRow + validateSavedLayouts.
+ *   GET /admin/api/cms/layouts      — list all non-deleted layout rows as
+ *                                     DataRow[] (gated by `site.read`). The
+ *                                     client adapter converts these to
+ *                                     SavedLayout[] via savedLayoutFromRow +
+ *                                     validateSavedLayouts.
+ *   GET /admin/api/cms/layouts?id=X — the single row X (empty `rows` when
+ *                                     deleted or not a layout) — the conflict
+ *                                     banner's "Load theirs" fetch.
  *
  * The response returns raw DataRow objects (not SavedLayout objects) so the
  * client adapter can reconstruct layouts via savedLayoutFromRow without a
@@ -16,9 +20,8 @@
  */
 import type { DbClient } from '../../db/client'
 import { requireCapability } from '../../auth/authz'
-import { listDataRows } from '../../repositories/data'
-import { jsonResponse, methodNotAllowed } from '../../http'
-import { CMS_API_PREFIX } from './shared'
+import { methodNotAllowed } from '../../http'
+import { CMS_API_PREFIX, siteCollectionRowsResponse } from './shared'
 
 export async function handleLayoutsRoutes(req: Request, db: DbClient): Promise<Response | null> {
   const url = new URL(req.url)
@@ -28,6 +31,5 @@ export async function handleLayoutsRoutes(req: Request, db: DbClient): Promise<R
   const user = await requireCapability(req, db, 'site.read')
   if (user instanceof Response) return user
 
-  const rows = await listDataRows(db, 'layouts')
-  return jsonResponse({ rows })
+  return siteCollectionRowsResponse(db, url, 'layouts')
 }

--- a/server/handlers/cms/pages.ts
+++ b/server/handlers/cms/pages.ts
@@ -1,9 +1,13 @@
 /**
  * Pages read endpoint backed by `data_rows` (table_id = 'pages').
  *
- *   GET /admin/api/cms/pages — list all non-deleted page rows as DataRow[]
- *                              (gated by `site.read`). The client adapter
- *                              converts these to Page[] via pageFromRow.
+ *   GET /admin/api/cms/pages       — list all non-deleted page rows as
+ *                                    DataRow[] (gated by `site.read`). The
+ *                                    client adapter converts these to Page[]
+ *                                    via pageFromRow.
+ *   GET /admin/api/cms/pages?id=X  — the single row X (empty `rows` when it
+ *                                    is deleted or not a page) — the conflict
+ *                                    banner's "Load theirs" fetch.
  *
  * The response intentionally returns raw DataRow objects (not Page objects)
  * so the client adapter can reconstruct Pages via pageFromRow without a
@@ -16,9 +20,8 @@
  */
 import type { DbClient } from '../../db/client'
 import { requireCapability } from '../../auth/authz'
-import { listDataRows } from '../../repositories/data'
-import { jsonResponse, methodNotAllowed } from '../../http'
-import { CMS_API_PREFIX } from './shared'
+import { methodNotAllowed } from '../../http'
+import { CMS_API_PREFIX, siteCollectionRowsResponse } from './shared'
 
 export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Response | null> {
   const url = new URL(req.url)
@@ -28,6 +31,5 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
   const user = await requireCapability(req, db, 'site.read')
   if (user instanceof Response) return user
 
-  const rows = await listDataRows(db, 'pages')
-  return jsonResponse({ rows })
+  return siteCollectionRowsResponse(db, url, 'pages')
 }

--- a/server/handlers/cms/shared.ts
+++ b/server/handlers/cms/shared.ts
@@ -6,14 +6,18 @@
  * - `mutationErrorResponse` — translates the typed mutation errors thrown
  *   by repositories (`UserMutationError`, `RoleMutationError`) into the
  *   `{ error }` JSON envelope clients expect.
+ * - `siteCollectionRowsResponse` — the one `{ rows }` list/single-row read
+ *   shared by the pages / components / layouts GET endpoints.
  *
  * These helpers are intentionally small and dependency-free so any new
  * handler module can pull them in without dragging the rest of the CMS
  * surface along with it.
  */
 import { Type } from '@core/utils/typeboxHelpers'
+import type { DbClient } from '../../db/client'
 import { jsonResponse } from '../../http'
 import { clientIp } from '../../auth/security'
+import { getDataRow, listDataRows } from '../../repositories/data'
 import { UserMutationError } from '../../repositories/users'
 import { RoleMutationError } from '../../repositories/roles'
 
@@ -38,6 +42,27 @@ export function requestAuditContext(req: Request): { ipAddress: string | null; u
     ipAddress: clientIp(req),
     userAgent: req.headers.get('user-agent'),
   }
+}
+
+/**
+ * `{ rows }` response for one of the three site collection GETs
+ * (pages / components / layouts), honoring the optional `?id=<rowId>`
+ * single-row filter — the conflict banner's "Load theirs" fetch. A
+ * soft-deleted or foreign-table id yields `{ rows: [] }`: absence is the
+ * "deleted remotely" signal, and the table check keeps the endpoint from
+ * leaking rows of other data tables.
+ */
+export async function siteCollectionRowsResponse(
+  db: DbClient,
+  url: URL,
+  tableId: 'pages' | 'components' | 'layouts',
+): Promise<Response> {
+  const id = url.searchParams.get('id')
+  if (id !== null) {
+    const row = await getDataRow(db, id)
+    return jsonResponse({ rows: row && row.tableId === tableId ? [row] : [] })
+  }
+  return jsonResponse({ rows: await listDataRows(db, tableId) })
 }
 
 export function mutationErrorResponse(err: unknown): Response {

--- a/server/handlers/cms/site.ts
+++ b/server/handlers/cms/site.ts
@@ -2,8 +2,10 @@
  * Draft-site shell read endpoint.
  *
  *   GET /admin/api/cms/site — load the draft site shell (gated by `site.read`).
- *                              Returns the SiteShell without pages; the client
- *                              adapter fetches pages separately via GET /pages.
+ *                              Returns `{ site, seq }`: the SiteShell without
+ *                              pages plus the shell's sync seq (the client's
+ *                              conflict-detection base). Pages are fetched
+ *                              separately via GET /pages.
  *
  * Writes go through the transactional site-document save
  * (PUT /admin/api/cms/site-document — see ./siteDocument.ts), which persists
@@ -11,7 +13,7 @@
  */
 import type { DbClient } from '../../db/client'
 import { requireCapability } from '../../auth/authz'
-import { getDraftSite } from '../../repositories/site'
+import { getDraftSite, getDraftSiteSeq } from '../../repositories/site'
 import { jsonResponse, methodNotAllowed } from '../../http'
 
 export async function handleSiteRoutes(req: Request, db: DbClient): Promise<Response | null> {
@@ -24,5 +26,5 @@ export async function handleSiteRoutes(req: Request, db: DbClient): Promise<Resp
 
   const shell = await getDraftSite(db)
   if (!shell) return jsonResponse({ error: 'draft site not found' }, { status: 404 })
-  return jsonResponse({ site: shell })
+  return jsonResponse({ site: shell, seq: await getDraftSiteSeq(db) })
 }

--- a/server/handlers/cms/siteDiff.ts
+++ b/server/handlers/cms/siteDiff.ts
@@ -237,6 +237,17 @@ function diffFiles(
   }
 }
 
+/**
+ * True when two shells are content-identical. The transactional save uses
+ * this to SKIP the shell write + seq stamp on row-only saves — the pillar of
+ * the shell conflict check: the shell seq advances only when shell content
+ * genuinely changed, so a stale-but-untouched shell shipped alongside a page
+ * edit never trips a spurious conflict.
+ */
+export function shellsEqual(a: SiteShell, b: SiteShell): boolean {
+  return deepEqual(a, b)
+}
+
 // ---------------------------------------------------------------------------
 // Small deep-equal helpers
 // ---------------------------------------------------------------------------

--- a/server/handlers/cms/siteDocument.ts
+++ b/server/handlers/cms/siteDocument.ts
@@ -26,11 +26,17 @@
  *      post-save component roster (kept existing + changed in this batch),
  *      so a page referencing a component created in the same save is valid
  *      by construction — no cross-request ordering contract.
- *   2. ONE transaction: allocate the site-global sync seq, write the shell,
- *      then apply components → layouts → pages (deletes first inside each,
- *      freeing slugs; see repositories/data/rows/apply.ts). The repository
- *      calls are `…InTx` functions — nesting `db.transaction` wedges the
- *      SQLite adapter's serialized chain.
+ *   2. ONE transaction: allocate the site-global sync seq (the counter-row
+ *      lock serializes concurrent saves, making the conflict reads exact),
+ *      run the base-seq conflict check (incremental mode — any shipped row
+ *      stored NEWER than the client's base seq throws SaveConflictError,
+ *      rolling everything back into a 409 + conflicts payload), write the
+ *      shell ONLY when its content actually changed (so the shell seq stays
+ *      an honest conflict signal), then apply components → layouts → pages
+ *      (deletes first inside each, freeing slugs; see
+ *      repositories/data/rows/apply.ts). The repository calls are `…InTx`
+ *      functions — nesting `db.transaction` wedges the SQLite adapter's
+ *      serialized chain.
  *   3. Post-commit effects: bump the publish version when a published page
  *      was deleted (never inside the transaction — the publish lock can be
  *      queued behind the transaction chain). This is also the emission point
@@ -47,9 +53,15 @@ import {
   applyDataRowChangesInTx,
   listDataRowIdSlugs,
   listDataRows,
+  listDataRowSeqs,
   type DataRowWrite,
 } from '../../repositories/data'
-import { getDraftSite, saveDraftSite, stampDraftSiteSeq } from '../../repositories/site'
+import {
+  getDraftSite,
+  getDraftSiteSeq,
+  saveDraftSite,
+  stampDraftSiteSeq,
+} from '../../repositories/site'
 import { allocateSiteSeq } from '../../repositories/syncSequence'
 import { pageFromRow, pageToCells } from '../../../src/core/data/pageFromRow'
 import { visualComponentFromRow, visualComponentToCells } from '../../../src/core/data/componentFromRow'
@@ -64,11 +76,12 @@ import { validateSavedLayoutsForPartialWrite } from '@core/persistence/validateL
 import { VisualComponentSchema, vcSlugFromName, type VisualComponent } from '@core/visualComponents'
 import { SavedLayoutSchema, layoutSlugFromName, type SavedLayout } from '@core/layouts'
 import type { Page } from '@core/page-tree'
+import { SaveConflictError, type SaveConflict } from '@core/persistence/saveConflict'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../http'
 import { bumpPublishVersionSerialized } from '../../publish/publishState'
 import { Type, type Static } from '@core/utils/typeboxHelpers'
 import { CMS_API_PREFIX } from './shared'
-import { ForbiddenSiteChangeError, validateSiteWriteDiff } from './siteDiff'
+import { ForbiddenSiteChangeError, shellsEqual, validateSiteWriteDiff } from './siteDiff'
 import { validatePageWriteDiff } from './pageDiff'
 
 const SITE_WRITE_CAPABILITIES = [
@@ -88,6 +101,23 @@ const SiteDocumentBodySchema = Type.Object({
   deletedComponentIds: Type.Array(Type.String()),
   changedLayouts: Type.Array(SavedLayoutSchema),
   deletedLayoutIds: Type.Array(Type.String()),
+  /**
+   * Conflict detection (incremental mode): rowId → the stored seq the client
+   * last synchronized with, for every changed AND deleted row. Inside the
+   * save transaction, a stored row that is NEWER than its base — or that has
+   * no base entry at all — 409s the whole save with a conflicts payload
+   * (see @core/persistence/saveConflict). Client-created rows have no stored
+   * counterpart and pass by construction. Ignored in replace mode (imports
+   * are deliberate replace-everything operations).
+   */
+  baseSeqs: Type.Record(Type.String(), Type.Number()),
+  /**
+   * The shell seq the client last synchronized with. Checked only when the
+   * incoming shell content actually differs from the stored shell — the
+   * shell is shipped with every save, so an unconditional check would 409
+   * every concurrent save pair. Ignored in replace mode.
+   */
+  shellBaseSeq: Type.Number(),
 }, { additionalProperties: false })
 
 type SiteDocumentBody = Static<typeof SiteDocumentBodySchema>
@@ -172,6 +202,13 @@ export async function handleSiteDocumentRoutes(req: Request, db: DbClient): Prom
     const previousShell = await getDraftSite(db)
     const shell = validateSite(body.site)
     validateSiteWriteDiff(previousShell, shell, user.capabilities)
+
+    // The shell ships with EVERY save, changed or not. Detecting "actually
+    // changed" here (CPU work, outside the transaction) lets phase 2 skip the
+    // shell write + seq stamp on row-only saves — which in turn keeps the
+    // shell seq an honest conflict signal (an unconditional stamp would 409
+    // every concurrent save pair on the shell).
+    const shellChanged = previousShell === null || !shellsEqual(previousShell, shell)
 
     const hasAllSiteCaps =
       user.capabilities.includes('site.structure.edit') &&
@@ -307,9 +344,49 @@ export async function handleSiteDocumentRoutes(req: Request, db: DbClient): Prom
     let seq = 0
     let deletedPublishedPage = false
     await db.transaction(async (tx) => {
+      // Allocate FIRST: the counter-row UPDATE takes a row lock, so two
+      // concurrent save transactions serialize here (on Postgres as well as
+      // SQLite's fully-serialized chain) — which makes the conflict reads
+      // below exact, not best-effort.
       seq = await allocateSiteSeq(tx)
-      await saveDraftSite(tx, shell, user.id)
-      await stampDraftSiteSeq(tx, seq)
+
+      // Conflict check (incremental mode): any shipped row whose STORED seq
+      // is newer than the client's base — or that the client has no base
+      // entry for — would be a silent overwrite of another admin's work.
+      // Throwing rolls the transaction back, so nothing is written on 409.
+      if (body.mode === 'incremental') {
+        const conflicts: SaveConflict[] = []
+        if (shellChanged) {
+          const storedShellSeq = await getDraftSiteSeq(tx)
+          if (storedShellSeq > body.shellBaseSeq) {
+            conflicts.push({ table: 'site', rowId: 'default', seq: storedShellSeq })
+          }
+        }
+        const rowChecks = [
+          { table: 'pages', ids: [...changedPageIdsRaw, ...pageDeleteIds] },
+          { table: 'components', ids: [...changedComponentIds, ...componentDeleteIds] },
+          { table: 'layouts', ids: [...changedLayoutIds, ...layoutDeleteIds] },
+        ] as const
+        for (const { table, ids } of rowChecks) {
+          // listDataRowSeqs sees soft-deleted rows too: a remote deletion is
+          // a newer write, not absence. Rows with no stored counterpart are
+          // client creations and pass by construction (absent from the result).
+          for (const stored of await listDataRowSeqs(tx, table, ids)) {
+            const base = body.baseSeqs[stored.id]
+            if (base === undefined || stored.seq > base) {
+              conflicts.push({ table, rowId: stored.id, seq: stored.seq })
+            }
+          }
+        }
+        if (conflicts.length > 0) throw new SaveConflictError(conflicts)
+      }
+
+      // Shell write + seq stamp only when the shell content actually changed
+      // — see the shellChanged comment in phase 1.
+      if (shellChanged) {
+        await saveDraftSite(tx, shell, user.id)
+        await stampDraftSiteSeq(tx, seq)
+      }
       // Empty change sets skip their table entirely — a shell-only save
       // issues no row queries inside the transaction.
       if (componentWrites.length > 0 || componentDeleteIds.size > 0) {
@@ -349,6 +426,9 @@ export async function handleSiteDocumentRoutes(req: Request, db: DbClient): Prom
         { error: err.message, kind: err.kind, path: err.path },
         { status: 403 },
       )
+    }
+    if (err instanceof SaveConflictError) {
+      return jsonResponse({ error: err.message, conflicts: err.conflicts }, { status: 409 })
     }
     throw err
   }

--- a/server/repositories/data/index.ts
+++ b/server/repositories/data/index.ts
@@ -31,6 +31,7 @@ export {
 export {
   listDataRows,
   listDataRowIdSlugs,
+  listDataRowSeqs,
   listDataRowsWithFilter,
   searchDataRows,
   getDataRow,

--- a/server/repositories/data/rows/index.ts
+++ b/server/repositories/data/rows/index.ts
@@ -19,6 +19,7 @@
 export {
   listDataRows,
   listDataRowIdSlugs,
+  listDataRowSeqs,
   getDataRow,
   getDataRowMany,
   getDataRowBySlug,

--- a/server/repositories/data/rows/mapper.ts
+++ b/server/repositories/data/rows/mapper.ts
@@ -56,6 +56,7 @@ interface DataRowRow extends UserJoinColumns {
   cells_json: Record<string, unknown>
   slug: string
   status: DataRowStatus
+  seq: number
   author_user_id: string | null
   created_by_user_id: string | null
   updated_by_user_id: string | null
@@ -78,6 +79,7 @@ function mapRow(row: DataRowRow): DataRow {
     cells: row.cells_json,
     slug: row.slug,
     status: row.status,
+    seq: Number(row.seq),
     authorUserId: row.author_user_id ?? null,
     createdByUserId: row.created_by_user_id ?? null,
     updatedByUserId: row.updated_by_user_id ?? null,
@@ -114,6 +116,7 @@ const DATA_ROW_COLUMNS = `data_rows.id,
        data_rows.cells_json,
        data_rows.slug,
        data_rows.status,
+       data_rows.seq,
        data_rows.author_user_id,
        data_rows.created_by_user_id,
        data_rows.updated_by_user_id,

--- a/server/repositories/data/rows/read.ts
+++ b/server/repositories/data/rows/read.ts
@@ -54,10 +54,10 @@ interface DataRowIdSlug {
 }
 
 /**
- * Lightweight (id, slug) projection of a table's non-deleted rows. The roster
- * reconcilers (PUT /pages, PUT /components) need exactly this — the reap diff
- * and the cross-row slug-uniqueness check — so they must not pay the hydrated
- * SELECT's full `cells_json` parse per row per save.
+ * Lightweight (id, slug) projection of a table's non-deleted rows. The
+ * transactional site-document save needs exactly this — the replace-mode reap
+ * diff and the cross-row slug-uniqueness check — so it must not pay the
+ * hydrated SELECT's full `cells_json` parse per row per save.
  */
 export async function listDataRowIdSlugs(
   db: DbClient,
@@ -87,6 +87,34 @@ export async function listSoftDeletedDataRowIds(
       and deleted_at is not null
   `
   return rows.map((r) => r.id)
+}
+
+export interface DataRowSeq {
+  id: string
+  seq: number
+}
+
+/**
+ * Lean (id, seq) projection for a set of row ids in one table — the
+ * transactional save's conflict check. Deliberately NO `deleted_at` filter:
+ * a remote soft-delete stamps the row's seq, and a stale client editing that
+ * row must see it as a conflict, not as absence. Runs INSIDE the save
+ * transaction (after `allocateSiteSeq` — the counter-row lock serializes
+ * concurrent saves, so the read is exact).
+ */
+export async function listDataRowSeqs(
+  db: DbClient,
+  tableId: string,
+  rowIds: ReadonlyArray<string>,
+): Promise<DataRowSeq[]> {
+  if (rowIds.length === 0) return []
+  const placeholders = rowIds.map((_, i) => placeholder(db.dialect, i + 2)).join(', ')
+  const { rows } = await db.unsafe<DataRowSeq>(
+    `select id, seq from data_rows
+     where table_id = ${placeholder(db.dialect, 1)} and id in (${placeholders})`,
+    [tableId, ...rowIds],
+  )
+  return rows.map((r) => ({ id: r.id, seq: Number(r.seq) }))
 }
 
 export async function getDataRow(

--- a/server/repositories/site.ts
+++ b/server/repositories/site.ts
@@ -97,10 +97,28 @@ export async function saveDraftSite(
 }
 
 /**
+ * The shell's current sync seq — 0 before setup (no site row) and for
+ * installs that predate the sync-sequence migration. The transactional save
+ * reads this inside the transaction for the shell conflict check; the GET
+ * shell endpoint returns it so clients can seed their base seq.
+ */
+export async function getDraftSiteSeq(db: DbClient): Promise<number> {
+  const { rows } = await db<{ seq: number }>`
+    select seq from site
+    where id = 'default'
+    limit 1
+  `
+  return rows[0] ? Number(rows[0].seq) : 0
+}
+
+/**
  * Stamp the site-global sync seq on the draft-site row. The transactional
  * site-document save calls this right after `saveDraftSite` inside the same
- * transaction, so shell changes participate in delta reconciliation exactly
- * like row changes (see repositories/syncSequence.ts).
+ * transaction — but ONLY when the shell content actually changed. An
+ * unconditional stamp would advance the shell seq on every row-only save and
+ * make the shell conflict check fire on every concurrent save pair; a
+ * conditional stamp keeps the shell seq an honest "shell content changed"
+ * signal (see repositories/syncSequence.ts).
  */
 export async function stampDraftSiteSeq(db: DbClient, seq: number): Promise<void> {
   await db`

--- a/src/__tests__/editor-hooks/siteEditorDataDeepLink.test.tsx
+++ b/src/__tests__/editor-hooks/siteEditorDataDeepLink.test.tsx
@@ -63,9 +63,11 @@ function makeAdapter(site: SiteDocument): IPersistenceAdapter & { loadCount: () 
   return {
     async loadSite() {
       loads += 1
-      return site
+      return { site, rowSeqs: {}, shellSeq: 0 }
     },
-    async saveSite() {},
+    async saveSite() {
+      return { seq: 1 }
+    },
     loadCount: () => loads,
   }
 }
@@ -79,9 +81,11 @@ function makeControlledAdapter(
     async loadSite() {
       loads += 1
       await new Promise<void>((resolve) => resolvers.push(resolve))
-      return site
+      return { site, rowSeqs: {}, shellSeq: 0 }
     },
-    async saveSite() {},
+    async saveSite() {
+      return { seq: 1 }
+    },
     loadCount: () => loads,
     resolveNextLoad: () => {
       resolvers.shift()?.()

--- a/src/__tests__/editor-store/saveConflicts.test.ts
+++ b/src/__tests__/editor-store/saveConflicts.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Save-conflict resolution + base-seq bookkeeping (multi-admin level A).
+ *
+ * Covers the store half of the conflict protocol:
+ *   - seedBaseSeqs / commitSavedBaseSeqs — the conflict-detection bases every
+ *     incremental save ships, seeded at load and bumped on success (deleted
+ *     rows KEEP their entries so a resurrect-by-undo carries the right base),
+ *   - resolveSaveConflictKeepMine — bumps the target's base seq so the next
+ *     save overwrites as a stated decision; dirty marks stay untouched,
+ *   - resolveSaveConflictTheirs — swaps the remote version in (or removes a
+ *     remotely-deleted target), clears the target's dirty marks, syncs the
+ *     base seq, clears the undo history, and — for Visual Components —
+ *     propagates to consumer pages with REAL dirty marks (slot re-sync /
+ *     ref-cascade removal).
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import { useEditorStore } from '@site/store/store'
+import { emptyDirtyMarks } from '@site/store/slices/site/dirtyTracking'
+import { makeNode, makePage, makeSite, makeVC } from '../fixtures'
+
+function loadFixtureSite(overrides: Parameters<typeof makeSite>[0] = {}) {
+  useEditorStore.getState().loadSite(makeSite(overrides))
+}
+
+beforeEach(() => {
+  useEditorStore.getState().clearSite()
+})
+
+// ---------------------------------------------------------------------------
+// Base-seq bookkeeping
+// ---------------------------------------------------------------------------
+
+describe('base-seq bookkeeping', () => {
+  it('seedBaseSeqs replaces the maps wholesale', () => {
+    loadFixtureSite()
+    useEditorStore.getState().seedBaseSeqs({ 'page-1': 4, 'vc-1': 5 }, 6)
+    expect(useEditorStore.getState().baseSeqs).toEqual({ 'page-1': 4, 'vc-1': 5 })
+    expect(useEditorStore.getState().shellBaseSeq).toBe(6)
+
+    useEditorStore.getState().seedBaseSeqs({ 'page-2': 9 }, 10)
+    expect(useEditorStore.getState().baseSeqs).toEqual({ 'page-2': 9 })
+    expect(useEditorStore.getState().shellBaseSeq).toBe(10)
+  })
+
+  it('commitSavedBaseSeqs (incremental) bumps exactly the shipped ids — deleted rows keep entries', () => {
+    loadFixtureSite({ pages: [makePage({ id: 'page-a' }), makePage({ id: 'page-b', slug: 'b' })] })
+    useEditorStore.getState().seedBaseSeqs({ 'page-a': 1, 'page-b': 1, 'vc-gone': 1 }, 1)
+
+    const dirty = {
+      ...emptyDirtyMarks(),
+      pageIds: new Set(['page-a']),
+      deletedComponentIds: new Set(['vc-gone']),
+    }
+    useEditorStore.getState().commitSavedBaseSeqs(useEditorStore.getState().site!, dirty, 7)
+
+    const { baseSeqs, shellBaseSeq } = useEditorStore.getState()
+    expect(baseSeqs['page-a']).toBe(7)
+    // Deleted rows keep a base at the delete-save's seq: an undo that
+    // resurrects the row must not read as a blind overwrite.
+    expect(baseSeqs['vc-gone']).toBe(7)
+    // Unshipped rows keep their old base.
+    expect(baseSeqs['page-b']).toBe(1)
+    expect(shellBaseSeq).toBe(7)
+  })
+
+  it('commitSavedBaseSeqs (replace) rebuilds the map from the shipped site', () => {
+    loadFixtureSite({ pages: [makePage({ id: 'page-a' })] })
+    useEditorStore.getState().seedBaseSeqs({ 'stale-row': 3 }, 3)
+
+    useEditorStore.getState().commitSavedBaseSeqs(useEditorStore.getState().site!, undefined, 9)
+
+    expect(useEditorStore.getState().baseSeqs).toEqual({ 'page-a': 9 })
+    expect(useEditorStore.getState().shellBaseSeq).toBe(9)
+  })
+
+  it('a successful save clears pending conflicts', () => {
+    loadFixtureSite()
+    useEditorStore.getState().setSaveConflicts([{ table: 'pages', rowId: 'page-1', seq: 5 }])
+    useEditorStore.getState().commitSavedBaseSeqs(useEditorStore.getState().site!, undefined, 9)
+    expect(useEditorStore.getState().saveConflicts).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Keep mine
+// ---------------------------------------------------------------------------
+
+describe('resolveSaveConflictKeepMine', () => {
+  it('bumps the row base to the remote seq and drops the conflict; dirty marks survive', () => {
+    loadFixtureSite()
+    useEditorStore.getState().seedBaseSeqs({ 'page-1': 2 }, 2)
+    useEditorStore.setState((s) => {
+      s._dirtySave.pageIds.add('page-1')
+    })
+    useEditorStore.getState().setSaveConflicts([{ table: 'pages', rowId: 'page-1', seq: 8 }])
+
+    useEditorStore.getState().resolveSaveConflictKeepMine({ table: 'pages', rowId: 'page-1', seq: 8 })
+
+    const state = useEditorStore.getState()
+    expect(state.saveConflicts).toEqual([])
+    expect(state.baseSeqs['page-1']).toBe(8)
+    expect(state._dirtySave.pageIds.has('page-1')).toBe(true)
+  })
+
+  it('bumps the shell base for a site conflict', () => {
+    loadFixtureSite()
+    useEditorStore.getState().seedBaseSeqs({}, 2)
+    useEditorStore.getState().setSaveConflicts([{ table: 'site', rowId: 'default', seq: 11 }])
+
+    useEditorStore.getState().resolveSaveConflictKeepMine({ table: 'site', rowId: 'default', seq: 11 })
+
+    expect(useEditorStore.getState().shellBaseSeq).toBe(11)
+    expect(useEditorStore.getState().saveConflicts).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Load theirs
+// ---------------------------------------------------------------------------
+
+describe('resolveSaveConflictTheirs', () => {
+  it('swaps a remote page in, clears its dirty marks, syncs the base seq, clears history', () => {
+    loadFixtureSite({ pages: [makePage({ id: 'page-a', title: 'Mine' })] })
+    useEditorStore.getState().seedBaseSeqs({ 'page-a': 1 }, 1)
+    // Local unsaved edit — real history + dirty marks.
+    useEditorStore.getState().renamePage('page-a', 'Mine (edited)')
+    expect(useEditorStore.getState().canUndo).toBe(true)
+    expect(useEditorStore.getState()._dirtySave.pageIds.has('page-a')).toBe(true)
+    useEditorStore.getState().setSaveConflicts([{ table: 'pages', rowId: 'page-a', seq: 6 }])
+
+    useEditorStore.getState().resolveSaveConflictTheirs({
+      table: 'pages',
+      rowId: 'page-a',
+      row: makePage({ id: 'page-a', title: 'Theirs' }),
+      seq: 6,
+    })
+
+    const state = useEditorStore.getState()
+    expect(state.site!.pages.find((p) => p.id === 'page-a')!.title).toBe('Theirs')
+    expect(state._dirtySave.pageIds.has('page-a')).toBe(false)
+    expect(state.baseSeqs['page-a']).toBe(6)
+    expect(state.saveConflicts).toEqual([])
+    // Site-relative history patches are undefined across a swapped tree.
+    expect(state.canUndo).toBe(false)
+    expect(state._historyPast).toEqual([])
+  })
+
+  it('removes a remotely-deleted page and moves the active page off it', () => {
+    loadFixtureSite({
+      pages: [
+        makePage({ id: 'page-home', slug: 'index', title: 'Home' }),
+        makePage({ id: 'page-b', slug: 'b', title: 'B' }),
+      ],
+    })
+    useEditorStore.getState().seedBaseSeqs({ 'page-home': 1, 'page-b': 1 }, 1)
+    useEditorStore.getState().setActivePage('page-b')
+
+    useEditorStore.getState().resolveSaveConflictTheirs({
+      table: 'pages',
+      rowId: 'page-b',
+      row: null,
+      seq: 6,
+    })
+
+    const state = useEditorStore.getState()
+    expect(state.site!.pages.map((p) => p.id)).toEqual(['page-home'])
+    expect(state.activePageId).toBe('page-home')
+    expect(state.baseSeqs['page-b']).toBeUndefined()
+  })
+
+  it('swaps remote shell fields in place, leaving the row collections untouched', () => {
+    loadFixtureSite({ name: 'Mine', pages: [makePage({ id: 'page-a' })] })
+    useEditorStore.getState().seedBaseSeqs({ 'page-a': 1 }, 1)
+    const remoteShell = (() => {
+      const { pages: _p, visualComponents: _v, layouts: _l, ...shell } = makeSite({ name: 'Theirs' })
+      return shell
+    })()
+
+    useEditorStore.getState().resolveSaveConflictTheirs({
+      table: 'site',
+      shell: remoteShell,
+      seq: 12,
+    })
+
+    const state = useEditorStore.getState()
+    expect(state.site!.name).toBe('Theirs')
+    expect(state.site!.pages.map((p) => p.id)).toEqual(['page-a'])
+    expect(state.shellBaseSeq).toBe(12)
+  })
+
+  it('a remotely-deleted VC cascades ref removal into consumer pages WITH dirty marks', () => {
+    const vc = makeVC({ id: 'vc-1', name: 'Card' })
+    const page = makePage({
+      id: 'page-a',
+      nodes: {
+        root: makeNode({ id: 'root', moduleId: 'base.body', children: ['ref-1'] }),
+        'ref-1': makeNode({
+          id: 'ref-1',
+          moduleId: 'base.visual-component-ref',
+          props: { componentId: 'vc-1' },
+        }),
+      },
+    })
+    loadFixtureSite({ pages: [page], visualComponents: [vc] })
+    useEditorStore.getState().seedBaseSeqs({ 'page-a': 1, 'vc-1': 1 }, 1)
+    useEditorStore.getState().setSaveConflicts([{ table: 'components', rowId: 'vc-1', seq: 4 }])
+
+    useEditorStore.getState().resolveSaveConflictTheirs({
+      table: 'components',
+      rowId: 'vc-1',
+      row: null,
+      seq: 4,
+    })
+
+    const state = useEditorStore.getState()
+    expect(state.site!.visualComponents).toEqual([])
+    // The consumer page lost its ref node…
+    expect(state.site!.pages[0].nodes['ref-1']).toBeUndefined()
+    // …and now DIFFERS from storage, so it must ship with the next save.
+    expect(state._dirtySave.pageIds.has('page-a')).toBe(true)
+    expect(state.baseSeqs['vc-1']).toBeUndefined()
+    expect(state.saveConflicts).toEqual([])
+  })
+})

--- a/src/__tests__/persistence/cmsAdapter.test.ts
+++ b/src/__tests__/persistence/cmsAdapter.test.ts
@@ -3,6 +3,7 @@ import type { Page, SiteDocument } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
 import type { SavedLayout } from '@core/layouts'
 import { CmsAdapter } from '@core/persistence/cms'
+import { SaveConflictError } from '@core/persistence/saveConflict'
 
 function makePage(id: string, slug: string): Page {
   return {
@@ -96,7 +97,7 @@ describe('CmsAdapter', () => {
 
     const loaded = await adapter.loadSite('ignored-in-single-site-mode')
 
-    expect(loaded?.id).toBe('project_1')
+    expect(loaded?.site.id).toBe('project_1')
     expect(calls[0]).toMatchObject({
       input: '/admin/api/cms/site',
       init: { method: 'GET', credentials: 'include' },
@@ -295,5 +296,103 @@ describe('CmsAdapter save wire shapes', () => {
     expect(ids(body.changedComponents)).toEqual(['vc-1', 'vc-2'])
     expect(ids(body.changedLayouts)).toEqual(['layout-1', 'layout-2'])
     expect(body.deletedPageIds).toEqual([])
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Conflict-detection wire shapes — baseSeqs / shellBaseSeq + the 409 path
+// ---------------------------------------------------------------------------
+
+describe('CmsAdapter conflict protocol', () => {
+  function emptyDirty() {
+    return {
+      all: false,
+      pageIds: new Set<string>(),
+      componentIds: new Set<string>(),
+      layoutIds: new Set<string>(),
+      deletedPageIds: new Set<string>(),
+      deletedComponentIds: new Set<string>(),
+      deletedLayoutIds: new Set<string>(),
+    }
+  }
+
+  it('ships the base-seq subset covering exactly the changed + deleted rows, plus shellBaseSeq', async () => {
+    const calls: Array<{ init?: RequestInit }> = []
+    const adapter = new CmsAdapter(async (_input, init) => {
+      calls.push({ init })
+      return new Response(JSON.stringify({ ok: true, seq: 9 }), { status: 200 })
+    })
+
+    const doc = site()
+    const result = await adapter.saveSite(doc, {
+      dirty: {
+        ...emptyDirty(),
+        pageIds: new Set(['page_home']),
+        deletedComponentIds: new Set(['vc-gone']),
+      },
+      baseSeqs: {
+        page_home: 4,
+        'vc-gone': 5,
+        'unrelated-row': 99, // not shipped — must not leak onto the wire
+      },
+      shellBaseSeq: 7,
+    })
+
+    expect(result.seq).toBe(9)
+    const body = JSON.parse(String(calls[0].init?.body)) as Record<string, unknown>
+    expect(body.baseSeqs).toEqual({ page_home: 4, 'vc-gone': 5 })
+    expect(body.shellBaseSeq).toBe(7)
+  })
+
+  it('throws SaveConflictError with the parsed conflicts on a 409', async () => {
+    const conflicts = [{ table: 'pages', rowId: 'page_home', seq: 12 }]
+    const adapter = new CmsAdapter(async () =>
+      new Response(JSON.stringify({ error: 'save conflict', conflicts }), { status: 409 }))
+
+    const err = await adapter
+      .saveSite(site(), { dirty: emptyDirty(), baseSeqs: {}, shellBaseSeq: 0 })
+      .then(() => null, (e: unknown) => e)
+    expect(err).toBeInstanceOf(SaveConflictError)
+    expect((err as SaveConflictError).conflicts).toEqual([
+      { table: 'pages', rowId: 'page_home', seq: 12 },
+    ])
+  })
+
+  it('loadSite returns per-row seqs and the shell seq alongside the document', async () => {
+    const adapter = new CmsAdapter(async (input) => {
+      const url = String(input)
+      if (url.endsWith('/site')) {
+        return new Response(JSON.stringify({ site: site(), seq: 3 }), { status: 200 })
+      }
+      if (url.endsWith('/pages')) {
+        return new Response(JSON.stringify({
+          rows: [{
+            id: 'page_home', tableId: 'pages', slug: 'index', status: 'draft', seq: 2,
+            cells: { title: 'index', slug: 'index', body: { rootNodeId: 'root', nodes: { root: { id: 'root', moduleId: 'base.body', props: {}, breakpointOverrides: {}, children: [] } } } },
+            authorUserId: null, createdByUserId: null, updatedByUserId: null, publishedByUserId: null,
+            author: null, createdBy: null, updatedBy: null, publishedBy: null,
+            createdAt: '2026-01-01', updatedAt: '2026-01-01', publishedAt: null,
+            scheduledPublishAt: null, deletedAt: null,
+          }],
+        }), { status: 200 })
+      }
+      return new Response(JSON.stringify({ rows: [] }), { status: 200 })
+    })
+
+    const loaded = await adapter.loadSite('default')
+    expect(loaded?.shellSeq).toBe(3)
+    expect(loaded?.rowSeqs).toEqual({ page_home: 2 })
+  })
+
+  it('loadSiteRow fetches the single-row filter and returns null for a deleted row', async () => {
+    const requested: string[] = []
+    const adapter = new CmsAdapter(async (input) => {
+      requested.push(String(input))
+      return new Response(JSON.stringify({ rows: [] }), { status: 200 })
+    })
+
+    const row = await adapter.loadSiteRow('pages', 'page-gone')
+    expect(row).toBeNull()
+    expect(requested[0]).toBe('/admin/api/cms/pages?id=page-gone')
   })
 })

--- a/src/__tests__/persistence/savePersistenceQueue.test.tsx
+++ b/src/__tests__/persistence/savePersistenceQueue.test.tsx
@@ -20,6 +20,7 @@ import React, { useEffect } from 'react'
 import { cleanup, render, waitFor } from '@testing-library/react'
 import { usePersistence } from '@site/hooks/usePersistence'
 import type { IPersistenceAdapter, SaveSiteOptions } from '@core/persistence/types'
+import { SaveConflictError } from '@core/persistence/saveConflict'
 import type { SiteDocument } from '@core/page-tree'
 import { useEditorStore } from '@site/store/store'
 import { emptyDirtyMarks } from '@site/store/slices/site/dirtyTracking'
@@ -54,7 +55,8 @@ function makeGatedAdapter(): { adapter: IPersistenceAdapter; saves: RecordedSave
     saveSite: (_site: SiteDocument, opts: SaveSiteOptions = {}) => {
       const gate = deferred()
       saves.push({ dirty: opts.dirty, gate })
-      return gate.promise
+      // Each released save reports a strictly-increasing seq, like the server.
+      return gate.promise.then(() => ({ seq: saves.length }))
     },
   }
   return { adapter, saves }
@@ -204,5 +206,52 @@ describe('usePersistence single-flight save queue', () => {
     expect(saves[1].dirty!.pageIds.has('page-b')).toBe(true)
     saves[1].gate.resolve()
     await second
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Conflict flow — a 409'd save surfaces the resolution UI, loses nothing
+// ---------------------------------------------------------------------------
+
+describe('usePersistence conflict flow', () => {
+  it('a SaveConflictError sets store.saveConflicts, restores the dirty marks, and bumps nothing', async () => {
+    seedStore()
+    useEditorStore.getState().seedBaseSeqs({ 'page-a': 3 }, 3)
+    const conflicts = [{ table: 'pages' as const, rowId: 'page-a', seq: 7 }]
+    const adapter: IPersistenceAdapter = {
+      loadSite: async () => undefined,
+      saveSite: async () => {
+        throw new SaveConflictError(conflicts)
+      },
+    }
+    const save = await mountHook(adapter)
+
+    editPage('page-a')
+    await expect(save()).rejects.toBeInstanceOf(SaveConflictError)
+
+    const state = useEditorStore.getState()
+    expect(state.saveConflicts).toEqual(conflicts)
+    // The failed snapshot merged back — nothing lost, next save re-ships it.
+    expect(state._dirtySave.pageIds.has('page-a')).toBe(true)
+    // Base seqs untouched by the failure — only a resolution changes them.
+    expect(state.baseSeqs['page-a']).toBe(3)
+  })
+
+  it('a successful save commits the shipped bases to the response seq and clears conflicts', async () => {
+    seedStore()
+    useEditorStore.getState().seedBaseSeqs({ 'page-a': 3, 'page-b': 3 }, 3)
+    const adapter: IPersistenceAdapter = {
+      loadSite: async () => undefined,
+      saveSite: async () => ({ seq: 15 }),
+    }
+    const save = await mountHook(adapter)
+
+    editPage('page-a')
+    await save()
+
+    const state = useEditorStore.getState()
+    expect(state.baseSeqs['page-a']).toBe(15)
+    expect(state.baseSeqs['page-b']).toBe(3)
+    expect(state.shellBaseSeq).toBe(15)
   })
 })

--- a/src/__tests__/server/capabilityRouteMatrix.test.ts
+++ b/src/__tests__/server/capabilityRouteMatrix.test.ts
@@ -21,6 +21,28 @@ async function loadSiteShell(
   return body.site
 }
 
+/** The shell's live sync seq — the conflict-detection base a fresh client would hold. */
+async function loadShellSeq(
+  harness: Awaited<ReturnType<typeof createCapabilityTestHarness>>,
+  cookie: string,
+): Promise<number> {
+  const res = await harness.cms('/admin/api/cms/site', { method: 'GET', cookie })
+  expect(res.status).toBe(200)
+  const body = await readJson<{ seq?: number }>(res)
+  return body.seq ?? 0
+}
+
+/** Live per-row sync seqs for the pages collection — a fresh client's base map. */
+async function pagesBaseSeqs(
+  harness: Awaited<ReturnType<typeof createCapabilityTestHarness>>,
+  cookie: string,
+): Promise<Record<string, number>> {
+  const res = await harness.cms('/admin/api/cms/pages', { method: 'GET', cookie })
+  expect(res.status).toBe(200)
+  const body = await readJson<{ rows: DataRow[] }>(res)
+  return Object.fromEntries((body.rows ?? []).map((row) => [row.id, row.seq ?? 0]))
+}
+
 async function loadPages(
   harness: Awaited<ReturnType<typeof createCapabilityTestHarness>>,
   cookie: string,
@@ -43,6 +65,8 @@ function siteDocBody(overrides: {
   deletedComponentIds?: string[]
   changedLayouts?: unknown[]
   deletedLayoutIds?: string[]
+  baseSeqs?: Record<string, number>
+  shellBaseSeq?: number
 }): Record<string, unknown> {
   return {
     mode: 'incremental',
@@ -52,6 +76,11 @@ function siteDocBody(overrides: {
     deletedComponentIds: [],
     changedLayouts: [],
     deletedLayoutIds: [],
+    // Conflict-detection bases — scenarios that expect a save to LAND pass
+    // live values; scenarios rejected by the capability diff gate (403,
+    // phase 1) never reach the conflict check, so the defaults suffice.
+    baseSeqs: {},
+    shellBaseSeq: 0,
     ...overrides,
   }
 }
@@ -134,7 +163,10 @@ describe('capability route matrix', () => {
       const styleAllowed = await harness.cms('/admin/api/cms/site-document', {
         method: 'PUT',
         cookie: styleUser.cookie,
-        json: siteDocBody({ site: styleEdit }),
+        json: siteDocBody({
+          site: styleEdit,
+          shellBaseSeq: await loadShellSeq(harness, styleUser.cookie),
+        }),
       })
       expect(styleAllowed.status).toBe(200)
 
@@ -155,7 +187,10 @@ describe('capability route matrix', () => {
       const structureAllowed = await harness.cms('/admin/api/cms/site-document', {
         method: 'PUT',
         cookie: structureUser.cookie,
-        json: siteDocBody({ site: { ...afterStyle, name: 'Capability Matrix Renamed' } }),
+        json: siteDocBody({
+          site: { ...afterStyle, name: 'Capability Matrix Renamed' },
+          shellBaseSeq: await loadShellSeq(harness, structureUser.cookie),
+        }),
       })
       expect(structureAllowed.status).toBe(200)
 
@@ -287,7 +322,11 @@ describe('capability route matrix', () => {
       const seedRes = await harness.cms('/admin/api/cms/site-document', {
         method: 'PUT',
         cookie: ownerCookie,
-        json: siteDocBody({ site: ownerShell, changedPages: [seededPage] }),
+        json: siteDocBody({
+          site: ownerShell,
+          changedPages: [seededPage],
+          baseSeqs: await pagesBaseSeqs(harness, ownerCookie),
+        }),
       })
       expect(seedRes.status).toBe(200)
 
@@ -299,7 +338,11 @@ describe('capability route matrix', () => {
       const editRes = await harness.cms('/admin/api/cms/site-document', {
         method: 'PUT',
         cookie: contentEditor.cookie,
-        json: siteDocBody({ site: editorShell, changedPages: [editedPage] }),
+        json: siteDocBody({
+          site: editorShell,
+          changedPages: [editedPage],
+          baseSeqs: await pagesBaseSeqs(harness, contentEditor.cookie),
+        }),
       })
       expect(editRes.status).toBe(200)
 

--- a/src/__tests__/server/cmsRouteAuthorization.test.ts
+++ b/src/__tests__/server/cmsRouteAuthorization.test.ts
@@ -109,7 +109,12 @@ async function currentSiteDocument(db: DbClient, cookie: string): Promise<SiteDo
   return { ...shellPayload.site, pages }
 }
 
-/** Shell-only incremental body for PUT /admin/api/cms/site-document. */
+/**
+ * Shell-only incremental body for PUT /admin/api/cms/site-document.
+ * `shellBaseSeq: 0` matches every scenario here: the freshly-seeded shell has
+ * seq 0, and the later stale-base saves are rejected by the capability diff
+ * gate (403, phase 1) before the conflict check would run.
+ */
 function shellPutBody(site: SiteDocument | SiteShell): string {
   const { pages: _pages, ...shell } = site as SiteDocument
   return JSON.stringify({
@@ -121,6 +126,8 @@ function shellPutBody(site: SiteDocument | SiteShell): string {
     deletedComponentIds: [],
     changedLayouts: [],
     deletedLayoutIds: [],
+    baseSeqs: {},
+    shellBaseSeq: 0,
   })
 }
 

--- a/src/__tests__/server/cmsSiteHandlers.test.ts
+++ b/src/__tests__/server/cmsSiteHandlers.test.ts
@@ -67,12 +67,20 @@ function makeFakeDb() {
     if (normalized.includes('select id, name, settings_json')) {
       return { rows: siteRow ? [siteRow as Row] : [], rowCount: siteRow ? 1 : 0 }
     }
+    // getDraftSiteSeq — shell conflict-detection base (0 when unstamped)
+    if (normalized.includes('select seq from site')) {
+      return {
+        rows: siteRow ? [{ seq: Number(siteRow.seq ?? 0) } as unknown as Row] : [],
+        rowCount: siteRow ? 1 : 0,
+      }
+    }
     // allocateSiteSeq — the site-document save's sync counter
     if (normalized.includes('update site_sync_state')) {
       return { rows: [{ seq: 1 } as unknown as Row], rowCount: 1 }
     }
     // stampDraftSiteSeq
     if (normalized.includes('update site set seq')) {
+      if (siteRow) siteRow.seq = values[0]
       return { rows: [], rowCount: 1 }
     }
     // listDataRows / listDataRowIdSlugs / listSoftDeletedDataRowIds — this
@@ -175,6 +183,8 @@ describe('cms site handlers', () => {
         deletedComponentIds: [],
         changedLayouts: [],
         deletedLayoutIds: [],
+        baseSeqs: {},
+        shellBaseSeq: 0,
       }),
       headers: {
         'content-type': 'application/json',

--- a/src/__tests__/server/siteDocumentSave.test.ts
+++ b/src/__tests__/server/siteDocumentSave.test.ts
@@ -21,7 +21,12 @@
  *   - replace mode (imports): server-derived deletions, deleted*Ids must be
  *     empty,
  *   - the site-global sync seq: response seq strictly increases and is
- *     stamped on written AND deleted rows.
+ *     stamped on written AND deleted rows,
+ *   - conflict detection: incremental saves carry base seqs; a shipped row
+ *     stored NEWER than its base (or with no base entry at all) 409s the
+ *     whole save with a `conflicts` payload and writes nothing. The shell
+ *     participates only when its content actually changed (row-only saves
+ *     don't stamp the shell seq). Replace mode skips the check.
  *
  * Runs against a real isolated SQLite DB through the established capability
  * harness (`createCapabilityTestHarness` → `createTestDb`): migrations
@@ -180,23 +185,73 @@ interface DocOverrides {
   deletedComponentIds?: string[]
   changedLayouts?: unknown[]
   deletedLayoutIds?: string[]
+  baseSeqs?: Record<string, number>
+  shellBaseSeq?: number
 }
 
-function putDoc(ctx: Ctx, overrides: DocOverrides = {}): Promise<Response> {
+/** Every row id an incremental body touches — changed + deleted, all collections. */
+function touchedIds(body: {
+  changedPages: unknown[]
+  deletedPageIds: string[]
+  changedComponents: unknown[]
+  deletedComponentIds: string[]
+  changedLayouts: unknown[]
+  deletedLayoutIds: string[]
+}): string[] {
+  const changed = [...body.changedPages, ...body.changedComponents, ...body.changedLayouts]
+    .map((row) => (row && typeof row === 'object' ? (row as { id?: unknown }).id : undefined))
+    .filter((id): id is string => typeof id === 'string')
+  return [...changed, ...body.deletedPageIds, ...body.deletedComponentIds, ...body.deletedLayoutIds]
+}
+
+/** Stored seqs for `ids` (soft-deleted rows included) — the up-to-date client's base map. */
+async function liveBaseSeqs(harness: CapabilityTestHarness, ids: string[]): Promise<Record<string, number>> {
+  if (ids.length === 0) return {}
+  const { rows } = await harness.db<{ id: string; seq: number }>`
+    select id, seq from data_rows
+  `
+  const wanted = new Set(ids)
+  const bases: Record<string, number> = {}
+  for (const row of rows) {
+    if (wanted.has(row.id)) bases[row.id] = Number(row.seq)
+  }
+  return bases
+}
+
+async function liveShellSeq(harness: CapabilityTestHarness): Promise<number> {
+  const { rows } = await harness.db<{ seq: number }>`
+    select seq from site where id = 'default'
+  `
+  return rows[0] ? Number(rows[0].seq) : 0
+}
+
+/**
+ * PUT the document. Unless the test overrides them, `baseSeqs` and
+ * `shellBaseSeq` are derived from live storage — modeling a fully
+ * synchronized client, so pre-conflict scenarios stay focused on their own
+ * concern. Conflict tests pass stale values explicitly.
+ */
+async function putDoc(ctx: Ctx, overrides: DocOverrides = {}): Promise<Response> {
+  const json = {
+    mode: 'incremental' as const,
+    site: ctx.shell,
+    changedPages: [] as unknown[],
+    deletedPageIds: [] as string[],
+    changedComponents: [] as unknown[],
+    deletedComponentIds: [] as string[],
+    changedLayouts: [] as unknown[],
+    deletedLayoutIds: [] as string[],
+    ...overrides,
+  }
+  const body = {
+    ...json,
+    baseSeqs: json.baseSeqs ?? (await liveBaseSeqs(ctx.harness, touchedIds(json))),
+    shellBaseSeq: json.shellBaseSeq ?? (await liveShellSeq(ctx.harness)),
+  }
   return ctx.harness.cms('/admin/api/cms/site-document', {
     method: 'PUT',
     cookie: ctx.cookie,
-    json: {
-      mode: 'incremental',
-      site: ctx.shell,
-      changedPages: [],
-      deletedPageIds: [],
-      changedComponents: [],
-      deletedComponentIds: [],
-      changedLayouts: [],
-      deletedLayoutIds: [],
-      ...overrides,
-    },
+    json: body,
   })
 }
 
@@ -743,6 +798,212 @@ describe('site-document save — sync seq', () => {
       // The home page was never written after seeding — seq untouched (0 or
       // whatever the seed left), definitely below save #1's seq.
       expect(rows.get(ctx.homeId)!.seq).toBeLessThan(first)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Conflict detection — baseSeqs / shellBaseSeq (multi-admin level A)
+// ---------------------------------------------------------------------------
+
+describe('site-document save — conflict detection', () => {
+  it('409s a save whose shipped row is stored NEWER than its base seq; nothing is written', async () => {
+    const ctx = await setupHarness()
+    try {
+      const first = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Original')],
+      }))
+      // "Admin A" edits the row again — storage moves past `first`.
+      const second = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin A v2')],
+      }))
+
+      // "Admin B" saves from the stale base — rejected, atomically.
+      const res = await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin B stale')],
+        baseSeqs: { 'page-a': first },
+      })
+      expect(res.status).toBe(409)
+      const body = await readJson<{ error: string; conflicts: unknown[] }>(res)
+      expect(body.conflicts).toEqual([{ table: 'pages', rowId: 'page-a', seq: second }])
+
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.cells_json.title).toBe('Admin A v2')
+      expect(rows.get('page-a')!.seq).toBe(second)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('Keep-mine: the identical save succeeds once the base seq is bumped to the conflict seq', async () => {
+    const ctx = await setupHarness()
+    try {
+      const first = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Original')],
+      }))
+      const second = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin A v2')],
+      }))
+
+      const stale = await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin B wins')],
+        baseSeqs: { 'page-a': first },
+      })
+      expect(stale.status).toBe(409)
+
+      // Keep-mine bumps the base to the remote seq — the stated overwrite lands.
+      await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin B wins')],
+        baseSeqs: { 'page-a': second },
+      }))
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.cells_json.title).toBe('Admin B wins')
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('client-created rows (no stored counterpart) pass with no base entry', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-new', 'fresh')],
+        baseSeqs: {},
+      }))
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('a stored row shipped with NO base entry conflicts — a blind overwrite is never silent', async () => {
+    const ctx = await setupHarness()
+    try {
+      const seq = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about')],
+      }))
+      const res = await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'blind write')],
+        baseSeqs: {},
+      })
+      expect(res.status).toBe(409)
+      const body = await readJson<{ conflicts: unknown[] }>(res)
+      expect(body.conflicts).toEqual([{ table: 'pages', rowId: 'page-a', seq }])
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('deleting a remotely-newer row conflicts; the row survives', async () => {
+    const ctx = await setupHarness()
+    try {
+      const first = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Original')],
+      }))
+      await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin A v2')],
+      }))
+
+      const res = await putDoc(ctx, {
+        deletedPageIds: ['page-a'],
+        baseSeqs: { 'page-a': first },
+      })
+      expect(res.status).toBe(409)
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.deleted_at).toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('editing a remotely-DELETED row conflicts — soft-deleted rows are visible to the check', async () => {
+    const ctx = await setupHarness()
+    try {
+      const first = await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Original')],
+      }))
+      // "Admin A" deletes the row — the deletion stamps a newer seq.
+      const second = await expectOk(await putDoc(ctx, { deletedPageIds: ['page-a'] }))
+
+      const res = await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'stale edit')],
+        baseSeqs: { 'page-a': first },
+      })
+      expect(res.status).toBe(409)
+      const body = await readJson<{ conflicts: unknown[] }>(res)
+      expect(body.conflicts).toEqual([{ table: 'pages', rowId: 'page-a', seq: second }])
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.deleted_at).not.toBeNull()
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('row-only saves do NOT stamp the shell seq (the shell write is skipped when unchanged)', async () => {
+    const ctx = await setupHarness()
+    try {
+      const before = await liveShellSeq(ctx.harness)
+      await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about')],
+      }))
+      expect(await liveShellSeq(ctx.harness)).toBe(before)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('shell conflicts fire only on REAL shell changes with a stale base', async () => {
+    const ctx = await setupHarness()
+    try {
+      // "Admin A" renames the site — a real shell change stamps the shell seq.
+      await expectOk(await putDoc(ctx, { site: { ...ctx.shell, name: 'Renamed by A' } }))
+      const shellSeq = await liveShellSeq(ctx.harness)
+      expect(shellSeq).toBeGreaterThan(0)
+
+      // "Admin B" ships ANOTHER shell change from a stale base — 409.
+      const res = await putDoc(ctx, {
+        site: { ...ctx.shell, name: 'Renamed by B (stale)' },
+        shellBaseSeq: shellSeq - 1,
+      })
+      expect(res.status).toBe(409)
+      const body = await readJson<{ conflicts: unknown[] }>(res)
+      expect(body.conflicts).toEqual([{ table: 'site', rowId: 'default', seq: shellSeq }])
+
+      // But a row-only save re-shipping the CURRENT stored shell verbatim
+      // passes even with a stale shell base — unchanged content is no
+      // overwrite, so the coarse shell check must not fire.
+      const shellRes = await ctx.harness.cms('/admin/api/cms/site', { method: 'GET', cookie: ctx.cookie })
+      const { site: storedShell } = await readJson<{ site: unknown }>(shellRes)
+      await expectOk(await putDoc(ctx, {
+        site: storedShell,
+        changedPages: [pagePayload('page-b', 'contact')],
+        shellBaseSeq: 0,
+      }))
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('replace mode skips the conflict check entirely (imports replace deliberately)', async () => {
+    const ctx = await setupHarness()
+    try {
+      await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Original')],
+      }))
+      await expectOk(await putDoc(ctx, {
+        changedPages: [pagePayload('page-a', 'about', 'Admin A v2')],
+      }))
+
+      // Stale bases + replace mode — bulldozes by design.
+      await expectOk(await putDoc(ctx, {
+        mode: 'replace',
+        changedPages: [pagePayload('page-a', 'about', 'Imported')],
+        baseSeqs: { 'page-a': 0 },
+        shellBaseSeq: 0,
+      }))
+      const rows = await storedRows(ctx.harness, 'pages')
+      expect(rows.get('page-a')!.cells_json.title).toBe('Imported')
     } finally {
       await ctx.harness.cleanup()
     }

--- a/src/admin/layouts/AdminCanvasLayout/AdminCanvasLayout.tsx
+++ b/src/admin/layouts/AdminCanvasLayout/AdminCanvasLayout.tsx
@@ -93,6 +93,15 @@ const SettingsModal = lazy(() =>
   import('@admin/modals/Settings/SettingsModal').then((m) => ({ default: m.SettingsModal })),
 )
 
+// Save-conflict resolution banner — mounts only while a 409'd save has
+// unresolved conflicts (multi-admin conflict safety, level A), so its chunk
+// stays out of the route shell on first paint.
+const SaveConflictBanner = lazy(() =>
+  import('@admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner').then((m) => ({
+    default: m.SaveConflictBanner,
+  })),
+)
+
 // Editor-only toolbar surface: preview iframe. It self-gates on store state,
 // but we ALSO conditionally render it at the call site (below) so its chunk
 // isn't fetched on first paint — the preview overlay drags in the entire
@@ -117,6 +126,7 @@ export function AdminCanvasLayout() {
   const faviconUrl = useEditorStore((s) => s.site?.settings.faviconUrl ?? null)
   // Editor-only toolbar surface — gate its lazy chunk on store state.
   const previewOpen = useEditorStore((s) => s.previewOpen)
+  const hasSaveConflicts = useEditorStore((s) => s.saveConflicts.length > 0)
   // Settings modal mount gate. adminUi is the canonical source — the
   // editor's `settingsSlice.openSettings` mirrors into it, and the admin
   // shell reads from it too.
@@ -234,6 +244,12 @@ export function AdminCanvasLayout() {
             </>
           )}
         />
+
+        {hasSaveConflicts && (
+          <Suspense fallback={null}>
+            <SaveConflictBanner />
+          </Suspense>
+        )}
 
         {loadEditorBody ? (
           <LazyChunkBoundary

--- a/src/admin/modals/Settings/useSiteSettingsController.ts
+++ b/src/admin/modals/Settings/useSiteSettingsController.ts
@@ -39,6 +39,7 @@
 import { useEffect } from 'react'
 import { create } from 'zustand'
 import { cmsAdapter } from '@core/persistence/cms'
+import { SaveConflictError } from '@core/persistence/saveConflict'
 import { DEFAULT_FRAMEWORK_PREFERENCES } from '@core/framework'
 import type { SiteDocument, SiteSettings } from '@core/page-tree'
 import type { FrameworkPreferencesSettings } from '@core/framework-schema'
@@ -68,6 +69,11 @@ const SHELL_ONLY_DIRTY = {
 interface SettingsDraftState {
   /** The persisted document loaded for standalone (non-editor) editing. */
   doc: SiteDocument | null
+  /**
+   * The shell seq this store last synchronized with — the conflict-detection
+   * base its shell-only saves ship (and bump from each save response).
+   */
+  shellBaseSeq: number
   status: 'idle' | 'loading' | 'ready' | 'error'
   error: string | null
   /** Load the document once (idempotent; shares a single in-flight fetch). */
@@ -91,8 +97,16 @@ const useSettingsDraftStore = create<SettingsDraftState>((set, get) => {
   function persist(next: SiteDocument): void {
     set({ doc: next })
     saveChain = saveChain
-      .then(() => cmsAdapter.saveSite(next, { dirty: SHELL_ONLY_DIRTY }))
-      .then(() => {
+      .then(() =>
+        cmsAdapter.saveSite(next, {
+          dirty: SHELL_ONLY_DIRTY,
+          baseSeqs: {},
+          shellBaseSeq: get().shellBaseSeq,
+        }),
+      )
+      .then(({ seq }) => {
+        // This save's seq is the new shell base for the next one.
+        set({ shellBaseSeq: seq })
         // Refresh the toolbar brand + any other site-summary readers, and let
         // the editor store re-hydrate from disk next time it loads.
         useAdminUi.getState().setSiteSummary({
@@ -103,12 +117,24 @@ const useSettingsDraftStore = create<SettingsDraftState>((set, get) => {
       })
       .catch((err: unknown) => {
         console.error('[useSiteSettingsController] failed to save site settings:', err)
+        if (err instanceof SaveConflictError) {
+          // Another admin changed the shell since this modal loaded. The
+          // stale doc must not be re-saved over their work — force a reload
+          // on the next open instead of offering a per-row banner here.
+          set({
+            doc: null,
+            status: 'idle',
+            error: 'Site settings were changed by another admin — close and reopen Settings to load the latest.',
+          })
+          return
+        }
         set({ error: getErrorMessage(err, 'Failed to save site settings') })
       })
   }
 
   return {
     doc: null,
+    shellBaseSeq: 0,
     status: 'idle',
     error: null,
 
@@ -118,12 +144,12 @@ const useSettingsDraftStore = create<SettingsDraftState>((set, get) => {
       set({ status: 'loading', error: null })
       inFlightLoad = (async () => {
         try {
-          const site = await cmsAdapter.loadSite(SITE_ID)
-          if (!site) {
+          const result = await cmsAdapter.loadSite(SITE_ID)
+          if (!result) {
             set({ status: 'error', error: 'No site found. Complete first-run setup first.' })
             return
           }
-          set({ doc: site, status: 'ready', error: null })
+          set({ doc: result.site, shellBaseSeq: result.shellSeq, status: 'ready', error: null })
         } catch (err) {
           console.error('[useSiteSettingsController] failed to load site settings:', err)
           set({ status: 'error', error: getErrorMessage(err, 'Failed to load site settings') })

--- a/src/admin/modals/SiteImport/shared/importPlanning.ts
+++ b/src/admin/modals/SiteImport/shared/importPlanning.ts
@@ -174,10 +174,11 @@ export async function ensureCurrentSiteForStaticImport(): Promise<SiteDocument> 
   const existingSite = useEditorStore.getState().site
   if (existingSite) return existingSite
 
-  const loadedSite = await cmsAdapter.loadSite('default')
-  if (loadedSite) {
-    useEditorStore.getState().loadSite(loadedSite)
-    return loadedSite
+  const loaded = await cmsAdapter.loadSite('default')
+  if (loaded) {
+    useEditorStore.getState().loadSite(loaded.site)
+    useEditorStore.getState().seedBaseSeqs(loaded.rowSeqs, loaded.shellSeq)
+    return loaded.site
   }
 
   return useEditorStore.getState().createSite('My Site')
@@ -187,7 +188,10 @@ export async function ensureCurrentSiteForStaticImport(): Promise<SiteDocument> 
 export async function saveImportedDraftSite(): Promise<void> {
   const site = useEditorStore.getState().site
   if (!site) throw new Error('Import completed, but no draft site is loaded.')
-  await cmsAdapter.saveSite(site)
+  // Replace-mode full save (no dirty hints) — an import deliberately
+  // replaces whatever is stored, so there is no conflict check to feed.
+  const { seq } = await cmsAdapter.saveSite(site)
+  useEditorStore.getState().commitSavedBaseSeqs(site, undefined, seq)
   useEditorStore.getState().setHasUnsavedChanges(false)
   requestCmsSiteReload()
 }

--- a/src/admin/pages/dashboard/components/OnboardingPanel.test.tsx
+++ b/src/admin/pages/dashboard/components/OnboardingPanel.test.tsx
@@ -49,8 +49,9 @@ const FACTS: OnboardingFacts = {
 
 describe('OnboardingPanel framework import', () => {
   it('dispatches a CMS site reload after a successful import so the editor refetches', async () => {
-    const loadSpy = spyOn(cmsAdapter, 'loadSite').mockResolvedValue(fakeSite())
-    const saveSpy = spyOn(cmsAdapter, 'saveSite').mockResolvedValue(undefined)
+    const loadSpy = spyOn(cmsAdapter, 'loadSite')
+      .mockResolvedValue({ site: fakeSite(), rowSeqs: {}, shellSeq: 0 })
+    const saveSpy = spyOn(cmsAdapter, 'saveSite').mockResolvedValue({ seq: 1 })
 
     let reloadFired = false
     const onReload = () => { reloadFired = true }

--- a/src/admin/pages/dashboard/components/OnboardingPanel.tsx
+++ b/src/admin/pages/dashboard/components/OnboardingPanel.tsx
@@ -135,8 +135,9 @@ export function OnboardingPanel({ facts, onDismiss, onFrameworkImported }: Onboa
   const onboardingApplier: FrameworkManagerApplier = {
     capabilities: { canRemove: true },
     apply: async (target) => {
-      const site = await cmsAdapter.loadSite('default')
-      if (!site) throw new Error('Site is not ready yet — finish setup first.')
+      const loaded = await cmsAdapter.loadSite('default')
+      if (!loaded) throw new Error('Site is not ready yet — finish setup first.')
+      const { site, shellSeq } = loaded
       site.settings.framework = applyFrameworkPreset(site.settings.framework, target)
       // Regenerate / prune the generated `framework:` utility classes (and strip
       // stale classIds off nodes) to match the new settings — the same reconcile
@@ -145,7 +146,9 @@ export function OnboardingPanel({ facts, onDismiss, onFrameworkImported }: Onboa
       // styleRules, so the Site editor keeps showing them until a hard refresh.
       reconcileFrameworkClasses(site)
       // Shell-only incremental save: framework settings live on the shell,
-      // no rows changed and nothing was deleted.
+      // no rows changed and nothing was deleted. The shell base seq comes
+      // from the load above — a concurrent shell change 409s instead of
+      // being silently overwritten.
       await cmsAdapter.saveSite(site, {
         dirty: {
           all: false,
@@ -156,6 +159,8 @@ export function OnboardingPanel({ facts, onDismiss, onFrameworkImported }: Onboa
           deletedComponentIds: new Set(),
           deletedLayoutIds: new Set(),
         },
+        baseSeqs: {},
+        shellBaseSeq: shellSeq,
       })
       // The framework settings were written to storage outside the editor. If
       // the Site editor's store was hydrated earlier this session, its in-memory

--- a/src/admin/pages/dashboard/hooks/useOnboardingState.ts
+++ b/src/admin/pages/dashboard/hooks/useOnboardingState.ts
@@ -58,7 +58,7 @@ export function useOnboardingState(): OnboardingStateResult {
       listCmsUsers(),
     ])
 
-    const site = siteResult.status === 'fulfilled' ? siteResult.value : undefined
+    const site = siteResult.status === 'fulfilled' ? siteResult.value?.site : undefined
     const plugins = pluginsResult.status === 'fulfilled' ? pluginsResult.value.plugins : []
     const users = usersResult.status === 'fulfilled' ? usersResult.value : []
 

--- a/src/admin/pages/site/hooks/usePersistence.ts
+++ b/src/admin/pages/site/hooks/usePersistence.ts
@@ -35,6 +35,7 @@ import { useEditorStore } from '@site/store/store'
 import type { SiteDocument } from '@core/page-tree'
 import type { IPersistenceAdapter } from '@core/persistence/types'
 import { cmsAdapter } from '@core/persistence/cms'
+import { SaveConflictError } from '@core/persistence/saveConflict'
 import { SiteValidationError } from '@core/persistence/validate'
 import {
   readAutoSaveDelayMs,
@@ -134,8 +135,14 @@ export function usePersistence(
   // Exception #1: referenced in the useCallback dep array of saveCurrentSite,
   // so exhaustive-deps requires a stable identity here.
   const runSave = useCallback(async () => {
-    const { site, setHasUnsavedChanges, takeDirtySaveSnapshot, restoreDirtySaveSnapshot } =
-      useEditorStore.getState()
+    const {
+      site,
+      setHasUnsavedChanges,
+      takeDirtySaveSnapshot,
+      restoreDirtySaveSnapshot,
+      baseSeqs,
+      shellBaseSeq,
+    } = useEditorStore.getState()
     if (!site) return
 
     setSaveStatus({ state: 'saving', message: 'Saving draft' })
@@ -144,7 +151,10 @@ export function usePersistence(
     // failed save merges this snapshot back so nothing is lost.
     const dirty = takeDirtySaveSnapshot()
     try {
-      await adapterRef.current.saveSite(site, { dirty })
+      const { seq } = await adapterRef.current.saveSite(site, { dirty, baseSeqs, shellBaseSeq })
+      // Storage now holds this save — bump the conflict-detection bases of
+      // everything it shipped to the save's seq.
+      useEditorStore.getState().commitSavedBaseSeqs(site, dirty, seq)
       // Clear the unsaved flag ONLY when no mutation landed while the save
       // was on the wire — every store mutation produces a new `site`
       // reference, so reference equality is the exact signal. Without this
@@ -155,6 +165,13 @@ export function usePersistence(
       setSaveStatus({ state: 'saved', lastSavedAt: Date.now() })
     } catch (err) {
       restoreDirtySaveSnapshot(dirty)
+      if (err instanceof SaveConflictError) {
+        // Another admin stored newer versions of rows this save shipped.
+        // Surface the resolution UI (conflict banner) instead of a plain
+        // error; the restored dirty marks keep the local edits safe while
+        // the user decides per row.
+        useEditorStore.getState().setSaveConflicts(err.conflicts)
+      }
       setSaveStatus({ state: 'error', message: errorMessage(err, 'Save failed') })
       throw err
     }
@@ -243,11 +260,14 @@ export function usePersistence(
         try {
           // The adapter validates internally (validateSite + validatePages).
           // Constraint #230 is satisfied at the adapter boundary.
-          const site = await adapterRef.current.loadSite(idToTry)
-          if (site && !cancelled) {
+          const result = await adapterRef.current.loadSite(idToTry)
+          if (result && !cancelled) {
             if (pendingCmsSiteReload) consumePendingCmsSiteReload()
-            loadSite(site)
-            applyDefaultBreakpointPreference(site.breakpoints)
+            loadSite(result.site)
+            // Seed the conflict-detection bases from the same read that
+            // produced the document — every future save compares against these.
+            useEditorStore.getState().seedBaseSeqs(result.rowSeqs, result.shellSeq)
+            applyDefaultBreakpointPreference(result.site.breakpoints)
             loadedRef.current = true
             setSaveStatus({ state: 'saved', lastSavedAt: Date.now() })
             return
@@ -287,9 +307,11 @@ export function usePersistence(
         try {
           // Replace-mode full save (no dirty hints): the site doesn't exist
           // in storage yet.
-          await adapterRef.current.saveSite(created)
-          // Storage now matches the store — drop the createSite all-dirty mark.
+          const { seq } = await adapterRef.current.saveSite(created)
+          // Storage now matches the store — drop the createSite all-dirty
+          // mark and seed the conflict-detection bases at the save's seq.
           useEditorStore.getState().takeDirtySaveSnapshot()
+          useEditorStore.getState().commitSavedBaseSeqs(created, undefined, seq)
           setSaveStatus({ state: 'saved', lastSavedAt: Date.now() })
         } catch (err) {
           setHasUnsavedChanges(true)
@@ -316,14 +338,15 @@ export function usePersistence(
       const pendingCmsSiteReload = hasPendingCmsSiteReload()
       try {
         // Adapter validates internally (Constraint #230).
-        const site = await adapterRef.current.loadSite(idToTry)
-        if (!site) {
+        const result = await adapterRef.current.loadSite(idToTry)
+        if (!result) {
           if (pendingCmsSiteReload) consumePendingCmsSiteReload()
           return
         }
-        const { loadSite, setHasUnsavedChanges } = useEditorStore.getState()
-        loadSite(site)
-        applyDefaultBreakpointPreference(site.breakpoints)
+        const { loadSite, setHasUnsavedChanges, seedBaseSeqs } = useEditorStore.getState()
+        loadSite(result.site)
+        seedBaseSeqs(result.rowSeqs, result.shellSeq)
+        applyDefaultBreakpointPreference(result.site.breakpoints)
         // The site doc on disk is now authoritative; clear the unsaved flag so
         // the auto-save loop doesn't immediately overwrite it back.
         setHasUnsavedChanges(false)
@@ -356,6 +379,9 @@ export function usePersistence(
       clearTimeout(timer)
       if (!loadedRef.current) return
       if (!useEditorStore.getState().hasUnsavedChanges) return
+      // Pending conflicts need a per-row decision — an autosave retry would
+      // just 409 again. The conflict banner resumes saving on resolution.
+      if (useEditorStore.getState().saveConflicts.length > 0) return
       if (!readAutoSavePreference()) return
 
       // Read the delay each time auto-save is scheduled — toggling the
@@ -390,11 +416,12 @@ export function usePersistence(
     // is retried by the next save). One request now, so either the whole
     // save lands or none of it does — no partial-prefix commits at unload.
     function flushBeforeUnload() {
-      const { site, hasUnsavedChanges, peekDirtySaveSnapshot } = useEditorStore.getState()
+      const { site, hasUnsavedChanges, peekDirtySaveSnapshot, baseSeqs, shellBaseSeq } =
+        useEditorStore.getState()
       if (!site || !loadedRef.current || !hasUnsavedChanges) return
       clearTimeout(timer)
       void adapterRef.current
-        .saveSite(site, { dirty: peekDirtySaveSnapshot() })
+        .saveSite(site, { dirty: peekDirtySaveSnapshot(), baseSeqs, shellBaseSeq })
         .catch((err) => {
           console.error('[persistence] flush save failed:', err)
         })

--- a/src/admin/pages/site/store/slices/saveTrackingSlice.ts
+++ b/src/admin/pages/site/store/slices/saveTrackingSlice.ts
@@ -1,6 +1,10 @@
 /**
- * Save-tracking slice — the unsaved-changes flag and the patch-derived
- * save-dirty accumulator (see slices/site/dirtyTracking.ts).
+ * Save-tracking slice — the unsaved-changes flag, the patch-derived
+ * save-dirty accumulator (see slices/site/dirtyTracking.ts), and the
+ * multi-admin sync bookkeeping: per-row + shell base seqs (the
+ * conflict-detection bases every incremental save ships) and the
+ * pending-conflicts list behind the SaveConflictBanner. Conflict RESOLUTION
+ * actions live in slices/site/conflictActions.ts — they mutate the document.
  *
  * Autosave takes a snapshot (which resets the accumulator), ships only the
  * named page/component/layout writes plus explicit deleted-row ids, and
@@ -21,6 +25,7 @@
  */
 
 import type { SiteDocument } from '@core/page-tree'
+import type { SaveConflict } from '@core/persistence/saveConflict'
 import type { EditorStoreSliceCreator } from '@site/store/types'
 import { emptyDirtyMarks, mergeDirtyMarks, type DirtyMarks } from './site/dirtyTracking'
 
@@ -42,6 +47,32 @@ interface SaveTrackingSlice {
   peekDirtySaveSnapshot: () => DirtyMarks
   /** Merge a failed save's snapshot back so the next save retries it. */
   restoreDirtySaveSnapshot: (marks: DirtyMarks) => void
+
+  /**
+   * Conflict-detection bases: rowId → the sync seq this editor last
+   * synchronized with (seeded at load, bumped to the response seq on every
+   * successful save — for DELETED rows too, so an undo that resurrects a
+   * saved-deleted row carries the right base instead of reading as a blind
+   * overwrite). Every incremental save ships the subset covering its
+   * changed + deleted rows; the server 409s when storage is newer.
+   */
+  baseSeqs: Record<string, number>
+  /** The shell's counterpart to `baseSeqs` — one coarse seq for the whole shell. */
+  shellBaseSeq: number
+  /**
+   * Conflicts reported by the last 409'd save, pending user resolution via
+   * the conflict banner (Keep mine / Load theirs — see site/conflictActions).
+   * Autosave is suppressed while non-empty; a successful save clears it.
+   */
+  saveConflicts: SaveConflict[]
+  /** Replace the base-seq maps wholesale — the load/reload path. */
+  seedBaseSeqs: (rowSeqs: Record<string, number>, shellSeq: number) => void
+  /**
+   * After a successful save: bump the bases of everything the save shipped to
+   * the response seq. Incremental saves cover the dirty-snapshot ids + the
+   * shell; replace-mode saves rebuild the whole map from the shipped site.
+   */
+  commitSavedBaseSeqs: (savedSite: SiteDocument, dirty: DirtyMarks | undefined, seq: number) => void
 }
 
 declare module '@site/store/types' {
@@ -116,5 +147,41 @@ export const createSaveTrackingSlice: EditorStoreSliceCreator<SaveTrackingSlice>
   restoreDirtySaveSnapshot: (marks) =>
     set((state) => {
       mergeDirtyMarks(state._dirtySave, marks)
+    }),
+
+  baseSeqs: {},
+  shellBaseSeq: 0,
+  saveConflicts: [],
+
+  seedBaseSeqs: (rowSeqs, shellSeq) =>
+    set((state) => {
+      state.baseSeqs = { ...rowSeqs }
+      state.shellBaseSeq = shellSeq
+    }),
+
+  commitSavedBaseSeqs: (savedSite, dirty, seq) =>
+    set((state) => {
+      if (!dirty || dirty.all) {
+        // Replace-mode save — storage now holds exactly the shipped site.
+        const next: Record<string, number> = {}
+        for (const page of savedSite.pages) next[page.id] = seq
+        for (const vc of savedSite.visualComponents) next[vc.id] = seq
+        for (const layout of savedSite.layouts) next[layout.id] = seq
+        state.baseSeqs = next
+      } else {
+        const shippedIds = [
+          ...dirty.pageIds, ...dirty.deletedPageIds,
+          ...dirty.componentIds, ...dirty.deletedComponentIds,
+          ...dirty.layoutIds, ...dirty.deletedLayoutIds,
+        ]
+        for (const id of shippedIds) state.baseSeqs[id] = seq
+      }
+      // Correct even when the server skipped the shell write (content
+      // unchanged): the stored shell seq then stays BELOW this save's seq,
+      // and the conflict check only fires on stored > base.
+      state.shellBaseSeq = seq
+      // A successful save proves no shipped row conflicted — stale banner
+      // entries (all conflicts come from shipped rows) are moot.
+      state.saveConflicts = []
     }),
 })

--- a/src/admin/pages/site/store/slices/site/conflictActions.ts
+++ b/src/admin/pages/site/store/slices/site/conflictActions.ts
@@ -1,0 +1,210 @@
+/**
+ * Save-conflict resolution actions — multi-admin conflict safety (level A).
+ *
+ * When an incremental save 409s, the failed save restores its dirty marks and
+ * `setSaveConflicts` fills the pending list; the conflict banner then offers
+ * two resolutions per conflicted target:
+ *
+ *   Keep mine   — bump the target's base seq to the remote seq. The local
+ *                 edits stay dirty and the NEXT save overwrites the remote
+ *                 version — a stated decision instead of a silent one.
+ *   Load theirs — the banner fetches the remote state and hands it here as a
+ *                 `RemoteConflictSnapshot`; the target is swapped in place
+ *                 (or removed, when deleted remotely) WITHOUT undo history,
+ *                 its dirty marks are cleared, and the base seq syncs to the
+ *                 remote seq.
+ *
+ * Both resolutions clear the undo history: history entries are site-relative
+ * Mutative patches with array indices — replaying them across a remotely
+ * swapped tree is undefined behavior. (Keep-mine keeps the local document
+ * intact, so its history survives.)
+ *
+ * VC consumer propagation: adopting a remote Visual Component re-syncs the
+ * slot instances of every ref to it, and adopting a remote VC DELETION
+ * cascades ref removal — both through `mutateSite`, so the affected consumer
+ * pages earn REAL dirty marks (they now differ from storage and must ship
+ * with the next save). The history entries those mutations push are cleared
+ * along with everything else.
+ */
+
+import type { BaseNode } from '@core/page-tree'
+import { findHomePage, reconcileSiteExplorerInPlace, reindexNodeParents } from '@core/page-tree'
+import { clonePackageJson } from '@core/site-dependencies/manifest'
+import { cloneSiteRuntimeConfig } from '@core/site-runtime'
+import type { EditorStore } from '@site/store/types'
+import type { Draft } from 'mutative'
+import { renderCache } from '@site/canvas/renderCache'
+import { clearCanvasSelectionDraft } from '../selectionSlice'
+import { allTreeNodeMaps, syncAllVCRefSlotInstances } from '../vcSlotReconcile'
+import { cascadeRemoveVCRefs } from '../vcTreeOps'
+import { reconcileFrameworkClasses } from './framework/reconcile'
+import type { SiteSlice, SiteSliceHelpers } from './types'
+
+type ConflictActions = Pick<
+  SiteSlice,
+  'setSaveConflicts' | 'resolveSaveConflictKeepMine' | 'resolveSaveConflictTheirs'
+>
+
+function dropConflict(state: Draft<EditorStore>, table: string, rowId: string): void {
+  state.saveConflicts = state.saveConflicts.filter(
+    (c) => !(c.table === table && c.rowId === rowId),
+  )
+}
+
+function clearUndoHistory(state: Draft<EditorStore>): void {
+  state._historyPast = []
+  state._historyFuture = []
+  state._historyCoalesceKey = null
+  state.canUndo = false
+  state.canRedo = false
+}
+
+export function createConflictActions({ set, mutateSite }: SiteSliceHelpers): ConflictActions {
+  return {
+    setSaveConflicts: (conflicts) =>
+      set((state) => {
+        state.saveConflicts = [...conflicts]
+      }),
+
+    resolveSaveConflictKeepMine: (conflict) =>
+      set((state) => {
+        dropConflict(state, conflict.table, conflict.rowId)
+        if (conflict.table === 'site') {
+          state.shellBaseSeq = Math.max(state.shellBaseSeq, conflict.seq)
+        } else {
+          state.baseSeqs[conflict.rowId] = Math.max(
+            state.baseSeqs[conflict.rowId] ?? 0,
+            conflict.seq,
+          )
+        }
+        // The failed save restored its dirty marks — nothing else to do; the
+        // next save ships the same rows and now passes the seq check.
+      }),
+
+    resolveSaveConflictTheirs: (snapshot) => {
+      // Consumer propagation FIRST (see module doc): mutateSite gives the
+      // affected pages real patch-derived dirty marks. Neither helper needs
+      // the VC swapped in yet — the sync takes the remote VC as an argument,
+      // and the cascade only reads ref nodes.
+      if (snapshot.table === 'components') {
+        if (snapshot.row) {
+          const vc = snapshot.row
+          mutateSite((site) => {
+            syncAllVCRefSlotInstances(allTreeNodeMaps(site), vc.id, vc)
+          })
+        } else {
+          mutateSite((site) => {
+            for (const page of site.pages) {
+              cascadeRemoveVCRefs(page.nodes as Record<string, BaseNode>, snapshot.rowId)
+            }
+            for (const vc of site.visualComponents) {
+              if (vc.id !== snapshot.rowId) {
+                cascadeRemoveVCRefs(vc.tree.nodes as Record<string, BaseNode>, snapshot.rowId)
+              }
+            }
+          })
+        }
+      }
+
+      // Remote HTML swaps under the canvas — drop cached renders wholesale.
+      renderCache.clear()
+
+      set((state) => {
+        const site = state.site
+        if (!site) return
+        dropConflict(state, snapshot.table, snapshot.table === 'site' ? 'default' : snapshot.rowId)
+
+        switch (snapshot.table) {
+          case 'site': {
+            // Overwrite every shell field in place; the row-backed
+            // collections stay untouched. `conditions` is the one optional
+            // shell key — drop it explicitly when the remote shell lacks it.
+            Object.assign(site, snapshot.shell)
+            if (snapshot.shell.conditions === undefined) delete site.conditions
+            reconcileFrameworkClasses(site)
+            reconcileSiteExplorerInPlace(site)
+            state.packageJson = clonePackageJson(snapshot.shell.packageJson)
+            state.siteRuntime = cloneSiteRuntimeConfig(snapshot.shell.runtime)
+            state.shellBaseSeq = snapshot.seq
+            break
+          }
+
+          case 'pages': {
+            state._dirtySave.pageIds.delete(snapshot.rowId)
+            state._dirtySave.deletedPageIds.delete(snapshot.rowId)
+            const idx = site.pages.findIndex((p) => p.id === snapshot.rowId)
+            const wasActive =
+              state.activePageId === snapshot.rowId &&
+              (state.activeDocument === null || state.activeDocument.kind === 'page')
+            if (snapshot.row) {
+              reindexNodeParents(snapshot.row.nodes)
+              if (idx >= 0) site.pages[idx] = snapshot.row
+              else site.pages.push(snapshot.row)
+              state.baseSeqs[snapshot.rowId] = snapshot.seq
+            } else {
+              if (idx >= 0) site.pages.splice(idx, 1)
+              delete state.baseSeqs[snapshot.rowId]
+              if (state.activePageId === snapshot.rowId) {
+                state.activePageId = (findHomePage(site.pages) ?? site.pages[0])?.id ?? null
+              }
+              // A page-kind activeDocument pointing at the removed page would
+              // make mutateActiveTree silently no-op — fall back to page mode.
+              if (
+                state.activeDocument?.kind === 'page' &&
+                state.activeDocument.pageId === snapshot.rowId
+              ) {
+                state.activeDocument = null
+              }
+            }
+            reconcileSiteExplorerInPlace(site)
+            // The canvas may hold selection/hover state into the replaced
+            // (or removed) tree — clear it when that document was active.
+            if (wasActive) clearCanvasSelectionDraft(state)
+            break
+          }
+
+          case 'components': {
+            state._dirtySave.componentIds.delete(snapshot.rowId)
+            state._dirtySave.deletedComponentIds.delete(snapshot.rowId)
+            const idx = site.visualComponents.findIndex((vc) => vc.id === snapshot.rowId)
+            const wasActive =
+              state.activeDocument?.kind === 'visualComponent' &&
+              state.activeDocument.vcId === snapshot.rowId
+            if (snapshot.row) {
+              reindexNodeParents(snapshot.row.tree.nodes)
+              if (idx >= 0) site.visualComponents[idx] = snapshot.row
+              else site.visualComponents.push(snapshot.row)
+              state.baseSeqs[snapshot.rowId] = snapshot.seq
+            } else {
+              if (idx >= 0) site.visualComponents.splice(idx, 1)
+              delete state.baseSeqs[snapshot.rowId]
+              // The open document was deleted remotely — fall back to page mode.
+              if (wasActive) state.activeDocument = null
+            }
+            reconcileSiteExplorerInPlace(site)
+            if (wasActive) clearCanvasSelectionDraft(state)
+            break
+          }
+
+          case 'layouts': {
+            state._dirtySave.layoutIds.delete(snapshot.rowId)
+            state._dirtySave.deletedLayoutIds.delete(snapshot.rowId)
+            const idx = site.layouts.findIndex((layout) => layout.id === snapshot.rowId)
+            if (snapshot.row) {
+              reindexNodeParents(snapshot.row.nodes)
+              if (idx >= 0) site.layouts[idx] = snapshot.row
+              else site.layouts.push(snapshot.row)
+              state.baseSeqs[snapshot.rowId] = snapshot.seq
+            } else {
+              if (idx >= 0) site.layouts.splice(idx, 1)
+              delete state.baseSeqs[snapshot.rowId]
+            }
+            break
+          }
+        }
+
+        clearUndoHistory(state)
+      })
+    },
+  }
+}

--- a/src/admin/pages/site/store/slices/site/lifecycleActions.ts
+++ b/src/admin/pages/site/store/slices/site/lifecycleActions.ts
@@ -66,6 +66,10 @@ export function createLifecycleActions({
         state.hasUnsavedChanges = false
         // A brand-new site has no stored rows at all — first save is full.
         state._dirtySave = { ...emptyDirtyMarks(), all: true }
+        // No stored rows → no sync bases and nothing to conflict with.
+        state.baseSeqs = {}
+        state.shellBaseSeq = 0
+        state.saveConflicts = []
       })
       return site
     },
@@ -96,6 +100,12 @@ export function createLifecycleActions({
         state.canRedo = false
         state.hasUnsavedChanges = false
         state._dirtySave = emptyDirtyMarks()
+        // Sync bases for the fresh document are seeded by the load path
+        // (usePersistence → seedBaseSeqs) — reset here so a hand-assembled
+        // load never inherits a previous document's bases or conflicts.
+        state.baseSeqs = {}
+        state.shellBaseSeq = 0
+        state.saveConflicts = []
       })
     },
 
@@ -114,6 +124,9 @@ export function createLifecycleActions({
         state.canUndo = false
         state.canRedo = false
         state._dirtySave = emptyDirtyMarks()
+        state.baseSeqs = {}
+        state.shellBaseSeq = 0
+        state.saveConflicts = []
       })
     },
 

--- a/src/admin/pages/site/store/slices/site/types.ts
+++ b/src/admin/pages/site/store/slices/site/types.ts
@@ -20,16 +20,31 @@ import type {
   SiteDocument,
   SiteExplorerSectionId,
   SiteSettings,
+  SiteShell,
   PageTemplateConfig,
   ConditionDef,
   StructuralExplorerRowOrder,
   StructuralSiteExplorerSectionId,
 } from '@core/page-tree'
+import type { SaveConflict } from '@core/persistence/saveConflict'
+import type { VisualComponent } from '@core/visualComponents'
+import type { SavedLayout } from '@core/layouts'
 import type { FontEntry, FontToken } from '@core/fonts'
 import type { ImportFragment } from '@core/htmlImport'
 import type { NewStyleRule, SiteImportTransaction } from '@core/siteImport'
 import type { FrameworkChangeImpact, FrameworkPreset } from '@core/framework'
 import type { EditorStore } from '@site/store/types'
+
+/**
+ * The remote ("theirs") state of one conflicted target, fetched by the
+ * conflict banner for `resolveSaveConflictTheirs`. `row: null` means the
+ * target was deleted remotely — resolution removes it locally.
+ */
+export type RemoteConflictSnapshot =
+  | { table: 'site'; shell: SiteShell; seq: number }
+  | { table: 'pages'; rowId: string; row: Page | null; seq: number }
+  | { table: 'components'; rowId: string; row: VisualComponent | null; seq: number }
+  | { table: 'layouts'; rowId: string; row: SavedLayout | null; seq: number }
 
 
 // ---------------------------------------------------------------------------
@@ -127,6 +142,23 @@ export interface SiteSlice {
   loadSite: (site: SiteDocument) => void
   clearSite: () => void
   updateSiteName: (name: string) => void
+
+  // Save-conflict resolution (multi-admin conflict safety — level A)
+  /** Replace the pending-conflicts list (set from the save pipeline's 409 handler). */
+  setSaveConflicts: (conflicts: readonly SaveConflict[]) => void
+  /**
+   * Keep the local version: bump the target's base seq to the remote seq so
+   * the next save passes the conflict check — the overwrite becomes a stated
+   * decision instead of a silent one. Local dirty marks stay untouched.
+   */
+  resolveSaveConflictKeepMine: (conflict: SaveConflict) => void
+  /**
+   * Adopt the remote version: swap it into the document (or remove the
+   * target when deleted remotely) without pushing undo history, clear the
+   * target's dirty marks, and sync the base seq. Clears the undo history —
+   * site-relative patches are undefined across a remotely swapped tree.
+   */
+  resolveSaveConflictTheirs: (snapshot: RemoteConflictSnapshot) => void
 
   // Page mutations
   addPage: (title: string, slug?: string) => Page

--- a/src/admin/pages/site/store/slices/siteSlice.ts
+++ b/src/admin/pages/site/store/slices/siteSlice.ts
@@ -12,6 +12,7 @@
  *   - `./site/helpers`          — buildSiteHelpers (mutate* + patch-based history) + depthInTree
  *   - `./site/undoRedoActions`  — undo / redo
  *   - `./site/lifecycleActions` — createSite / loadSite / clearSite / updateSiteName
+ *   - `./site/conflictActions`  — save-conflict resolution (Keep mine / Load theirs)
  *   - `./site/pageActions`      — page CRUD + template conversions
  *   - `./site/explorerActions`  — Site Explorer folder/order organization
  *   - `./site/nodeActions`      — the 11 named tree mutations + multi-select variants + dynamic bindings
@@ -25,6 +26,7 @@ import type { EditorStoreSliceCreator } from '@site/store/types'
 import { buildSiteHelpers } from './site/helpers'
 import { createUndoRedoActions } from './site/undoRedoActions'
 import { createLifecycleActions } from './site/lifecycleActions'
+import { createConflictActions } from './site/conflictActions'
 import { createPageActions } from './site/pageActions'
 import { createExplorerActions } from './site/explorerActions'
 import { createNodeActions } from './site/nodeActions'
@@ -72,6 +74,7 @@ export const createSiteSlice: EditorStoreSliceCreator<SiteSlice> = (set, get) =>
     // ─── Action surface ──────────────────────────────────────────────────────
     ...createUndoRedoActions(helpers),
     ...createLifecycleActions(helpers),
+    ...createConflictActions(helpers),
     ...createPageActions(helpers),
     ...createExplorerActions(helpers),
     ...createNodeActions(helpers),

--- a/src/admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner.module.css
+++ b/src/admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner.module.css
@@ -1,0 +1,64 @@
+/**
+ * Save-conflict banner — a persistent resolution surface floating below the
+ * toolbar. Warning identity comes from the 2px left rule (Toast convention);
+ * everything else stays achromatic per the two-layer color model.
+ */
+
+.banner {
+  position: fixed;
+  top: 64px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: var(--z-dropdown);
+  width: min(560px, calc(100vw - 32px));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-s);
+  padding: var(--space-m) var(--space-l);
+  background: var(--bg-surface);
+  border: 1px solid var(--overlay-10);
+  border-left: 2px solid var(--warning);
+  border-radius: var(--panel-radius);
+  box-shadow: var(--shadow-panel);
+}
+
+.title {
+  font-size: var(--text-m);
+  font-weight: 600;
+  color: var(--text);
+}
+
+.subtitle {
+  font-size: var(--text-s);
+  color: var(--text-subtle);
+}
+
+.conflictList {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.conflictRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-s);
+  padding: var(--space-xs) 0;
+}
+
+.conflictLabel {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--text-s);
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.conflictKind {
+  color: var(--text-subtle);
+}

--- a/src/admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner.tsx
+++ b/src/admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner.tsx
@@ -1,0 +1,166 @@
+/**
+ * SaveConflictBanner — the resolution UI for 409'd saves (multi-admin
+ * conflict safety, level A).
+ *
+ * Renders when the store holds pending `saveConflicts` (set by the save
+ * pipeline when the server rejects an incremental save because another admin
+ * stored newer versions of shipped rows). One row per conflicted target with
+ * the two resolutions:
+ *
+ *   Load theirs — fetch the remote state (single-row `?id=` fetch, or the
+ *                 shell GET) and adopt it via `resolveSaveConflictTheirs`,
+ *                 discarding the local unsaved edits to that target only.
+ *   Keep mine   — `resolveSaveConflictKeepMine` bumps the base seq; the next
+ *                 save overwrites the remote version as a stated decision.
+ *                 The button label carries the "(overwrite)" warning — that
+ *                 IS the explicit confirmation.
+ *
+ * This is deliberately a persistent banner, not a toast: a conflict is not a
+ * transient failure but a decision the user must make per target, and the
+ * unsaved local edits stay parked until they do (autosave is suppressed
+ * while conflicts pend). Once the last conflict is resolved, the pending
+ * edits are flushed through the editor save queue (`flushEditorSave`).
+ */
+
+import { useState } from 'react'
+import type { SiteDocument } from '@core/page-tree'
+import type { SaveConflict } from '@core/persistence/saveConflict'
+import { cmsAdapter } from '@core/persistence/cms'
+import { pageFromRow } from '@core/data/pageFromRow'
+import { visualComponentFromRow } from '@core/data/componentFromRow'
+import { savedLayoutFromRow } from '@core/data/layoutFromRow'
+import { getErrorMessage } from '@core/utils/errorMessage'
+import { Button } from '@ui/components/Button'
+import { pushToast } from '@ui/components/Toast'
+import { useEditorStore } from '@site/store/store'
+import type { RemoteConflictSnapshot } from '@site/store/slices/site/types'
+import { flushEditorSave } from '@site/hooks/editorSaveRef'
+import styles from './SaveConflictBanner.module.css'
+
+const KIND_LABEL: Record<SaveConflict['table'], string> = {
+  site: 'Site settings',
+  pages: 'Page',
+  components: 'Component',
+  layouts: 'Layout',
+}
+
+/** Human label for a conflicted target, resolved from the local document. */
+function conflictLabel(site: SiteDocument | null, conflict: SaveConflict): string {
+  if (conflict.table === 'site') return 'Site settings & styles'
+  if (!site) return conflict.rowId
+  if (conflict.table === 'pages') {
+    return site.pages.find((p) => p.id === conflict.rowId)?.title ?? conflict.rowId
+  }
+  if (conflict.table === 'components') {
+    return site.visualComponents.find((vc) => vc.id === conflict.rowId)?.name ?? conflict.rowId
+  }
+  return site.layouts.find((layout) => layout.id === conflict.rowId)?.name ?? conflict.rowId
+}
+
+/** Fetch the remote ("theirs") state of one conflicted target. */
+async function fetchRemoteSnapshot(conflict: SaveConflict): Promise<RemoteConflictSnapshot> {
+  if (conflict.table === 'site') {
+    const remote = await cmsAdapter.loadSiteShell()
+    if (!remote) throw new Error('The site shell no longer exists on the server.')
+    return { table: 'site', shell: remote.shell, seq: remote.seq }
+  }
+  const row = await cmsAdapter.loadSiteRow(conflict.table, conflict.rowId)
+  const seq = row?.seq ?? conflict.seq
+  if (conflict.table === 'pages') {
+    return { table: 'pages', rowId: conflict.rowId, row: row ? pageFromRow(row) : null, seq }
+  }
+  if (conflict.table === 'components') {
+    return {
+      table: 'components',
+      rowId: conflict.rowId,
+      row: row ? visualComponentFromRow(row) : null,
+      seq,
+    }
+  }
+  return { table: 'layouts', rowId: conflict.rowId, row: row ? savedLayoutFromRow(row) : null, seq }
+}
+
+/** Ship the surviving local edits once the last conflict is decided. */
+async function flushIfResolved(): Promise<void> {
+  const { saveConflicts, hasUnsavedChanges } = useEditorStore.getState()
+  if (saveConflicts.length > 0 || !hasUnsavedChanges) return
+  await flushEditorSave()
+}
+
+export function SaveConflictBanner() {
+  const conflicts = useEditorStore((s) => s.saveConflicts)
+  // Subscribed (not getState) so labels track renames/removals live.
+  const site = useEditorStore((s) => s.site)
+  const [busyKey, setBusyKey] = useState<string | null>(null)
+
+  if (conflicts.length === 0) return null
+
+  async function loadTheirs(conflict: SaveConflict) {
+    setBusyKey(`${conflict.table}:${conflict.rowId}`)
+    try {
+      const snapshot = await fetchRemoteSnapshot(conflict)
+      useEditorStore.getState().resolveSaveConflictTheirs(snapshot)
+      await flushIfResolved()
+    } catch (err) {
+      console.error('[SaveConflictBanner] failed to load the remote version:', err)
+      pushToast({
+        kind: 'error',
+        title: 'Could not load their version',
+        body: getErrorMessage(err, 'Unknown conflict-resolution error'),
+      })
+    } finally {
+      setBusyKey(null)
+    }
+  }
+
+  async function keepMine(conflict: SaveConflict) {
+    useEditorStore.getState().resolveSaveConflictKeepMine(conflict)
+    try {
+      await flushIfResolved()
+    } catch (err) {
+      // The save pipeline already surfaces failures via saveStatus / a
+      // fresh conflict banner; log for the console trail only.
+      console.error('[SaveConflictBanner] post-resolution save failed:', err)
+    }
+  }
+
+  return (
+    <div className={styles.banner} role="alert">
+      <div className={styles.title}>Another admin saved newer changes</div>
+      <div className={styles.subtitle}>
+        Your edits are safe but unsaved. Decide per item: load their version
+        (discards your unsaved edits to it) or keep yours (overwrites theirs on
+        the next save).
+      </div>
+      <ul className={styles.conflictList}>
+        {conflicts.map((conflict) => {
+          const key = `${conflict.table}:${conflict.rowId}`
+          return (
+            <li key={key} className={styles.conflictRow}>
+              <span className={styles.conflictLabel}>
+                <span className={styles.conflictKind}>{KIND_LABEL[conflict.table]} · </span>
+                {conflictLabel(site, conflict)}
+              </span>
+              <Button
+                variant="secondary"
+                size="xs"
+                disabled={busyKey !== null}
+                onClick={() => void loadTheirs(conflict)}
+              >
+                Load theirs
+              </Button>
+              <Button
+                variant="destructive"
+                size="xs"
+                disabled={busyKey !== null}
+                onClick={() => void keepMine(conflict)}
+              >
+                Keep mine (overwrite)
+              </Button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/src/admin/spotlight/commands/editor.ts
+++ b/src/admin/spotlight/commands/editor.ts
@@ -4,7 +4,10 @@
  *
  * All commands are gated to workspace: ['site'] only.
  * Undo/redo use useEditorStore.getState() (Zustand getState is safe outside React).
- * Save uses cmsAdapter.saveSite() directly (mirrors usePersistence logic).
+ * Save flushes through `usePersistence`'s registered save (editorSaveRef) so
+ * it rides the single-flight queue, the dirty-mark snapshot, and the
+ * conflict-detection base seqs — a raw adapter call here would bulldoze all
+ * three and ship a replace-mode full save.
  * Publish calls publishCmsDraft() from the persistence layer, wrapped in
  * `ctx.runStepUp` so the StepUpProvider's password re-entry dialog opens
  * when the server replies with `step_up_required` (publish is gated on a
@@ -12,7 +15,7 @@
  */
 
 import { StepUpCancelledMessage } from '@admin/shared/StepUp'
-import { cmsAdapter, publishCmsDraft } from '@core/persistence'
+import { publishCmsDraft } from '@core/persistence'
 import type { Command } from '../types'
 
 /** Mirrors `SITE_WRITE_CAPABILITIES` — any holder can save a draft. */
@@ -36,12 +39,10 @@ export function getEditorCommands(): Command[] {
       run: async (ctx) => {
         ctx.closeSpotlight()
         try {
-          // Import lazily to avoid loading the editor store in non-site contexts.
-          const { useEditorStore } = await import('@site/store/store')
-          const { site, setHasUnsavedChanges } = useEditorStore.getState()
-          if (!site) return
-          await cmsAdapter.saveSite(site)
-          setHasUnsavedChanges(false)
+          // Import lazily to avoid loading editor code in non-site contexts.
+          // No-op when the editor isn't mounted (the command is site-only).
+          const { flushEditorSave } = await import('@site/hooks/editorSaveRef')
+          await flushEditorSave()
         } catch (err) {
           console.error('[spotlight] save failed:', err)
         }

--- a/src/admin/state/useSiteSummary.ts
+++ b/src/admin/state/useSiteSummary.ts
@@ -33,7 +33,7 @@ let initialFetchPromise: Promise<void> | null = null
 
 async function fetchAndPublishSummary(): Promise<void> {
   try {
-    const site = await cmsAdapter.loadSite('default')
+    const site = (await cmsAdapter.loadSite('default'))?.site
     useAdminUi.getState().setSiteSummary({
       name: site?.name ?? null,
       faviconUrl: site?.settings?.faviconUrl ?? null,

--- a/src/core/data/schemas.ts
+++ b/src/core/data/schemas.ts
@@ -353,6 +353,14 @@ export const DataRowSchema = Type.Object({
   /** Denormalized from `cells.slug` for fast unique / route lookup. */
   slug: Type.String(),
   status: DataRowStatusSchema,
+  /**
+   * Site-global sync seq stamped by the last transactional save that wrote or
+   * soft-deleted this row (0 = never stamped). Conflict-detection and
+   * delta-reconciliation substrate for multi-admin sync. OPTIONAL because
+   * `DataRowSchema` also validates bundle archives exported before seqs
+   * existed — server reads always populate it.
+   */
+  seq: Type.Optional(Type.Number()),
   authorUserId: NullableUserIdSchema,
   createdByUserId: NullableUserIdSchema,
   updatedByUserId: NullableUserIdSchema,

--- a/src/core/persistence/cms.ts
+++ b/src/core/persistence/cms.ts
@@ -1,7 +1,13 @@
 import { reconcileSiteExplorerOrganization, type SiteDocument, type SiteShell } from '@core/page-tree'
-import type { IPersistenceAdapter, SaveSiteOptions } from './types'
+import type {
+  IPersistenceAdapter,
+  SaveSiteOptions,
+  SaveSiteResult,
+  SiteLoadResult,
+} from './types'
+import { SaveConflictError, SaveConflictsEnvelopeSchema } from './saveConflict'
 import { parseJsonResponse } from '@core/utils/jsonValidate'
-import { apiRequest, assertOk, type FetchLike } from '@core/http'
+import { apiRequest, assertOk, readEnvelope, type FetchLike } from '@core/http'
 import {
   CmsSiteEnvelopeSchema,
   CmsSiteDocumentSaveEnvelopeSchema,
@@ -11,6 +17,7 @@ import {
 } from './responseSchemas'
 import { validateSite, validatePages, validateVisualComponents } from './validate'
 import { validateSavedLayouts } from './validateLayouts'
+import type { DataRow } from '@core/data/schemas'
 import { pageFromRow } from '@core/data/pageFromRow'
 import { visualComponentFromRow } from '@core/data/componentFromRow'
 import { savedLayoutFromRow } from '@core/data/layoutFromRow'
@@ -18,6 +25,15 @@ import type { VisualComponent } from '@core/visualComponents'
 import type { SavedLayout } from '@core/layouts'
 
 const defaultFetch: FetchLike = (input, init) => globalThis.fetch(input, init)
+
+/** The three row-backed site collections (the shell is not one of them). */
+export type SiteCollectionTable = 'pages' | 'components' | 'layouts'
+
+const COLLECTION_ENVELOPES = {
+  pages: CmsPagesEnvelopeSchema,
+  components: CmsComponentsEnvelopeSchema,
+  layouts: CmsLayoutsEnvelopeSchema,
+} as const
 
 export class CmsAdapter implements IPersistenceAdapter {
   private readonly fetchImpl: FetchLike
@@ -48,11 +64,28 @@ export class CmsAdapter implements IPersistenceAdapter {
    * gone: the server validates pages against the merged post-save component
    * roster inside the same transaction.
    */
-  async saveSite(site: SiteDocument, opts: SaveSiteOptions = {}): Promise<void> {
+  async saveSite(site: SiteDocument, opts: SaveSiteOptions = {}): Promise<SaveSiteResult> {
     // Extract shell (strip the row-backed collections from the full SiteDocument)
     const { pages, visualComponents, layouts, ...shell } = site
     const { dirty } = opts
     const incremental = dirty !== undefined && !dirty.all
+
+    // Ship the base seqs covering exactly the rows this save touches —
+    // changed AND deleted (deleting a remotely-newer row is an overwrite
+    // too). Rows the client has never synchronized (its own creations) have
+    // no entry, which is how the server tells creations apart.
+    const baseSeqs: Record<string, number> = {}
+    if (incremental) {
+      const shippedIds = [
+        ...dirty.pageIds, ...dirty.deletedPageIds,
+        ...dirty.componentIds, ...dirty.deletedComponentIds,
+        ...dirty.layoutIds, ...dirty.deletedLayoutIds,
+      ]
+      for (const id of shippedIds) {
+        const base = opts.baseSeqs?.[id]
+        if (base !== undefined) baseSeqs[id] = base
+      }
+    }
 
     const body = incremental
       ? {
@@ -64,6 +97,8 @@ export class CmsAdapter implements IPersistenceAdapter {
           deletedComponentIds: [...dirty.deletedComponentIds],
           changedLayouts: layouts.filter((layout) => dirty.layoutIds.has(layout.id)),
           deletedLayoutIds: [...dirty.deletedLayoutIds],
+          baseSeqs,
+          shellBaseSeq: opts.shellBaseSeq ?? 0,
         }
       : {
           mode: 'replace',
@@ -74,15 +109,55 @@ export class CmsAdapter implements IPersistenceAdapter {
           deletedComponentIds: [],
           changedLayouts: layouts,
           deletedLayoutIds: [],
+          // Ignored in replace mode — imports and bootstraps replace
+          // deliberately, so there is nothing to conflict with.
+          baseSeqs,
+          shellBaseSeq: opts.shellBaseSeq ?? 0,
         }
 
-    await apiRequest(`${this.basePath}/site-document`, {
+    // Own fetch instead of `apiRequest`: a 409 carries the typed conflicts
+    // payload, which the generic ApiError cannot transport.
+    const res = await this.fetchImpl(`${this.basePath}/site-document`, {
       method: 'PUT',
-      body,
-      schema: CmsSiteDocumentSaveEnvelopeSchema,
-      fetchImpl: this.fetchImpl,
-      fallbackMessage: 'Site save failed',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
     })
+    if (res.status === 409) {
+      const conflictBody = await parseJsonResponse(res, SaveConflictsEnvelopeSchema)
+      throw new SaveConflictError(conflictBody.conflicts)
+    }
+    const saved = await readEnvelope(res, CmsSiteDocumentSaveEnvelopeSchema, 'Site save failed')
+    return { seq: saved.seq }
+  }
+
+  /**
+   * Load the current shell (with its sync seq) on its own — the conflict
+   * banner's "Load theirs" fetch for a shell conflict.
+   */
+  async loadSiteShell(): Promise<{ shell: SiteShell; seq: number } | undefined> {
+    const body = await apiRequest(`${this.basePath}/site`, {
+      schema: CmsSiteEnvelopeSchema,
+      fetchImpl: this.fetchImpl,
+      fallbackMessage: 'CMS shell load failed',
+    })
+    if (!body.site) return undefined
+    return { shell: validateSite(body.site), seq: body.seq ?? 0 }
+  }
+
+  /**
+   * Load a single row of one site collection — the conflict banner's
+   * "Load theirs" fetch. Returns null when the row is (soft-)deleted:
+   * absence IS the "deleted remotely" signal.
+   */
+  async loadSiteRow(table: SiteCollectionTable, rowId: string): Promise<DataRow | null> {
+    const body = await apiRequest(`${this.basePath}/${table}`, {
+      query: { id: rowId },
+      schema: COLLECTION_ENVELOPES[table],
+      fetchImpl: this.fetchImpl,
+      fallbackMessage: `CMS ${table} row load failed`,
+    })
+    return body.rows?.[0] ?? null
   }
 
   /**
@@ -96,8 +171,11 @@ export class CmsAdapter implements IPersistenceAdapter {
    *      savedLayoutFromRow, validated by validateSavedLayouts)
    *
    * Returns undefined when any endpoint returns 404 (before setup).
+   *
+   * Alongside the document, returns the sync-seq bases (per-row + shell) the
+   * editor tracks for save conflict detection.
    */
-  async loadSite(_id: string): Promise<SiteDocument | undefined> {
+  async loadSite(_id: string): Promise<SiteLoadResult | undefined> {
     // Parallel fetch — all four are GETs with no dependency on each other
     const [shellRes, pagesRes, componentsRes, layoutsRes] = await Promise.all([
       this.fetchImpl(`${this.basePath}/site`, {
@@ -168,7 +246,14 @@ export class CmsAdapter implements IPersistenceAdapter {
 
     const site: SiteDocument = { ...shell, pages, visualComponents, layouts }
     site.explorer = reconcileSiteExplorerOrganization(site.explorer, site)
-    return site
+
+    // Sync-seq bases: one entry per stored row (across all three
+    // collections — row ids are globally unique) plus the shell's seq.
+    const rowSeqs: Record<string, number> = {}
+    for (const row of [...rawDataRows, ...rawVCRows, ...(layoutsBody.rows ?? [])]) {
+      rowSeqs[row.id] = row.seq ?? 0
+    }
+    return { site, rowSeqs, shellSeq: shellBody.seq ?? 0 }
   }
 }
 

--- a/src/core/persistence/responseSchemas.ts
+++ b/src/core/persistence/responseSchemas.ts
@@ -227,16 +227,24 @@ export const CmsRuntimePreviewResponseSchema = Type.Object(
 // cms.ts — envelopes only; inner types are deep
 // ---------------------------------------------------------------------------
 
+/**
+ * Envelope for GET /admin/api/cms/site. `seq` is the shell's sync sequence
+ * number — the client's conflict-detection base for shell changes (absent
+ * only in pre-setup 404 shapes, which return no `site` either).
+ */
 export const CmsSiteEnvelopeSchema = Type.Object(
-  { site: Type.Optional(Type.Unknown()) },
+  {
+    site: Type.Optional(Type.Unknown()),
+    seq: Type.Optional(Type.Number()),
+  },
   { additionalProperties: true },
 )
 
 /**
  * Envelope for PUT /admin/api/cms/site-document — the transactional
- * whole-document save. `seq` is the save's site-global sync sequence number
- * (multi-admin sync substrate; informational to the client until the
- * live-sync plan consumes it for conflict detection).
+ * whole-document save. `seq` is the save's site-global sync sequence number:
+ * every row the save wrote or deleted (and the shell, when it changed) is
+ * stamped with it, so the client bumps its base seqs to `seq` on success.
  */
 export const CmsSiteDocumentSaveEnvelopeSchema = Type.Object(
   {

--- a/src/core/persistence/saveConflict.ts
+++ b/src/core/persistence/saveConflict.ts
@@ -1,0 +1,57 @@
+/**
+ * Save-conflict protocol shapes — shared by the transactional save endpoint
+ * (server) and the CMS persistence adapter (client).
+ *
+ * An incremental site-document save carries base seqs: for every changed or
+ * deleted row, the site-global sync seq the client last synchronized with
+ * (seeded at load, bumped on every successful save). Inside the save
+ * transaction the server compares each shipped row's STORED seq against its
+ * base seq; any stored row that is newer — or that the client has no base for
+ * at all — means the save would silently overwrite another admin's work, so
+ * the whole save is rejected with 409 and this envelope. Nothing is written.
+ *
+ * The shell participates coarsely: one seq for the whole shell (settings +
+ * style rules + files), checked only when the incoming shell actually differs
+ * from the stored one. `table: 'site'` conflicts carry the draft-site row id
+ * (`'default'`).
+ *
+ * The same `SaveConflictError` class is thrown on both sides: the server
+ * handler throws it out of the transaction (caught and turned into the 409
+ * response), and the client adapter re-throws it after parsing the 409 body —
+ * so editor code has exactly one typed error to branch on.
+ */
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+export const SaveConflictSchema = Type.Object({
+  /** Which collection conflicted; `'site'` is the shell (rowId `'default'`). */
+  table: Type.Union([
+    Type.Literal('site'),
+    Type.Literal('pages'),
+    Type.Literal('components'),
+    Type.Literal('layouts'),
+  ]),
+  rowId: Type.String(),
+  /** The STORED row's seq — the newer version the save would have overwritten. */
+  seq: Type.Number(),
+})
+
+export type SaveConflict = Static<typeof SaveConflictSchema>
+
+/** 409 response body of PUT /admin/api/cms/site-document. */
+export const SaveConflictsEnvelopeSchema = Type.Object(
+  {
+    error: Type.String(),
+    conflicts: Type.Array(SaveConflictSchema),
+  },
+  { additionalProperties: true },
+)
+
+export class SaveConflictError extends Error {
+  readonly conflicts: SaveConflict[]
+
+  constructor(conflicts: SaveConflict[]) {
+    super('Another admin saved a newer version of content in this save')
+    this.name = 'SaveConflictError'
+    this.conflicts = conflicts
+  }
+}

--- a/src/core/persistence/types.ts
+++ b/src/core/persistence/types.ts
@@ -25,6 +25,34 @@ interface SaveDirtyHints {
 export interface SaveSiteOptions {
   /** Dirty hints from the editor store. Absent → replace-mode full save. */
   dirty?: SaveDirtyHints
+  /**
+   * Conflict-detection bases for an incremental save: rowId → the sync seq
+   * the client last synchronized with (seeded at load, bumped on every
+   * successful save). The adapter ships the subset covering the changed and
+   * deleted rows; the server 409s the save when any stored row is newer.
+   * Irrelevant for replace-mode saves (the server skips the check).
+   */
+  baseSeqs?: Readonly<Record<string, number>>
+  /** The shell seq the client last synchronized with (same protocol as `baseSeqs`). */
+  shellBaseSeq?: number
+}
+
+export interface SaveSiteResult {
+  /**
+   * The save's site-global sync seq — stamped on every row the save wrote or
+   * deleted (and the shell, when it changed). The client bumps its base seqs
+   * to this value on success.
+   */
+  seq: number
+}
+
+/** The loaded document plus the sync-seq bases the editor tracks alongside it. */
+export interface SiteLoadResult {
+  site: SiteDocument
+  /** rowId → stored sync seq at load time, across pages + components + layouts. */
+  rowSeqs: Record<string, number>
+  /** The shell's sync seq at load time. */
+  shellSeq: number
 }
 
 /**
@@ -37,12 +65,16 @@ export interface IPersistenceAdapter {
    * only the changed pages/components/layouts plus explicitly deleted row
    * ids. Without hints (or `dirty.all`), ships a replace-mode full save —
    * the server derives deletions as stored − shipped.
+   *
+   * Throws `SaveConflictError` (see ./saveConflict) when the server rejects
+   * an incremental save because another admin stored newer versions of rows
+   * this save ships. Nothing is written on conflict.
    */
-  saveSite(site: SiteDocument, opts?: SaveSiteOptions): Promise<void>
+  saveSite(site: SiteDocument, opts?: SaveSiteOptions): Promise<SaveSiteResult>
 
   /**
-   * Load the single site draft document (shell + pages assembled).
-   * Returns undefined before setup creates it.
+   * Load the single site draft document (shell + pages assembled) together
+   * with its sync-seq bases. Returns undefined before setup creates it.
    */
-  loadSite(id: string): Promise<SiteDocument | undefined>
+  loadSite(id: string): Promise<SiteLoadResult | undefined>
 }


### PR DESCRIPTION
> **Stacked on #169** (`feat/transactional-site-save`) — review after that one merges; this diff only makes sense on top of the transactional save.

## What changed

Two admins with the editor open were invisible to each other: saves were last-writer-wins per row, so admin B's save **silently overwrote** admin A's work — no error, both toolbars said "Saved". This is **level A of the multi-admin live-sync plan**: conflict *safety* (detection + explicit resolution), building on the transactional save's site-global seq stamping.

### Server

- The incremental save body gains **`baseSeqs`** (rowId → the seq the client last synchronized with, covering changed **and** deleted rows) and **`shellBaseSeq`**.
- The conflict check runs **inside the save transaction, after `allocateSiteSeq`** — the counter-row lock serializes concurrent saves on both dialects, so the check is exact (no TOCTOU). Any shipped row stored newer than its base — or with **no base entry at all** (blind overwrite guard) — throws `SaveConflictError`, rolling everything back into a **409** with `{ conflicts: [{ table, rowId, seq }] }`. Nothing is written.
- Soft-deleted rows are visible to the check (`listDataRowSeqs` has no `deleted_at` filter): a remote delete conflicts with a stale edit instead of reading as absence.
- **The shell write + seq stamp are now conditional on real content change** (`shellsEqual`). The shell ships with every save — an unconditional stamp would have made every concurrent save pair 409 on the shell. Row-only saves no longer touch the site row at all.
- `DataRow` exposes `seq` (optional in the schema so pre-seq bundle archives still validate), `GET /site` returns the shell seq, and the three collection GETs accept `?id=<rowId>` for the banner's single-row fetch.
- Replace-mode saves skip the check — imports replace deliberately.

### Client

- The editor store tracks `baseSeqs`/`shellBaseSeq` (seeded at load, bumped to the response seq on every successful save; deleted rows **keep** entries so a saved-delete + undo resurrection carries the right base) plus the pending `saveConflicts` list. Autosave is suppressed while conflicts pend.
- **`SaveConflictBanner`** (lazy-mounted in `AdminCanvasLayout`, chunk stays out of the route shell) offers per-target resolution:
  - **Load theirs** — fetches the remote state and adopts it: swap without undo history, clear the target's dirty marks, clear undo history (site-relative patches are undefined across a swapped tree), and for VCs propagate slot re-sync / ref-cascade removal into consumer pages *with* real dirty marks.
  - **Keep mine (overwrite)** — bumps the base seq; the next save overwrites as a stated decision.
  - Resolving the last conflict flushes the surviving edits through the save queue.
- Fixed a discovered wart: the **Spotlight Save command** did a raw replace-mode adapter save that bypassed the single-flight queue and dirty tracking — it now routes through `flushEditorSave()`.
- Settings modal + onboarding shell saves carry their own shell base seq; on conflict the modal forces a reload instead of re-saving stale state.

### Known v1 blind spot (documented in `docs/features/site-shell.md`)

Writers outside the transactional save (plugin pack installs, data-workspace edits) don't stamp seqs and coordinate via `requestCmsSiteReload()` — widening stamping is live-sync phase B scope.

## Impact

- Concurrent admin saves that would silently clobber each other now fail loudly with a per-target resolution UI. No data path changed for single-admin use: an up-to-date client's saves pass the check by construction.
- New wire fields are required in the save body; the endpoint, adapter, and all callers updated in this PR (no compat shims, per repo policy).

## Verification

```
bun test        # 5984 pass / 0 fail
bun run build   # tsc -b && vite build — clean
bun run lint    # clean
```

New coverage: 9 endpoint conflict scenarios (`siteDocumentSave.test.ts`), adapter wire shapes + 409 parsing (`cmsAdapter.test.ts`), store bookkeeping + both resolutions incl. VC ref-cascade propagation (`saveConflicts.test.ts`), and the usePersistence 409 flow (`savePersistenceQueue.test.tsx`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)