### PR TITLE
ci: drop E2E job from PR checks until the suite is CI-ready

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,49 +72,8 @@ jobs:
       - name: Test
         run: bun test
 
-  e2e:
-    name: E2E
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Set up Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      # Playwright pins a browser build per version; cache it keyed on the
-      # installed @playwright/test version so we only re-download on upgrades.
-      - name: Resolve Playwright version
-        id: pw
-        shell: bash
-        run: echo "version=$(bun pm ls 2>/dev/null | grep -oE '@playwright/test@[^ ]+' | head -n1 | cut -d@ -f3)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Playwright browsers
-        id: pw-cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
-
-      - name: Install Playwright browser
-        run: bunx playwright install --with-deps chromium
-
-      # The Playwright config starts its own stack via `bun run e2e:dev`
-      # (Vite + Bun CMS on a disposable SQLite DB), so no services are needed.
-      - name: Run E2E tests
-        run: bun run test:e2e
-
-      - name: Upload Playwright report
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: .tmp/playwright-report
-          retention-days: 7
-          if-no-files-found: ignore
+# NOTE: The Playwright E2E suite is intentionally NOT run in CI yet. As
+# configured (`workers: 1`, fully serial, 156 tests) it takes ~45-60 min and is
+# timeout-fragile against the un-optimized dev server, so it cannot gate PRs
+# reliably today. Run it locally with `bun run test:e2e`. It will be reintroduced
+# as its own workflow once the suite is sharded/parallelized and stabilized.


### PR DESCRIPTION
## Summary

Removes the `E2E` job from the PR CI workflow (`.github/workflows/ci.yml`), leaving **Build & Typecheck / Lint / Test** as the fast, reliable PR gate.

## Why

When the workflow was first exercised (on PRs #183, #182, #174), the E2E job failed on every run — but not because of those PRs. Two suite-level problems make it unfit to gate PRs today:

- **Too slow to finish.** The Playwright suite runs fully serially (`workers: 1`, `fullyParallel: false`, 156 tests) and needs ~45–60 min. It only ever reached ~1/3 of the suite before tripping its own 20-min timeout, so it would be cancelled even if every test passed.
- **Pre-existing, timeout-fragile failures.** The same specs (`admin-navigation`, `ai`, `capabilities`) failed identically across three unrelated PRs, which points at the suite/environment rather than the changes. The failures cluster on editor/canvas-dependent specs racing 20s timeouts against the un-optimized dev server (the "6.5× faster dev boot" work is not merged yet).

Rather than block every PR on a slow, pre-existing-red suite, drop it from CI for now. Build/Lint/Test give the reliable signal today.

## Impact

- PR CI = `Build & Typecheck`, `Lint`, `Test` only.
- The E2E suite is unchanged and still runs locally via `bun run test:e2e`.
- A comment in `ci.yml` records why E2E is absent and that it will return as its own sharded/parallelized workflow once stabilized.

## Verification

- [x] `ci.yml` parses; jobs are now `build`, `lint`, `test`.
- No product code touched — workflow config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQimijBDYixvpHp2HRiSJu)_