### PR TITLE
fix(scripts): launch vite through dev script on Windows

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -21,7 +21,7 @@
  *   - Pre-checks ports 3001 (cms) and 5173 (vite) and prints an
  *     actionable message if either is held by something we don't own.
  *   - Spawns the cms (`bun --watch server/index.ts`) and vite
- *     (`bun run vite --host 127.0.0.1`) as children, forwarding their output
+ *     (`bun run dev:vite --host 127.0.0.1`) as children, forwarding their output
  *     and signals so Ctrl+C cleanly kills both.
  */
 
@@ -252,7 +252,7 @@ const processes: DevProcess[] = [
   },
   {
     name: 'vite',
-    command: bunRunCommand('vite', '--host', '127.0.0.1', '--port', String(VITE_PORT), '--strictPort'),
+    command: bunRunCommand('dev:vite', '--host', '127.0.0.1', '--port', String(VITE_PORT), '--strictPort'),
   },
 ]
 

--- a/scripts/e2e-dev.ts
+++ b/scripts/e2e-dev.ts
@@ -47,7 +47,7 @@ function stopChildren(signal: NodeJS.Signals = 'SIGTERM'): void {
 
 for (const command of [
   bunCommand('server/index.ts'),
-  bunRunCommand('vite', '--host', '127.0.0.1', '--port', VITE_PORT, '--strictPort'),
+  bunRunCommand('dev:vite', '--host', '127.0.0.1', '--port', VITE_PORT, '--strictPort'),
 ]) {
   const child = Bun.spawn(command, {
     env: sharedEnv,

--- a/src/__tests__/devWorkflow.test.ts
+++ b/src/__tests__/devWorkflow.test.ts
@@ -17,6 +17,7 @@ describe('development workflow', () => {
     expect(pkg.scripts['dev']).toBe('bun run scripts/dev.ts')
     expect(pkg.scripts['dev:agent']).toBe('bun run dev:server')
     expect(pkg.scripts['dev:server']).toBe('bun --watch server/index.ts')
+    expect(pkg.scripts['dev:vite']).toBe('vite')
     expect(pkg.scripts['dev:all']).toBeUndefined()
     expect(existsSync(new URL('scripts/dev.ts', root))).toBe(true)
     expect(existsSync(new URL('scripts/dev-all.ts', root))).toBe(false)
@@ -24,7 +25,7 @@ describe('development workflow', () => {
     const script = readSiteFile('scripts/dev.ts')
     // Spawns cms + vite without a recursive `bun run dev` call.
     expect(script).toContain("bunCommand('--watch', 'server/index.ts')")
-    expect(script).toContain("bunRunCommand('vite', '--host', '127.0.0.1'")
+    expect(script).toContain("bunRunCommand('dev:vite', '--host', '127.0.0.1'")
     expect(script).not.toContain('command: `vite')
     expect(script).not.toContain('command.split')
     // Knows about the docker postgres host port.
@@ -49,18 +50,20 @@ describe('development workflow', () => {
       '--watch',
       'server/index.ts',
     ])
-    expect(bunRunCommand('vite', '--host', '127.0.0.1')).toEqual([
+    expect(bunRunCommand('dev:vite', '--host', '127.0.0.1')).toEqual([
       process.execPath,
       'run',
-      'vite',
+      'dev:vite',
       '--host',
       '127.0.0.1',
     ])
 
-    expect(devScript).toContain("bunRunCommand('vite', '--host', '127.0.0.1'")
+    expect(devScript).toContain("bunRunCommand('dev:vite', '--host', '127.0.0.1'")
+    expect(devScript).not.toContain("bunRunCommand('vite'")
     expect(devScript).not.toContain('command: `vite')
     expect(devScript).not.toContain('command.split')
-    expect(e2eScript).toContain("bunRunCommand('vite', '--host', '127.0.0.1'")
+    expect(e2eScript).toContain("bunRunCommand('dev:vite', '--host', '127.0.0.1'")
+    expect(e2eScript).not.toContain("bunRunCommand('vite'")
     expect(e2eScript).not.toContain("['vite'")
     expect(e2eScript).not.toContain("['bun'")
     expect(startScript).toContain("bunRunCommand('build')")


### PR DESCRIPTION
## What changed

- Route the dev and e2e Vite child process through the existing `dev:vite` package script.
- Keep child process spawning anchored on `process.execPath` from the current Bun runtime.
- Extend the development workflow regression test so it rejects both direct `vite` spawning and `bun run vite` binary lookup.

## Why

The previous fix removed Windows `uv_spawn` failures by avoiding direct `bun` / `vite` executable lookup. After pulling that change, a Windows user hit `error: Script not found "vite"`, which shows that `bun run vite` is not portable on their Bun/Windows setup. Using `bun run dev:vite` targets an explicit package script already present in `package.json`, so Bun resolves the script first and the script invokes Vite through the package manager environment.

## Impact

`bun run dev` and the e2e dev launcher should no longer depend on Windows shell shim or package-binary lookup behavior for Vite.

## Verification

- `bun run dev:vite --version`
- `bun -e "const r=Bun.spawnSync([process.execPath,'run','dev:vite','--version'],{stdout:'pipe',stderr:'pipe'}); console.log(r.exitCode); console.log(r.stdout.toString()); console.error(r.stderr.toString())"`
- `bun test src/__tests__/devWorkflow.test.ts`
- `bun run lint`
- `bun run build`
- `bun test`