### PR TITLE
ci: run typecheck, lint, tests, and e2e on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,120 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+# Cancel superseded runs on the same ref (e.g. a new push to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build & Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # `bun run build` is `tsc -b && vite build` — typecheck and bundle in one.
+      - name: Build
+        run: bun run build
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test
+        run: bun test
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      # Playwright pins a browser build per version; cache it keyed on the
+      # installed @playwright/test version so we only re-download on upgrades.
+      - name: Resolve Playwright version
+        id: pw
+        shell: bash
+        run: echo "version=$(bun pm ls 2>/dev/null | grep -oE '@playwright/test@[^ ]+' | head -n1 | cut -d@ -f3)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      # The Playwright config starts its own stack via `bun run e2e:dev`
+      # (Vite + Bun CMS on a disposable SQLite DB), so no services are needed.
+      - name: Run E2E tests
+        run: bun run test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: .tmp/playwright-report
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

Adds PR-triggered CI. Until now the only workflow was `release.yml`, which runs on version tags — so pull requests got no automated checks (e.g. #187 shows 0 checks). This adds `.github/workflows/ci.yml`, running on `pull_request` and `push` to `main`, with four parallel jobs so each check reports its own PR status and one failure doesn't mask another:

- **Build & Typecheck** — `bun run build` (`tsc -b && vite build`)
- **Lint** — `bun run lint`
- **Test** — `bun test`
- **E2E** — `playwright install --with-deps chromium` then `bun run test:e2e`

Design notes:

- Mirrors the existing `release.yml` `verify` job conventions: `oven-sh/setup-bun@v2` pinned to `1.3.11`, `bun install --frozen-lockfile`.
- The E2E job needs no external services or secrets — the Playwright config boots its own stack via `bun run e2e:dev` (Vite + Bun CMS on a disposable SQLite DB). Chromium is cached keyed on the `@playwright/test` version, and the HTML report uploads as an artifact on failure.
- A `concurrency` group cancels superseded runs when a PR branch gets new commits.

Note: first-time fork contributions (like #187) still require a maintainer to approve workflow runs under **Settings → Actions → Fork pull request workflows**; that gate is independent of this change.

## Verification

- [ ] `bun run build`
- [ ] `bun test`
- [ ] `bun run lint`
- [ ] Docker/deployment check, if relevant

This change adds a GitHub Actions workflow file only — it has no runtime surface, so `build`/`test`/`lint` are unaffected by it. The workflow YAML was validated (parses cleanly; 4 jobs; `pull_request` + `push` triggers), and the Playwright version-resolution step was confirmed to return `1.60.0` locally. The jobs themselves will run against this PR once CI is enabled.

## Checklist

- [x] Tests cover behavior changes. (N/A — CI config only, no product behavior changed.)
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed. (Workflow is self-documenting via inline comments; no doc surface describes CI.)
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQimijBDYixvpHp2HRiSJu)_