### PR TITLE
fix(scripts): diagnose incomplete dev installs

### DIFF
--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -29,6 +29,11 @@ import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isSqliteUrl } from '../server/db'
 import { bunCommand, viteCommand } from './lib/bunCommand'
+import {
+  checkDevDependencies,
+  formatDevDependencyError,
+  formatProcessExit,
+} from './lib/devEnvironment'
 import { ensurePortFree } from './lib/freePort'
 
 const CMS_PORT = Number(process.env.PORT ?? '3001')
@@ -207,6 +212,9 @@ async function waitForPostgresReady(timeoutMs = 60_000): Promise<void> {
 
 // --- main -----------------------------------------------------------------
 
+const dependencyCheck = checkDevDependencies()
+if (!dependencyCheck.ok) fail(formatDevDependencyError(dependencyCheck))
+
 if (isSqliteUrl(DATABASE_URL)) {
   const dbPath = DATABASE_URL.replace(/^sqlite:|^file:/, '')
   await mkdir(dirname(dbPath), { recursive: true })
@@ -276,8 +284,10 @@ for (const cfg of processes) {
   void child.exited.then((code) => {
     if (shuttingDown) return
     shuttingDown = true
+    log(formatProcessExit(cfg.name, code, cfg.command))
+    log('Shutting down the other dev process.')
     stopChildren()
-    process.exit(code)
+    process.exit(code ?? 1)
   })
 }
 

--- a/scripts/e2e-dev.ts
+++ b/scripts/e2e-dev.ts
@@ -14,6 +14,7 @@
  */
 import { mkdir, rm } from 'node:fs/promises'
 import { bunCommand, viteCommand } from './lib/bunCommand'
+import { formatProcessExit } from './lib/devEnvironment'
 
 const DATABASE_PATH = './.tmp/e2e-agent.db'
 const UPLOADS_DIR = './.tmp/e2e-uploads'
@@ -45,11 +46,11 @@ function stopChildren(signal: NodeJS.Signals = 'SIGTERM'): void {
   }
 }
 
-for (const command of [
-  bunCommand('server/index.ts'),
-  viteCommand('--host', '127.0.0.1', '--port', VITE_PORT, '--strictPort'),
+for (const cfg of [
+  { name: 'cms', command: bunCommand('server/index.ts') },
+  { name: 'vite', command: viteCommand('--host', '127.0.0.1', '--port', VITE_PORT, '--strictPort') },
 ]) {
-  const child = Bun.spawn(command, {
+  const child = Bun.spawn(cfg.command, {
     env: sharedEnv,
     stdin: 'inherit',
     stdout: 'inherit',
@@ -60,6 +61,7 @@ for (const command of [
     if (shuttingDown) return
     // One half of the stack died on its own — bring the other down and exit so
     // Playwright sees the failure instead of half a stack.
+    console.error(`[e2e-dev] ${formatProcessExit(cfg.name, code, cfg.command)}`)
     stopChildren()
     process.exit(code ?? 1)
   })

--- a/scripts/lib/devEnvironment.ts
+++ b/scripts/lib/devEnvironment.ts
@@ -1,0 +1,68 @@
+export interface RequiredDevDependency {
+  name: string
+  specifier: string
+}
+
+export interface DevDependencyCheck {
+  ok: boolean
+  missing: RequiredDevDependency[]
+}
+
+type PackageResolver = (specifier: string) => string
+
+const requiredDevDependencies: RequiredDevDependency[] = [
+  { name: '@sinclair/typebox', specifier: '@sinclair/typebox/package.json' },
+  { name: 'vite', specifier: 'vite/package.json' },
+  { name: 'tinyglobby', specifier: 'tinyglobby/package.json' },
+]
+
+function resolvePackage(specifier: string): string {
+  return Bun.resolveSync(specifier, process.cwd())
+}
+
+export function checkDevDependencies(resolver: PackageResolver = resolvePackage): DevDependencyCheck {
+  const missing: RequiredDevDependency[] = []
+  for (const dependency of requiredDevDependencies) {
+    try {
+      resolver(dependency.specifier)
+    } catch {
+      missing.push(dependency)
+    }
+  }
+  return { ok: missing.length === 0, missing }
+}
+
+export function formatDevDependencyError(
+  check: DevDependencyCheck,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const missing = check.missing.map((dependency) => `  - ${dependency.name}`).join('\n')
+  const removeNodeModules = platform === 'win32'
+    ? 'Remove-Item -Recurse -Force node_modules'
+    : 'rm -rf node_modules'
+
+  return [
+    'Local dependencies are incomplete; bun install likely stopped before it finished.',
+    'Missing packages:',
+    missing,
+    '',
+    'Run this from the repository root, and make sure it reaches the final "packages installed" summary:',
+    '  bun install --frozen-lockfile',
+    '',
+    'If the same packages are still missing, remove the partial install and retry:',
+    `  ${removeNodeModules}`,
+    '  bun install --frozen-lockfile',
+  ].join('\n')
+}
+
+export function formatCommandForLog(command: string[]): string {
+  return command.map((arg) => {
+    if (arg === '') return '""'
+    if (!/[\s"']/.test(arg)) return arg
+    return JSON.stringify(arg)
+  }).join(' ')
+}
+
+export function formatProcessExit(name: string, code: number | null, command: string[]): string {
+  return `${name} exited with code ${code ?? 'unknown'}. Command: ${formatCommandForLog(command)}`
+}

--- a/src/__tests__/devWorkflow.test.ts
+++ b/src/__tests__/devWorkflow.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import { bunCommand, bunRunCommand, viteCommand } from '../../scripts/lib/bunCommand'
+import {
+  checkDevDependencies,
+  formatCommandForLog,
+  formatDevDependencyError,
+  formatProcessExit,
+} from '../../scripts/lib/devEnvironment'
 
 const root = new URL('../../', import.meta.url)
 
@@ -29,6 +35,8 @@ describe('development workflow', () => {
     // Spawns cms + vite without a recursive `bun run dev` call.
     expect(script).toContain("bunCommand('--watch', 'server/index.ts')")
     expect(script).toContain("viteCommand('--host', '127.0.0.1'")
+    expect(script).toContain('checkDevDependencies()')
+    expect(script).toContain('formatProcessExit(cfg.name')
     expect(script).not.toContain('command: `vite')
     expect(script).not.toContain('command.split')
     // Knows about the docker postgres host port.
@@ -70,11 +78,36 @@ describe('development workflow', () => {
     expect(e2eScript).not.toContain("bunRunCommand('vite'")
     expect(e2eScript).not.toContain("['vite'")
     expect(e2eScript).not.toContain("['bun'")
+    expect(e2eScript).toContain('formatProcessExit(cfg.name')
     expect(viteScript).toContain('viteCommand(...Bun.argv.slice(2))')
     expect(viteScript).not.toContain("['vite'")
     expect(startScript).toContain("bunRunCommand('build')")
     expect(startScript).toContain("bunRunCommand('server/index.ts')")
     expect(startScript).not.toContain("['bun'")
+  })
+
+  it('dev diagnostics explain incomplete installs and child exits', () => {
+    const missingTinyglobby = checkDevDependencies((specifier) => {
+      if (specifier === 'tinyglobby/package.json') throw new Error('missing')
+      return `/repo/node_modules/${specifier}`
+    })
+
+    expect(missingTinyglobby.ok).toBe(false)
+    expect(missingTinyglobby.missing.map((dependency) => dependency.name)).toEqual(['tinyglobby'])
+    expect(formatDevDependencyError(missingTinyglobby, 'win32')).toContain('bun install likely stopped before it finished')
+    expect(formatDevDependencyError(missingTinyglobby, 'win32')).toContain('tinyglobby')
+    expect(formatDevDependencyError(missingTinyglobby, 'win32')).toContain('Remove-Item -Recurse -Force node_modules')
+
+    const command = [
+      process.execPath,
+      'D:\\Instatic Project\\node_modules\\vite\\bin\\vite.js',
+      '--host',
+      '127.0.0.1',
+    ]
+
+    expect(formatCommandForLog(command)).toContain('"D:\\\\Instatic Project\\\\node_modules\\\\vite\\\\bin\\\\vite.js"')
+    expect(formatProcessExit('vite', 5, command)).toContain('vite exited with code 5')
+    expect(formatProcessExit('vite', 5, command)).toContain('Command:')
   })
 
   it('Vite proxies CMS API and uploaded media to the local Bun server', () => {


### PR DESCRIPTION
## What changed

- Add a dev preflight that checks the packages implicated by the Windows reports before starting the CMS or Vite child processes.
- Print a focused recovery message when `node_modules` is partial, including the missing packages and Windows-friendly cleanup command.
- Log which child process exited, plus the exact command, when the dev or e2e dev stack shuts down because one side died.

## Why

The latest Windows report is no longer the original bare `vite` / `bun` spawn issue. The log shows `bun install` returning early while still at progress like `[27/731]`, followed by missing packages such as `@sinclair/typebox` and `tinyglobby`. That means the local dependency install is incomplete. After repeated installs completed, the remaining `error: script "dev" exited with code 5` was too opaque because the launcher did not say whether `cms` or `vite` exited.

This PR does not make Bun's installer succeed when it stops early, but it prevents Instatic from half-starting with a partial install and makes the next report actionable.

## User/developer impact

Users with incomplete installs now get an explicit message telling them `bun install` likely stopped before finishing and listing the packages that are missing. If the install is complete but a child process exits, the dev script now prints e.g. `vite exited with code 5. Command: ...` or `cms exited with code 5. Command: ...` before shutting down the other process.

## Verification

- `bun run lint`
- `bun run build`
- `bun test` (`6025 pass`, `0 fail`)