### PR TITLE
fix(mcp): serve site_list_documents headlessly over MCP

### DIFF
--- a/docs/features/mcp-connectors.md
+++ b/docs/features/mcp-connectors.md
@@ -12,7 +12,7 @@ The server is implemented with the official `@modelcontextprotocol/sdk`. That pa
 
 - **Instatic is an MCP server.** One Streamable-HTTP endpoint at `/_instatic/mcp` serves both local and remote clients (local is just `localhost`).
 - **Thin adapter over the existing tool engine.** No tool logic is duplicated. MCP is a new *caller* alongside the built-in agent and the plugin host; tool dispatch reuses `executeAiTool`.
-- **Tool surface = the full catalog.** Server-resolved tools (content reads + `site_read_styles`) run headless — no editor needed. Every browser-execution tool the agent panel has (structure edits, insert HTML, apply CSS, assign classes, set design tokens, manage pages, content CRUD, code assets, live-DOM reads) is exposed too, **relayed to an open editor via the live editor bridge** — the single source of truth for page editing. If the connector owner has no editor open, those tools return a clear "open the editor" error; the headless reads still work.
+- **Tool surface = the full catalog.** Server-resolved tools (content reads + `site_list_documents` + `site_read_styles`) run headless — no editor needed. Every browser-execution tool the agent panel has (structure edits, insert HTML, apply CSS, assign classes, set design tokens, manage pages, content CRUD, code assets, live-DOM reads) is exposed too, **relayed to an open editor via the live editor bridge** — the single source of truth for page editing. If the connector owner has no editor open, those tools return a clear "open the editor" error; the headless reads still work.
 - **Bearer-token auth, one secret per connector.** The token is shown once on creation and stored only as a SHA-256 hash. New tokens expire after 90 days by default; admins can choose a custom TTL or explicitly create a non-expiring token. Revocable.
 - **Capability-gated.** A connector carries a granted capability subset; the same gate the built-in agent uses (`toolAllowedForCapabilities`) filters the toolset. An MCP caller can never invoke a tool the granting capabilities couldn't authorize over HTTP.
 - **Privilege floor.** An admin can only grant capabilities they themselves hold.
@@ -36,9 +36,9 @@ server/ai/mcp/server.ts               low-level SDK Server; tools filtered by ca
         │
 server/ai/mcp/registry.ts             AiTool registry → MCP tools (TypeBox inputSchema sent verbatim as JSON Schema)
         │
-executeAiTool(...) / treeService      in-process, ctx { db, userId, capabilities }
+executeAiTool(...) / live editor bridge
         ▼
-repositories (data_rows, media) + applyTreeOperation + saveDataRowDraft
+repositories (headless reads) / live editor store (browser tools)
 ```
 
 ### Module layout — `server/ai/mcp/`
@@ -48,14 +48,13 @@ repositories (data_rows, media) + applyTreeOperation + saveDataRowDraft
 | `transports/http.ts` | Mounts the SDK's Web-standard Streamable-HTTP transport; stateless per request (`enableJsonResponse`). |
 | `auth.ts` | Bearer resolution → `{ connectorId, userId, capabilities }`; spec-correct 401 with an RFC 9728 `resource_metadata` pointer. |
 | `server.ts` | Builds a capability-scoped low-level `Server` (`ListTools` / `CallTool` handlers). Uses the low-level `Server`, not `McpServer.registerTool`, because the latter needs Zod (banned) — this lets the TypeBox `inputSchema` pass through verbatim. |
-| `registry.ts` | The exposable toolset = full catalog (content + site + page-tree), deduped by name, filtered by `toolAllowedForCapabilities`. |
+| `registry.ts` | Headless reads plus the browser-relayed site/content catalog, deduped by name and filtered by `toolAllowedForCapabilities`. |
+| `tools/documentTools.ts` | `site_list_documents` — pages, templates, and visual components, headless from the DB. |
 | `tools/styleTools.ts` | `site_read_styles` — the design system as a CSS stylesheet, headless from the DB. |
 | `editorBridge.ts` | Per-user live editor bridge registry + `createEditorBridgeStream`; `getEditorBridgeForUser` routes browser tools to the owner's open editor. |
 | `handlers/editorBridge.ts` | `GET /admin/api/ai/editor-bridge` — the NDJSON stream the editor holds open. |
 | `connectors/` | `types.ts` (server-only record), `token.ts` (generate + SHA-256 hash), `store.ts` (CRUD + `toConnectorView`). |
 | `handlers/connectors.ts` | `/admin/api/ai/mcp/connectors` CRUD, gated by `ai.providers.manage`. |
-
-The headless page-tree path (load → `applyTreeOperation` → persist) lives in `server/ai/content/treeService.ts` and is shared with the plugin RPC `cms.content.tree.mutate` — neither caller duplicates the engine. Gated by `plugin-content-tree-via-engine.test.ts`.
 
 ---
 
@@ -68,6 +67,7 @@ MCP exposes the **full tool catalog** (deduped by name), capability-filtered. To
 **Headless (server-resolved) — work with no editor open:**
 - Content reads — list/read collections, entries, data rows, media.
 - `get_context({ entryId? })` — orientation in one call: is a live editor connected (browser tools need it), which "everywhere"/post-type templates wrap pages, site name. Call it first if a browser tool returns "open the editor."
+- `site_list_documents` — editable pages, templates, and visual components with document references, root node ids, template metadata, and summaries. Nothing is marked active/current because headless calls have no editor focus.
 - `site_read_styles({ format?, className?, includeTokens? })` — the design system as a **CSS stylesheet**: design tokens (CSS custom properties) + every class/ambient rule, read straight from the DB via the publisher's emitters. `format:"summary"` returns a compact class catalog (selector + referenced token vars, no declarations) to scan first. Symmetric with reading pages as HTML / writing CSS via `site_apply_css`. Replaces the old snapshot-dependent `list_tokens`.
 - `site_list_breakpoints` — configured viewport ids/labels/widths (the first is the base), so `site_render_snapshot` can target one deliberately. Headless version replaces the snapshot-dependent one.
 
@@ -155,7 +155,6 @@ An admin cannot grant a capability they do not hold (enforced in `handlers/conne
 ## Tests
 
 - `server/ai/mcp/connectors/{token,store}.test.ts` — token hashing, expiry, and store CRUD.
