### PR TITLE
test(agent): fix read-surface base64 fixture broken by htmlAttributes hardening

### DIFF
--- a/src/__tests__/agent/readDocument.test.ts
+++ b/src/__tests__/agent/readDocument.test.ts
@@ -71,13 +71,15 @@ describe('renderAgentDocument', () => {
     const longUrl = `https://cdn.example.com/assets/${'path-'.repeat(180)}hero.png?signature=${'b'.repeat(500)}`
     const page = makePage({
       root: { moduleId: 'base.body', children: ['inlineData', 'remoteImage'] },
+      // The base64 payload rides TEXT CONTENT — the one channel that still
+      // legitimately reaches the read surface (a pasted blob in a paragraph).
+      // URL-bearing attributes can no longer carry it: `isSafeUrl` rejects
+      // data: schemes in src/href, and sanitizeRenderableHtmlAttribute
+      // (@core/htmlAttributes) rejects data:-scheme values in custom
+      // attributes outright.
       inlineData: {
         moduleId: 'base.text',
-        props: {
-          text: 'Preview',
-          tag: 'p',
-          htmlAttributes: { 'data-preview': `data:image/png;base64,${longBase64}` },
-        },
+        props: { text: `Pasted blob: data:image/png;base64,${longBase64}`, tag: 'p' },
       },
       remoteImage: { moduleId: 'base.image', props: { src: longUrl } },
     })


### PR DESCRIPTION
## What changed

`renderAgentDocument > cleans base64 data URLs and very long URLs before paging` has been failing on `main` since #155 merged. This updates the stale test fixture — one file, test-only.

## Why

The test planted its base64 payload in a custom `htmlAttributes` value (`data-preview="data:image/png;base64,…"`). #155's stored-XSS hardening (`sanitizeRenderableHtmlAttribute`) now rejects `data:`-scheme values in custom attributes, so the attribute never renders and the cleaner has nothing to clean. The production behavior is correct — the fixture was exercising a channel that intentionally no longer exists. It slipped through because CI runs CodeQL but not `bun test`.

Base64 blobs can now only reach the agent read surface through **text content** (URL attributes are scheme-checked by `isSafeUrl`, which also blocks `data:`), so the fixture pastes the blob into a paragraph — also the realistic shape the cleaner exists for.

## Impact

- `bun test` is green on main again.
- No production code touched.

## Verification

```
bun test src/__tests__/agent/ src/__tests__/security/   # 207 pass, 0 fail
bun run lint                                            # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)