### PR TITLE
fix(editor): derive font weights from installed variants

### DIFF
--- a/src/__tests__/panels/FontWeightOptions.test.tsx
+++ b/src/__tests__/panels/FontWeightOptions.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import type { FontEntry } from '@core/fonts'
+import { StyleSectionsEditor } from '@site/panels/PropertiesPanel/StyleSectionsEditor'
+import { setEditorPreference } from '@site/preferences/editorPreferences'
+import { useEditorStore } from '@site/store/store'
+import { makeSite } from '../fixtures'
+
+const inter: FontEntry = {
+  id: 'font-inter',
+  source: 'google',
+  family: 'Inter',
+  variants: ['300', '400', '700', '900'],
+  subsets: ['latin'],
+  files: [
+    { variant: '300', subset: 'latin', path: '/uploads/fonts/inter/300-latin.woff2', format: 'woff2' },
+    { variant: '400', subset: 'latin', path: '/uploads/fonts/inter/400-latin.woff2', format: 'woff2' },
+    { variant: '700', subset: 'latin', path: '/uploads/fonts/inter/700-latin.woff2', format: 'woff2' },
+    { variant: '900', subset: 'latin', path: '/uploads/fonts/inter/900-latin.woff2', format: 'woff2' },
+  ],
+  category: 'Sans Serif',
+  createdAt: 1,
+  updatedAt: 1,
+}
+
+beforeEach(() => {
+  setEditorPreference('propertiesSectionsExpanded', true)
+  useEditorStore.setState({
+    site: makeSite({
+      settings: {
+        shortcuts: {},
+        fonts: {
+          items: [inter],
+          tokens: [
+            {
+              id: 'token-primary',
+              name: 'Primary',
+              variable: 'font-primary',
+              familyId: inter.id,
+              fallback: 'sans-serif',
+              order: 0,
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+        },
+      },
+    }),
+  } as Parameters<typeof useEditorStore.setState>[0])
+})
+
+afterEach(() => {
+  cleanup()
+  localStorage.clear()
+})
+
+describe('font weight style options', () => {
+  it('reflects the installed variants for the active font token', () => {
+    renderFontWeightRow({ fontFamily: 'var(--font-primary)' })
+
+    expect(fontWeightOptionValues()).toEqual(['', '300', '400', '700', '900'])
+  })
+
+  it('uses the default body font token when no explicit font family is set', () => {
+    renderFontWeightRow({})
+
+    expect(fontWeightOptionValues()).toEqual(['', '300', '400', '700', '900'])
+  })
+})
+
+function renderFontWeightRow(styles: Record<string, unknown>): void {
+  render(
+    <StyleSectionsEditor
+      storedStyles={styles}
+      currentStyles={styles}
+      sectionKey="base"
+      styleQuery="font weight"
+      onChange={() => {}}
+      onRemove={() => {}}
+      onClearProperty={() => {}}
+      onClearProperties={() => {}}
+      onPreview={() => {}}
+      onClearPreview={() => {}}
+    />,
+  )
+}
+
+function fontWeightOptionValues(): string[] {
+  const row = screen.getByTestId('css-property-row-fontWeight')
+  const select = row.querySelector('select')
+  expect(select).toBeInstanceOf(HTMLSelectElement)
+
+  return Array.from(select?.options ?? [], (option) => option.value)
+}

--- a/src/admin/pages/site/panels/PropertiesPanel/ClassPropertyRow.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/ClassPropertyRow.tsx
@@ -18,6 +18,7 @@ import { ColorControl } from '@site/property-controls/ColorControl'
 import { SelectControl } from '@site/property-controls/SelectControl'
 import { BackgroundImageControl } from '@site/property-controls/BackgroundImageControl'
 import { FontFamilyControl } from '@site/property-controls/FontFamilyControl'
+import { useEditorStore } from '@site/store/store'
 import { ControlRow } from '@ui/components/ControlRow'
 import { TokenAwareInput } from '@site/property-controls/TokenAwareInput'
 import {
@@ -35,6 +36,7 @@ import {
   cssPropertyLabel,
   NUMBER_TYPED_PROPS,
 } from './cssControlTypes'
+import { getFontWeightOptions } from './fontWeightOptions'
 import styles from './ClassPropertyRow.module.css'
 
 // ---------------------------------------------------------------------------
@@ -45,6 +47,7 @@ interface ClassPropertyRowProps {
   property: keyof CSSPropertyBag
   value: string | number | undefined
   placeholder?: string | number
+  fontFamilyValue?: unknown
   isSet?: boolean
   onChange: (property: keyof CSSPropertyBag, value: string | number | undefined) => void
   onRemove: (property: keyof CSSPropertyBag) => void
@@ -64,6 +67,7 @@ export function ClassPropertyRow({
   property,
   value,
   placeholder,
+  fontFamilyValue,
   isSet = true,
   onChange,
   onRemove,
@@ -74,6 +78,7 @@ export function ClassPropertyRow({
   const tokenSource = getCSSPropertyTokenSource(property)
   const label = cssPropertyLabel(String(property))
   const placeholderText = placeholder !== undefined ? String(placeholder) : undefined
+  const fonts = useEditorStore((state) => state.site?.settings.fonts ?? null)
 
   // Always read both token catalogs — hooks must run unconditionally on
   // every render. The selected catalog is forwarded to TokenAwareInput
@@ -208,7 +213,10 @@ export function ClassPropertyRow({
       break
 
     case 'select': {
-      const opts = getEnumOptions(property) ?? []
+      const enumOptions = getEnumOptions(property) ?? []
+      const opts = property === 'fontWeight'
+        ? getFontWeightOptions(fontFamilyValue, fonts, enumOptions)
+        : enumOptions
       control = (
         <SelectControl
           propKey={String(property)}

--- a/src/admin/pages/site/panels/PropertiesPanel/StyleSectionsEditor.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/StyleSectionsEditor.tsx
@@ -241,6 +241,7 @@ function StyleSectionGroup({
                 property={prop}
                 value={isSet ? (storedValue as string | number) : undefined}
                 placeholder={!isSet ? fallbackValue : undefined}
+                fontFamilyValue={currentStyles.fontFamily}
                 isSet={isSet}
                 onChange={onChange}
                 onRemove={onRemove}
@@ -313,6 +314,7 @@ function AdvancedRows({
               property={prop}
               value={isSet ? (storedValue as string | number) : undefined}
               placeholder={!isSet ? fallbackValue : undefined}
+              fontFamilyValue={currentStyles.fontFamily}
               isSet={isSet}
               onChange={onChange}
               onRemove={onRemove}

--- a/src/admin/pages/site/panels/PropertiesPanel/fontWeightOptions.ts
+++ b/src/admin/pages/site/panels/PropertiesPanel/fontWeightOptions.ts
@@ -1,0 +1,127 @@
+import {
+  fontFamilyStackForEntry,
+  fontTokenCssVariable,
+  parseVariant,
+  sortFontTokens,
+  type FontEntry,
+  type FontToken,
+  type SiteFontsSettings,
+} from '@core/fonts'
+
+export function getFontWeightOptions(
+  fontFamilyValue: unknown,
+  fonts: SiteFontsSettings | null | undefined,
+  fallbackOptions: readonly string[],
+): string[] {
+  const entry = resolveFontEntryForWeightOptions(fontFamilyValue, fonts)
+  const installedWeights = entry ? weightOptionsForEntry(entry) : []
+  return installedWeights.length > 0 ? installedWeights : [...fallbackOptions]
+}
+
+function resolveFontEntryForWeightOptions(
+  fontFamilyValue: unknown,
+  fonts: SiteFontsSettings | null | undefined,
+): FontEntry | undefined {
+  const items = fontItems(fonts)
+  if (items.length === 0) return undefined
+
+  const explicitFamily = typeof fontFamilyValue === 'string' ? fontFamilyValue.trim() : ''
+  if (explicitFamily) {
+    const entry = resolveExplicitFontEntry(explicitFamily, fonts, items)
+    if (entry || !isUnsetFontFamilyValue(explicitFamily)) return entry
+  }
+
+  return resolveDefaultBodyFontEntry(fonts, items)
+}
+
+function resolveExplicitFontEntry(
+  fontFamilyValue: string,
+  fonts: SiteFontsSettings | null | undefined,
+  items: readonly FontEntry[],
+): FontEntry | undefined {
+  const tokenVariable = readCssVariableReference(fontFamilyValue)
+  if (tokenVariable) {
+    const token = fontTokens(fonts).find(
+      (candidate) => fontTokenCssVariable(candidate.variable) === tokenVariable,
+    )
+    return token?.familyId ? items.find((entry) => entry.id === token.familyId) : undefined
+  }
+
+  const normalizedStack = normalizeCssFamilyStack(fontFamilyValue)
+  const exactStackMatch = items.find(
+    (entry) => normalizeCssFamilyStack(fontFamilyStackForEntry(entry)) === normalizedStack,
+  )
+  if (exactStackMatch) return exactStackMatch
+
+  const firstFamily = normalizeCssFamilyName(readFirstCssFamily(fontFamilyValue))
+  if (!firstFamily) return undefined
+  return items.find((entry) => normalizeCssFamilyName(entry.family) === firstFamily)
+}
+
+function resolveDefaultBodyFontEntry(
+  fonts: SiteFontsSettings | null | undefined,
+  items: readonly FontEntry[],
+): FontEntry | undefined {
+  const tokens = fontTokens(fonts)
+  const bodyToken = tokens[1] ?? tokens[0]
+  if (bodyToken?.familyId) {
+    const entry = items.find((item) => item.id === bodyToken.familyId)
+    if (entry) return entry
+  }
+  return items[1] ?? items[0]
+}
+
+function weightOptionsForEntry(entry: FontEntry): string[] {
+  const weights = new Set<number>()
+  const variants = [
+    ...entry.variants,
+    ...entry.files.map((file) => file.variant),
+  ]
+  for (const variant of variants) {
+    const parsed = parseVariant(variant)
+    if (parsed) weights.add(parsed.weight)
+  }
+  return [...weights].sort((a, b) => a - b).map(String)
+}
+
+function fontItems(fonts: SiteFontsSettings | null | undefined): readonly FontEntry[] {
+  return Array.isArray(fonts?.items) ? fonts.items : []
+}
+
+function fontTokens(fonts: SiteFontsSettings | null | undefined): FontToken[] {
+  return Array.isArray(fonts?.tokens) ? sortFontTokens(fonts.tokens) : []
+}
+
+function readCssVariableReference(value: string): string | undefined {
+  const match = /^var\(\s*(--[a-zA-Z0-9_-]+)\s*(?:,[^)]+)?\)$/.exec(value)
+  return match?.[1]
+}
+
+function isUnsetFontFamilyValue(value: string): boolean {
+  const normalized = value.toLowerCase()
+  return normalized === 'inherit' || normalized === 'initial' || normalized === 'unset' || normalized === 'revert'
+}
+
+function readFirstCssFamily(value: string): string {
+  const trimmed = value.trim()
+  if (!trimmed) return ''
+  const quote = trimmed[0]
+  if (quote === '"' || quote === "'") {
+    for (let index = 1; index < trimmed.length; index += 1) {
+      if (trimmed[index] === quote && trimmed[index - 1] !== '\\') {
+        return trimmed.slice(1, index)
+      }
+    }
+    return trimmed.slice(1)
+  }
+  const comma = trimmed.indexOf(',')
+  return (comma === -1 ? trimmed : trimmed.slice(0, comma)).trim()
+}
+
+function normalizeCssFamilyStack(value: string): string {
+  return value.trim().replace(/\s+/g, ' ').toLowerCase()
+}
+
+function normalizeCssFamilyName(value: string): string {
+  return value.trim().replace(/^['"]|['"]$/g, '').toLowerCase()
+}


### PR DESCRIPTION
## Summary
- Fixes #190.
- Derives the `font-weight` style select from the active installed font variants instead of the static enum.
- Resolves both explicit font-token references such as `var(--font-primary)` and the site default/body font token when no explicit family is set.
- Keeps the existing generic font-weight list as the fallback when no installed font can be matched.

## Reproduction
- Live smoke on `main` reproduced the issue with Inter installed at 300/400/700/900: the editor offered 500/600/bold/normal and omitted 900.

## Verification
- `bun test src/__tests__/panels/FontWeightOptions.test.tsx`
- `bun test`
- `bun run build`
- `bun run lint`
- `bun run doctor`
- `bun run doctor -- --verbose --diff` (warning-only pre-existing findings in touched StyleSectionsEditor: repo-barrel conflict and unrelated map/filter note)