-- `server/ai/content/treeService.test.ts` — headless load/mutate/persist.
-- `server/ai/mcp/{registry,auth,server,transports/http}.test.ts` — capability filtering, bearer auth + 401, full MCP round-trip (list/read/mutate), HTTP handshake.
+- `server/ai/mcp/{registry,auth,server,transports/http}.test.ts` and `server/ai/mcp/tools/documentTools.test.ts` — capability filtering, headless document listing, bearer auth + 401, full MCP round-trip (list/read/mutate), HTTP handshake.
 - `src/__tests__/ai/mcpConnectorsHandler.test.ts` — CRUD, privilege floor, capability gating.
 - `src/__tests__/architecture/ai-mcp-connectors-never-leak.test.ts` — token never serialized.

--- a/server/ai/mcp/registry.ts
+++ b/server/ai/mcp/registry.ts
@@ -3,8 +3,8 @@
  * filtered to the connector's granted capabilities.
  *
  * Two execution classes are exposed:
- *   - server-resolved tools (content reads + `site_read_styles`) run in-process and
- *     work with NO editor open;
+ *   - server-resolved tools (content reads + `site_list_documents` +
+ *     `site_read_styles`) run in-process and work with NO editor open;
  *   - browser tools (structure edits, HTML/CSS authoring, design tokens, page
  *     lifecycle, content CRUD, code assets, live-DOM reads) are relayed to the
  *     connector owner's open editor via the live editor bridge
