### PR TITLE
fix(canvas): support middle mouse panning

### DIFF
--- a/src/__tests__/canvas/useCanvasWheelSync.test.tsx
+++ b/src/__tests__/canvas/useCanvasWheelSync.test.tsx
@@ -4,6 +4,7 @@ import { act, cleanup as cleanupRender, fireEvent, render, screen } from '@testi
 import { useEditorStore } from '@site/store/store'
 import { RESET_ZOOM } from '@site/canvas/math'
 import {
+  isCanvasPointerPanActive,
   isCanvasSpacePanActive,
   panDeltaFromWheel,
   setCanvasSpacePanActive,
@@ -37,6 +38,21 @@ function dispatchWheel(target: Element, props: Record<string, unknown>) {
   }
   target.dispatchEvent(event)
   return event
+}
+
+function dispatchPointer(target: Element, type: string, props: Record<string, unknown>) {
+  const event = new Event(type, { bubbles: true, cancelable: true })
+  for (const [key, value] of Object.entries(props)) {
+    Object.defineProperty(event, key, { configurable: true, value })
+  }
+  target.dispatchEvent(event)
+  return event
+}
+
+function parseTranslate(transform: string): { x: number; y: number } {
+  const match = /^translate\((-?\d+)px, (-?\d+)px\) scale\(1\)$/.exec(transform)
+  if (!match) throw new Error(`Unexpected transform: ${transform}`)
+  return { x: Number(match[1]), y: Number(match[2]) }
 }
 
 beforeEach(() => {
@@ -124,6 +140,55 @@ describe('useCanvas wheel pan sync', () => {
     expect(layer.style.transform).toContain('scale(1.')
     expect(layer.style.transform).not.toBe('translate(0px, 0px) scale(1)')
   })
+
+  it('pans the canvas with middle-mouse dragging', async () => {
+    render(<TestCanvas />)
+
+    const root = screen.getByTestId('test-canvas-root')
+    const layer = screen.getByTestId('test-transform-layer')
+
+    fireEvent.pointerDown(root, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: 1,
+      buttons: 4,
+      clientX: 100,
+      clientY: 100,
+    })
+    fireEvent.pointerMove(root, {
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: -1,
+      buttons: 4,
+      clientX: 130,
+      clientY: 140,
+    })
+
+    await act(async () => {
+      await nextAnimationFrame()
+    })
+
+    const translate = parseTranslate(layer.style.transform)
+    expect(translate.x).toBeGreaterThan(0)
+    expect(translate.y).toBeGreaterThan(0)
+  })
+
+  it('prevents browser defaults when middle-mouse pan starts', () => {
+    render(<TestCanvas />)
+
+    const root = screen.getByTestId('test-canvas-root')
+
+    const pointerDown = dispatchPointer(root, 'pointerdown', {
+      pointerId: 1,
+      pointerType: 'mouse',
+      button: 1,
+      buttons: 4,
+      clientX: 100,
+      clientY: 100,
+    })
+
+    expect(pointerDown.defaultPrevented).toBe(true)
+  })
 })
 
 describe('canvas mouse pan input policy', () => {
@@ -144,9 +209,13 @@ describe('canvas mouse pan input policy', () => {
     expect(panDeltaFromWheel({ shiftKey: false, deltaX: 0, deltaY: 120 })).toEqual({ dx: 0, dy: -120 })
   })
 
-  it('does not use middle-button dragging as a canvas pan gesture', () => {
-    expect(shouldStartCanvasPointerPan({ button: 1 }, { spaceHeld: false })).toBe(false)
-    expect(shouldStartCanvasPointerPan({ button: 1 }, { spaceHeld: true })).toBe(false)
+  it('uses middle-button dragging as a canvas pan gesture', () => {
+    expect(shouldStartCanvasPointerPan({ button: 1 }, { spaceHeld: false })).toBe(true)
+    expect(shouldStartCanvasPointerPan({ button: 1 }, { spaceHeld: true })).toBe(true)
+    expect(shouldStartCanvasPointerPan({ button: 0 }, { spaceHeld: false })).toBe(false)
     expect(shouldStartCanvasPointerPan({ button: 0 }, { spaceHeld: true })).toBe(true)
+    expect(isCanvasPointerPanActive({ buttons: 4 }, { spaceHeld: false })).toBe(true)
+    expect(isCanvasPointerPanActive({ buttons: 1 }, { spaceHeld: false })).toBe(false)
+    expect(isCanvasPointerPanActive({ buttons: 1 }, { spaceHeld: true })).toBe(true)
   })
 })

--- a/src/admin/pages/site/canvas/canvasPanInput.ts
+++ b/src/admin/pages/site/canvas/canvasPanInput.ts
@@ -8,6 +8,10 @@ interface PointerPanEvent {
   button: number
 }
 
+interface PointerPanState {
+  buttons: number
+}
+
 interface PointerPanOptions {
   spaceHeld: boolean
 }
@@ -19,6 +23,16 @@ const CANVAS_SPACE_PAN_DATA_KEYS: Record<CanvasSpacePanSource, string> = {
   iframe: 'instaticCanvasIframeSpacePan',
 }
 
+const PRIMARY_MOUSE_BUTTON = 0
+const MIDDLE_MOUSE_BUTTON = 1
+const PRIMARY_MOUSE_BUTTON_MASK = 1
+const MIDDLE_MOUSE_BUTTON_MASK = 4
+
+export const CANVAS_DRAG_PAN_BUTTONS = [
+  PRIMARY_MOUSE_BUTTON_MASK,
+  MIDDLE_MOUSE_BUTTON_MASK,
+] as const
+
 export function panDeltaFromWheel(event: WheelPanEvent): { dx: number; dy: number } {
   const wheelX = event.shiftKey && event.deltaX === 0 ? event.deltaY : event.deltaX
   const wheelY = event.shiftKey ? 0 : event.deltaY
@@ -29,7 +43,21 @@ export function shouldStartCanvasPointerPan(
   event: PointerPanEvent,
   { spaceHeld }: PointerPanOptions,
 ): boolean {
-  return spaceHeld && event.button === 0
+  return event.button === MIDDLE_MOUSE_BUTTON || (spaceHeld && event.button === PRIMARY_MOUSE_BUTTON)
+}
+
+export function isCanvasPointerPanActive(
+  event: PointerPanState,
+  { spaceHeld }: PointerPanOptions,
+): boolean {
+  return (
+    (event.buttons & MIDDLE_MOUSE_BUTTON_MASK) !== 0 ||
+    (spaceHeld && (event.buttons & PRIMARY_MOUSE_BUTTON_MASK) !== 0)
+  )
+}
+
+export function isMiddleMousePointerPan(event: PointerPanState): boolean {
+  return (event.buttons & MIDDLE_MOUSE_BUTTON_MASK) !== 0
 }
 
 export function setCanvasSpacePanActive(

--- a/src/admin/pages/site/hooks/useCanvas.ts
+++ b/src/admin/pages/site/hooks/useCanvas.ts
@@ -30,7 +30,13 @@ import {
   incrementalScaleFromPinchMovement,
 } from '@site/canvas/math'
 import { panToCenterBreakpointFrame } from '@site/canvas/canvasDomGeometry'
-import { panDeltaFromWheel, setCanvasSpacePanActive } from '@site/canvas/canvasPanInput'
+import {
+  CANVAS_DRAG_PAN_BUTTONS,
+  isCanvasPointerPanActive,
+  isMiddleMousePointerPan,
+  panDeltaFromWheel,
+  setCanvasSpacePanActive,
+} from '@site/canvas/canvasPanInput'
 
 interface Transform {
   zoom: number
@@ -430,11 +436,17 @@ export function useCanvas({ canvasRootRef, transformLayerRef, enabled }: UseCanv
 
   // ─── Gesture handlers ─────────────────────────────────────────────────────
 
-  const bind = useGesture(
+  const gestureBind = useGesture(
     {
-      onDrag: ({ delta: [dx, dy], buttons, first, last }) => {
+      onDrag: ({ delta: [dx, dy], buttons, first, last, event }) => {
         if (first) {
-          isDraggingRef.current = spaceActiveRef.current && (buttons & 1) !== 0
+          isDraggingRef.current = isCanvasPointerPanActive(
+            { buttons },
+            { spaceHeld: spaceActiveRef.current },
+          )
+          if (isDraggingRef.current && isMiddleMousePointerPan({ buttons }) && event.cancelable) {
+            event.preventDefault()
+          }
         }
 
         if (!isDraggingRef.current) return
@@ -472,7 +484,10 @@ export function useCanvas({ canvasRootRef, transformLayerRef, enabled }: UseCanv
       },
     },
     {
-      drag: { filterTaps: true },
+      drag: {
+        filterTaps: true,
+        pointer: { buttons: [...CANVAS_DRAG_PAN_BUTTONS] },
+      },
       pinch: {
         eventOptions: { passive: false },
         // Trackpad pinch already arrives here through the native ctrl/meta
@@ -482,6 +497,31 @@ export function useCanvas({ canvasRootRef, transformLayerRef, enabled }: UseCanv
       },
     },
   )
+
+  const bind = () => {
+    const gestureHandlers = gestureBind()
+    return {
+      ...gestureHandlers,
+      onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+        if (isMiddleMousePointerPan({ buttons: event.buttons }) && event.cancelable) {
+          event.preventDefault()
+        }
+        gestureHandlers.onPointerDown?.(event)
+      },
+      onMouseDown: (event: React.MouseEvent<HTMLElement>) => {
+        if (event.button === 1 && event.cancelable) {
+          event.preventDefault()
+        }
+        gestureHandlers.onMouseDown?.(event)
+      },
+      onAuxClick: (event: React.MouseEvent<HTMLElement>) => {
+        if (event.button === 1 && event.cancelable) {
+          event.preventDefault()
+        }
+        gestureHandlers.onAuxClick?.(event)
+      },
+    }
+  }
 
   // ─── Cleanup on unmount ───────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #175.

Middle-mouse dragging now pans the editor canvas directly. The previous implementation never worked for this path because the canvas pan policy rejected button 1 and `@use-gesture` only accepted the primary-button mask by default.

## Changes

- Treat middle-button dragging as a canvas pan gesture without requiring Space.
- Configure the canvas drag gesture to accept both primary and middle mouse button masks.
- Suppress browser middle-click defaults for the middle-button pan path only.
- Add focused tests for the input policy, hook behavior, and middle-click default prevention.

## Verification

- `bun test src/__tests__/canvas/useCanvasWheelSync.test.tsx`
- Browser smoke test: middle-button drag changed canvas transform from `translate(-591.281px, -32px) scale(0.5)` to `translate(-454.281px, 55px) scale(0.5)` with no post-editor console errors.
- `bun test` — 5956 pass, 0 fail
- `bun run build`
- `bun run lint`
- `npx react-doctor@latest --verbose --scope changed` — exit 0; reports two warning-tier findings in untouched `CanvasRoot.tsx` that are outside this PR diff.