### PR TITLE
fix(scripts): launch dev tools through current Bun executable

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -21,13 +21,14 @@
  *   - Pre-checks ports 3001 (cms) and 5173 (vite) and prints an
  *     actionable message if either is held by something we don't own.
  *   - Spawns the cms (`bun --watch server/index.ts`) and vite
- *     (`vite --host 127.0.0.1`) as children, forwarding their output
+ *     (`bun run vite --host 127.0.0.1`) as children, forwarding their output
  *     and signals so Ctrl+C cleanly kills both.
  */
 
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isSqliteUrl } from '../server/db'
+import { bunCommand, bunRunCommand } from './lib/bunCommand'
 import { ensurePortFree } from './lib/freePort'
 
 const CMS_PORT = Number(process.env.PORT ?? '3001')
@@ -234,14 +235,14 @@ log('')
 
 interface DevProcess {
   name: string
-  command: string
+  command: string[]
   env?: Record<string, string>
 }
 
 const processes: DevProcess[] = [
   {
     name: 'cms',
-    command: 'bun --watch server/index.ts',
+    command: bunCommand('--watch', 'server/index.ts'),
     env: {
       PORT: String(CMS_PORT),
       DATABASE_URL,
@@ -251,7 +252,7 @@ const processes: DevProcess[] = [
   },
   {
     name: 'vite',
-    command: `vite --host 127.0.0.1 --port ${VITE_PORT} --strictPort`,
+    command: bunRunCommand('vite', '--host', '127.0.0.1', '--port', String(VITE_PORT), '--strictPort'),
   },
 ]
 
@@ -265,9 +266,7 @@ function stopChildren(signal: NodeJS.Signals = 'SIGTERM'): void {
 }
 
 for (const cfg of processes) {
-  const args = cfg.command.split(' ')
-  if (args[0] === 'bun') args[0] = process.execPath
-  const child = Bun.spawn(args, {
+  const child = Bun.spawn(cfg.command, {
     env: { ...process.env, ...cfg.env },
     stdin: 'inherit',
     stdout: 'inherit',

--- a/scripts/e2e-dev.ts
+++ b/scripts/e2e-dev.ts
@@ -13,6 +13,7 @@
  * admin app mid-test either.
  */
 import { mkdir, rm } from 'node:fs/promises'
+import { bunCommand, bunRunCommand } from './lib/bunCommand'
 
 const DATABASE_PATH = './.tmp/e2e-agent.db'
 const UPLOADS_DIR = './.tmp/e2e-uploads'
@@ -45,8 +46,8 @@ function stopChildren(signal: NodeJS.Signals = 'SIGTERM'): void {
 }
 
 for (const command of [
-  ['bun', 'server/index.ts'],
-  ['vite', '--host', '127.0.0.1', '--port', VITE_PORT, '--strictPort'],
+  bunCommand('server/index.ts'),
+  bunRunCommand('vite', '--host', '127.0.0.1', '--port', VITE_PORT, '--strictPort'),
 ]) {
   const child = Bun.spawn(command, {
     env: sharedEnv,

--- a/scripts/lib/bunCommand.ts
+++ b/scripts/lib/bunCommand.ts
@@ -1,0 +1,7 @@
+export function bunCommand(...args: string[]): string[] {
+  return [process.execPath, ...args]
+}
+
+export function bunRunCommand(...args: string[]): string[] {
+  return bunCommand('run', ...args)
+}

--- a/scripts/start.ts
+++ b/scripts/start.ts
@@ -19,6 +19,7 @@
  * Override any of these via env (`PORT=4000 bun run start`, etc.).
  */
 
+import { bunRunCommand } from './lib/bunCommand'
 import { ensurePortFree } from './lib/freePort'
 
 const CMS_PORT = Number(process.env.PORT ?? '3001')
@@ -41,11 +42,7 @@ function runStep(name: string, command: string[]): void {
 
 // --- build ---------------------------------------------------------------
 
-runStep('Building admin SPA (tsc -b && vite build)', [
-  'bun',
-  'run',
-  'build',
-])
+runStep('Building admin SPA (tsc -b && vite build)', bunRunCommand('build'))
 
 // --- port pre-flight -----------------------------------------------------
 
@@ -57,7 +54,7 @@ log('')
 log(`Starting server on http://localhost:${CMS_PORT}`)
 log('')
 
-const child = Bun.spawn(['bun', 'run', 'server/index.ts'], {
+const child = Bun.spawn(bunRunCommand('server/index.ts'), {
   env: { ...process.env, PORT: String(CMS_PORT) },
   stdin: 'inherit',
   stdout: 'inherit',

--- a/src/__tests__/devWorkflow.test.ts
+++ b/src/__tests__/devWorkflow.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
+import { bunCommand, bunRunCommand } from '../../scripts/lib/bunCommand'
 
 const root = new URL('../../', import.meta.url)
 
@@ -21,9 +22,11 @@ describe('development workflow', () => {
     expect(existsSync(new URL('scripts/dev-all.ts', root))).toBe(false)
 
     const script = readSiteFile('scripts/dev.ts')
-    // Spawns cms + vite directly (no recursive `bun run dev` call).
-    expect(script).toContain('bun --watch server/index.ts')
-    expect(script).toContain('vite --host 127.0.0.1')
+    // Spawns cms + vite without a recursive `bun run dev` call.
+    expect(script).toContain("bunCommand('--watch', 'server/index.ts')")
+    expect(script).toContain("bunRunCommand('vite', '--host', '127.0.0.1'")
+    expect(script).not.toContain('command: `vite')
+    expect(script).not.toContain('command.split')
     // Knows about the docker postgres host port.
     expect(script).toContain('127.0.0.1')
     expect(script).toContain('5433')
@@ -34,6 +37,35 @@ describe('development workflow', () => {
     // Forwards signals to children.
     expect(script).toContain('SIGINT')
     expect(script).toContain('SIGTERM')
+  })
+
+  it('development launchers route local Vite binaries through Bun on Windows', () => {
+    const devScript = readSiteFile('scripts/dev.ts')
+    const e2eScript = readSiteFile('scripts/e2e-dev.ts')
+    const startScript = readSiteFile('scripts/start.ts')
+
+    expect(bunCommand('--watch', 'server/index.ts')).toEqual([
+      process.execPath,
+      '--watch',
+      'server/index.ts',
+    ])
+    expect(bunRunCommand('vite', '--host', '127.0.0.1')).toEqual([
+      process.execPath,
+      'run',
+      'vite',
+      '--host',
+      '127.0.0.1',
+    ])
+
+    expect(devScript).toContain("bunRunCommand('vite', '--host', '127.0.0.1'")
+    expect(devScript).not.toContain('command: `vite')
+    expect(devScript).not.toContain('command.split')
+    expect(e2eScript).toContain("bunRunCommand('vite', '--host', '127.0.0.1'")
+    expect(e2eScript).not.toContain("['vite'")
+    expect(e2eScript).not.toContain("['bun'")
+    expect(startScript).toContain("bunRunCommand('build')")
+    expect(startScript).toContain("bunRunCommand('server/index.ts')")
+    expect(startScript).not.toContain("['bun'")
   })
 
   it('Vite proxies CMS API and uploaded media to the local Bun server', () => {


### PR DESCRIPTION
## What changed
- Added a small Bun command helper that uses `process.execPath` for child Bun invocations.
- Updated `bun run dev`, E2E dev, and local `start` launchers to run CMS/Vite/build commands through that helper.
- Added a regression test that blocks direct `vite`/`bun` child spawns in these launchers.

## Why
Windows users with Bun installed via npm can hit `uv_spawn` ENOENT when a script spawns package-bin shims like `vite` directly, or spawns `bun` by name. Routing through the current Bun executable and `bun run vite` avoids relying on Windows `.cmd` shim resolution.

## Impact
`bun run dev` should no longer fail after the CMS starts with `uv_spawn 'vite'` on Windows. The same process-launch pattern is also fixed for `scripts/e2e-dev.ts` and `scripts/start.ts`.

## Verification
- `bun test src/__tests__/devWorkflow.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`