@@ -43,9 +43,9 @@ import { documentMcpTools } from './tools/documentTools'
 const MCP_EXCLUDED_TOOLS = new Set<string>(['site_list_tokens'])
 
 function allMcpTools(): AiTool[] {
-  // De-dup by tool name. Order matters: the headless style + content tools win
-  // over the site toolset for any shared name (e.g. `list_documents`), so the
-  // version that works without an open editor is the one exposed.
+  // De-dup by tool name. Order matters: the headless MCP-specific + content
+  // tools win over the site toolset for shared names, so the version that works
+  // without an open editor is the one exposed.
   const ordered = [...contextMcpTools, ...styleMcpTools, ...documentMcpTools, ...contentTools, ...siteTools]
   const byName = new Map<string, AiTool>()
   for (const tool of ordered) {

--- a/server/ai/mcp/registry.ts
+++ b/server/ai/mcp/registry.ts
@@ -29,19 +29,24 @@ import { contentTools } from '../tools/content'
 import { siteTools } from '../tools/site'
 import { styleMcpTools } from './tools/styleTools'
 import { contextMcpTools } from './tools/contextTool'
+import { documentMcpTools } from './tools/documentTools'
 
 // Server-resolved site read tools whose handlers read the browser-posted
-// `ctx.snapshot`, which is null over MCP — they'd silently return nothing.
-// `site_read_styles` (headless) replaces `site_list_tokens`. The snapshot-based
-// `site_list_breakpoints` is excluded too; a headless `site_list_breakpoints` is provided
-// by `styleMcpTools` (which is ordered first, so it wins the de-dup).
+// `ctx.snapshot`, which is null over MCP — they'd return nothing or throw.
+// Each is handled one of two ways:
+//   - `site_list_tokens` → excluded; `site_read_styles` (headless) replaces it.
+//   - `site_list_breakpoints` → shadowed by a headless version in `styleMcpTools`.
+//   - `site_list_documents` → shadowed by a headless version in `documentMcpTools`
+//     (the snapshot-based one throws on `null.currentDocument`).
+// The headless tool sets are ordered ahead of `siteTools` below, so they win
+// the de-dup for any shared name.
 const MCP_EXCLUDED_TOOLS = new Set<string>(['site_list_tokens'])
 
 function allMcpTools(): AiTool[] {
   // De-dup by tool name. Order matters: the headless style + content tools win
   // over the site toolset for any shared name (e.g. `list_documents`), so the
   // version that works without an open editor is the one exposed.
-  const ordered = [...contextMcpTools, ...styleMcpTools, ...contentTools, ...siteTools]
+  const ordered = [...contextMcpTools, ...styleMcpTools, ...documentMcpTools, ...contentTools, ...siteTools]
   const byName = new Map<string, AiTool>()
   for (const tool of ordered) {
     if (MCP_EXCLUDED_TOOLS.has(tool.name)) continue

--- a/server/ai/mcp/tools/documentTools.test.ts
+++ b/server/ai/mcp/tools/documentTools.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, beforeEach } from 'bun:test'
+import { createSqliteClient } from '../../../db/sqlite'
+import { sqliteMigrations } from '../../../db/migrations-sqlite'
+import { runMigrations } from '../../../db/runMigrations'
+import type { DbClient } from '../../../db/client'
+import type { ToolContext } from '../../runtime/types'
+import { mcpToolsForCapabilities } from '../registry'
+
+const PAGE_TREE = {
+  rootNodeId: 'root',
+  nodes: {
+    root: { id: 'root', moduleId: 'base.body', props: {}, breakpointOverrides: {}, classIds: [], children: [] },
+  },
+}
+
+async function freshDb(): Promise<DbClient> {
+  const db = createSqliteClient(':memory:')
+  await runMigrations(db, sqliteMigrations)
+  // The default site shell row is created at first-run setup, not by migrations.
+  await db`
+    insert into site (id, name, settings_json)
+    values ('default', 'Test', ${{ cmsSiteSchemaVersion: 1, site: {} }})
+  `
+  // Seed one page row into the (already-seeded) `pages` system table.
+  const cells = JSON.stringify({ title: 'Home', slug: 'index', body: PAGE_TREE })
+  await db`
+    insert into data_rows (id, table_id, cells_json, slug, status)
+    values ('home', 'pages', ${cells}, 'index', 'draft')
+  `
+  return db
+}
+
+function headlessCtx(db: DbClient): ToolContext {
+  return {
+    db,
+    userId: 'u1',
+    capabilities: ['site.read'],
+    scope: 'site',
+    conversationId: 'mcp:test',
+    snapshot: null, // MCP has no browser-posted snapshot — this is the crash case.
+    signal: new AbortController().signal,
+  }
+}
+
+describe('mcp site_list_documents (headless)', () => {
+  let db: DbClient
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('the MCP registry exposes a server-resolved site_list_documents that does not need a snapshot', async () => {
+    const tool = mcpToolsForCapabilities(['site.read']).find((t) => t.name === 'site_list_documents')
+    expect(tool).toBeTruthy()
+    expect(tool!.execution).toBe('server')
+
+    // The site-scope (chat) version throws on `null.currentDocument`; the headless
+    // one resolves the catalog from the DB. Over MCP this must not throw.
+    const result = (await tool!.handler!({}, headlessCtx(db))) as {
+      currentDocument: unknown
+      documents: { document: { type: string; id: string }; slug?: string }[]
+    }
+
+    expect(Array.isArray(result.documents)).toBe(true)
+    expect(result.documents.some((d) => d.slug === 'index')).toBe(true)
+    // No open-editor focus server-side, so nothing is reported as current.
+    expect(result.currentDocument).toBeNull()
+  })
+})

--- a/server/ai/mcp/tools/documentTools.test.ts
+++ b/server/ai/mcp/tools/documentTools.test.ts
@@ -50,19 +50,32 @@ describe('mcp site_list_documents (headless)', () => {
 
   it('the MCP registry exposes a server-resolved site_list_documents that does not need a snapshot', async () => {
     const tool = mcpToolsForCapabilities(['site.read']).find((t) => t.name === 'site_list_documents')
-    expect(tool).toBeTruthy()
-    expect(tool!.execution).toBe('server')
+    if (!tool?.handler) throw new Error('Expected site_list_documents handler')
+    expect(tool.execution).toBe('server')
 
     // The site-scope (chat) version throws on `null.currentDocument`; the headless
     // one resolves the catalog from the DB. Over MCP this must not throw.
-    const result = (await tool!.handler!({}, headlessCtx(db))) as {
+    const result = (await tool.handler({}, headlessCtx(db))) as {
       currentDocument: unknown
-      documents: { document: { type: string; id: string }; slug?: string }[]
+      documents: {
+        document: { type: string; id: string }
+        slug?: string
+        active: boolean
+        current: boolean
+      }[]
     }
 
     expect(Array.isArray(result.documents)).toBe(true)
     expect(result.documents.some((d) => d.slug === 'index')).toBe(true)
     // No open-editor focus server-side, so nothing is reported as current.
     expect(result.currentDocument).toBeNull()
+    expect(result.documents.every((document) => !document.active && !document.current)).toBe(true)
+  })
+
+  it('does not expose the catalog to an edit-only connector without site.read', () => {
+    const tool = mcpToolsForCapabilities(['pages.edit']).find(
+      (candidate) => candidate.name === 'site_list_documents',
+    )
+    expect(tool).toBeUndefined()
   })
 })

--- a/server/ai/mcp/tools/documentTools.ts
+++ b/server/ai/mcp/tools/documentTools.ts
@@ -1,0 +1,52 @@
+/**
+ * Headless site-document catalog for MCP.
+ *
+ * `site_list_documents` lists editable documents — pages, templates, and visual
+ * components — so an MCP agent can orient itself before reading or editing
+ * (the site system prompt tells it to call this first for chrome/template work).
+ *
+ * The site-scope `site_list_documents` in `../../tools/site/readTools.ts` resolves
+ * from the browser-posted `ctx.snapshot`, which is null over MCP (no chat turn,
+ * no editor snapshot) — calling it there throws on `snap.currentDocument`. This
+ * headless version assembles the catalog straight from the DB
+ * (`getDraftSiteDocument`) and is ordered ahead of the site toolset in the MCP
+ * registry so it wins the de-dup. There is no open-editor focus server-side, so
+ * no document is marked active/current; `get_context` reports the live editor.
+ */
+import { Type } from '@core/utils/typeboxHelpers'
+import { describeAgentDocuments } from '@core/ai'
+import type { CoreCapability } from '@core/capabilities'
+import type { AiTool, ToolContext } from '../../runtime/types'
+import { getDraftSiteDocument } from '../../../repositories/publish'
+
+const SITE_READ_CAPS: readonly CoreCapability[] = [
+  'site.read',
+  'site.structure.edit',
+  'site.content.edit',
+  'site.style.edit',
+  'pages.edit',
+]
+
+// A document ref that `documentRefEquals` never matches against a real id, so
+// the headless listing marks nothing current — there is no editor focus here.
+const NO_CURRENT_DOCUMENT: Parameters<typeof describeAgentDocuments>[2] = { type: 'page', id: '' }
+
+export const documentMcpTools: AiTool[] = [
+  {
+    name: 'site_list_documents',
+    description:
+      'List editable documents: pages, templates, and visual components. Use the returned document refs with site_read_document/site_open_document. Each item includes rootNodeId, template metadata, and a short summary. Headless — no editor needed.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object({}, { additionalProperties: false }),
+    requiredCapabilities: SITE_READ_CAPS,
+    handler: async (_input, ctx: ToolContext) => {
+      const site = await getDraftSiteDocument(ctx.db)
+      if (!site) return { ok: false, error: 'No site found.' }
+      return {
+        currentDocument: null,
+        documents: describeAgentDocuments(site, '', NO_CURRENT_DOCUMENT),
+      }
+    },
+  },
+]

--- a/server/ai/mcp/tools/documentTools.ts
+++ b/server/ai/mcp/tools/documentTools.ts
@@ -15,21 +15,17 @@
  */
 import { Type } from '@core/utils/typeboxHelpers'
 import { describeAgentDocuments } from '@core/ai'
-import type { CoreCapability } from '@core/capabilities'
 import type { AiTool, ToolContext } from '../../runtime/types'
 import { getDraftSiteDocument } from '../../../repositories/publish'
 
-const SITE_READ_CAPS: readonly CoreCapability[] = [
-  'site.read',
-  'site.structure.edit',
-  'site.content.edit',
-  'site.style.edit',
-  'pages.edit',
-]
-
-// A document ref that `documentRefEquals` never matches against a real id, so
-// the headless listing marks nothing current — there is no editor focus here.
-const NO_CURRENT_DOCUMENT: Parameters<typeof describeAgentDocuments>[2] = { type: 'page', id: '' }
+// A document ref whose id can never match a real document id, so the headless
+// listing marks nothing current — there is no server-side editor focus. Kept
+// non-empty to satisfy AgentDocumentRefSchema's `minLength: 1` if it is ever
+// validated downstream.
+const NO_CURRENT_DOCUMENT: Parameters<typeof describeAgentDocuments>[2] = {
+  type: 'page',
+  id: '__no_current_document__',
+}
 
 export const documentMcpTools: AiTool[] = [
   {
@@ -39,7 +35,7 @@ export const documentMcpTools: AiTool[] = [
     scope: 'site',
     execution: 'server',
     inputSchema: Type.Object({}, { additionalProperties: false }),
-    requiredCapabilities: SITE_READ_CAPS,
+    requiredCapabilities: ['site.read'],
     handler: async (_input, ctx: ToolContext) => {
       const site = await getDraftSiteDocument(ctx.db)
       if (!site) return { ok: false, error: 'No site found.' }

--- a/server/ai/mcp/tools/documentTools.ts
+++ b/server/ai/mcp/tools/documentTools.ts
@@ -18,15 +18,6 @@ import { describeAgentDocuments } from '@core/ai'
 import type { AiTool, ToolContext } from '../../runtime/types'
 import { getDraftSiteDocument } from '../../../repositories/publish'
 
-// A document ref whose id can never match a real document id, so the headless
-// listing marks nothing current — there is no server-side editor focus. Kept
-// non-empty to satisfy AgentDocumentRefSchema's `minLength: 1` if it is ever
-// validated downstream.
-const NO_CURRENT_DOCUMENT: Parameters<typeof describeAgentDocuments>[2] = {
-  type: 'page',
-  id: '__no_current_document__',
-}
-
 export const documentMcpTools: AiTool[] = [
   {
     name: 'site_list_documents',
@@ -41,7 +32,7 @@ export const documentMcpTools: AiTool[] = [
       if (!site) return { ok: false, error: 'No site found.' }
       return {
         currentDocument: null,
-        documents: describeAgentDocuments(site, '', NO_CURRENT_DOCUMENT),
+        documents: describeAgentDocuments(site, null, null),
       }
     },
   },

--- a/src/core/ai/documentRefs.ts
+++ b/src/core/ai/documentRefs.ts
@@ -26,8 +26,8 @@ export function documentRefEquals(a: AgentDocumentRef | null | undefined, b: Age
 
 export function describeAgentDocuments(
   site: SiteDocument,
-  activePageId: string,
-  currentDocument: AgentDocumentRef,
+  activePageId: string | null,
+  currentDocument: AgentDocumentRef | null,
 ): AgentDocumentDescriptor[] {
   const descriptors: AgentDocumentDescriptor[] = []
 


### PR DESCRIPTION
## Summary

Adds a headless `site_list_documents` to the MCP server so external MCP clients can list editable documents (pages, templates, visual components) without an open editor.

The site-scope `site_list_documents` resolves from `ctx.snapshot`, the browser-posted editor snapshot. Over MCP there is no snapshot (`ctx.snapshot === null`), and `asSnap` is an unchecked cast, so `snap.currentDocument` throws a `TypeError` and the tool crashes for every MCP caller.

This PR adds `documentMcpTools` (`server/ai/mcp/tools/documentTools.ts`), which builds the catalog from the DB (`getDraftSiteDocument` + `describeAgentDocuments`) and orders it ahead of `siteTools` in `server/ai/mcp/registry.ts` so it wins the name de-dup, the same pattern the existing `styleMcpTools` uses to shadow `site_list_breakpoints`. Nothing is marked active/current because a headless call has no editor focus. The in-editor chat path is unchanged.

## Review follow-ups

- Scope `requiredCapabilities` to `['site.read']`, preventing edit-only callers from listing documents under the gate's ANY-OF semantics.
- Model the absent active/current document as `null` instead of a synthetic document id.
- Add regression coverage for no active/current descriptor and edit-only capability denial.
- Document the headless document catalog and remove stale headless page-tree wording.

The remaining full-site-load performance suggestion is intentionally separate: `getDraftSiteDocument` is the existing canonical site read path, while a metadata-only cross-dialect projection is a broader repository optimization.

## Verification

- `bun test` — 6,026 passed, 0 failed
- `bun run build`
- `bun run lint`

Docker/deployment check is not applicable.