### PR TITLE
fix(publish): Windows-safe slot symlink swap

### DIFF
--- a/server/publish/staticArtefact.ts
+++ b/server/publish/staticArtefact.ts
@@ -37,7 +37,9 @@ import {
   readlink,
   rename,
   rm,
+  rmdir,
   symlink,
+  unlink,
   writeFile,
 } from 'node:fs/promises'
 
@@ -260,6 +262,14 @@ export async function writeArtefact(
  *
  * Any leftover `current.tmp` from a previously-crashed publish is silently
  * removed before creating a new one.
+ *
+ * Windows note: `rename(2)` over an existing symlink is atomic on POSIX, but
+ * Win32 `MoveFile` refuses to replace an existing target (`EEXIST`/`EPERM`),
+ * leaving `current` stuck on the old slot and `current.tmp` orphaned. There we
+ * fall back to unlink-then-rename — a sub-millisecond window where `current` is
+ * absent, which `readArtefact` already treats as a miss and serves via the
+ * Layer B live-render path. Production runs Linux/Docker and always takes the
+ * atomic branch; the fallback is a dev-on-Windows affordance only.
  */
 export async function swapSlot(uploadsDir: string, targetSlot: Slot): Promise<void> {
   const publishDir = getPublishedDir(uploadsDir)
@@ -270,14 +280,45 @@ export async function swapSlot(uploadsDir: string, targetSlot: Slot): Promise<vo
   await mkdir(publishDir, { recursive: true })
 
   // Remove any leftover tmp symlink from a previous crashed publish
-  await rm(tmpPath, { force: true })
+  await removeSymlinkEntry(tmpPath)
 
   // Create a new symlink at current.tmp pointing to the target slot name.
   // symlink(target, path) creates a link at `path` that points to `target`.
   await symlink(targetSlot, tmpPath)
 
-  // Atomically replace `current` with the new symlink
-  await rename(tmpPath, currentPath)
+  // Atomically replace `current` with the new symlink.
+  try {
+    await rename(tmpPath, currentPath)
+  } catch (err) {
+    // Win32 `MoveFile` won't replace an existing target (`EEXIST`/`EPERM`/
+    // `EACCES`). Drop the old `current` link first, then rename into the now-
+    // free path. Sub-millisecond gap where `current` is absent → `readArtefact`
+    // treats it as a miss and serves via Layer B. POSIX never reaches here.
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'EEXIST' && code !== 'EPERM' && code !== 'EISDIR' && code !== 'EACCES') throw err
+    await removeSymlinkEntry(currentPath)
+    await rename(tmpPath, currentPath)
+  }
+}
+
+/**
+ * Remove a symlink entry (the link itself, never its target) cross-platform.
+ * `rm`/`unlink` on a Windows *directory* symlink can fail (`EFAULT`/`EPERM`);
+ * `rmdir` removes a directory-symlink link there without recursing into the
+ * slot it points at. Tries the POSIX path (`unlink`) first, then the Win32
+ * directory-symlink path (`rmdir`). A missing path is a no-op.
+ */
+async function removeSymlinkEntry(path: string): Promise<void> {
+  try {
+    await unlink(path)
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    try {
+      await rmdir(path)
+    } catch (err2) {
+      if ((err2 as NodeJS.ErrnoException).code !== 'ENOENT') throw err2
+    }
+  }
 }
 
 /**

--- a/server/publish/staticArtefact.ts
+++ b/server/publish/staticArtefact.ts
@@ -290,10 +290,13 @@ export async function swapSlot(uploadsDir: string, targetSlot: Slot): Promise<vo
   try {
     await rename(tmpPath, currentPath)
   } catch (err) {
-    // Win32 `MoveFile` won't replace an existing target (`EEXIST`/`EPERM`/
-    // `EACCES`). Drop the old `current` link first, then rename into the now-
-    // free path. Sub-millisecond gap where `current` is absent → `readArtefact`
-    // treats it as a miss and serves via Layer B. POSIX never reaches here.
+    // Windows-only fallback. Win32 `MoveFile` won't replace an existing target
+    // (`EEXIST`/`EPERM`/`EISDIR`/`EACCES`): drop the old `current` link first,
+    // then rename into the now-free path. Sub-millisecond gap where `current` is
+    // absent → `readArtefact` treats it as a miss and serves via Layer B. On
+    // POSIX `rename(2)` replaces the symlink atomically, so any failure there is
+    // a real error — never run the destructive remove-then-rename off Windows.
+    if (process.platform !== 'win32') throw err
     const code = (err as NodeJS.ErrnoException).code
     if (code !== 'EEXIST' && code !== 'EPERM' && code !== 'EISDIR' && code !== 'EACCES') throw err
     await removeSymlinkEntry(currentPath)
@@ -303,16 +306,20 @@ export async function swapSlot(uploadsDir: string, targetSlot: Slot): Promise<vo
 
 /**
  * Remove a symlink entry (the link itself, never its target) cross-platform.
- * `rm`/`unlink` on a Windows *directory* symlink can fail (`EFAULT`/`EPERM`);
- * `rmdir` removes a directory-symlink link there without recursing into the
- * slot it points at. Tries the POSIX path (`unlink`) first, then the Win32
- * directory-symlink path (`rmdir`). A missing path is a no-op.
+ * `unlink` handles symlinks on POSIX. On Windows a *directory* symlink/junction
+ * can reject `unlink` (`EPERM`/`EISDIR`); there `rmdir` removes the link without
+ * recursing into the slot it points at. The `rmdir` fallback is therefore
+ * Windows-only — on POSIX a non-ENOENT `unlink` failure is a real error and must
+ * surface rather than risk removing a real directory at this path. A missing
+ * path is a no-op.
  */
 async function removeSymlinkEntry(path: string): Promise<void> {
   try {
     await unlink(path)
   } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return
+    const code = (err as NodeJS.ErrnoException).code
+    if (code === 'ENOENT') return
+    if (process.platform !== 'win32') throw err
     try {
       await rmdir(path)
     } catch (err2) {

--- a/src/__tests__/server/publishAtomicityRace.test.ts
+++ b/src/__tests__/server/publishAtomicityRace.test.ts
@@ -15,6 +15,15 @@
  *
  * We use real tmpdir filesystem operations — not mocks — so actual rename(2)
  * and symlink atomicity semantics are exercised.
+ *
+ * Platform note: the strict "never null" guarantee relies on POSIX `rename(2)`
+ * atomically replacing a directory symlink. Win32 `MoveFile` cannot replace an
+ * existing directory-symlink target, so `swapSlot` falls back to
+ * remove-then-rename there — a sub-millisecond window where `current` is absent.
+ * Production runs Linux/Docker (atomic branch), and on Windows that transient
+ * Layer A miss is covered by the Layer B live-render path, so a visitor still
+ * never sees a 404. The strict test is therefore POSIX-only; the coherence test
+ * below (which tolerates null) runs on every platform.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
@@ -43,7 +52,10 @@ afterEach(async () => {
 })
 
 describe('publishAtomicityRace', () => {
-  it(
+  // POSIX-only: the never-null invariant depends on atomic symlink rename.
+  // On Windows swapSlot uses a non-atomic remove-then-rename fallback (Layer B
+  // covers the transient miss), so the strict assertion cannot hold there.
+  it.skipIf(process.platform === 'win32')(
     'readArtefact never returns null for routes present in both slot generations',
     async () => {
       // ── Phase 0: Seed both slots with initial content ──────────────────────


### PR DESCRIPTION
## Summary

Makes the publisher's two-slot static-artefact symlink swap work on Windows dev machines.

`swapSlot` relies on `rename(2)` atomically replacing the `current` directory symlink. That holds on POSIX, but Win32 `MoveFile` refuses to overwrite an existing target (`EEXIST`, `EPERM`, `EISDIR`, `EACCES`), so on Windows `current` stays stuck on the old slot and `current.tmp` is orphaned, and a publish silently never takes effect.

Changes:

- `swapSlot` catches the Win32 rename failure and falls back to unlink-then-rename.
- A new `removeSymlinkEntry` helper removes a symlink entry cross-platform: `unlink` first, then `rmdir` for Windows directory-symlinks (which removes the link without recursing into the slot it points at).
- The fallback opens a sub-millisecond window where `current` is absent. `readArtefact` already treats that as a Layer A miss and serves the route via the Layer B live-render path, so a visitor never sees a 404.

Production runs Linux/Docker and always takes the atomic branch, so this is strictly a dev-on-Windows affordance.

Review follow-up (dda0252): gated both the fallback and the `rmdir` branch behind `process.platform === 'win32'` and rethrow elsewhere, so a POSIX rename failure can never trigger a destructive remove-then-rename.

Tests: the strict "never null" atomicity assertion depends on atomic symlink rename, so it is now `it.skipIf(process.platform === 'win32')`. The coherence test (which tolerates the transient miss) still runs on every platform.

## Verification

Run on Windows 11, Bun 1.3.14:

- [x] `bun run build`
- [x] `bun test` (covering suite `bun test publishAtomicityRace`: 1 pass, 1 skip on win32, 0 fail; full suite left to CI)
- [x] `bun run lint`
- [ ] Docker/deployment check, if relevant (production path unchanged; POSIX keeps the existing atomic branch)

## Checklist

- [x] Tests cover behavior changes. (Atomicity race test updated for the platform split.)
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed. (No user-facing surface changed; the behavior is documented inline in `swapSlot`.)
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
