### PR TITLE
feat(cms): live pull over WebSocket — sibling saves merge into open editors

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -89,6 +89,7 @@ The repo is organized by responsibility, not by feature. Every file has one reas
 | HTTP & routing               | `server/router.ts`, `server/http.ts`  | Request dispatch, body parsing, error envelopes                      |
 | CMS endpoints                | `server/handlers/cms/*.ts`            | Per-resource handlers (pages, posts, components, media, plugins, …)  |
 | Auth & sessions              | `server/auth/*`                       | Session validation, capability checks, login flow                    |
+| Live-sync events             | `server/events/*`                     | Multi-admin sync: in-process event bus (Bun pub/sub) + the `/admin/api/cms/site-socket` WebSocket (upgrade gating, seq-cursor reconnect delta) |
 | Repositories                 | `server/repositories/*.ts`            | Database access; dialect-naive ANSI SQL only                         |
 | Database adapters            | `server/db/postgres.ts`, `sqlite.ts`  | Engine-specific `DbClient` implementation                            |
 | Migrations                   | `server/db/migrations-*.ts`           | Schema in both dialects, parity-gated                                |

--- a/docs/features/site-shell.md
+++ b/docs/features/site-shell.md
@@ -477,8 +477,54 @@ deliberately).
 Known v1 blind spot: writers OUTSIDE the transactional save (plugin pack
 installs via `saveDraftSite`/`saveDataRowDraft`, data-workspace row edits)
 do not stamp seqs, so conflict detection cannot see them — those flows
