### PR TITLE
fix(editor): refresh Publish affordance after bridge-driven save

### DIFF
--- a/src/admin/pages/site/toolbar/PublishButton.tsx
+++ b/src/admin/pages/site/toolbar/PublishButton.tsx
@@ -78,6 +78,37 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
     return () => { cancelled = true }
   }, [enabled, siteId])
 
+  // Re-confirm publish availability whenever a draft save completes. The
+  // `hasUnsavedChanges` reset effect below catches manual edits (the flag stays
+  // true long enough to be observed), but an MCP editor-bridge edit flushes the
+  // save immediately (`flushEditorSave`), flipping the flag true→false within a
+  // single tick — too fast for that effect to ever render with `true`, so the
+  // button stayed stuck on "Published". Keying off the save's `lastSavedAt`
+  // re-asks the server after every save (manual OR bridge), so bridge-driven
+  // edits surface the Publish affordance without an editor reload.
+  const lastSavedAt = saveStatus?.state === 'saved' ? saveStatus.lastSavedAt : undefined
+  useEffect(() => {
+    if (!enabled || !siteId || lastSavedAt === undefined) return
+    let cancelled = false
+
+    async function refreshAfterSave() {
+      try {
+        const status = await getCmsPublishStatus()
+        if (cancelled) return
+        setState((prev) => {
+          if (prev === 'publishing') return prev // never interrupt an in-flight publish
+          if (status.draftMatchesPublished) return 'published'
+          return prev === 'published' ? 'idle' : prev // draft now differs → re-enable Publish
+        })
+      } catch (err) {
+        console.warn('[toolbar] Failed to refresh publish status:', err)
+      }
+    }
+
+    void refreshAfterSave()
+    return () => { cancelled = true }
+  }, [enabled, siteId, lastSavedAt])
+
   useEffect(() => {
     if (!hasUnsavedChanges || state !== 'published') return
     if (statusTimerRef.current) clearTimeout(statusTimerRef.current)


### PR DESCRIPTION
## Summary

Keeps the Site editor toolbar's Publish button in sync after a save that comes from the MCP editor bridge.

A bridge-driven edit flushes the draft save immediately (`flushEditorSave`), so `hasUnsavedChanges` flips from true to false within a single tick. The existing reset effect never gets a render where the flag is true, so the Publish button stayed stuck on "Published", and a bridge edit could not be published without reloading the editor.

This adds an effect keyed off the save's `lastSavedAt` that re-queries publish status (`getCmsPublishStatus`) after every completed save, manual or bridge. It never interrupts an in-flight publish and re-enables Publish when the draft differs from what is published. Manual editing is unaffected, since the same refresh now also covers it.

## Verification

Run on Windows 11, Bun 1.3.14:

- [x] `bun run build`
- [ ] `bun test` (no unit test added; see checklist note)
- [x] `bun run lint`
- [ ] Docker/deployment check, if relevant (not applicable)

## Checklist

- [ ] Tests cover behavior changes. (No automated test added: the fix is a toolbar effect that depends on the live editor bridge and the save pipeline. Verified by build, lint, and a manual bridge-save exercise. Happy to add a test if you prefer.)
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed. (No user-facing surface or public API changed.)
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