-coordinate through `requestCmsSiteReload()` instead. Widening seq stamping
-to every writer is live-sync phase B territory.
+coordinate through `requestCmsSiteReload()` instead.
+
+One subtlety: the editor bumps `site.updatedAt` on EVERY historic mutation,
+so `shellsEqual` (`@core/persistence/shellsEqual`, shared by the server's
+shell-skip and the client's echo detection) deliberately ignores it, and the
+dirty tracker never marks the shell for `updatedAt`-only patches — otherwise
+every page edit would read as a shell change and destroy the shell seq as a
+conflict signal.
+
+### Live pull (multi-admin level B)
+
+Open editors learn about sibling admins' saves the moment they land — no
+polling, no manual refresh:
+
+- **Channel**: `GET /admin/api/cms/site-socket` upgrades to a WebSocket
+  (`server/events/siteSocket.ts`; wired at the `Bun.serve` boundary in
+  `server/index.ts` — an upgrade is a different protocol lifecycle from the
+  request/response router). Gated at upgrade time by `site.read` AND an
+  `originAllowed` check (browsers always send Origin on WS handshakes, so
+  this closes cross-site WebSocket hijacking). The dev Vite proxy forwards
+  the upgrade (`ws: true`).
+- **Events** (`@core/persistence/syncEvents`): `rows-changed` /
+  `rows-deleted` / `shell-changed` / `site-reloaded` (replace-mode saves
+  collapse to ONE event) / `published`. Events carry **ids + seqs, never
+  payloads** — they are idempotent hints. The transactional save publishes
+  them post-commit through the in-process bus (`server/events/siteEvents.ts`,
+  Bun's native pub/sub — correct for the single-process-by-definition
+  deployment model; multi-process would need a shared bus and is out of
+  scope).
+- **Self-healing reconnect**: on every (re)connect the client sends its seq
+  cursor (`{ kind: 'subscribe', cursor }`) and the server replies with the
+  missed delta synthesized from `rows where seq > cursor` (soft-deleted rows
+  included — a missed deletion surfaces as `rows-deleted`, not silence).
+  Live events are hints; the delta is truth, so a dropped frame can never
+  cause drift.
+- **Client** (`useSiteSocket` = transport with backoff reconnect,
+  `siteSyncMerge.ts` = policy): per event target — ① base seq ≥ event seq →
+  skip (own-save echo); ② target dirty locally → pending conflict (the SAME
+  banner as a 409'd save — one resolution UX for levels A and B; dirtiness
+  is re-checked after the fetch, so an edit landing mid-wire degrades to a
+  conflict, never a silent overwrite); ③ clean → fetch current state
+  (`fetchRemoteSnapshot`) and `applyRemoteSnapshot` it. The apply
+  deep-equal-skips identical content, so undo history resets only when
+  remote content genuinely replaced local state — a toast explains exactly
+  then. A remote deletion of the open page navigates home with a toast;
+  `site-reloaded` reloads the document through the ordinary persistence
+  reload path. Events process strictly in arrival order through one promise
+  chain.
 
 Client side: `loadSite` seeds `baseSeqs`/`shellBaseSeq` in the editor store
 (per-row seqs ride the collection GET responses — `DataRow.seq`; the shell

--- a/docs/server.md
+++ b/docs/server.md
@@ -38,7 +38,13 @@ server/index.ts
     ├─→ mediaStorageRegistry.configureLocalDisk({ uploadsDir })   ← register local-disk media adapter
     ├─→ activateInstalledServerPlugins(db, uploadsDir)            ← run plugin lifecycle: activate
     │
-    └─→ Bun.serve({ fetch: req => handleServerRequest(req, runtime) })
+    ├─→ Bun.serve({ fetch: req => handleServerRequest(req, runtime),
+    │               websocket: createSiteSocketHandlers(db) })
+    │     (the live-sync socket `/admin/api/cms/site-socket` upgrades at this
+    │      boundary — see server/events/siteSocket.ts; everything else goes
+    │      through the router)
+    │
+    └─→ setSiteEventPublisher(server)        ← wire the live-sync bus to Bun pub/sub
 ```
 
 Boot is sequential and fail-fast. If migrations fail, the process exits. If a plugin's `activate` throws, the host logs `[plugin:<id>]` and continues — one bad plugin doesn't bring the server down.

--- a/server/events/siteEvents.ts
+++ b/server/events/siteEvents.ts
@@ -1,0 +1,37 @@
+/**
+ * Site events bus — the in-process fan-out behind the multi-admin live-pull
+ * channel (level B of the live-sync plan).
+ *
+ * Instatic is self-hosted and runs as ONE Bun process by product definition,
+ * so an in-memory bus wrapping Bun's native pub/sub is *correct*, not a
+ * shortcut — multi-process deployments would need a shared bus and are
+ * explicitly out of scope (documented in docs/features/site-shell.md).
+ *
+ * The publisher is the `Bun.Server` instance, registered at boot
+ * (server/index.ts) AFTER `Bun.serve` returns. Until then — and in tests
+ * that exercise handlers without a listening server — `publishSiteEvent`
+ * drops events silently, which is safe by design: events are idempotent
+ * HINTS; the seq-cursor delta on (re)connect is the truth
+ * (see @core/persistence/syncEvents).
+ */
+import type { SiteSyncEvent } from '@core/persistence/syncEvents'
+
+/** The one durable topic every open editor subscribes to. */
+export const SITE_EVENTS_TOPIC = 'site'
+
+interface SiteEventPublisher {
+  publish(topic: string, data: string): number
+}
+
+let publisher: SiteEventPublisher | null = null
+
+/** Register the boot-time publisher (the Bun server). Pass null to detach (tests). */
+export function setSiteEventPublisher(next: SiteEventPublisher | null): void {
+  publisher = next
+}
+
+/** Broadcast one sync event to every subscribed editor socket. */
+export function publishSiteEvent(event: SiteSyncEvent): void {
+  if (!publisher) return
+  publisher.publish(SITE_EVENTS_TOPIC, JSON.stringify(event))
+}

--- a/server/events/siteSocket.ts
+++ b/server/events/siteSocket.ts
@@ -1,0 +1,128 @@
+/**
+ * Site socket — the WebSocket endpoint of the multi-admin live-pull channel.
+ *
+ *   GET /admin/api/cms/site-socket → WebSocket upgrade
+ *
+ * Auth happens at upgrade time: the session cookie must resolve to a user
+ * with `site.read`, and the Origin header must pass `originAllowed` — the
+ * browser always sends Origin on WebSocket handshakes, so this closes
+ * cross-origin WebSocket hijacking (CSWSH): cookies ride the handshake, but
+ * a foreign origin is rejected before the socket opens.
+ *
+ * Protocol (shapes in @core/persistence/syncEvents):
+ *   1. On open the socket subscribes to the `site` topic — every
+ *      post-commit save event published through server/events/siteEvents
+ *      fans out to it via Bun's native pub/sub (subscriptions die with the
+ *      socket; no cleanup bookkeeping to leak).
+ *   2. The client sends `{ kind: 'subscribe', cursor }` with the highest
+ *      seq it has synchronized. The server replies with DELTA events
+ *      synthesized from `rows where seq > cursor` (soft-deleted included —
+ *      a missed deletion surfaces as `rows-deleted`, not silence) plus a
+ *      `shell-changed` when the shell seq is past the cursor. This makes
+ *      the socket self-healing: live events are hints; the delta is truth.
+ *   3. Malformed or non-string frames are logged and dropped — never acted
+ *      on.
+ */
+import type { ServerWebSocket, WebSocketHandler } from 'bun'
+import type { SiteSyncEvent, SiteSyncTable } from '@core/persistence/syncEvents'
+import { SITE_SOCKET_PATH, SiteSocketSubscribeSchema } from '@core/persistence/syncEvents'
+import { safeParseJson } from '@core/utils/jsonValidate'
+import { requireCapability } from '../auth/authz'
+import { originAllowed } from '../auth/security'
+import type { DbClient } from '../db/client'
+import { jsonResponse } from '../http'
+import { listChangedDataRowRefsSince } from '../repositories/data'
+import { getDraftSiteSeq } from '../repositories/site'
+import { SITE_EVENTS_TOPIC } from './siteEvents'
+
+export { SITE_SOCKET_PATH }
+
+export interface SiteSocketData {
+  userId: string
+}
+
+const SITE_SYNC_TABLES: readonly SiteSyncTable[] = ['pages', 'components', 'layouts']
+
+interface UpgradeCapableServer {
+  upgrade(req: Request, options: { data: SiteSocketData }): boolean
+}
+
+/**
+ * Gate + upgrade the socket request. Returns `null` when the connection was
+ * upgraded (the caller must then return `undefined` from `fetch`), or an
+ * error `Response` (401/403/426) to send instead.
+ */
+export async function handleSiteSocketUpgrade(
+  req: Request,
+  db: DbClient,
+  server: UpgradeCapableServer,
+): Promise<Response | null> {
+  // CSWSH defense — a cookie-bearing cross-origin handshake is rejected
+  // before auth even runs.
+  if (!originAllowed(req)) {
+    return jsonResponse({ error: 'Origin not allowed' }, { status: 403 })
+  }
+  const user = await requireCapability(req, db, 'site.read')
+  if (user instanceof Response) return user
+  const upgraded = server.upgrade(req, { data: { userId: user.id } })
+  if (!upgraded) {
+    return jsonResponse({ error: 'WebSocket upgrade required' }, { status: 426 })
+  }
+  return null
+}
+
+/**
+ * Reconnect delta: every sync event the client with this cursor has missed,
+ * in seq order, ready to run through the client's ordinary merge rule.
+ * Delta events carry no actor — the originating saves are no longer known.
+ */
+export async function computeDeltaEvents(db: DbClient, cursor: number): Promise<SiteSyncEvent[]> {
+  const refs = await listChangedDataRowRefsSince(db, SITE_SYNC_TABLES, cursor)
+
+  const changed = new Map<SiteSyncTable, Record<string, number>>()
+  const deleted = new Map<SiteSyncTable, Record<string, number>>()
+  for (const ref of refs) {
+    const table = ref.tableId as SiteSyncTable // query is scoped to SITE_SYNC_TABLES
+    const bucket = ref.deleted ? deleted : changed
+    const seqs = bucket.get(table) ?? {}
+    seqs[ref.id] = ref.seq
+    bucket.set(table, seqs)
+  }
+
+  const events: SiteSyncEvent[] = []
+  for (const [table, seqs] of changed) events.push({ kind: 'rows-changed', table, seqs })
+  for (const [table, seqs] of deleted) events.push({ kind: 'rows-deleted', table, seqs })
+
+  const shellSeq = await getDraftSiteSeq(db)
+  if (shellSeq > cursor) events.push({ kind: 'shell-changed', seq: shellSeq })
+
+  return events
+}
+
+/** The `websocket` config for `Bun.serve` — one instance per boot, bound to the db. */
+export function createSiteSocketHandlers(db: DbClient): WebSocketHandler<SiteSocketData> {
+  return {
+    open(ws: ServerWebSocket<SiteSocketData>) {
+      ws.subscribe(SITE_EVENTS_TOPIC)
+    },
+
+    async message(ws: ServerWebSocket<SiteSocketData>, raw: string | Buffer) {
+      if (typeof raw !== 'string') return // binary frames are not part of the protocol
+      const parsed = safeParseJson(raw, SiteSocketSubscribeSchema)
+      if (!parsed.ok) {
+        console.warn('[siteSocket] dropping malformed client message')
+        return
+      }
+      try {
+        const events = await computeDeltaEvents(db, parsed.value.cursor)
+        for (const event of events) ws.send(JSON.stringify(event))
+      } catch (err) {
+        console.error('[siteSocket] delta computation failed:', err)
+      }
+    },
+
+    close() {
+      // Bun drops the socket's topic subscriptions automatically.
+    },
+  }
+}

--- a/server/handlers/cms/siteDiff.ts
+++ b/server/handlers/cms/siteDiff.ts
@@ -33,6 +33,7 @@ import type {
   StyleRule,
   SiteShell,
 } from '@core/page-tree'
+import { deepEqual } from '@core/utils/deepEqual'
 
 type SiteChangeKind = 'structure' | 'content' | 'style'
 
@@ -237,44 +238,4 @@ function diffFiles(
   }
 }
 
-/**
- * True when two shells are content-identical. The transactional save uses
- * this to SKIP the shell write + seq stamp on row-only saves — the pillar of
- * the shell conflict check: the shell seq advances only when shell content
- * genuinely changed, so a stale-but-untouched shell shipped alongside a page
- * edit never trips a spurious conflict.
- */
-export function shellsEqual(a: SiteShell, b: SiteShell): boolean {
-  return deepEqual(a, b)
-}
 
-// ---------------------------------------------------------------------------
-// Small deep-equal helpers
-// ---------------------------------------------------------------------------
-
-function deepEqual(a: unknown, b: unknown): boolean {
-  if (a === b) return true
-  if (a === null || b === null) return a === b
-  if (typeof a !== typeof b) return false
-  if (typeof a !== 'object') return false
-  if (Array.isArray(a)) {
-    if (!Array.isArray(b)) return false
-    if (a.length !== b.length) return false
-    for (let i = 0; i < a.length; i++) {
-      if (!deepEqual(a[i], b[i])) return false
-    }
-    return true
-  }
-  if (Array.isArray(b)) return false
-  const aKeys = Object.keys(a as Record<string, unknown>)
-  const bKeys = Object.keys(b as Record<string, unknown>)
-  if (aKeys.length !== bKeys.length) return false
-  for (const k of aKeys) {
-    if (!Object.prototype.hasOwnProperty.call(b, k)) return false
-    if (!deepEqual(
-      (a as Record<string, unknown>)[k],
-      (b as Record<string, unknown>)[k],
-    )) return false
-  }
-  return true
-}

--- a/server/handlers/cms/siteDocument.ts
+++ b/server/handlers/cms/siteDocument.ts
@@ -77,11 +77,14 @@ import { VisualComponentSchema, vcSlugFromName, type VisualComponent } from '@co
 import { SavedLayoutSchema, layoutSlugFromName, type SavedLayout } from '@core/layouts'
 import type { Page } from '@core/page-tree'
 import { SaveConflictError, type SaveConflict } from '@core/persistence/saveConflict'
+import { shellsEqual } from '@core/persistence/shellsEqual'
+import type { SiteSyncActor, SiteSyncTable } from '@core/persistence/syncEvents'
+import { publishSiteEvent } from '../../events/siteEvents'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../http'
 import { bumpPublishVersionSerialized } from '../../publish/publishState'
 import { Type, type Static } from '@core/utils/typeboxHelpers'
 import { CMS_API_PREFIX } from './shared'
-import { ForbiddenSiteChangeError, shellsEqual, validateSiteWriteDiff } from './siteDiff'
+import { ForbiddenSiteChangeError, validateSiteWriteDiff } from './siteDiff'
 import { validatePageWriteDiff } from './pageDiff'
 
 const SITE_WRITE_CAPABILITIES = [
@@ -414,9 +417,34 @@ export async function handleSiteDocumentRoutes(req: Request, db: DbClient): Prom
     // Deleting a published page retracts its public route — invalidate the
     // render cache AFTER the transaction commits (never inside it: the bump
     // serializes against the publish lock, which itself waits on the
-    // transaction chain). The multi-admin live-sync plan emits its site
-    // events from this point too.
+    // transaction chain).
     if (deletedPublishedPage) await bumpPublishVersionSerialized()
+
+    // Live-sync fan-out — idempotent hints to every open editor socket
+    // (ids + seqs only, never payloads; see @core/persistence/syncEvents).
+    // A replace-mode save collapses to ONE site-reloaded event instead of
+    // thousands of row events.
+    const actor: SiteSyncActor = { userId: user.id, name: user.displayName || user.email }
+    if (body.mode === 'replace') {
+      publishSiteEvent({ kind: 'site-reloaded', seq, actor })
+    } else {
+      if (shellChanged) publishSiteEvent({ kind: 'shell-changed', seq, actor })
+      const rowGroups: Array<{ table: SiteSyncTable; changedIds: Iterable<string>; deleteIds: Iterable<string> }> = [
+        { table: 'pages', changedIds: changedPageIdsRaw, deleteIds: pageDeleteIds },
+        { table: 'components', changedIds: changedComponentIds, deleteIds: componentDeleteIds },
+        { table: 'layouts', changedIds: changedLayoutIds, deleteIds: layoutDeleteIds },
+      ]
+      for (const { table, changedIds, deleteIds } of rowGroups) {
+        const changedSeqs = Object.fromEntries([...changedIds].map((id) => [id, seq]))
+        if (Object.keys(changedSeqs).length > 0) {
+          publishSiteEvent({ kind: 'rows-changed', table, seqs: changedSeqs, actor })
+        }
+        const deletedSeqs = Object.fromEntries([...deleteIds].map((id) => [id, seq]))
+        if (Object.keys(deletedSeqs).length > 0) {
+          publishSiteEvent({ kind: 'rows-deleted', table, seqs: deletedSeqs, actor })
+        }
+      }
+    }
 
     return jsonResponse({ ok: true, seq })
   } catch (err) {

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,9 @@ await import('./richtextSanitizer')
 const { handleServerRequest } = await import('./router')
 const { activateInstalledServerPlugins } = await import('./plugins/runtime')
 const { mediaStorageRegistry } = await import('@core/plugins/mediaStorageRegistry')
+const { setSiteEventPublisher } = await import('./events/siteEvents')
+const { SITE_SOCKET_PATH, createSiteSocketHandlers, handleSiteSocketUpgrade } =
+  await import('./events/siteSocket')
 
 const config = readServerConfig()
 configureTrustedProxyCidrs(config.trustedProxyCidrs)
@@ -58,7 +61,7 @@ function corsHeaders(origin: string | null): Record<string, string> {
   }
 }
 
-Bun.serve({
+const server = Bun.serve({
   port: config.port,
 
   // Disable Bun's default 10-second idle timeout. The agent endpoint streams
@@ -86,6 +89,17 @@ Bun.serve({
         new Response(null, { status: 204, headers: cors }),
         pathname,
       )
+    }
+
+    // Multi-admin live-sync socket — a WebSocket upgrade is a different
+    // protocol lifecycle from the request/response router, so it dispatches
+    // here at the `Bun.serve` boundary (the only place `server.upgrade` is
+    // available). Returning `undefined` hands the connection to the
+    // `websocket` handlers below.
+    if (pathname === SITE_SOCKET_PATH) {
+      const rejection = await handleSiteSocketUpgrade(req, db, server)
+      if (rejection === null) return undefined
+      return applySecurityHeaders(rejection, pathname)
     }
 
     try {
@@ -116,10 +130,17 @@ Bun.serve({
     }
   },
 
+  websocket: createSiteSocketHandlers(db),
+
   error(err: Error) {
     console.error('[server] Unhandled error:', err)
     return new Response('Internal Server Error', { status: 500 })
   },
 })
+
+// The bus needs the live server handle for Bun pub/sub fan-out — register it
+// now that `Bun.serve` returned. Save events emitted before this line (none
+// in practice) would drop harmlessly: they are hints, the delta is truth.
+setSiteEventPublisher(server)
 
 console.log(`[server] Listening on http://localhost:${config.port}`)

--- a/server/publish/publishSite.ts
+++ b/server/publish/publishSite.ts
@@ -49,6 +49,7 @@ import {
 import { buildPublishedSiteCssBundle } from './siteCssBundle'
 import { bakePublishedDataRowArtefacts } from './bakeDataRows'
 import { bumpPublishVersion, getPublishVersion, withPublishLock } from './publishState'
+import { publishSiteEvent } from '../events/siteEvents'
 
 interface PublishResult {
   publishedPages: number
@@ -299,6 +300,11 @@ async function publishDraftSiteLocked(
   // window where the freshly-swapped shells (stamped nextPublishVersion) are
   // live while the version counter still reads the old value.
   bumpPublishVersion()
+
+  // Live-sync hint: open editors learn the site was published without
+  // polling. No actor — the publish lock context only carries the user id,
+  // and the event is informational.
+  publishSiteEvent({ kind: 'published', publishVersion: getPublishVersion() })
 
   return { publishedPages }
 }

--- a/server/repositories/data/index.ts
+++ b/server/repositories/data/index.ts
@@ -32,6 +32,7 @@ export {
   listDataRows,
   listDataRowIdSlugs,
   listDataRowSeqs,
+  listChangedDataRowRefsSince,
   listDataRowsWithFilter,
   searchDataRows,
   getDataRow,

--- a/server/repositories/data/rows/index.ts
+++ b/server/repositories/data/rows/index.ts
@@ -20,6 +20,7 @@ export {
   listDataRows,
   listDataRowIdSlugs,
   listDataRowSeqs,
+  listChangedDataRowRefsSince,
   getDataRow,
   getDataRowMany,
   getDataRowBySlug,

--- a/server/repositories/data/rows/read.ts
+++ b/server/repositories/data/rows/read.ts
@@ -117,6 +117,40 @@ export async function listDataRowSeqs(
   return rows.map((r) => ({ id: r.id, seq: Number(r.seq) }))
 }
 
+export interface ChangedDataRowRef {
+  id: string
+  tableId: string
+  seq: number
+  deleted: boolean
+}
+
+/**
+ * Lean refs of every row in the given tables whose seq is PAST the client's
+ * cursor — the reconnect delta of the live-sync channel. Soft-deleted rows
+ * included (a deletion the client missed must surface as a `rows-deleted`
+ * hint, not as silence). O(delta) via `data_rows_table_seq_idx`.
+ */
+export async function listChangedDataRowRefsSince(
+  db: DbClient,
+  tableIds: ReadonlyArray<string>,
+  cursor: number,
+): Promise<ChangedDataRowRef[]> {
+  if (tableIds.length === 0) return []
+  const placeholders = tableIds.map((_, i) => placeholder(db.dialect, i + 2)).join(', ')
+  const { rows } = await db.unsafe<{ id: string; table_id: string; seq: number; deleted_at: string | null }>(
+    `select id, table_id, seq, deleted_at from data_rows
+     where seq > ${placeholder(db.dialect, 1)} and table_id in (${placeholders})
+     order by seq asc`,
+    [cursor, ...tableIds],
+  )
+  return rows.map((row) => ({
+    id: row.id,
+    tableId: row.table_id,
+    seq: Number(row.seq),
+    deleted: row.deleted_at !== null,
+  }))
+}
+
 export async function getDataRow(
   db: DbClient,
   rowId: string,

--- a/src/__tests__/editor-store/dirtyTracking.test.ts
+++ b/src/__tests__/editor-store/dirtyTracking.test.ts
@@ -124,15 +124,20 @@ describe('collectDirtyFromSitePatches', () => {
     expect(marks.all).toBe(true)
   })
 
-  it('marks nothing for shell-field paths — the shell is always saved', () => {
+  it('marks the SHELL (no row marks) for shell-field paths — feeds the live-sync merge rule', () => {
     const site = twoPageTwoVcSite()
     const patches: Patches = [
       { op: 'replace', path: ['styleRules', 'x'], value: {} },
       { op: 'replace', path: ['name'], value: 'Renamed' },
-      { op: 'replace', path: ['updatedAt'], value: 123 },
     ]
     const marks = collectDirtyFromSitePatches(patches, site, site)
-    expect(marks).toEqual(emptyDirtyMarks())
+    expect(marks).toEqual({ ...emptyDirtyMarks(), shell: true })
+  })
+
+  it('does NOT mark the shell for updatedAt — bumped by every mutation, bookkeeping not content', () => {
+    const site = twoPageTwoVcSite()
+    const patches: Patches = [{ op: 'replace', path: ['updatedAt'], value: 123 }]
+    expect(collectDirtyFromSitePatches(patches, site, site)).toEqual(emptyDirtyMarks())
   })
 
   it('attributes an element add at [pages, i] to the added page', () => {
@@ -460,12 +465,12 @@ describe('editor store dirty-save tracking', () => {
     expect([...snapshot.deletedPageIds]).toEqual(['page-b'])
   })
 
-  it('shell-only mutations (site rename) accumulate no marks', () => {
+  it('shell-only mutations (site rename) accumulate the shell mark and NO row marks', () => {
     loadTwoPageSite()
     useEditorStore.getState().updateSiteName('Renamed Site')
 
     expect(useEditorStore.getState().site!.name).toBe('Renamed Site')
     expect(useEditorStore.getState().hasUnsavedChanges).toBe(true)
-    expect(dirty()).toEqual(emptyDirtyMarks())
+    expect(dirty()).toEqual({ ...emptyDirtyMarks(), shell: true })
   })
 })

--- a/src/__tests__/editor-store/saveConflicts.test.ts
+++ b/src/__tests__/editor-store/saveConflicts.test.ts
@@ -7,7 +7,7 @@
  *     rows KEEP their entries so a resurrect-by-undo carries the right base),
  *   - resolveSaveConflictKeepMine — bumps the target's base seq so the next
  *     save overwrites as a stated decision; dirty marks stay untouched,
- *   - resolveSaveConflictTheirs — swaps the remote version in (or removes a
+ *   - applyRemoteSnapshot — swaps the remote version in (or removes a
  *     remotely-deleted target), clears the target's dirty marks, syncs the
  *     base seq, clears the undo history, and — for Visual Components —
  *     propagates to consumer pages with REAL dirty marks (slot re-sync /
@@ -118,7 +118,7 @@ describe('resolveSaveConflictKeepMine', () => {
 // Load theirs
 // ---------------------------------------------------------------------------
 
-describe('resolveSaveConflictTheirs', () => {
+describe('applyRemoteSnapshot', () => {
   it('swaps a remote page in, clears its dirty marks, syncs the base seq, clears history', () => {
     loadFixtureSite({ pages: [makePage({ id: 'page-a', title: 'Mine' })] })
     useEditorStore.getState().seedBaseSeqs({ 'page-a': 1 }, 1)
@@ -128,7 +128,7 @@ describe('resolveSaveConflictTheirs', () => {
     expect(useEditorStore.getState()._dirtySave.pageIds.has('page-a')).toBe(true)
     useEditorStore.getState().setSaveConflicts([{ table: 'pages', rowId: 'page-a', seq: 6 }])
 
-    useEditorStore.getState().resolveSaveConflictTheirs({
+    useEditorStore.getState().applyRemoteSnapshot({
       table: 'pages',
       rowId: 'page-a',
       row: makePage({ id: 'page-a', title: 'Theirs' }),
@@ -155,7 +155,7 @@ describe('resolveSaveConflictTheirs', () => {
     useEditorStore.getState().seedBaseSeqs({ 'page-home': 1, 'page-b': 1 }, 1)
     useEditorStore.getState().setActivePage('page-b')
 
-    useEditorStore.getState().resolveSaveConflictTheirs({
+    useEditorStore.getState().applyRemoteSnapshot({
       table: 'pages',
       rowId: 'page-b',
       row: null,
@@ -176,7 +176,7 @@ describe('resolveSaveConflictTheirs', () => {
       return shell
     })()
 
-    useEditorStore.getState().resolveSaveConflictTheirs({
+    useEditorStore.getState().applyRemoteSnapshot({
       table: 'site',
       shell: remoteShell,
       seq: 12,
@@ -205,7 +205,7 @@ describe('resolveSaveConflictTheirs', () => {
     useEditorStore.getState().seedBaseSeqs({ 'page-a': 1, 'vc-1': 1 }, 1)
     useEditorStore.getState().setSaveConflicts([{ table: 'components', rowId: 'vc-1', seq: 4 }])
 
-    useEditorStore.getState().resolveSaveConflictTheirs({
+    useEditorStore.getState().applyRemoteSnapshot({
       table: 'components',
       rowId: 'vc-1',
       row: null,

--- a/src/__tests__/editor-store/siteSyncMerge.test.ts
+++ b/src/__tests__/editor-store/siteSyncMerge.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Live-pull merge policy (multi-admin level B) — processSiteSyncEvent.
+ *
+ * The rule, per event target:
+ *   1. base seq ≥ event seq → skipped entirely (own-save echo, no fetch),
+ *   2. dirty locally → pending conflict, content untouched,
+ *   3. clean → fetch + applyRemoteSnapshot; identical content (echo that
+ *      outran the save response) is bookkeeping-only and PRESERVES history;
+ *      genuinely newer content swaps in and clears history,
+ *   4. dirtiness is re-checked after the fetch — an edit landing mid-wire
+ *      degrades to a conflict, never a silent overwrite.
+ *
+ * Plus: the shell path keys off the dedicated `shell` dirty mark, deletions
+ * remove rows, and the cursor advances with every processed event. The
+ * snapshot fetch is injected (`SiteSyncMergeDeps`) so no HTTP or module
+ * mocking is involved.
+ */
+import { describe, it, expect, beforeEach } from 'bun:test'
+import type { Page } from '@core/page-tree'
+import { useEditorStore } from '@site/store/store'
+import { processSiteSyncEvent, type SiteSyncMergeDeps } from '@site/hooks/siteSyncMerge'
+import type { RemoteSnapshot } from '@site/store/slices/site/types'
+import { makePage, makeSite } from '../fixtures'
+
+function depsReturning(snapshot: RemoteSnapshot): SiteSyncMergeDeps & { calls: number } {
+  const deps = {
+    calls: 0,
+    fetchSnapshot: async () => {
+      deps.calls += 1
+      return snapshot
+    },
+  }
+  return deps
+}
+
+function depsThatMustNotFetch(): SiteSyncMergeDeps {
+  return {
+    fetchSnapshot: () => {
+      throw new Error('fetchSnapshot must not be called for this event')
+    },
+  }
+}
+
+function loadTwoPageSite(): void {
+  useEditorStore.getState().loadSite(
+    makeSite({
+      pages: [
+        makePage({ id: 'page-a', slug: 'index', title: 'Home' }),
+        makePage({ id: 'page-b', slug: 'about', title: 'About' }),
+      ],
+    }),
+  )
+  useEditorStore.getState().seedBaseSeqs({ 'page-a': 5, 'page-b': 5 }, 5)
+}
+
+function remotePage(title: string): Page {
+  return makePage({ id: 'page-a', slug: 'index', title })
+}
+
+beforeEach(() => {
+  useEditorStore.getState().clearSite()
+})
+
+describe('processSiteSyncEvent — rows-changed', () => {
+  it('applies a newer remote row to a clean target and advances the cursor', async () => {
+    loadTwoPageSite()
+    const deps = depsReturning({
+      table: 'pages',
+      rowId: 'page-a',
+      row: remotePage('Home (remote v2)'),
+      seq: 9,
+    })
+
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 9 } },
+      deps,
+    )
+
+    const state = useEditorStore.getState()
+    expect(deps.calls).toBe(1)
+    expect(state.site!.pages.find((p) => p.id === 'page-a')!.title).toBe('Home (remote v2)')
+    expect(state.baseSeqs['page-a']).toBe(9)
+    expect(state.syncCursor).toBe(9)
+    expect(state.saveConflicts).toEqual([])
+  })
+
+  it('skips events at or below the base seq without fetching (own-save echo, fast path)', async () => {
+    loadTwoPageSite()
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 5 } },
+      depsThatMustNotFetch(),
+    )
+    expect(useEditorStore.getState().site!.pages[0].title).toBe('Home')
+  })
+
+  it('degrades to a pending conflict when the target is dirty locally — content untouched, no fetch', async () => {
+    loadTwoPageSite()
+    useEditorStore.getState().renamePage('page-a', 'Home (my edit)')
+
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 9 } },
+      depsThatMustNotFetch(),
+    )
+
+    const state = useEditorStore.getState()
+    expect(state.saveConflicts).toEqual([{ table: 'pages', rowId: 'page-a', seq: 9 }])
+    expect(state.site!.pages.find((p) => p.id === 'page-a')!.title).toBe('Home (my edit)')
+    // The conflict does not stop the cursor — the pending entry carries the info.
+    expect(state.syncCursor).toBe(9)
+  })
+
+  it('re-checks dirtiness AFTER the fetch — an edit landing mid-wire becomes a conflict, not an overwrite', async () => {
+    loadTwoPageSite()
+    const deps: SiteSyncMergeDeps = {
+      fetchSnapshot: async () => {
+        // The user edits while the fetch is on the wire.
+        useEditorStore.getState().renamePage('page-a', 'Home (raced edit)')
+        return { table: 'pages', rowId: 'page-a', row: remotePage('Home (remote)'), seq: 9 }
+      },
+    }
+
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 9 } },
+      deps,
+    )
+
+    const state = useEditorStore.getState()
+    expect(state.site!.pages.find((p) => p.id === 'page-a')!.title).toBe('Home (raced edit)')
+    expect(state.saveConflicts).toEqual([{ table: 'pages', rowId: 'page-a', seq: 9 }])
+  })
+
+  it('an echo with identical content is bookkeeping-only — undo history survives', async () => {
+    loadTwoPageSite()
+    // Real local history on ANOTHER page — must survive the echo.
+    useEditorStore.getState().renamePage('page-b', 'About (edited)')
+    expect(useEditorStore.getState().canUndo).toBe(true)
+
+    // The fetched remote page-a equals the local one byte-for-byte.
+    const local = useEditorStore.getState().site!.pages.find((p) => p.id === 'page-a')!
+    const deps = depsReturning({
+      table: 'pages',
+      rowId: 'page-a',
+      row: structuredClone(local) as Page,
+      seq: 9,
+    })
+
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 9 } },
+      deps,
+    )
+
+    const state = useEditorStore.getState()
+    expect(state.canUndo).toBe(true) // history preserved
+    expect(state.baseSeqs['page-a']).toBe(9) // bookkeeping synced
+  })
+})
+
+describe('processSiteSyncEvent — rows-deleted', () => {
+  it('removes a remotely-deleted clean row without any fetch', async () => {
+    loadTwoPageSite()
+    await processSiteSyncEvent(
+      { kind: 'rows-deleted', table: 'pages', seqs: { 'page-b': 9 } },
+      depsThatMustNotFetch(),
+    )
+
+    const state = useEditorStore.getState()
+    expect(state.site!.pages.map((p) => p.id)).toEqual(['page-a'])
+    expect(state.baseSeqs['page-b']).toBeUndefined()
+    expect(state.syncCursor).toBe(9)
+  })
+
+  it('a remote deletion of a locally-DIRTY row becomes a conflict', async () => {
+    loadTwoPageSite()
+    useEditorStore.getState().renamePage('page-b', 'About (my edit)')
+
+    await processSiteSyncEvent(
+      { kind: 'rows-deleted', table: 'pages', seqs: { 'page-b': 9 } },
+      depsThatMustNotFetch(),
+    )
+
+    const state = useEditorStore.getState()
+    expect(state.site!.pages).toHaveLength(2)
+    expect(state.saveConflicts).toEqual([{ table: 'pages', rowId: 'page-b', seq: 9 }])
+  })
+})
+
+describe('processSiteSyncEvent — shell-changed', () => {
+  it('applies a remote shell when the local shell is untouched', async () => {
+    loadTwoPageSite()
+    const { pages: _p, visualComponents: _v, layouts: _l, ...shell } = makeSite({
+      name: 'Renamed remotely',
+    })
+    const deps = depsReturning({ table: 'site', shell, seq: 9 })
+
+    await processSiteSyncEvent({ kind: 'shell-changed', seq: 9 }, deps)
+
+    const state = useEditorStore.getState()
+    expect(state.site!.name).toBe('Renamed remotely')
+    expect(state.shellBaseSeq).toBe(9)
+    expect(state.syncCursor).toBe(9)
+  })
+
+  it('a dirty local shell degrades to a conflict — the dedicated shell mark gates it', async () => {
+    loadTwoPageSite()
+    // A shell-field mutation sets the shell dirty mark via patch tracking.
+    useEditorStore.getState().updateSiteName('Renamed locally')
+    expect(useEditorStore.getState()._dirtySave.shell).toBe(true)
+
+    await processSiteSyncEvent({ kind: 'shell-changed', seq: 9 }, depsThatMustNotFetch())
+
+    const state = useEditorStore.getState()
+    expect(state.site!.name).toBe('Renamed locally')
+    expect(state.saveConflicts).toEqual([{ table: 'site', rowId: 'default', seq: 9 }])
+  })
+
+  it('a page edit does NOT mark the shell dirty — sibling shell changes still apply live', async () => {
+    loadTwoPageSite()
+    useEditorStore.getState().renamePage('page-a', 'Home (edited)')
+    expect(useEditorStore.getState()._dirtySave.shell).toBe(false)
+  })
+})
+
+describe('processSiteSyncEvent — conflict dedupe', () => {
+  it('repeated events for the same dirty target keep ONE pending conflict at the newest seq', async () => {
+    loadTwoPageSite()
+    useEditorStore.getState().renamePage('page-a', 'Home (my edit)')
+
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 9 } },
+      depsThatMustNotFetch(),
+    )
+    await processSiteSyncEvent(
+      { kind: 'rows-changed', table: 'pages', seqs: { 'page-a': 12 } },
+      depsThatMustNotFetch(),
+    )
+
+    expect(useEditorStore.getState().saveConflicts).toEqual([
+      { table: 'pages', rowId: 'page-a', seq: 12 },
+    ])
+  })
+})
+
+describe('processSiteSyncEvent — aligned deletions', () => {
+  it('a remote deletion of a row this editor ALSO deleted merges silently (agreement, not conflict)', async () => {
+    loadTwoPageSite()
+    useEditorStore.getState().deletePage('page-b')
+    expect(useEditorStore.getState()._dirtySave.deletedPageIds.has('page-b')).toBe(true)
+
+    await processSiteSyncEvent(
+      { kind: 'rows-deleted', table: 'pages', seqs: { 'page-b': 9 } },
+      depsThatMustNotFetch(),
+    )
+
+    const state = useEditorStore.getState()
+    expect(state.saveConflicts).toEqual([])
+    // The now-moot local deletion mark is cleared — nothing left to ship.
+    expect(state._dirtySave.deletedPageIds.has('page-b')).toBe(false)
+    expect(state.baseSeqs['page-b']).toBeUndefined()
+  })
+})

--- a/src/__tests__/server/siteDocumentSave.test.ts
+++ b/src/__tests__/server/siteDocumentSave.test.ts
@@ -948,6 +948,14 @@ describe('site-document save — conflict detection', () => {
         changedPages: [pagePayload('page-a', 'about')],
       }))
       expect(await liveShellSeq(ctx.harness)).toBe(before)
+
+      // The REAL editor bumps `updatedAt` on every mutation — a shell that
+      // differs only by that bookkeeping timestamp is still "unchanged".
+      await expectOk(await putDoc(ctx, {
+        site: { ...ctx.shell, updatedAt: Date.now() + 60_000 },
+        changedPages: [pagePayload('page-a', 'about', 'About v2')],
+      }))
+      expect(await liveShellSeq(ctx.harness)).toBe(before)
     } finally {
       await ctx.harness.cleanup()
     }

--- a/src/__tests__/server/siteSocket.test.ts
+++ b/src/__tests__/server/siteSocket.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Site socket — the live-pull channel's server half (multi-admin level B).
+ *
+ * Covered here:
+ *   - upgrade gating: no session → 401; wrong Origin → 403 (CSWSH defense);
+ *     authenticated non-WS request → 426; authenticated WS handshake →
+ *     upgraded (null),
+ *   - post-commit event emission from the transactional save: rows-changed /
+ *     rows-deleted / shell-changed carry the save's seq and actor; a
+ *     replace-mode save emits ONE site-reloaded; row-only saves emit no
+ *     shell-changed,
+ *   - the reconnect delta (`computeDeltaEvents`): rows past the cursor
+ *     surface as changed/deleted hints (soft-deleted included), the shell
+ *     only when its seq is past the cursor, nothing at the live cursor,
+ *   - a REAL WebSocket round-trip against `Bun.serve`: subscribe → delta,
+ *     then a live save fans out through the bus to the open socket.
+ *
+ * Uses the capability harness for auth/session/save plumbing; the publisher
+ * is injected per test via `setSiteEventPublisher` and detached afterwards
+ * (the module-global default is null — handlers drop events silently).
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import type { SiteShell } from '@core/page-tree'
+import type { SiteSyncEvent } from '@core/persistence/syncEvents'
+import { publishSiteEvent, setSiteEventPublisher, SITE_EVENTS_TOPIC } from '../../../server/events/siteEvents'
+import {
+  computeDeltaEvents,
+  createSiteSocketHandlers,
+  handleSiteSocketUpgrade,
+  SITE_SOCKET_PATH,
+  type SiteSocketData,
+} from '../../../server/events/siteSocket'
+import {
+  createCapabilityTestHarness,
+  readJson,
+  type CapabilityTestHarness,
+} from '../helpers/capabilityHarness'
+
+afterEach(() => {
+  setSiteEventPublisher(null)
+})
+
+// ---------------------------------------------------------------------------
+// Shared save plumbing (mirrors siteDocumentSave.test.ts, trimmed)
+// ---------------------------------------------------------------------------
+
+function pagePayload(id: string, slug: string, title = slug): Record<string, unknown> {
+  const rootId = `root-${id}`
+  return {
+    id,
+    slug,
+    title,
+    rootNodeId: rootId,
+    nodes: {
+      [rootId]: { id: rootId, moduleId: 'base.body', props: {}, breakpointOverrides: {}, children: [] },
+    },
+  }
+}
+
+interface Ctx {
+  harness: CapabilityTestHarness
+  cookie: string
+  shell: SiteShell
+}
+
+async function setupHarness(): Promise<Ctx> {
+  const harness = await createCapabilityTestHarness()
+  const cookie = await harness.setupOwner()
+  const shellRes = await harness.cms('/admin/api/cms/site', { method: 'GET', cookie })
+  const { site: shell } = await readJson<{ site: SiteShell }>(shellRes)
+  return { harness, cookie, shell }
+}
+
+async function liveBaseSeqs(harness: CapabilityTestHarness, ids: string[]): Promise<Record<string, number>> {
+  const { rows } = await harness.db<{ id: string; seq: number }>`select id, seq from data_rows`
+  const wanted = new Set(ids)
+  return Object.fromEntries(rows.filter((r) => wanted.has(r.id)).map((r) => [r.id, Number(r.seq)]))
+}
+
+async function putDoc(
+  ctx: Ctx,
+  overrides: {
+    mode?: 'incremental' | 'replace'
+    site?: unknown
+    changedPages?: unknown[]
+    deletedPageIds?: string[]
+  } = {},
+): Promise<number> {
+  const json = {
+    mode: 'incremental' as const,
+    site: ctx.shell,
+    changedPages: [] as unknown[],
+    deletedPageIds: [] as string[],
+    changedComponents: [],
+    deletedComponentIds: [],
+    changedLayouts: [],
+    deletedLayoutIds: [],
+    ...overrides,
+  }
+  const ids = [
+    ...json.changedPages
+      .map((p) => (p && typeof p === 'object' ? (p as { id?: unknown }).id : undefined))
+      .filter((id): id is string => typeof id === 'string'),
+    ...json.deletedPageIds,
+  ]
+  const res = await ctx.harness.cms('/admin/api/cms/site-document', {
+    method: 'PUT',
+    cookie: ctx.cookie,
+    json: { ...json, baseSeqs: await liveBaseSeqs(ctx.harness, ids), shellBaseSeq: 0 },
+  })
+  expect(res.status).toBe(200)
+  const body = await readJson<{ seq: number }>(res)
+  return body.seq
+}
+
+/** Capture bus output for one test. */
+function captureEvents(): SiteSyncEvent[] {
+  const events: SiteSyncEvent[] = []
+  setSiteEventPublisher({
+    publish: (_topic, data) => {
+      events.push(JSON.parse(data) as SiteSyncEvent)
+      return 0
+    },
+  })
+  return events
+}
+
+// ---------------------------------------------------------------------------
+// Upgrade gating
+// ---------------------------------------------------------------------------
+
+describe('site socket — upgrade gating', () => {
+  function fakeServer(upgradeResult: boolean): { upgrade: () => boolean; upgraded: () => boolean } {
+    let upgraded = false
+    return {
+      upgrade: () => {
+        upgraded = true
+        return upgradeResult
+      },
+      upgraded: () => upgraded,
+    }
+  }
+
+  it('rejects an unauthenticated handshake with 401 before upgrading', async () => {
+    const ctx = await setupHarness()
+    try {
+      const server = fakeServer(true)
+      const res = await handleSiteSocketUpgrade(
+        new Request(`http://localhost${SITE_SOCKET_PATH}`),
+        ctx.harness.db,
+        server,
+      )
+      expect(res?.status).toBe(401)
+      expect(server.upgraded()).toBe(false)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  /** `cookie`/`origin` are fetch-forbidden constructor headers — set after construction. */
+  function socketRequest(headers: Record<string, string>): Request {
+    const req = new Request(`http://localhost${SITE_SOCKET_PATH}`)
+    for (const [name, value] of Object.entries(headers)) req.headers.set(name, value)
+    return req
+  }
+
+  it('rejects a cross-origin handshake with 403 (CSWSH defense) even with a valid session', async () => {
+    const ctx = await setupHarness()
+    try {
+      const server = fakeServer(true)
+      const req = socketRequest({ cookie: ctx.cookie, origin: 'https://evil.example' })
+      const res = await handleSiteSocketUpgrade(req, ctx.harness.db, server)
+      expect(res?.status).toBe(403)
+      expect(server.upgraded()).toBe(false)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('upgrades an authenticated same-origin handshake; a non-WS request gets 426', async () => {
+    const ctx = await setupHarness()
+    try {
+      const req = socketRequest({ cookie: ctx.cookie })
+      expect(await handleSiteSocketUpgrade(req, ctx.harness.db, fakeServer(true))).toBeNull()
+      const rejected = await handleSiteSocketUpgrade(
+        socketRequest({ cookie: ctx.cookie }),
+        ctx.harness.db,
+        fakeServer(false),
+      )
+      expect(rejected?.status).toBe(426)
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Save emission
+// ---------------------------------------------------------------------------
+
+describe('site socket — save event emission', () => {
+  it('an incremental save emits rows-changed/rows-deleted with the save seq and actor, and NO shell event on row-only saves', async () => {
+    const ctx = await setupHarness()
+    try {
+      const events = captureEvents()
+      const createSeq = await putDoc(ctx, { changedPages: [pagePayload('page-a', 'about')] })
+      const deleteSeq = await putDoc(ctx, { deletedPageIds: ['page-a'] })
+
+      expect(events).toEqual([
+        {
+          kind: 'rows-changed',
+          table: 'pages',
+          seqs: { 'page-a': createSeq },
+          actor: { userId: expect.any(String), name: expect.any(String) },
+        },
+        {
+          kind: 'rows-deleted',
+          table: 'pages',
+          seqs: { 'page-a': deleteSeq },
+          actor: { userId: expect.any(String), name: expect.any(String) },
+        },
+      ])
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('a shell change emits shell-changed; a replace-mode save emits ONE site-reloaded', async () => {
+    const ctx = await setupHarness()
+    try {
+      const events = captureEvents()
+      const shellSeq = await putDoc(ctx, { site: { ...ctx.shell, name: 'Renamed' } })
+      expect(events).toEqual([
+        expect.objectContaining({ kind: 'shell-changed', seq: shellSeq }),
+      ])
+
+      events.length = 0
+      const replaceSeq = await putDoc(ctx, {
+        mode: 'replace',
+        site: { ...ctx.shell, name: 'Imported site' },
+        changedPages: [pagePayload('page-b', 'contact')],
+      })
+      expect(events).toEqual([
+        expect.objectContaining({ kind: 'site-reloaded', seq: replaceSeq }),
+      ])
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Reconnect delta
+// ---------------------------------------------------------------------------
+
+describe('site socket — reconnect delta', () => {
+  it('synthesizes changed + deleted row hints past the cursor, and nothing at the live cursor', async () => {
+    const ctx = await setupHarness()
+    try {
+      const seqA = await putDoc(ctx, { changedPages: [pagePayload('page-a', 'about')] })
+      const seqB = await putDoc(ctx, { changedPages: [pagePayload('page-b', 'contact')] })
+      const seqDel = await putDoc(ctx, { deletedPageIds: ['page-a'] })
+
+      // Cursor 0 → everything: page-a surfaces as DELETED (its latest state),
+      // page-b as changed. No shell event — row-only saves never stamped it.
+      const fromZero = await computeDeltaEvents(ctx.harness.db, 0)
+      expect(fromZero).toEqual([
+        { kind: 'rows-changed', table: 'pages', seqs: { 'page-b': seqB } },
+        { kind: 'rows-deleted', table: 'pages', seqs: { 'page-a': seqDel } },
+      ])
+
+      // Mid cursor → only what came after.
+      const fromA = await computeDeltaEvents(ctx.harness.db, seqA)
+      expect(fromA).toEqual([
+        { kind: 'rows-changed', table: 'pages', seqs: { 'page-b': seqB } },
+        { kind: 'rows-deleted', table: 'pages', seqs: { 'page-a': seqDel } },
+      ])
+
+      // Live cursor → empty delta.
+      expect(await computeDeltaEvents(ctx.harness.db, seqDel)).toEqual([])
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+
+  it('includes shell-changed only when the shell seq is past the cursor', async () => {
+    const ctx = await setupHarness()
+    try {
+      const shellSeq = await putDoc(ctx, { site: { ...ctx.shell, name: 'Renamed' } })
+      const delta = await computeDeltaEvents(ctx.harness.db, 0)
+      expect(delta).toEqual([{ kind: 'shell-changed', seq: shellSeq }])
+      expect(await computeDeltaEvents(ctx.harness.db, shellSeq)).toEqual([])
+    } finally {
+      await ctx.harness.cleanup()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Real WebSocket round-trip
+// ---------------------------------------------------------------------------
+
+describe('site socket — WebSocket round-trip', () => {
+  it('subscribe returns the delta, and a live publish fans out to the open socket', async () => {
+    const ctx = await setupHarness()
+    const seqA = await putDoc(ctx, { changedPages: [pagePayload('page-a', 'about')] })
+
+    const server = Bun.serve<SiteSocketData, Record<string, never>>({
+      port: 0,
+      async fetch(req, srv) {
+        const rejection = await handleSiteSocketUpgrade(req, ctx.harness.db, srv)
+        return rejection === null ? undefined : rejection
+      },
+      websocket: createSiteSocketHandlers(ctx.harness.db),
+    })
+
+    try {
+      setSiteEventPublisher(server)
+
+      const received: SiteSyncEvent[] = []
+      const gotDelta = Promise.withResolvers<void>()
+      const gotLive = Promise.withResolvers<void>()
+
+      const ws = new WebSocket(`ws://localhost:${server.port}${SITE_SOCKET_PATH}`, {
+        headers: { cookie: ctx.cookie },
+      })
+      ws.onmessage = (msg) => {
+        received.push(JSON.parse(String(msg.data)) as SiteSyncEvent)
+        if (received.length === 1) gotDelta.resolve()
+        if (received.length === 2) gotLive.resolve()
+      }
+      await new Promise<void>((resolve, reject) => {
+        ws.onopen = () => resolve()
+        ws.onerror = () => reject(new Error('socket failed to open'))
+      })
+
+      ws.send(JSON.stringify({ kind: 'subscribe', cursor: 0 }))
+      await gotDelta.promise
+      expect(received[0]).toEqual({
+        kind: 'rows-changed',
+        table: 'pages',
+        seqs: { 'page-a': seqA },
+      })
+
+      // Live fan-out through the bus (same path the save handler uses).
+      publishSiteEvent({ kind: 'shell-changed', seq: seqA + 1 })
+      await gotLive.promise
+      expect(received[1]).toEqual({ kind: 'shell-changed', seq: seqA + 1 })
+
+      ws.close()
+    } finally {
+      server.stop(true)
+      await ctx.harness.cleanup()
+    }
+  })
+})

--- a/src/admin/layouts/AdminCanvasLayout/AdminCanvasLayout.tsx
+++ b/src/admin/layouts/AdminCanvasLayout/AdminCanvasLayout.tsx
@@ -44,6 +44,7 @@ import { useEditorSelectPreference } from '@admin/pages/site/preferences/editorP
 import { usePersistence } from '@admin/pages/site/hooks/usePersistence'
 import { useSiteEditorUrlSync } from '@admin/pages/site/hooks/useSiteEditorUrlSync'
 import { useEditorLayoutPersistence } from '@admin/pages/site/hooks/useEditorLayoutPersistence'
+import { useSiteSocket } from '@admin/pages/site/hooks/useSiteSocket'
 import { useEditorStore } from '@admin/pages/site/store/store'
 import { cmsAdapter } from '@core/persistence/cms'
 import { useAdminUi } from '@admin/state/adminUi'
@@ -181,6 +182,11 @@ export function AdminCanvasLayout() {
     enabled: true,
     loaded: persistence.saveStatus.state !== 'loading',
   })
+  // Multi-admin live pull — sibling admins' saves merge into this editor as
+  // they land (or surface in the conflict banner when they collide with
+  // local unsaved edits). Gated on the document being loaded: before that
+  // there is no sync cursor to subscribe with.
+  useSiteSocket(site !== null)
   useEditorLayoutPersistence()
   useInstalledEditorPlugins(pluginBackgroundWorkEnabled)
   // Mount the SSE bridge ONCE per admin tab — gives toasts on plugin

--- a/src/admin/pages/site/hooks/remoteSnapshot.ts
+++ b/src/admin/pages/site/hooks/remoteSnapshot.ts
@@ -1,0 +1,55 @@
+/**
+ * fetchRemoteSnapshot — pull the CURRENT server state of one sync target and
+ * convert it to the domain shape `applyRemoteSnapshot` consumes.
+ *
+ * Shared by the conflict banner's "Load theirs" and the live-sync socket's
+ * clean-target pull. Row targets ride the collection GETs' single-row `?id=`
+ * filter; absence (`row: null`) IS the "deleted remotely" signal. The shell
+ * rides `GET /site`, which carries its sync seq.
+ *
+ * The returned seq prefers the FETCHED row's seq over the triggering
+ * event/conflict seq — the row may have moved further since.
+ */
+import { cmsAdapter } from '@core/persistence/cms'
+import { pageFromRow } from '@core/data/pageFromRow'
+import { visualComponentFromRow } from '@core/data/componentFromRow'
+import { savedLayoutFromRow } from '@core/data/layoutFromRow'
+import type { RemoteSnapshot } from '@site/store/slices/site/types'
+
+export interface RemoteSnapshotTarget {
+  table: 'site' | 'pages' | 'components' | 'layouts'
+  rowId: string
+  /** The seq that triggered the fetch — fallback when the target is deleted. */
+  seq: number
+}
+
+/** Row snapshot — the variants of {@link RemoteSnapshot} that carry a `row`. */
+export type RemoteRowSnapshot = Exclude<RemoteSnapshot, { table: 'site' }>
+
+// Overloads: a row-table target provably yields a row snapshot, so callers
+// that never fetch the shell (the socket's row handler) get the narrow type.
+export async function fetchRemoteSnapshot(
+  target: RemoteSnapshotTarget & { table: RemoteRowSnapshot['table'] },
+): Promise<RemoteRowSnapshot>
+export async function fetchRemoteSnapshot(target: RemoteSnapshotTarget): Promise<RemoteSnapshot>
+export async function fetchRemoteSnapshot(target: RemoteSnapshotTarget): Promise<RemoteSnapshot> {
+  if (target.table === 'site') {
+    const remote = await cmsAdapter.loadSiteShell()
+    if (!remote) throw new Error('The site shell no longer exists on the server.')
+    return { table: 'site', shell: remote.shell, seq: remote.seq }
+  }
+  const row = await cmsAdapter.loadSiteRow(target.table, target.rowId)
+  const seq = row?.seq ?? target.seq
+  if (target.table === 'pages') {
+    return { table: 'pages', rowId: target.rowId, row: row ? pageFromRow(row) : null, seq }
+  }
+  if (target.table === 'components') {
+    return {
+      table: 'components',
+      rowId: target.rowId,
+      row: row ? visualComponentFromRow(row) : null,
+      seq,
+    }
+  }
+  return { table: 'layouts', rowId: target.rowId, row: row ? savedLayoutFromRow(row) : null, seq }
+}

--- a/src/admin/pages/site/hooks/siteSocketClient.ts
+++ b/src/admin/pages/site/hooks/siteSocketClient.ts
@@ -1,0 +1,102 @@
+/**
+ * siteSocketClient — the live-pull TRANSPORT of the multi-admin sync channel
+ * (level B of the live-sync plan). Lazy-imported by `useSiteSocket` so the
+ * whole sync machinery (event schemas, merge policy, snapshot fetching)
+ * stays out of the site route's first-paint chunk.
+ *
+ * One WebSocket to `/admin/api/cms/site-socket` with exponential-backoff
+ * reconnect. On every (re)connect it sends the store's seq cursor and the
+ * server replies with the missed delta as ordinary events — the socket is a
+ * HINT channel; the delta query is the truth, so dropped events can never
+ * cause drift (self-healing by design).
+ *
+ * Incoming frames are TypeBox-validated (malformed frames are logged and
+ * dropped) and processed strictly in arrival order through one promise
+ * chain — a fetch for event N never interleaves with the apply of event
+ * N+1. What an event DOES to the store is the merge policy in
+ * `siteSyncMerge.ts`.
+ */
+import { SITE_SOCKET_PATH, SiteSyncEventSchema } from '@core/persistence/syncEvents'
+import { safeParseJson } from '@core/utils/jsonValidate'
+import { getErrorMessage } from '@core/utils/errorMessage'
+import { useEditorStore } from '@site/store/store'
+import { processSiteSyncEvent } from './siteSyncMerge'
+
+const RECONNECT_BASE_DELAY_MS = 1_000
+const RECONNECT_MAX_DELAY_MS = 30_000
+
+/**
+ * Open (and own) the live-sync socket. Returns the disposer that tears the
+ * connection down and stops reconnecting.
+ */
+export function connectSiteSocket(): () => void {
+  let socket: WebSocket | null = null
+  let disposed = false
+  let attempts = 0
+  let reconnectTimer: ReturnType<typeof setTimeout> | undefined
+  let chain: Promise<void> = Promise.resolve()
+
+  function scheduleReconnect() {
+    if (disposed) return
+    // Exponential backoff with jitter, capped — the delta-on-reconnect
+    // protocol makes aggressive retry unnecessary.
+    const delay =
+      Math.min(RECONNECT_MAX_DELAY_MS, RECONNECT_BASE_DELAY_MS * 2 ** attempts) +
+      Math.random() * 500
+    attempts += 1
+    reconnectTimer = setTimeout(connect, delay)
+  }
+
+  function connect() {
+    if (disposed) return
+    const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws'
+    socket = new WebSocket(`${protocol}://${window.location.host}${SITE_SOCKET_PATH}`)
+
+    socket.onopen = () => {
+      attempts = 0
+      socket?.send(
+        JSON.stringify({ kind: 'subscribe', cursor: useEditorStore.getState().syncCursor }),
+      )
+    }
+
+    socket.onmessage = (msg: MessageEvent) => {
+      if (typeof msg.data !== 'string') return // binary frames are not part of the protocol
+      const parsed = safeParseJson(msg.data, SiteSyncEventSchema)
+      if (!parsed.ok) {
+        console.warn('[siteSocketClient] dropping malformed sync event')
+        return
+      }
+      const event = parsed.value
+      chain = chain.then(() =>
+        processSiteSyncEvent(event).catch((err) => {
+          console.error(
+            '[siteSocketClient] failed to apply sync event:',
+            getErrorMessage(err, 'unknown error'),
+            err,
+          )
+        }),
+      )
+    }
+
+    // Errors always surface as a close — reconnect is scheduled there.
+    socket.onerror = () => {}
+
+    socket.onclose = () => {
+      socket = null
+      scheduleReconnect()
+    }
+  }
+
+  connect()
+
+  return () => {
+    disposed = true
+    clearTimeout(reconnectTimer)
+    if (socket) {
+      // Detach first — the close handler would otherwise schedule a
+      // reconnect for a socket we are deliberately tearing down.
+      socket.onclose = null
+      socket.close()
+    }
+  }
+}

--- a/src/admin/pages/site/hooks/siteSyncMerge.ts
+++ b/src/admin/pages/site/hooks/siteSyncMerge.ts
@@ -1,0 +1,197 @@
+/**
+ * siteSyncMerge — the merge POLICY of the live-pull channel: what one
+ * incoming sync event does to the editor store. The transport (WebSocket
+ * lifecycle, ordering, reconnect) lives in `useSiteSocket`; keeping the
+ * policy separate makes it testable with a plain fake snapshot fetcher.
+ *
+ * Merge rule per event target (order matters):
+ *   1. base seq already ≥ event seq → skip. Absorbs the echo of this
+ *      editor's own saves when the save response beat the event.
+ *   2. target dirty locally → do NOT touch it; add a pending conflict — the
+ *      same banner as a 409'd save, one resolution UX for levels A and B.
+ *   3. clean → fetch the current remote state and `applyRemoteSnapshot` it.
+ *      Dirtiness is re-checked after the fetch (an edit can land mid-wire).
+ *      The apply deep-equal-skips identical content (own-save echoes that
+ *      outran the response), so undo history only resets when remote content
+ *      genuinely replaced local state — and the toast fires exactly then.
+ *
+ * `site-reloaded` (replace-mode save — import/bootstrap) hands off to the
+ * ordinary persistence reload path. `published` is informational.
+ */
+import type { SiteSyncEvent, SiteSyncTable } from '@core/persistence/syncEvents'
+import { pushToast } from '@ui/components/Toast'
+import { requestCmsSiteReload } from '@admin/state/adminEvents'
+import { useEditorStore } from '@site/store/store'
+import type { RemoteSnapshot } from '@site/store/slices/site/types'
+import { fetchRemoteSnapshot, type RemoteSnapshotTarget } from './remoteSnapshot'
+
+/** Injectable fetch seam — tests hand in a fake that returns domain snapshots. */
+export interface SiteSyncMergeDeps {
+  fetchSnapshot: (target: RemoteSnapshotTarget) => Promise<RemoteSnapshot>
+}
+
+const defaultDeps: SiteSyncMergeDeps = { fetchSnapshot: fetchRemoteSnapshot }
+
+function isTargetDirty(table: SiteSyncTable, rowId: string): boolean {
+  const { _dirtySave } = useEditorStore.getState()
+  if (_dirtySave.all) return true
+  if (table === 'pages') {
+    return _dirtySave.pageIds.has(rowId) || _dirtySave.deletedPageIds.has(rowId)
+  }
+  if (table === 'components') {
+    return _dirtySave.componentIds.has(rowId) || _dirtySave.deletedComponentIds.has(rowId)
+  }
+  return _dirtySave.layoutIds.has(rowId) || _dirtySave.deletedLayoutIds.has(rowId)
+}
+
+/**
+ * True when the target's only local dirtiness is its own pending DELETION —
+ * a remote deletion of the same row is then agreement, not a conflict, and
+ * merges silently (the apply clears the now-moot deleted mark).
+ */
+function isOnlyLocallyDeleted(table: SiteSyncTable, rowId: string): boolean {
+  const { _dirtySave } = useEditorStore.getState()
+  if (_dirtySave.all) return false
+  if (table === 'pages') {
+    return _dirtySave.deletedPageIds.has(rowId) && !_dirtySave.pageIds.has(rowId)
+  }
+  if (table === 'components') {
+    return _dirtySave.deletedComponentIds.has(rowId) && !_dirtySave.componentIds.has(rowId)
+  }
+  return _dirtySave.deletedLayoutIds.has(rowId) && !_dirtySave.layoutIds.has(rowId)
+}
+
+/** Local display title of a row — for the remote-change toasts. */
+function localRowTitle(table: SiteSyncTable, rowId: string): string | null {
+  const site = useEditorStore.getState().site
+  if (!site) return null
+  if (table === 'pages') return site.pages.find((p) => p.id === rowId)?.title ?? null
+  if (table === 'components') {
+    return site.visualComponents.find((vc) => vc.id === rowId)?.name ?? null
+  }
+  return site.layouts.find((layout) => layout.id === rowId)?.name ?? null
+}
+
+async function handleRowEvent(
+  table: SiteSyncTable,
+  rowId: string,
+  seq: number,
+  deletedRemotely: boolean,
+  actorName: string | undefined,
+  deps: SiteSyncMergeDeps,
+): Promise<void> {
+  const store = useEditorStore.getState()
+  if ((store.baseSeqs[rowId] ?? -1) >= seq) return // own write / already applied
+  if (isTargetDirty(table, rowId)) {
+    // Exception: both sides deleted the row — agreement merges silently.
+    if (!(deletedRemotely && isOnlyLocallyDeleted(table, rowId))) {
+      store.addSaveConflicts([{ table, rowId, seq }])
+      return
+    }
+  }
+
+  const wasActivePage = table === 'pages' && store.activePageId === rowId
+  const title = localRowTitle(table, rowId)
+
+  let snapshot: RemoteSnapshot
+  if (deletedRemotely) {
+    // No fetch — the snapshot is synchronous, so nothing can interleave
+    // between the dirty check above and the apply below.
+    snapshot = { table, rowId, row: null, seq }
+  } else {
+    snapshot = await deps.fetchSnapshot({ table, rowId, seq })
+    // An edit may have landed while the fetch was on the wire — a dirty
+    // target must never be silently overwritten, so it degrades to a conflict.
+    if (isTargetDirty(table, rowId)) {
+      useEditorStore.getState().addSaveConflicts([{ table, rowId, seq }])
+      return
+    }
+  }
+
+  const result = useEditorStore.getState().applyRemoteSnapshot(snapshot)
+  if (!result.applied) return
+
+  const who = actorName ?? 'Another admin'
+  if (snapshot.table !== 'site' && snapshot.row === null && wasActivePage) {
+    pushToast({
+      kind: 'info',
+      title: 'Page deleted',
+      body: `${who} deleted ${title ? `"${title}"` : 'the page you were viewing'}.`,
+    })
+  } else if (result.clearedHistory) {
+    pushToast({
+      kind: 'info',
+      title: 'Updated with newer changes',
+      body: `${who} saved ${title ? `"${title}"` : 'content you have open'} — your undo history was reset.`,
+    })
+  }
+}
+
+async function handleShellEvent(
+  seq: number,
+  actorName: string | undefined,
+  deps: SiteSyncMergeDeps,
+): Promise<void> {
+  const store = useEditorStore.getState()
+  if (store.shellBaseSeq >= seq) return
+  if (store._dirtySave.shell || store._dirtySave.all) {
+    store.addSaveConflicts([{ table: 'site', rowId: 'default', seq }])
+    return
+  }
+
+  const snapshot = await deps.fetchSnapshot({ table: 'site', rowId: 'default', seq })
+  const after = useEditorStore.getState()
+  if (after._dirtySave.shell || after._dirtySave.all) {
+    after.addSaveConflicts([{ table: 'site', rowId: 'default', seq }])
+    return
+  }
+
+  const result = after.applyRemoteSnapshot(snapshot)
+  if (result.applied && result.clearedHistory) {
+    pushToast({
+      kind: 'info',
+      title: 'Site settings updated',
+      body: `${actorName ?? 'Another admin'} changed site settings or styles — your undo history was reset.`,
+    })
+  }
+}
+
+/** Apply one validated sync event to the editor store (see module doc). */
+export async function processSiteSyncEvent(
+  event: SiteSyncEvent,
+  deps: SiteSyncMergeDeps = defaultDeps,
+): Promise<void> {
+  switch (event.kind) {
+    case 'rows-changed':
+    case 'rows-deleted': {
+      const deletedRemotely = event.kind === 'rows-deleted'
+      for (const [rowId, seq] of Object.entries(event.seqs)) {
+        await handleRowEvent(event.table, rowId, seq, deletedRemotely, event.actor?.name, deps)
+      }
+      useEditorStore.getState().advanceSyncCursor(Math.max(...Object.values(event.seqs), 0))
+      break
+    }
+    case 'shell-changed': {
+      await handleShellEvent(event.seq, event.actor?.name, deps)
+      useEditorStore.getState().advanceSyncCursor(event.seq)
+      break
+    }
+    case 'site-reloaded': {
+      const store = useEditorStore.getState()
+      if (store.syncCursor >= event.seq) break
+      store.advanceSyncCursor(event.seq)
+      pushToast({
+        kind: 'info',
+        title: 'Site replaced',
+        body: `${event.actor?.name ?? 'Another admin'} replaced the site (import) — reloading the editor.`,
+      })
+      // The ordinary reload path refetches, revalidates, and reseeds the
+      // sync bases; local unsaved edits are moot against a replaced site.
+      requestCmsSiteReload()
+      break
+    }
+    case 'published':
+      // Informational — no editor state derives from the publish version yet.
+      break
+  }
+}

--- a/src/admin/pages/site/hooks/useSiteSocket.ts
+++ b/src/admin/pages/site/hooks/useSiteSocket.ts
@@ -1,0 +1,35 @@
+/**
+ * useSiteSocket — lifecycle glue for the live-pull channel (multi-admin
+ * level B). The actual transport + merge machinery lives in
+ * `siteSocketClient.ts` / `siteSyncMerge.ts` and is LAZY-imported here so
+ * its chunk (event schemas, snapshot fetching, conflict plumbing) stays out
+ * of the site route's first-paint bundle.
+ *
+ * `enabled` gates on the site document being loaded — before that there is
+ * no sync cursor to subscribe with and nothing to merge into.
+ */
+import { useEffect } from 'react'
+
+export function useSiteSocket(enabled: boolean): void {
+  useEffect(() => {
+    if (!enabled) return undefined
+    if (typeof WebSocket === 'undefined') return undefined
+
+    let dispose: (() => void) | null = null
+    let cancelled = false
+
+    void import('./siteSocketClient')
+      .then((mod) => {
+        if (cancelled) return
+        dispose = mod.connectSiteSocket()
+      })
+      .catch((err) => {
+        console.error('[useSiteSocket] failed to load the sync client:', err)
+      })
+
+    return () => {
+      cancelled = true
+      dispose?.()
+    }
+  }, [enabled])
+}

--- a/src/admin/pages/site/store/slices/saveTrackingSlice.ts
+++ b/src/admin/pages/site/store/slices/saveTrackingSlice.ts
@@ -65,6 +65,21 @@ interface SaveTrackingSlice {
    * Autosave is suppressed while non-empty; a successful save clears it.
    */
   saveConflicts: SaveConflict[]
+  /**
+   * The highest site-global seq this editor has synchronized — the cursor
+   * the live-sync socket sends on (re)connect so the server can reply with
+   * exactly the delta it missed. Advanced by loads, save responses, and
+   * every processed sync event.
+   */
+  syncCursor: number
+  /** Advance the sync cursor (monotonic — lower values are ignored). */
+  advanceSyncCursor: (seq: number) => void
+  /**
+   * Merge incoming conflicts (from live-sync events) into the pending list —
+   * deduped by table+rowId, keeping the newest seq. `setSaveConflicts`
+   * REPLACES the list and stays the 409 handler's entry point.
+   */
+  addSaveConflicts: (conflicts: readonly SaveConflict[]) => void
   /** Replace the base-seq maps wholesale — the load/reload path. */
   seedBaseSeqs: (rowSeqs: Record<string, number>, shellSeq: number) => void
   /**
@@ -93,6 +108,7 @@ function nettedDirtySnapshot(current: DirtyMarks, site: SiteDocument | null): Di
     // No document to net against — return the marks as accumulated.
     return {
       all: current.all,
+      shell: current.shell,
       pageIds: new Set(current.pageIds),
       componentIds: new Set(current.componentIds),
       layoutIds: new Set(current.layoutIds),
@@ -106,6 +122,7 @@ function nettedDirtySnapshot(current: DirtyMarks, site: SiteDocument | null): Di
   const layoutIds = new Set(site.layouts.map((l) => l.id))
   return {
     all: current.all,
+    shell: current.shell,
     pageIds: filteredSet(current.pageIds, (id) => pageIds.has(id)),
     componentIds: filteredSet(current.componentIds, (id) => componentIds.has(id)),
     layoutIds: filteredSet(current.layoutIds, (id) => layoutIds.has(id)),
@@ -152,11 +169,32 @@ export const createSaveTrackingSlice: EditorStoreSliceCreator<SaveTrackingSlice>
   baseSeqs: {},
   shellBaseSeq: 0,
   saveConflicts: [],
+  syncCursor: 0,
+
+  advanceSyncCursor: (seq) =>
+    set((state) => {
+      if (seq > state.syncCursor) state.syncCursor = seq
+    }),
+
+  addSaveConflicts: (conflicts) =>
+    set((state) => {
+      for (const incoming of conflicts) {
+        const existing = state.saveConflicts.find(
+          (c) => c.table === incoming.table && c.rowId === incoming.rowId,
+        )
+        if (existing) {
+          existing.seq = Math.max(existing.seq, incoming.seq)
+        } else {
+          state.saveConflicts.push({ ...incoming })
+        }
+      }
+    }),
 
   seedBaseSeqs: (rowSeqs, shellSeq) =>
     set((state) => {
       state.baseSeqs = { ...rowSeqs }
       state.shellBaseSeq = shellSeq
+      state.syncCursor = Math.max(shellSeq, ...Object.values(rowSeqs), 0)
     }),
 
   commitSavedBaseSeqs: (savedSite, dirty, seq) =>
@@ -180,6 +218,7 @@ export const createSaveTrackingSlice: EditorStoreSliceCreator<SaveTrackingSlice>
       // unchanged): the stored shell seq then stays BELOW this save's seq,
       // and the conflict check only fires on stored > base.
       state.shellBaseSeq = seq
+      if (seq > state.syncCursor) state.syncCursor = seq
       // A successful save proves no shipped row conflicted — stale banner
       // entries (all conflicts come from shipped rows) are moot.
       state.saveConflicts = []

--- a/src/admin/pages/site/store/slices/site/conflictActions.ts
+++ b/src/admin/pages/site/store/slices/site/conflictActions.ts
@@ -1,23 +1,24 @@
 /**
- * Save-conflict resolution actions — multi-admin conflict safety (level A).
+ * Remote-apply + save-conflict resolution actions (multi-admin levels A+B).
  *
- * When an incremental save 409s, the failed save restores its dirty marks and
- * `setSaveConflicts` fills the pending list; the conflict banner then offers
- * two resolutions per conflicted target:
+ * `applyRemoteSnapshot` is the ONE way remote state enters the live editor
+ * document. Two callers share it:
+ *   - the conflict banner's **Load theirs** (level A) — the user explicitly
+ *     discards their local edits to one conflicted target;
+ *   - the live-sync socket's **clean-target pull** (level B) — a sibling
+ *     admin saved a row this editor holds clean, so it merges in place.
  *
- *   Keep mine   — bump the target's base seq to the remote seq. The local
- *                 edits stay dirty and the NEXT save overwrites the remote
- *                 version — a stated decision instead of a silent one.
- *   Load theirs — the banner fetches the remote state and hands it here as a
- *                 `RemoteConflictSnapshot`; the target is swapped in place
- *                 (or removed, when deleted remotely) WITHOUT undo history,
- *                 its dirty marks are cleared, and the base seq syncs to the
- *                 remote seq.
- *
- * Both resolutions clear the undo history: history entries are site-relative
- * Mutative patches with array indices — replaying them across a remotely
- * swapped tree is undefined behavior. (Keep-mine keeps the local document
- * intact, so its history survives.)
+ * Apply semantics:
+ *   - the target is swapped in (or removed, when deleted remotely) WITHOUT
+ *     pushing undo history; its dirty marks, base seq, and any pending
+ *     conflict entry are synchronized;
+ *   - the undo history is cleared — history entries are site-relative
+ *     Mutative patches with array indices, and replaying them across a
+ *     remotely swapped tree is undefined behavior;
+ *   - EXCEPT when the fetched remote content deep-equals the local copy.
+ *     That is exactly what the echo of this editor's own save looks like
+ *     (the socket event can arrive before the save response), so the apply
+ *     collapses to bookkeeping — and the user's undo history survives.
  *
  * VC consumer propagation: adopting a remote Visual Component re-syncs the
  * slot instances of every ref to it, and adopting a remote VC DELETION
@@ -25,12 +26,19 @@
  * pages earn REAL dirty marks (they now differ from storage and must ship
  * with the next save). The history entries those mutations push are cleared
  * along with everything else.
+ *
+ * `resolveSaveConflictKeepMine` (level A) is the other resolution: bump the
+ * target's base seq so the NEXT save overwrites the remote version — a
+ * stated decision instead of a silent one. Local state stays untouched, so
+ * its history survives.
  */
 
 import type { BaseNode } from '@core/page-tree'
 import { findHomePage, reconcileSiteExplorerInPlace, reindexNodeParents } from '@core/page-tree'
+import { shellsEqual } from '@core/persistence/shellsEqual'
 import { clonePackageJson } from '@core/site-dependencies/manifest'
 import { cloneSiteRuntimeConfig } from '@core/site-runtime'
+import { deepEqual } from '@core/utils/deepEqual'
 import type { EditorStore } from '@site/store/types'
 import type { Draft } from 'mutative'
 import { renderCache } from '@site/canvas/renderCache'
@@ -38,11 +46,11 @@ import { clearCanvasSelectionDraft } from '../selectionSlice'
 import { allTreeNodeMaps, syncAllVCRefSlotInstances } from '../vcSlotReconcile'
 import { cascadeRemoveVCRefs } from '../vcTreeOps'
 import { reconcileFrameworkClasses } from './framework/reconcile'
-import type { SiteSlice, SiteSliceHelpers } from './types'
+import type { RemoteSnapshot, SiteSlice, SiteSliceHelpers } from './types'
 
 type ConflictActions = Pick<
   SiteSlice,
-  'setSaveConflicts' | 'resolveSaveConflictKeepMine' | 'resolveSaveConflictTheirs'
+  'setSaveConflicts' | 'resolveSaveConflictKeepMine' | 'applyRemoteSnapshot'
 >
 
 function dropConflict(state: Draft<EditorStore>, table: string, rowId: string): void {
@@ -59,7 +67,38 @@ function clearUndoHistory(state: Draft<EditorStore>): void {
   state.canRedo = false
 }
 
-export function createConflictActions({ set, mutateSite }: SiteSliceHelpers): ConflictActions {
+/** The snapshot's target rowId — the shell lives on the fixed 'default' row. */
+function snapshotRowId(snapshot: RemoteSnapshot): string {
+  return snapshot.table === 'site' ? 'default' : snapshot.rowId
+}
+
+/**
+ * True when the remote snapshot is content-identical to the local document —
+ * the apply can collapse to bookkeeping (see module doc). For a remote
+ * deletion, "identical" means the target is already absent locally.
+ */
+function snapshotMatchesLocal(
+  site: EditorStore['site'],
+  snapshot: RemoteSnapshot,
+): boolean {
+  if (!site) return false
+  if (snapshot.table === 'site') {
+    const { pages: _p, visualComponents: _v, layouts: _l, ...localShell } = site
+    // shellsEqual ignores `updatedAt` — bumped by every local mutation, so a
+    // plain deep-equal would misread every own-save echo as a remote change.
+    return shellsEqual(localShell, snapshot.shell)
+  }
+  const local =
+    snapshot.table === 'pages'
+      ? site.pages.find((p) => p.id === snapshot.rowId)
+      : snapshot.table === 'components'
+        ? site.visualComponents.find((vc) => vc.id === snapshot.rowId)
+        : site.layouts.find((layout) => layout.id === snapshot.rowId)
+  if (snapshot.row === null) return local === undefined
+  return local !== undefined && deepEqual(local, snapshot.row)
+}
+
+export function createConflictActions({ set, get, mutateSite }: SiteSliceHelpers): ConflictActions {
   return {
     setSaveConflicts: (conflicts) =>
       set((state) => {
@@ -81,7 +120,41 @@ export function createConflictActions({ set, mutateSite }: SiteSliceHelpers): Co
         // next save ships the same rows and now passes the seq check.
       }),
 
-    resolveSaveConflictTheirs: (snapshot) => {
+    applyRemoteSnapshot: (snapshot) => {
+      // Echo / no-op detection BEFORE any mutation: identical content means
+      // this editor is already synchronized (typically its own save echoing
+      // back through the socket) — sync the bookkeeping, keep the history.
+      if (snapshotMatchesLocal(get().site, snapshot)) {
+        set((state) => {
+          dropConflict(state, snapshot.table, snapshotRowId(snapshot))
+          if (snapshot.table === 'site') {
+            state.shellBaseSeq = Math.max(state.shellBaseSeq, snapshot.seq)
+          } else if (snapshot.row === null) {
+            delete state.baseSeqs[snapshot.rowId]
+            // Aligned deletion (both sides deleted) — nothing left to ship.
+            const deletedMarks =
+              snapshot.table === 'pages'
+                ? state._dirtySave.deletedPageIds
+                : snapshot.table === 'components'
+                  ? state._dirtySave.deletedComponentIds
+                  : state._dirtySave.deletedLayoutIds
+            deletedMarks.delete(snapshot.rowId)
+          } else {
+            state.baseSeqs[snapshot.rowId] = Math.max(
+              state.baseSeqs[snapshot.rowId] ?? 0,
+              snapshot.seq,
+            )
+          }
+        })
+        return { applied: false, clearedHistory: false }
+      }
+
+      // Read BEFORE the VC propagation below — `clearedHistory` reports
+      // whether the USER's undo entries were discarded, not the propagation's
+      // own transient entry.
+      const hadHistory =
+        get()._historyPast.length > 0 || get()._historyFuture.length > 0
+
       // Consumer propagation FIRST (see module doc): mutateSite gives the
       // affected pages real patch-derived dirty marks. Neither helper needs
       // the VC swapped in yet — the sync takes the remote VC as an argument,
@@ -112,7 +185,7 @@ export function createConflictActions({ set, mutateSite }: SiteSliceHelpers): Co
       set((state) => {
         const site = state.site
         if (!site) return
-        dropConflict(state, snapshot.table, snapshot.table === 'site' ? 'default' : snapshot.rowId)
+        dropConflict(state, snapshot.table, snapshotRowId(snapshot))
 
         switch (snapshot.table) {
           case 'site': {
@@ -205,6 +278,8 @@ export function createConflictActions({ set, mutateSite }: SiteSliceHelpers): Co
 
         clearUndoHistory(state)
       })
+
+      return { applied: true, clearedHistory: hadHistory }
     },
   }
 }

--- a/src/admin/pages/site/store/slices/site/dirtyTracking.ts
+++ b/src/admin/pages/site/store/slices/site/dirtyTracking.ts
@@ -42,6 +42,15 @@ import type { SiteDocument } from '@core/page-tree'
 
 export interface DirtyMarks {
   all: boolean
+  /**
+   * A shell field (settings, style rules, files, breakpoints, explorer, …)
+   * changed since the last successful save. The shell still SHIPS with every
+   * save regardless (the server skips writing an unchanged shell) — this
+   * mark exists for the live-sync merge rule: a remote `shell-changed` event
+   * applies silently when the local shell is untouched, and surfaces as a
+   * conflict when it isn't.
+   */
+  shell: boolean
   pageIds: Set<string>
   componentIds: Set<string>
   layoutIds: Set<string>
@@ -53,6 +62,7 @@ export interface DirtyMarks {
 export function emptyDirtyMarks(): DirtyMarks {
   return {
     all: false,
+    shell: false,
     pageIds: new Set(),
     componentIds: new Set(),
     layoutIds: new Set(),
@@ -122,7 +132,18 @@ export function collectDirtyFromSitePatches(
 
   for (const patch of patches) {
     const head = patch.path[0]
-    if (!TRACKED_COLLECTIONS.includes(head as TrackedCollection)) continue // shell field — always saved
+    if (!TRACKED_COLLECTIONS.includes(head as TrackedCollection)) {
+      // `updatedAt` is bumped by EVERY historic mutation (page edits
+      // included) — it is bookkeeping, not shell content, and must not make
+      // every edit look like a shell edit (the server's `shellsEqual`
+      // ignores it for the same reason).
+      if (head !== 'updatedAt') {
+        // Shell field — always shipped with the save; the mark feeds the
+        // live-sync merge rule (see the DirtyMarks doc).
+        marks.shell = true
+      }
+      continue
+    }
     const collection = head as TrackedCollection
 
     // Membership-shaped ops → pre/post id-set diff, once per collection.
@@ -162,6 +183,7 @@ export function collectDirtyFromSitePatches(
 /** Merge `incoming` into a draft's accumulated dirty state, in place. */
 export function mergeDirtyMarks(target: DirtyMarks, incoming: DirtyMarks): void {
   if (incoming.all) target.all = true
+  if (incoming.shell) target.shell = true
   for (const id of incoming.pageIds) target.pageIds.add(id)
   for (const id of incoming.componentIds) target.componentIds.add(id)
   for (const id of incoming.layoutIds) target.layoutIds.add(id)

--- a/src/admin/pages/site/store/slices/site/lifecycleActions.ts
+++ b/src/admin/pages/site/store/slices/site/lifecycleActions.ts
@@ -70,6 +70,7 @@ export function createLifecycleActions({
         state.baseSeqs = {}
         state.shellBaseSeq = 0
         state.saveConflicts = []
+        state.syncCursor = 0
       })
       return site
     },
@@ -106,6 +107,7 @@ export function createLifecycleActions({
         state.baseSeqs = {}
         state.shellBaseSeq = 0
         state.saveConflicts = []
+        state.syncCursor = 0
       })
     },
 
@@ -127,6 +129,7 @@ export function createLifecycleActions({
         state.baseSeqs = {}
         state.shellBaseSeq = 0
         state.saveConflicts = []
+        state.syncCursor = 0
       })
     },
 

--- a/src/admin/pages/site/store/slices/site/types.ts
+++ b/src/admin/pages/site/store/slices/site/types.ts
@@ -36,15 +36,24 @@ import type { FrameworkChangeImpact, FrameworkPreset } from '@core/framework'
 import type { EditorStore } from '@site/store/types'
 
 /**
- * The remote ("theirs") state of one conflicted target, fetched by the
- * conflict banner for `resolveSaveConflictTheirs`. `row: null` means the
- * target was deleted remotely — resolution removes it locally.
+ * The fetched remote state of one sync target — consumed by
+ * `applyRemoteSnapshot`, which serves both the conflict banner's
+ * "Load theirs" and the live-sync socket's clean-row pull. `row: null`
+ * means the target was deleted remotely — applying removes it locally.
  */
-export type RemoteConflictSnapshot =
+export type RemoteSnapshot =
   | { table: 'site'; shell: SiteShell; seq: number }
   | { table: 'pages'; rowId: string; row: Page | null; seq: number }
   | { table: 'components'; rowId: string; row: VisualComponent | null; seq: number }
   | { table: 'layouts'; rowId: string; row: SavedLayout | null; seq: number }
+
+/** What `applyRemoteSnapshot` actually did — the socket hook toasts on it. */
+export interface RemoteApplyResult {
+  /** False when the snapshot deep-equaled local state (echo) — bookkeeping only. */
+  applied: boolean
+  /** True when undo entries existed and were discarded by the apply. */
+  clearedHistory: boolean
+}
 
 
 // ---------------------------------------------------------------------------
@@ -153,12 +162,16 @@ export interface SiteSlice {
    */
   resolveSaveConflictKeepMine: (conflict: SaveConflict) => void
   /**
-   * Adopt the remote version: swap it into the document (or remove the
-   * target when deleted remotely) without pushing undo history, clear the
-   * target's dirty marks, and sync the base seq. Clears the undo history —
-   * site-relative patches are undefined across a remotely swapped tree.
+   * Adopt a remote version: swap it into the document (or remove the target
+   * when deleted remotely) without pushing undo history, clear the target's
+   * dirty marks and any pending conflict for it, and sync the base seq.
+   * Clears the undo history — site-relative patches are undefined across a
+   * remotely swapped tree — EXCEPT when the remote content deep-equals the
+   * local copy (the echo of one's own save), which is bookkeeping-only.
+   * Serves the conflict banner's "Load theirs" AND the live-sync socket's
+   * clean-target pull.
    */
-  resolveSaveConflictTheirs: (snapshot: RemoteConflictSnapshot) => void
+  applyRemoteSnapshot: (snapshot: RemoteSnapshot) => RemoteApplyResult
 
   // Page mutations
   addPage: (title: string, slug?: string) => Page

--- a/src/admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner.tsx
+++ b/src/admin/pages/site/ui/SaveConflictBanner/SaveConflictBanner.tsx
@@ -8,7 +8,7 @@
  * the two resolutions:
  *
  *   Load theirs — fetch the remote state (single-row `?id=` fetch, or the
- *                 shell GET) and adopt it via `resolveSaveConflictTheirs`,
+ *                 shell GET) and adopt it via `applyRemoteSnapshot`,
  *                 discarding the local unsaved edits to that target only.
  *   Keep mine   — `resolveSaveConflictKeepMine` bumps the base seq; the next
  *                 save overwrites the remote version as a stated decision.
@@ -25,15 +25,11 @@
 import { useState } from 'react'
 import type { SiteDocument } from '@core/page-tree'
 import type { SaveConflict } from '@core/persistence/saveConflict'
-import { cmsAdapter } from '@core/persistence/cms'
-import { pageFromRow } from '@core/data/pageFromRow'
-import { visualComponentFromRow } from '@core/data/componentFromRow'
-import { savedLayoutFromRow } from '@core/data/layoutFromRow'
 import { getErrorMessage } from '@core/utils/errorMessage'
 import { Button } from '@ui/components/Button'
 import { pushToast } from '@ui/components/Toast'
 import { useEditorStore } from '@site/store/store'
-import type { RemoteConflictSnapshot } from '@site/store/slices/site/types'
+import { fetchRemoteSnapshot } from '@site/hooks/remoteSnapshot'
 import { flushEditorSave } from '@site/hooks/editorSaveRef'
 import styles from './SaveConflictBanner.module.css'
 
@@ -57,29 +53,6 @@ function conflictLabel(site: SiteDocument | null, conflict: SaveConflict): strin
   return site.layouts.find((layout) => layout.id === conflict.rowId)?.name ?? conflict.rowId
 }
 
-/** Fetch the remote ("theirs") state of one conflicted target. */
-async function fetchRemoteSnapshot(conflict: SaveConflict): Promise<RemoteConflictSnapshot> {
-  if (conflict.table === 'site') {
-    const remote = await cmsAdapter.loadSiteShell()
-    if (!remote) throw new Error('The site shell no longer exists on the server.')
-    return { table: 'site', shell: remote.shell, seq: remote.seq }
-  }
-  const row = await cmsAdapter.loadSiteRow(conflict.table, conflict.rowId)
-  const seq = row?.seq ?? conflict.seq
-  if (conflict.table === 'pages') {
-    return { table: 'pages', rowId: conflict.rowId, row: row ? pageFromRow(row) : null, seq }
-  }
-  if (conflict.table === 'components') {
-    return {
-      table: 'components',
-      rowId: conflict.rowId,
-      row: row ? visualComponentFromRow(row) : null,
-      seq,
-    }
-  }
-  return { table: 'layouts', rowId: conflict.rowId, row: row ? savedLayoutFromRow(row) : null, seq }
-}
-
 /** Ship the surviving local edits once the last conflict is decided. */
 async function flushIfResolved(): Promise<void> {
   const { saveConflicts, hasUnsavedChanges } = useEditorStore.getState()
@@ -99,7 +72,7 @@ export function SaveConflictBanner() {
     setBusyKey(`${conflict.table}:${conflict.rowId}`)
     try {
       const snapshot = await fetchRemoteSnapshot(conflict)
-      useEditorStore.getState().resolveSaveConflictTheirs(snapshot)
+      useEditorStore.getState().applyRemoteSnapshot(snapshot)
       await flushIfResolved()
     } catch (err) {
       console.error('[SaveConflictBanner] failed to load the remote version:', err)

--- a/src/core/persistence/shellsEqual.ts
+++ b/src/core/persistence/shellsEqual.ts
@@ -1,0 +1,18 @@
+/**
+ * Shell content equality — shared by the transactional save (server skips
+ * the shell write + seq stamp when nothing changed) and the editor's
+ * remote-apply echo detection (identical shells are bookkeeping-only, no
+ * undo-history reset).
+ *
+ * `updatedAt` is deliberately EXCLUDED: the editor bumps it on every historic
+ * mutation (page edits included), so treating it as content would turn every
+ * save into a "shell change" and destroy the shell seq as a conflict signal.
+ * The stored shell's `updatedAt` consequently means "when shell CONTENT last
+ * changed".
+ */
+import type { SiteShell } from '@core/page-tree'
+import { deepEqual } from '@core/utils/deepEqual'
+
+export function shellsEqual(a: SiteShell, b: SiteShell): boolean {
+  return deepEqual({ ...a, updatedAt: 0 }, { ...b, updatedAt: 0 })
+}

--- a/src/core/persistence/syncEvents.ts
+++ b/src/core/persistence/syncEvents.ts
@@ -1,0 +1,93 @@
+/**
+ * Site sync-event protocol — the wire shapes of the multi-admin live-pull
+ * channel (`GET /admin/api/cms/site-socket`, level B of the live-sync plan).
+ *
+ * Design rules (from the live-sync plan):
+ *   - Events carry **ids + seqs, never row payloads**. They are idempotent
+ *     HINTS — the client fetches current rows itself, so a dropped, replayed,
+ *     or reordered event can never corrupt state. The seq-cursor delta on
+ *     (re)connect is the truth; the socket only makes it prompt.
+ *   - One save's rows share that save's seq; delta-synthesized events (sent
+ *     in response to `subscribe`) may span many saves, hence per-row seqs.
+ *   - `actor` is display-level identity for the awareness UI. Absent on
+ *     delta-synthesized events (the originating save is no longer known).
+ *
+ * The server constructs these events (server/events/siteEvents.ts emits them
+ * post-commit from the transactional save); the client validates every
+ * incoming frame against `SiteSyncEventSchema` before acting — an unknown or
+ * malformed frame is logged and dropped, never applied.
+ */
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+/** The socket endpoint — shared by the server upgrade dispatch and the client hook. */
+export const SITE_SOCKET_PATH = '/admin/api/cms/site-socket'
+
+/** The three row-backed site collections that sync per row. */
+export const SiteSyncTableSchema = Type.Union([
+  Type.Literal('pages'),
+  Type.Literal('components'),
+  Type.Literal('layouts'),
+])
+export type SiteSyncTable = Static<typeof SiteSyncTableSchema>
+
+/** Display-level identity of the admin (or connector-driven agent) who saved. */
+export const SiteSyncActorSchema = Type.Object({
+  userId: Type.Union([Type.String(), Type.Null()]),
+  name: Type.String(),
+})
+export type SiteSyncActor = Static<typeof SiteSyncActorSchema>
+
+const RowsChangedEventSchema = Type.Object({
+  kind: Type.Literal('rows-changed'),
+  table: SiteSyncTableSchema,
+  /** rowId → the seq stamped on that row by the save that changed it. */
+  seqs: Type.Record(Type.String(), Type.Number()),
+  actor: Type.Optional(SiteSyncActorSchema),
+})
+
+const RowsDeletedEventSchema = Type.Object({
+  kind: Type.Literal('rows-deleted'),
+  table: SiteSyncTableSchema,
+  /** rowId → the seq stamped on that row by the save that soft-deleted it. */
+  seqs: Type.Record(Type.String(), Type.Number()),
+  actor: Type.Optional(SiteSyncActorSchema),
+})
+
+const ShellChangedEventSchema = Type.Object({
+  kind: Type.Literal('shell-changed'),
+  seq: Type.Number(),
+  actor: Type.Optional(SiteSyncActorSchema),
+})
+
+/** A replace-mode save (import / bootstrap) rewrote the site wholesale. */
+const SiteReloadedEventSchema = Type.Object({
+  kind: Type.Literal('site-reloaded'),
+  seq: Type.Number(),
+  actor: Type.Optional(SiteSyncActorSchema),
+})
+
+const PublishedEventSchema = Type.Object({
+  kind: Type.Literal('published'),
+  publishVersion: Type.Number(),
+  actor: Type.Optional(SiteSyncActorSchema),
+})
+
+export const SiteSyncEventSchema = Type.Union([
+  RowsChangedEventSchema,
+  RowsDeletedEventSchema,
+  ShellChangedEventSchema,
+  SiteReloadedEventSchema,
+  PublishedEventSchema,
+])
+export type SiteSyncEvent = Static<typeof SiteSyncEventSchema>
+
+/**
+ * The one client→server message: sent on (re)connect with the client's seq
+ * cursor. The server replies with delta events synthesized from
+ * `rows where seq > cursor` (soft-deleted rows included) plus the shell —
+ * which is why a missed live event can never cause drift.
+ */
+export const SiteSocketSubscribeSchema = Type.Object({
+  kind: Type.Literal('subscribe'),
+  cursor: Type.Number(),
+})

--- a/src/core/utils/deepEqual.ts
+++ b/src/core/utils/deepEqual.ts
@@ -1,0 +1,37 @@
+/**
+ * Structural deep equality for plain JSON-shaped values (objects, arrays,
+ * primitives) — key order insensitive, no prototype/cycle handling (persisted
+ * CMS documents are acyclic plain data by construction).
+ *
+ * Shared by the server's shell diff (`server/handlers/cms/siteDiff.ts`) and
+ * the editor's remote-apply echo detection (`applyRemoteSnapshot` skips the
+ * swap — and the undo-history clear — when the fetched remote content is
+ * identical to the local copy, which is exactly what an echo of one's own
+ * save looks like).
+ */
+export function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true
+  if (a === null || b === null) return a === b
+  if (typeof a !== typeof b) return false
+  if (typeof a !== 'object') return false
+  if (Array.isArray(a)) {
+    if (!Array.isArray(b)) return false
+    if (a.length !== b.length) return false
+    for (let i = 0; i < a.length; i++) {
+      if (!deepEqual(a[i], b[i])) return false
+    }
+    return true
+  }
+  if (Array.isArray(b)) return false
+  const aKeys = Object.keys(a as Record<string, unknown>)
+  const bKeys = Object.keys(b as Record<string, unknown>)
+  if (aKeys.length !== bKeys.length) return false
+  for (const k of aKeys) {
+    if (!Object.prototype.hasOwnProperty.call(b, k)) return false
+    if (!deepEqual(
+      (a as Record<string, unknown>)[k],
+      (b as Record<string, unknown>)[k],
+    )) return false
+  }
+  return true
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -235,12 +235,13 @@ export default defineConfig({
       // Bun backend. Agent endpoints live under `/admin/api/agent` (and
       // `/admin/api/agent/tool-result`) so the admin session cookie —
       // scoped to `Path=/admin` to keep it off the public site — actually
-      // accompanies the request. The `ws: false` default suffices; we do
-      // not need WebSocket upgrades for the agent (NDJSON streams over a
-      // standard HTTP response).
+      // accompanies the request. `ws: true` forwards the live-sync socket
+      // upgrade (`/admin/api/cms/site-socket`); the agent itself still
+      // streams NDJSON over standard HTTP responses.
       '/admin/api': {
         target: CMS_DEV_SERVER_ORIGIN,
         changeOrigin: true,
+        ws: true,
       },
       '/uploads': {
         target: CMS_DEV_SERVER_ORIGIN,


### PR DESCRIPTION
> **Stacked on #171** (`feat/save-conflict-detection`), which stacks on #169. This is level B of the multi-admin live-sync plan; #171 is level A (conflict safety).

## What changed

Phase A made concurrent overwrites fail loudly. This phase makes them mostly **not happen**: an open editor now learns about sibling admins' saves the moment they land and merges them in place — the conflict banner only appears when a remote change genuinely collides with local unsaved edits.

### Server

- **Events bus** (`server/events/siteEvents.ts`): in-process fan-out over Bun's native pub/sub — correct (not a shortcut) for the single-process-by-definition deployment model; multi-process is documented out of scope. The transactional save publishes post-commit hints: `rows-changed` / `rows-deleted` / `shell-changed`, ONE `site-reloaded` for replace-mode saves; the publish flow emits `published`. Events carry **ids + seqs, never payloads** (`@core/persistence/syncEvents`, TypeBox-validated at the client boundary).
- **Socket** (`server/events/siteSocket.ts`): `GET /admin/api/cms/site-socket` upgrades at the `Bun.serve` boundary (a WS upgrade is a different protocol lifecycle from the request/response router). Gated by `site.read` **and** `originAllowed` — browsers always send Origin on WS handshakes, so this closes cross-origin WebSocket hijacking before auth even runs.
- **Self-healing reconnect**: the client subscribes with its seq cursor; the server replies with the missed delta synthesized from `rows where seq > cursor` (soft-deleted rows included — a missed deletion surfaces as `rows-deleted`, not silence). Live events are hints; the delta is truth, so dropped frames can never cause drift.
- Dev Vite proxy forwards the upgrade (`ws: true`).

### Client

- `useSiteSocket` (mounted in AdminCanvasLayout) **lazy-imports** the transport (`siteSocketClient.ts`: backoff reconnect, strict in-order event processing through one promise chain) — the sync machinery stays out of the route-shell chunk (budget gate stays green).
- **Merge policy** (`siteSyncMerge.ts`, injected-fetch seam for tests): ① base seq ≥ event seq → skip (own-save echo); ② target dirty → pending conflict — the **same banner as a 409'd save**, one resolution UX for levels A+B; dirtiness is re-checked after the fetch so an edit landing mid-wire degrades to a conflict, never a silent overwrite; ③ clean → fetch + `applyRemoteSnapshot`. Aligned deletions (both sides deleted the row) merge silently.
- `applyRemoteSnapshot` (generalized from the banner's Load-theirs) **deep-equal-skips identical content**, so echoes of one's own save never reset undo history. History resets only when remote content genuinely replaced local state — and a toast explains exactly then. A remote deletion of the open page navigates home with a toast; `site-reloaded` reloads through the ordinary persistence path.
- `DirtyMarks` gains a `shell` flag so remote shell changes apply silently when the local shell is untouched.

### Fixed a latent phase A hole

The editor bumps `site.updatedAt` on **every** historic mutation — every real-world save would have looked like a shell change, defeating the shell-skip and turning the shell seq into noise. `shellsEqual` (now shared at `@core/persistence/shellsEqual`) and the dirty tracker deliberately ignore `updatedAt`; covered by new endpoint + store tests.

## Verification

```
bun test        # 6005 pass / 0 fail
bun run build   # tsc -b && vite build — clean (bundle budgets green)
bun run lint    # clean
```

New coverage: real `Bun.serve` WebSocket round-trip (upgrade gating incl. CSWSH 403, subscribe → delta, live fan-out through the bus), save-emission shapes, delta computation (changed/deleted/shell, cursor semantics), and 12 merge-policy scenarios (echo skip, dirty→conflict, mid-wire race, aligned deletions, shell mark gating) via the injected snapshot fetcher.

🤖 Generated with [Claude Code](https://claude.com/claude-code)