### PR TITLE
feat(agent): add compact context meter with usage details

### DIFF
--- a/docs/features/agent.md
+++ b/docs/features/agent.md
@@ -121,8 +121,9 @@ src/admin/pages/site/panels/AgentPanel/
 ├── usePendingImageAttachments.ts — ref-backed sequential image queue and per-item cancellation
 ├── ModelPicker.tsx         — credential + model selector used in the input bar
 ├── ConversationHistory.tsx — history popover (browse, restore, delete past threads)
-├── ContextMeter.tsx        — "context used / window" progress indicator (display only)
+├── ContextMeter.tsx        — compact five-segment context + conversation-usage tooltip
 ├── ContextMeter.module.css
+├── contextMeterMetrics.ts  — five-band fill/tone calculation
 ├── AgentPanel.module.css
 └── index.ts                — barrel export
 
@@ -133,9 +134,11 @@ src/admin/pages/ai/
     ├── ProvidersTab.tsx    — CRUD for ai_credentials rows (provider-derived API key or endpoint credential shape)
     ├── DefaultsTab.tsx     — per-scope model defaults editor
     ├── AuditTab.tsx        — usage audit view: totals strip, by-model/user/scope tables, daily bar chart
-    ├── UsageTablePanel.tsx — shared table scaffolding (title + hint header, numeric-aligned columns, empty row)
-    └── usageFormat.ts      — formatNumber / formatCost helpers (plain .ts leaf; importable by tests and components alike)
+    └── UsageTablePanel.tsx — shared table scaffolding (title + hint header, numeric-aligned columns, empty row)
 ```
+
+Shared AI number and spend formatting lives in `src/admin/ai/usageFormat.ts`, so
+the Audit workspace and compact composer usage detail use identical labels.
 
 The Agent Panel owns the credential list load for its header, lock-state empty states, and model picker. The header always contains a `ConversationHistory` popover (browse and restore past threads), a "New chat" button (`startNewAgentConversation`), a conditional "Clear conversation" button (visible when `agentMessages.length > 0`), a streaming badge, and an "AI settings" shortcut that routes to `/admin/ai`. The AI settings button is always visible in the header, independent of credential state.
 
@@ -149,7 +152,7 @@ While credentials are still loading, `lockReason` stays `null` so the panel does
 
 When the panel opens, `AgentPanel` calls `loadScopeDefault()` so the model picker immediately shows the configured scope default — no "Default" placeholder, no send-time no-provider surprise. `composerLocked` is gated by `hasActiveProvider` (`Boolean(activeCredentialId && activeModelId)`), meaning a stale "No AI provider configured" error string never locks out the UI once a credential + model is staged; picking a model via `setAgentProvider` clears `agentError` immediately, re-enabling the composer.
 
-The composer area includes a `<ContextMeter>` that shows "context used / window" as a progress bar. `AgentComposer` resolves the full active-model descriptor from `GET /admin/api/ai/providers/:id/models?credentialId=…` (the same catalogue-enriched response the picker uses), then uses its `contextWindow`, `capabilities.visionInput`, and `capabilities.toolCalling`. A model known not to support tools is blocked with an inline "choose an agent-capable model" message; the server repeats that gate authoritatively. The meter appears as soon as a model is selected — before the first turn. The "used" half comes from `agentContextTokens` in the store (see slice state below). The meter is hidden when no context window is known (Ollama, uncatalogued models).
+The composer action row includes a compact five-segment `<ContextMeter>` immediately before Attach images and Send. `AgentComposer` resolves the full active-model descriptor from `GET /admin/api/ai/providers/:id/models?credentialId=…` (the same catalogue-enriched response the picker uses), then uses its `contextWindow`, pricing, `capabilities.visionInput`, and `capabilities.toolCalling`. A model known not to support tools is blocked with an inline "choose an agent-capable model" message; the server repeats that gate authoritatively. The meter appears as soon as a model with a known window is selected. It represents **context remaining**: a fresh conversation is five green segments and the battery drains toward amber/red as context is consumed. Hover or keyboard focus opens a wide graphical tooltip with exact context used/available, cumulative conversation input/output/cache tokens, authoritative USD spend, and current-model list rates. A context snapshot belongs to the credential/model selection that measured it, so switching models renders the meter indeterminate until the next provider response rather than comparing stale usage to a new window. The meter stays hidden when no context window is known (Ollama, uncatalogued models).
 
 ### Attaching user images
 
@@ -244,7 +247,7 @@ NDJSON stream events (one JSON object + \n per line):
     { type: 'toolCall', toolCallId, toolName, input, status: 'pending' }
     { type: 'toolRequest', requestId, toolName, input }    ← browser-bridged tools only
     { type: 'toolResult', toolCallId, toolName, ok, error? }
-    { type: 'usage', promptTokens, completionTokens, costUsd?, cacheReadTokens?, cacheCreationTokens? }
+    { type: 'usage', promptTokens, completionTokens, costUsd, cacheReadTokens?, cacheCreationTokens? }
     { type: 'context', contextTokens }                     ← per-round meter update
     { type: 'done' }
     { type: 'error', message }                             ← on server error
@@ -336,7 +339,7 @@ tz?:    string   // IANA timezone (e.g. "Europe/Bratislava"); defaults to UTC
 
 `byDay` is the time-series chart data — each `day` field is `YYYY-MM-DD` in the viewer's local timezone (not UTC). The daily rollup pulls raw message rows and bins them in JS via `localDayKeyFactory(timeZone)` (`server/time.ts`) rather than SQL date-truncation, because the day boundary depends on the viewer's timezone which the database doesn't know. The client (see `AuditTab.tsx` → `listAiAudit`) reads `Intl.DateTimeFormat().resolvedOptions().timeZone` and passes it as `?tz=`.
 
-The Audit tab (`src/admin/pages/ai/tabs/AuditTab.tsx`) consumes this endpoint. The daily rollup there also aligns its "Today" range window to local midnight (`setHours(0, 0, 0, 0)`) so the day boundary is consistent both in the filter and in the bar chart. The by-model, by-user, and by-scope rollups all render through `UsageTablePanel` (`tabs/UsageTablePanel.tsx`) — a shared table component that takes a `columns` config and handles the empty-state row. Number and cost formatting (`formatNumber`, `formatCost`) live in `tabs/usageFormat.ts`, a plain `.ts` leaf that both the tab components and their tests can import without triggering React Fast Refresh's components-only export rule on the component file.
+The Audit tab (`src/admin/pages/ai/tabs/AuditTab.tsx`) consumes this endpoint. The daily rollup there also aligns its "Today" range window to local midnight (`setHours(0, 0, 0, 0)`) so the day boundary is consistent both in the filter and in the bar chart. The by-model, by-user, and by-scope rollups all render through `UsageTablePanel` (`tabs/UsageTablePanel.tsx`) — a shared table component that takes a `columns` config and handles the empty-state row. Number and cost formatting (`formatNumber`, `formatCost`) live in `src/admin/ai/usageFormat.ts`, a plain shared leaf used by both Audit and the composer context tooltip.
 
 ### `POST /admin/api/ai/tool-result`
 
@@ -643,13 +646,17 @@ interface AgentSlice {
   agentActiveModelId:        string | null
   /** Conversation summaries for the history popover. */
   agentConversations:        ConversationView[]
-  /**
-   * Provider-normalised total input the model processed on the latest turn,
-   * for the ContextMeter. Null for a fresh conversation (no turns yet); the
-   * meter then shows 0 against the window. Hydrated from `ConversationView.contextTokens`
-   * on loadAgentConversation; updated live from each turn's `usage` event.
-   */
-  agentContextTokens:        number | null
+  /** Current-context snapshot plus cumulative conversation billing totals. */
+  agentUsage: {
+    contextTokens:           number | null
+    contextCredentialId:     string | null
+    contextModelId:          string | null
+    promptTokens:            number
+    completionTokens:        number
+    cacheReadTokens:         number
+    cacheCreationTokens:     number
+    costUsd:                 number
+  }
   /** Blocks Send/navigation while a history load or delete may replace the active chat. */
   isAgentConversationPending: boolean
   /** Blocks Send/navigation while an existing chat's model PUT is pending. */
@@ -715,14 +722,16 @@ The server admits only one active writer per conversation. A concurrent tab rece
 
 ### Context meter
 
-The `<ContextMeter>` shows how much of the active model's context window the current conversation has consumed. Two data sources drive it:
+The `<ContextMeter>` is a five-segment battery-style status beside the image action. Its hover/focus tooltip deliberately separates current context from cumulative billing:
 
-- **Window** (`windowTokens` prop from `AgentPanel`): the model's max total tokens, resolved once from `GET /admin/api/ai/providers/:id/models?credentialId=…`. The models endpoint enriches Anthropic and OpenAI models with `contextWindow` from the live OpenRouter catalogue (`server/ai/pricing/`); OpenRouter populates it from its own native fetch. Ollama models and uncatalogued models have no window — the meter hides.
-- **Used** (`agentContextTokens` in the store): the provider-normalised "context used" — the CURRENT context size, computed by `normalizeContextTokens(providerId, buckets)` in `server/ai/contextTokens.ts`:
+- **Window** (`windowTokens` prop from `AgentComposer`): the model's max total tokens, resolved once from `GET /admin/api/ai/providers/:id/models?credentialId=…`. The models endpoint enriches Anthropic and OpenAI models with `contextWindow` from the live OpenRouter catalogue (`server/ai/pricing/`); OpenRouter populates it from its own native fetch. Ollama models and uncatalogued models have no window — the meter hides.
+- **Current context** (`agentUsage.contextTokens`): the provider-normalised input held by the LATEST provider round, tagged with the credential/model selection that produced it. `normalizeContextTokens(providerId, buckets)` in `server/ai/contextTokens.ts` computes it:
   - Anthropic reports `input_tokens` excluding cache buckets, so the true total is `promptTokens + cacheReadTokens + cacheCreationTokens`.
   - OpenAI / OpenRouter / Ollama / Custom Provider report `input_tokens` as the full input; `promptTokens` alone is the total.
 
-**Live, per-round, not summed.** A turn makes one provider round-trip per tool batch. The toolLoop emits a `context` event **each round** carrying THAT round's input buckets; the chat handler injects the normalised `contextTokens` and the browser updates the meter on every round — so it climbs *during* a long tool loop instead of only at the end. The meter is the LATEST round's input (the current window fill), never the sum across rounds (which would over-count, since each round re-sends the growing context). The terminal `usage` event is **billing only** — its `promptTokens` stays summed across rounds (you pay input per round). The persister keeps the latest `context` value in memory (`recordContext`) and writes it once to `ai_conversations.context_tokens` with the final `usage` (overwritten per turn), so `loadAgentConversation` restores the true context on reload.
+**Live context, cumulative billing.** A turn makes one provider round-trip per tool batch. The tool loop emits a `context` event **each round** carrying THAT round's input buckets; the chat handler injects the normalised `contextTokens` and the browser updates the meter on every round — so the remaining-capacity battery drains *during* a long tool loop instead of only at the end. The measurement is the LATEST round's input, never the sum across rounds (which would over-count, since each round re-sends the growing context). The terminal `usage` event is **billing only**: prompt/completion/cache counts are summed across rounds. Before forwarding that terminal event, the persister resolves authoritative cache-aware spend (or accepts OpenRouter's native cost), writes the usage, then includes the resolved `costUsd` on the wire. The browser accumulates those totals in `agentUsage`; `loadAgentConversation` hydrates the same totals from `ConversationView`. The tooltip labels the sections “Context remaining” and “Conversation billing” so the two token meanings cannot be confused.
+
+Five equal bands approximate remaining capacity: an empty conversation has all five filled, then the display drains by fifths until no capacity remains. More than 40% remaining is healthy, 20–40% warns, and below 20% is danger. An unmeasured model switch uses five neutral segments until its first response. The keyboard-focusable details button exposes the exact remaining/window counts and percentage in its accessible name; segment count is only the compact visual approximation.
 
 ### Live model catalogue
 
@@ -828,7 +837,7 @@ unblocks deletion of the credential that had been protected by the default FK.
   - `src/admin/pages/ai/AiPage.tsx` — `/admin/ai` workspace (Providers / Defaults / Audit tabs)
   - `src/admin/pages/ai/tabs/AuditTab.tsx` — usage audit view (totals strip, tables, daily bar chart)
   - `src/admin/pages/ai/tabs/UsageTablePanel.tsx` — shared table scaffolding for audit rollups
-  - `src/admin/pages/ai/tabs/usageFormat.ts` — `formatNumber` / `formatCost` formatting helpers
+  - `src/admin/ai/usageFormat.ts` — shared `formatNumber` / `formatCost` helpers
   - `src/admin/pages/site/agent/agentSlice.ts` — scope-agnostic slice factory (`createAgentSlice`)
   - `src/admin/pages/site/agent/agentProviderUpdate.ts` — timed provider/model update and ambiguous-commit reconciliation
   - `src/admin/pages/site/agent/agentSliceConfig.site.ts` — site-editor scope config
@@ -850,8 +859,9 @@ unblocks deletion of the credential that had been protected by the default FK.
   - `src/admin/pages/content/agent/contentAgentStore.ts` — standalone content-workspace agent store
   - `src/admin/pages/content/agent/contentBridge.ts` — content write-tool browser dispatcher
   - `src/admin/pages/content/agent/contentBridgeHandle.ts` — imperative bridge handle registered by ContentPage
-  - `src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx` — Agent Panel; resolves `contextWindow` for the meter
-  - `src/admin/pages/site/panels/AgentPanel/ContextMeter.tsx` — context used / window progress bar
+  - `src/admin/pages/site/panels/AgentPanel/AgentComposer.tsx` — resolves model window/pricing/capabilities and places the meter in the action row
+  - `src/admin/pages/site/panels/AgentPanel/ContextMeter.tsx` — five-segment context status and rich usage tooltip
+  - `src/admin/pages/site/panels/AgentPanel/contextMeterMetrics.ts` — exact five-band fill/tone calculation
 - Gate tests:
   - `src/__tests__/architecture/ai-tool-schema-ssot.test.ts`
   - `src/__tests__/architecture/ai-driver-isolation.test.ts`

--- a/server/ai/runtime/persister.ts
+++ b/server/ai/runtime/persister.ts
@@ -32,7 +32,7 @@ export interface ConversationsPersister {
     costUsd?: number
     cacheReadTokens?: number
     cacheCreationTokens?: number
-  }): Promise<void>
+  }): Promise<number>
   /**
    * Record one round's context size (input buckets). Kept in memory; the LAST
    * value seen this turn is the true "context used" and is written to the
@@ -127,12 +127,10 @@ export function createConversationsPersister(
 
     async recordUsage(usage) {
       // Persist usage as a denormalised update on the LAST assistant
-      // message so a per-message cost view is possible later. If no
-      // assistant message exists yet, the conversation totals will pick
-      // up the increment anyway (appendMessage bumps them per row), so we
-      // simply skip — the totals are still correct, only the per-message
-      // attribution is lost in that edge case.
-      if (!lastAssistantMessageId) return
+      // message so a per-message cost view is possible later. A normal turn
+      // always has a text or tool-call row by this point; if a non-conforming
+      // provider reports only usage, still resolve and return its wire cost but
+      // do not invent a blank message in persisted conversation history.
       // Driver-supplied cost wins (OpenRouter reports a native per-call USD
       // cost). When absent (Anthropic, OpenAI) we price from the live
       // OpenRouter catalogue, cache-aware; Ollama is free. Token counts are
@@ -148,6 +146,7 @@ export function createConversationsPersister(
           cacheCreationTokens: usage.cacheCreationTokens ?? 0,
         },
       )
+      if (!lastAssistantMessageId) return costUsd
       // Provider-normalised "context used now" snapshot for the conversation
       // row, restored by the meter on reload. Prefer the LAST round's context
       // (tracked via recordContext) — the true current context size. Fall back
@@ -171,6 +170,7 @@ export function createConversationsPersister(
         usage.cacheCreationTokens ?? 0,
         contextTokens,
       )
+      return costUsd
     },
   }
 }

--- a/server/ai/runtime/runner.ts
+++ b/server/ai/runtime/runner.ts
@@ -54,10 +54,10 @@ export async function runChat(args: RunChatArgs): Promise<void> {
 
   try {
     for await (const event of driver.stream(request)) {
-      // Always forward to the wire first so the browser sees the event
-      // even if persistence fails (we never want to silently lose a UI
-      // update because the DB is slow).
-      emit(event)
+      // Forward live events immediately. Usage is the one exception: its USD
+      // value may need cache-aware server pricing, so that terminal event is
+      // emitted after persistence resolves the authoritative cost below.
+      if (event.type !== 'usage') emit(event)
 
       switch (event.type) {
         case 'text': {
@@ -112,13 +112,14 @@ export async function runChat(args: RunChatArgs): Promise<void> {
         }
         case 'usage': {
           await flushPendingAssistantText()
-          await persister.recordUsage({
+          const costUsd = await persister.recordUsage({
             promptTokens: event.promptTokens,
             completionTokens: event.completionTokens,
             costUsd: event.costUsd,
             cacheReadTokens: event.cacheReadTokens,
             cacheCreationTokens: event.cacheCreationTokens,
           })
+          emit({ ...event, costUsd })
           break
         }
         case 'error': {

--- a/src/__tests__/agent/agentSlice.test.ts
+++ b/src/__tests__/agent/agentSlice.test.ts
@@ -34,7 +34,16 @@ function freshAgentState() {
     agentConversationId: null,
     agentActiveCredentialId: null,
     agentActiveModelId: null,
-    agentContextTokens: null,
+    agentUsage: {
+      contextTokens: null,
+      contextCredentialId: null,
+      contextModelId: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0,
+    },
     isAgentConversationPending: false,
     isAgentProviderPending: false,
     agentComposerEpoch: 0,
@@ -205,6 +214,67 @@ describe('processStreamEvent — bridge handshake', () => {
     )
 
     expect(bridge.bridgeId).toBe('bridge-xyz')
+  })
+})
+
+describe('processStreamEvent — context and billing usage', () => {
+  it('keeps the current model context separate from cumulative billing totals', async () => {
+    const { assistantId } = freshAgentState()
+    useEditorStore.setState({
+      agentActiveCredentialId: 'cred-1',
+      agentActiveModelId: 'model-1',
+    })
+
+    await processStreamEvent(
+      { type: 'context', contextTokens: 4096 },
+      assistantId,
+      noopTextSink,
+      useEditorStore.setState,
+      emptyBridge(),
+      null,
+      executeAgentTool,
+    )
+    await processStreamEvent(
+      {
+        type: 'usage',
+        promptTokens: 5000,
+        completionTokens: 300,
+        cacheReadTokens: 2000,
+        cacheCreationTokens: 400,
+        costUsd: 0.012345,
+      },
+      assistantId,
+      noopTextSink,
+      useEditorStore.setState,
+      emptyBridge(),
+      null,
+      executeAgentTool,
+    )
+    await processStreamEvent(
+      {
+        type: 'usage',
+        promptTokens: 2000,
+        completionTokens: 100,
+        costUsd: 0.001,
+      },
+      assistantId,
+      noopTextSink,
+      useEditorStore.setState,
+      emptyBridge(),
+      null,
+      executeAgentTool,
+    )
+
+    expect(useEditorStore.getState().agentUsage).toEqual({
+      contextTokens: 4096,
+      contextCredentialId: 'cred-1',
+      contextModelId: 'model-1',
+      promptTokens: 7000,
+      completionTokens: 400,
+      cacheReadTokens: 2000,
+      cacheCreationTokens: 400,
+      costUsd: 0.013345,
+    })
   })
 })
 
@@ -778,7 +848,16 @@ describe('conversation reset key-set', () => {
     agentConversationId: null,
     agentActiveCredentialId: null,
     agentActiveModelId: null,
-    agentContextTokens: null,
+    agentUsage: {
+      contextTokens: null,
+      contextCredentialId: null,
+      contextModelId: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0,
+    },
     agentComposerEpoch: 1,
   }
 
@@ -791,7 +870,16 @@ describe('conversation reset key-set', () => {
       agentConversationId: 'conv-dirty',
       agentActiveCredentialId: 'cred-1',
       agentActiveModelId: 'model-1',
-      agentContextTokens: 4096,
+      agentUsage: {
+        contextTokens: 4096,
+        contextCredentialId: 'cred-1',
+        contextModelId: 'model-1',
+        promptTokens: 12_000,
+        completionTokens: 800,
+        cacheReadTokens: 4_000,
+        cacheCreationTokens: 500,
+        costUsd: 0.42,
+      },
     })
   }
 
@@ -803,7 +891,7 @@ describe('conversation reset key-set', () => {
       agentConversationId: s.agentConversationId,
       agentActiveCredentialId: s.agentActiveCredentialId,
       agentActiveModelId: s.agentActiveModelId,
-      agentContextTokens: s.agentContextTokens,
+      agentUsage: s.agentUsage,
       agentComposerEpoch: s.agentComposerEpoch,
     }
   }

--- a/src/__tests__/ai/auditUsagePersistence.test.ts
+++ b/src/__tests__/ai/auditUsagePersistence.test.ts
@@ -142,6 +142,11 @@ describe('AI audit usage persistence', () => {
       'usage',
       'done',
     ])
+    expect(emitted.find((event) => event.type === 'usage')).toMatchObject({
+      promptTokens: 123,
+      completionTokens: 45,
+      costUsd: 0,
+    })
 
     const since = new Date(Date.now() - 60_000).toISOString()
     const totals = await getUsageTotals(harness.db, since)

--- a/src/__tests__/ai/usageTablePanel.test.tsx
+++ b/src/__tests__/ai/usageTablePanel.test.tsx
@@ -8,7 +8,7 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { cleanup, render, screen } from '@testing-library/react'
 import { UsageTablePanel, type UsageTableColumn } from '@admin/pages/ai/tabs/UsageTablePanel'
-import { formatCost, formatNumber } from '@admin/pages/ai/tabs/usageFormat'
+import { formatCost, formatNumber } from '@admin/ai/usageFormat'
 
 type Row = { id: string; label: string; chatCount: number; costUsd: number }
 

--- a/src/__tests__/panels/agentPanel.test.tsx
+++ b/src/__tests__/panels/agentPanel.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { createStore } from 'zustand/vanilla'
 import { AgentStoreProvider } from '@admin/ai/AgentStoreContext'
-import { clearModelListCache } from '@admin/ai/api'
+import { clearModelListCache, type CredentialView } from '@admin/ai/api'
 import { MemoryRouter, useLocation } from '@admin/lib/routing'
 import { AdminSessionProvider } from '@admin/session'
 import type { AgentSlice } from '@site/agent'
@@ -23,11 +23,16 @@ const TEST_CREDENTIAL = {
   lastUsedAt: null,
 } as const
 
-function installModelFetch(visionInput: boolean, toolCalling = true): void {
+function installModelFetch(
+  visionInput: boolean,
+  toolCalling = true,
+  contextWindow: number | null = 128_000,
+  credential: CredentialView = TEST_CREDENTIAL,
+): void {
   globalThis.fetch = mock(async (input: RequestInfo | URL) => {
     const url = typeof input === 'string' ? input : input.toString()
     if (url.endsWith('/admin/api/ai/credentials')) {
-      return jsonResponse({ credentials: [TEST_CREDENTIAL] })
+      return jsonResponse({ credentials: [credential] })
     }
     if (url.includes('/admin/api/ai/providers/')) {
       return jsonResponse({
@@ -41,7 +46,8 @@ function installModelFetch(visionInput: boolean, toolCalling = true): void {
             promptCache: false,
             streaming: true,
           },
-          contextWindow: 128_000,
+          pricing: { inputPerMTok: 3, outputPerMTok: 15 },
+          ...(contextWindow === null ? {} : { contextWindow }),
         }],
       })
     }
@@ -143,7 +149,16 @@ function createAgentStore(overrides: Partial<AgentSlice> = {}) {
     agentActiveCredentialId: null,
     agentActiveModelId: null,
     agentConversations: [],
-    agentContextTokens: null,
+    agentUsage: {
+      contextTokens: null,
+      contextCredentialId: null,
+      contextModelId: null,
+      promptTokens: 0,
+      completionTokens: 0,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+      costUsd: 0,
+    },
     isAgentConversationPending: false,
     isAgentProviderPending: false,
     agentComposerEpoch: 0,
@@ -328,6 +343,72 @@ describe('AgentPanel', () => {
     // independent of credential state.
     expect(screen.getByTestId('agent-settings-header-button')).toBeTruthy()
     expect(screen.getByTestId('agent-new-chat-header-button')).toBeTruthy()
+  })
+
+  it('shows compact context, token, and cost detail beside the image action', async () => {
+    const credential = { ...TEST_CREDENTIAL, id: 'cred_context_meter' }
+    installModelFetch(true, true, 128_000, credential)
+    renderAgentPanel({
+      agentActiveCredentialId: credential.id,
+      agentActiveModelId: 'model-1',
+      agentUsage: {
+        contextTokens: 80_000,
+        contextCredentialId: credential.id,
+        contextModelId: 'model-1',
+        promptTokens: 12_345,
+        completionTokens: 678,
+        cacheReadTokens: 4_000,
+        cacheCreationTokens: 321,
+        costUsd: 0.004,
+      },
+    })
+
+    const meter = await screen.findByRole('button', { name: /AI context remaining/ })
+    const attach = screen.getByRole('button', { name: 'Attach images' })
+    expect(meter.querySelectorAll('[data-context-segment]')).toHaveLength(5)
+    expect(meter.querySelectorAll('[data-filled="true"]')).toHaveLength(2)
+    expect(meter.getAttribute('data-tone')).toBe('warning')
+    expect(meter.getAttribute('aria-label')).toContain(
+      '48,000 of 128,000 context tokens available (38%)',
+    )
+    expect(meter.compareDocumentPosition(attach) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+
+    fireEvent.focus(meter)
+    const tooltip = await screen.findByRole('tooltip')
+    expect(tooltip.textContent).toContain('38% available')
+    expect(tooltip.textContent).toContain('80K used')
+    expect(tooltip.textContent).toContain('48K available')
+    expect(tooltip.textContent).toContain('12,345')
+    expect(tooltip.textContent).toContain('< $0.01')
+    expect(tooltip.textContent).toContain('$3 in · $15 out')
+  })
+
+  it('shows a full healthy battery for an empty conversation', async () => {
+    const credential = { ...TEST_CREDENTIAL, id: 'cred_context_empty' }
+    installModelFetch(true, true, 128_000, credential)
+    renderAgentPanel({
+      agentActiveCredentialId: credential.id,
+      agentActiveModelId: 'model-1',
+    })
+
+    const meter = await screen.findByRole('button', { name: /AI context remaining/ })
+    expect(meter.querySelectorAll('[data-filled="true"]')).toHaveLength(5)
+    expect(meter.getAttribute('data-tone')).toBe('healthy')
+    expect(meter.getAttribute('aria-label')).toContain(
+      '128,000 of 128,000 context tokens available (100%)',
+    )
+  })
+
+  it('hides context status when the selected model has no known window', async () => {
+    const credential = { ...TEST_CREDENTIAL, id: 'cred_context_unknown' }
+    installModelFetch(true, true, null, credential)
+    renderAgentPanel({
+      agentActiveCredentialId: credential.id,
+      agentActiveModelId: 'model-1',
+    })
+
+    await screen.findByText('OpenAI · Model 1')
+    expect(screen.queryByRole('button', { name: /AI context remaining/ })).toBeNull()
   })
 
   it('prompts to choose a model when credentials exist but no default is set', async () => {

--- a/src/__tests__/panels/contextMeterMetrics.test.ts
+++ b/src/__tests__/panels/contextMeterMetrics.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'bun:test'
+import { getContextMeterMetrics } from '@site/panels/AgentPanel'
+
+describe('context meter metrics', () => {
+  it.each([
+    [null, 5, 'empty'],
+    [0, 5, 'healthy'],
+    [1, 5, 'healthy'],
+    [200, 4, 'healthy'],
+    [400, 3, 'healthy'],
+    [600, 2, 'healthy'],
+    [601, 2, 'warning'],
+    [800, 1, 'warning'],
+    [801, 1, 'danger'],
+    [1000, 0, 'danger'],
+    [1200, 0, 'danger'],
+  ] as const)(
+    'maps %s used tokens to %s filled segments and %s tone',
+    (usedTokens, filledSegments, tone) => {
+      const metrics = getContextMeterMetrics(usedTokens, 1000)
+      expect(metrics.filledSegments).toBe(filledSegments)
+      expect(metrics.tone).toBe(tone)
+    },
+  )
+
+  it('keeps unknown context indeterminate and clamps invalid progress values', () => {
+    expect(getContextMeterMetrics(null, 1000)).toMatchObject({
+      measured: false,
+      usedPercentage: null,
+      remainingPercentage: null,
+      progressValue: 1000,
+      remainingTokens: 1000,
+    })
+    expect(getContextMeterMetrics(-50, 1000)).toMatchObject({
+      measured: true,
+      usedTokens: 0,
+      progressValue: 1000,
+      usedPercentage: 0,
+      remainingPercentage: 100,
+    })
+    expect(getContextMeterMetrics(1200, 1000)).toMatchObject({
+      measured: true,
+      progressValue: 0,
+      remainingTokens: 0,
+      usedPercentage: 120,
+      remainingPercentage: 0,
+    })
+  })
+})

--- a/src/__tests__/ui/tooltip.test.tsx
+++ b/src/__tests__/ui/tooltip.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import React from 'react'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { Tooltip } from '@ui/components/Tooltip'
 
 afterEach(cleanup)
@@ -35,6 +35,41 @@ describe('Tooltip', () => {
     expect(bubble.textContent).toContain('Tooltip content')
 
     fireEvent.mouseLeave(trigger)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('shows on keyboard focus and hides on blur', () => {
+    render(
+      <Tooltip content="Keyboard detail" openOnFocus>
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' })
+    fireEvent.focus(trigger)
+
+    const bubble = screen.getByRole('tooltip')
+    expect(bubble.textContent).toContain('Keyboard detail')
+    expect(trigger.getAttribute('aria-describedby')).toBe(bubble.id)
+
+    fireEvent.blur(trigger)
+    expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('stays open until both hover and focus leave', () => {
+    render(
+      <Tooltip content="Persistent detail" openOnFocus>
+        <button>Trigger</button>
+      </Tooltip>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' })
+    fireEvent.mouseEnter(trigger)
+    fireEvent.focus(trigger)
+    fireEvent.mouseLeave(trigger)
+    expect(screen.getByRole('tooltip')).toBeDefined()
+
+    fireEvent.blur(trigger)
     expect(screen.queryByRole('tooltip')).toBeNull()
   })
 
@@ -75,6 +110,25 @@ describe('Tooltip', () => {
     expect(trigger.getAttribute('aria-describedby')).toBeNull()
   })
 
+  it('preserves an existing aria-describedby value', () => {
+    render(
+      <>
+        <p id="existing-description">Existing description</p>
+        <Tooltip content="Extra detail" openOnFocus>
+          <button aria-describedby="existing-description">Trigger</button>
+        </Tooltip>
+      </>,
+    )
+
+    const trigger = screen.getByRole('button', { name: 'Trigger' })
+    fireEvent.focus(trigger)
+    const tooltipId = screen.getByRole('tooltip').id
+    expect(trigger.getAttribute('aria-describedby')).toBe(`existing-description ${tooltipId}`)
+
+    fireEvent.blur(trigger)
+    expect(trigger.getAttribute('aria-describedby')).toBe('existing-description')
+  })
+
   it('hides on Escape keydown', () => {
     render(
       <Tooltip content="Press Escape to close">
@@ -90,5 +144,31 @@ describe('Tooltip', () => {
     // Global keydown on document.body bubbles to window where our listener lives.
     fireEvent.keyDown(document.body, { key: 'Escape' })
     expect(screen.queryByRole('tooltip')).toBeNull()
+  })
+
+  it('consumes Escape before a parent panel handler can close', () => {
+    let parentEscapeCount = 0
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') parentEscapeCount += 1
+    }
+    document.addEventListener('keydown', onKeyDown)
+
+    try {
+      render(
+        <Tooltip content="Press Escape to close" openOnFocus>
+          <button>Trigger</button>
+        </Tooltip>,
+      )
+      const trigger = screen.getByRole('button', { name: 'Trigger' })
+      act(() => trigger.focus())
+
+      fireEvent.keyDown(trigger, { key: 'Escape' })
+
+      expect(screen.queryByRole('tooltip')).toBeNull()
+      expect(parentEscapeCount).toBe(0)
+      expect(document.activeElement).toBe(trigger)
+    } finally {
+      document.removeEventListener('keydown', onKeyDown)
+    }
   })
 })

--- a/src/admin/ai/usageFormat.ts
+++ b/src/admin/ai/usageFormat.ts
@@ -1,10 +1,4 @@
-/**
- * Number/cost formatting for the AI usage audit tables.
- *
- * Lives in a non-component `.ts` leaf so both the AuditTab panels and the
- * shared `UsageTablePanel` (plus their tests) can import these without tripping
- * React Fast Refresh's "components-only export" rule on the component file.
- */
+/** Shared number and USD formatting for AI usage surfaces. */
 
 /** Whole-number with locale grouping, no fraction (e.g. token + chat counts). */
 export function formatNumber(value: number): string {

--- a/src/admin/pages/ai/tabs/AuditTab.tsx
+++ b/src/admin/pages/ai/tabs/AuditTab.tsx
@@ -24,7 +24,7 @@ import {
   type AiUsageByUserRow,
 } from '../../../ai/api'
 import { UsageTablePanel } from './UsageTablePanel'
-import { formatCost, formatNumber } from './usageFormat'
+import { formatCost, formatNumber } from '@admin/ai/usageFormat'
 import styles from '../AiPage.module.css'
 
 type Range = 'today' | '7d' | '30d' | 'all'

--- a/src/admin/pages/site/agent/agentSlice.ts
+++ b/src/admin/pages/site/agent/agentSlice.ts
@@ -34,12 +34,17 @@ import {
 import { readNdjsonStream } from '@admin/ai/ndjsonStream'
 import { processStreamEvent, ServerStreamEventSchema } from './streamEvents'
 import type {
+  AgentConversationUsage,
   AgentSlice,
   AgentSliceConfig,
   AgentSliceGet,
   EditorStoreSet,
 } from './agentSliceTypes'
-export type { AgentSlice, AgentSliceConfig } from './agentSliceTypes'
+export type {
+  AgentConversationUsage,
+  AgentSlice,
+  AgentSliceConfig,
+} from './agentSliceTypes'
 import type {
   AgentBridgeRuntime,
   AgentMessage,
@@ -131,8 +136,8 @@ async function ensureConversationId(
 
 // The canonical conversation-reset key-set, in ONE place. clearAgentMessages,
 // startNewAgentConversation, and deleteAgentConversation all reset through here
-// so they can't drift apart again (agentContextTokens was omitted from one copy
-// once already; agentError from another). A factory (not a shared constant) so
+// so they can't drift apart again (usage was omitted from one copy once;
+// agentError from another). A factory (not a shared constant) so
 // each reset gets a fresh `agentMessages` array.
 type ConversationResetKeys =
   | 'agentMessages'
@@ -140,8 +145,21 @@ type ConversationResetKeys =
   | 'agentConversationId'
   | 'agentActiveCredentialId'
   | 'agentActiveModelId'
-  | 'agentContextTokens'
+  | 'agentUsage'
   | 'agentComposerEpoch'
+
+function emptyConversationUsage(): AgentConversationUsage {
+  return {
+    contextTokens: null,
+    contextCredentialId: null,
+    contextModelId: null,
+    promptTokens: 0,
+    completionTokens: 0,
+    cacheReadTokens: 0,
+    cacheCreationTokens: 0,
+    costUsd: 0,
+  }
+}
 
 function conversationResetState(agentComposerEpoch: number): Pick<AgentSlice, ConversationResetKeys> {
   return {
@@ -150,7 +168,7 @@ function conversationResetState(agentComposerEpoch: number): Pick<AgentSlice, Co
     agentConversationId: null,
     agentActiveCredentialId: null,
     agentActiveModelId: null,
-    agentContextTokens: null,
+    agentUsage: emptyConversationUsage(),
     agentComposerEpoch,
   }
 }
@@ -265,7 +283,7 @@ export function createAgentSlice(
     agentActiveCredentialId: null,
     agentActiveModelId: null,
     agentConversations: [],
-    agentContextTokens: null,
+    agentUsage: emptyConversationUsage(),
     isAgentConversationPending: false,
     isAgentProviderPending: false,
     agentComposerEpoch: 0,
@@ -351,9 +369,16 @@ export function createAgentSlice(
           state.agentActiveModelId = conv.modelId
           state.agentMessages = rehydrateMessages(conv.messages)
           state.agentError = null
-          // Restore the meter from the persisted snapshot (0 → null so the
-          // meter reads as "empty" against the window until the next turn).
-          state.agentContextTokens = conv.contextTokens > 0 ? conv.contextTokens : null
+          state.agentUsage = {
+            contextTokens: conv.contextTokens > 0 ? conv.contextTokens : null,
+            contextCredentialId: conv.contextTokens > 0 ? conv.credentialId : null,
+            contextModelId: conv.contextTokens > 0 ? conv.modelId : null,
+            promptTokens: conv.promptTokensTotal,
+            completionTokens: conv.completionTokensTotal,
+            cacheReadTokens: conv.cacheReadTokensTotal,
+            cacheCreationTokens: conv.cacheCreationTokensTotal,
+            costUsd: conv.costUsdTotal,
+          }
           state.agentComposerEpoch += 1
         })
       } catch (err) {
@@ -424,10 +449,9 @@ export function createAgentSlice(
       // displayed value updates immediately. Clearing agentError is essential:
       // a prior send with no configured default leaves a sticky "no provider
       // configured" error that keeps the composer disabled — picking a model
-      // IS configuring a provider, so the composer must re-enable. The context
-      // "used" count is left as-is — the history size is unchanged by a model
-      // switch and the next turn re-measures it; the window half (view layer)
-      // tracks the new model.
+      // IS configuring a provider, so the composer must re-enable. The prior
+      // context snapshot keeps its owner IDs; the view renders the new model's
+      // meter indeterminate until the next response re-measures it.
       set({
         agentActiveCredentialId: credentialId,
         agentActiveModelId: modelId,

--- a/src/admin/pages/site/agent/agentSliceTypes.ts
+++ b/src/admin/pages/site/agent/agentSliceTypes.ts
@@ -28,6 +28,25 @@ export interface AgentSliceConfig {
   readonly noProviderMessage?: string
 }
 
+/**
+ * Usage attached to the active conversation.
+ *
+ * `contextTokens` is the latest provider round's input size, while the other
+ * fields are cumulative billing totals across every round in the conversation.
+ * Keeping both in one snapshot makes that distinction explicit at call sites.
+ */
+export interface AgentConversationUsage {
+  contextTokens: number | null
+  /** Selection that produced `contextTokens`; null until the first measured round. */
+  contextCredentialId: string | null
+  contextModelId: string | null
+  promptTokens: number
+  completionTokens: number
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  costUsd: number
+}
+
 export interface AgentSlice {
   isAgentOpen: boolean
   isAgentStreaming: boolean
@@ -37,7 +56,7 @@ export interface AgentSlice {
   agentActiveCredentialId: string | null
   agentActiveModelId: string | null
   agentConversations: ConversationView[]
-  agentContextTokens: number | null
+  agentUsage: AgentConversationUsage
   /** True while a history load/delete can replace the active conversation. */
   isAgentConversationPending: boolean
   /** True while an existing conversation's provider/model update is pending. */

--- a/src/admin/pages/site/agent/index.ts
+++ b/src/admin/pages/site/agent/index.ts
@@ -9,7 +9,11 @@
 
 // Slice factory + its public contract.
 export { createAgentSlice } from './agentSlice'
-export type { AgentSlice, AgentSliceConfig } from './agentSliceTypes'
+export type {
+  AgentConversationUsage,
+  AgentSlice,
+  AgentSliceConfig,
+} from './agentSliceTypes'
 
 // Site-editor wiring (scope, snapshot, dispatcher) handed to the factory.
 export { siteAgentSliceConfig } from './agentSliceConfig.site'

--- a/src/admin/pages/site/agent/streamEvents.ts
+++ b/src/admin/pages/site/agent/streamEvents.ts
@@ -75,7 +75,9 @@ export const ServerStreamEventSchema = Type.Union([
     type: Type.Literal('usage'),
     promptTokens: Type.Number(),
     completionTokens: Type.Number(),
-    costUsd: Type.Optional(Type.Number()),
+    costUsd: Type.Number(),
+    cacheReadTokens: Type.Optional(Type.Number()),
+    cacheCreationTokens: Type.Optional(Type.Number()),
   }),
   Type.Object({
     // Per-round context size — drives the live meter mid-turn. `contextTokens`
@@ -222,8 +224,18 @@ export async function processStreamEvent(
     }
 
     case 'usage': {
-      // Token + cost totals are persisted server-side automatically; nothing
-      // to do client-side. The context meter is driven by `context` events.
+      // Billing totals are cumulative across provider rounds and therefore
+      // separate from current context. The server resolves authoritative,
+      // cache-aware USD cost before this terminal event reaches the browser.
+      set((state) => {
+        state.agentUsage.promptTokens += event.promptTokens
+        state.agentUsage.completionTokens += event.completionTokens
+        state.agentUsage.cacheReadTokens += event.cacheReadTokens ?? 0
+        state.agentUsage.cacheCreationTokens += event.cacheCreationTokens ?? 0
+        state.agentUsage.costUsd = Number(
+          (state.agentUsage.costUsd + event.costUsd).toFixed(6),
+        )
+      })
       break
     }
 
@@ -234,7 +246,9 @@ export async function processStreamEvent(
       // window half is supplied by the view layer from the model catalogue.
       const used = event.contextTokens
       set((state) => {
-        state.agentContextTokens = used
+        state.agentUsage.contextTokens = used
+        state.agentUsage.contextCredentialId = state.agentActiveCredentialId
+        state.agentUsage.contextModelId = state.agentActiveModelId
       })
       break
     }

--- a/src/admin/pages/site/agent/types.ts
+++ b/src/admin/pages/site/agent/types.ts
@@ -116,7 +116,10 @@ interface UsageEvent {
   type: 'usage'
   promptTokens: number
   completionTokens: number
-  costUsd?: number
+  /** Authoritative cache-aware turn cost resolved by the server persister. */
+  costUsd: number
+  cacheReadTokens?: number
+  cacheCreationTokens?: number
 }
 
 /** Per-round context size — drives the live "context used" meter. Emitted once

--- a/src/admin/pages/site/panels/AgentPanel/AgentComposer.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentComposer.tsx
@@ -81,7 +81,7 @@ export function AgentComposer({
       }
     },
     [activeProviderId, activeCredentialId, activeModelId],
-    { fallbackError: 'Could not verify image support for this model.' },
+    { fallbackError: 'Could not load details for this model.' },
   )
   const resolvedSelection = activeModelResource.data
   const activeModel =
@@ -180,7 +180,6 @@ export function AgentComposer({
 
   return (
     <div className={styles.inputBar}>
-      <ContextMeter windowTokens={activeModel?.contextWindow ?? null} />
       {hasAttachments && (
         <PendingImageAttachmentGrid
           entries={attachments.pending}
@@ -246,6 +245,12 @@ export function AgentComposer({
             disabled={isStreaming || conversationPending || providerPending || submitting}
           />
           <div className={styles.inputControlActions}>
+            <ContextMeter
+              credentialId={activeCredentialId}
+              modelId={activeModel?.id ?? activeModelId}
+              windowTokens={activeModel?.contextWindow ?? null}
+              pricing={activeModel?.pricing ?? null}
+            />
             <FileUpload
               multiple
               accept="image/png,image/jpeg,image/webp"

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -209,12 +209,13 @@
   align-items: center;
   justify-content: space-between;
   gap: var(--space-s);
+  min-width: 0;
 }
 
 /* The picker takes the leftover width but never crowds out the button. */
 .inputControlsPicker {
   min-width: 0;
-  flex: 0 1 auto;
+  flex: 1 1 auto;
 }
 
 .inputControlActions {

--- a/src/admin/pages/site/panels/AgentPanel/ContextMeter.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/ContextMeter.module.css
@@ -1,52 +1,205 @@
-/* ContextMeter — compact single-line "context used / window" indicator in the
-   chat composer. Achromatic by default; the fill shifts to amber/red as a
-   state signal when the window is nearly full. */
-
 .meter {
-    display: flex;
-    align-items: center;
-    gap: var(--space-s);
-    padding: var(--space-4xs) var(--space-4xs) var(--space-xs);
-    font-size: var(--text-2xs);
-    color: var(--text-subtle);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  flex: 0 0 28px;
+  padding: 0;
+  border: 0;
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--text-subtle);
+  cursor: help;
+  outline: none;
 }
 
-.label {
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    font-weight: 600;
-    flex-shrink: 0;
+.meter:hover {
+  background: var(--overlay-5);
 }
 
-.track {
-    position: relative;
-    flex: 1;
-    min-width: 0;
-    height: 4px;
-    border-radius: var(--radius-sm);
-    background: var(--bg-surface-3);
-    overflow: hidden;
+.meter:focus-visible {
+  box-shadow: var(--focus-ring);
+  background: var(--overlay-5);
 }
 
-.fill {
-    position: absolute;
-    inset-block: 0;
-    inset-inline-start: 0;
-    width: var(--ctx-fill);
-    border-radius: var(--radius-sm);
-    background: var(--text-subtle);
-    transition: width 240ms ease;
+.battery {
+  position: relative;
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-px);
+  width: 19px;
+  height: 10px;
+  padding: var(--space-4xs);
+  border: 1px solid var(--overlay-20);
+  border-radius: var(--radius-sm);
 }
 
-.track[data-tone="warning"] .fill {
-    background: var(--warning);
+.battery::after {
+  content: '';
+  position: absolute;
+  top: 3px;
+  right: -3px;
+  width: 2px;
+  height: 4px;
+  border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+  background: var(--overlay-20);
 }
 
-.track[data-tone="danger"] .fill {
-    background: var(--danger);
+.battery > span,
+.detailsGauge > span {
+  flex: 1 1 0;
+  min-width: 0;
+  border-radius: var(--radius-sm);
+  background: var(--chart-segment-empty);
 }
 
-.count {
-    flex-shrink: 0;
-    font-variant-numeric: tabular-nums;
+.meter[data-tone='healthy'] [data-filled='true'],
+.detailsGauge[data-tone='healthy'] [data-filled='true'] {
+  background: var(--success);
+}
+
+.meter[data-tone='warning'] [data-filled='true'],
+.detailsGauge[data-tone='warning'] [data-filled='true'] {
+  background: var(--warning);
+}
+
+.meter[data-tone='danger'] [data-filled='true'],
+.detailsGauge[data-tone='danger'] [data-filled='true'] {
+  background: var(--danger);
+}
+
+.meter[data-tone='danger'] .battery {
+  border-color: var(--danger);
+}
+
+.meter[data-tone='danger'] .battery::after {
+  background: var(--danger);
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-m);
+  width: 100%;
+}
+
+.detailsHeader,
+.billingHeader,
+.contextNumbers,
+.pricing {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-m);
+}
+
+.detailsHeader > div {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3xs);
+}
+
+.eyebrow {
+  color: var(--text-subtle);
+  font-size: var(--text-3xs);
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.contextHeadline {
+  color: var(--text-bright);
+  font-size: var(--text-l);
+  font-variant-numeric: tabular-nums;
+}
+
+.status {
+  padding: var(--space-3xs) var(--space-xs);
+  border-radius: var(--input-radius);
+  background: var(--overlay-5);
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  white-space: nowrap;
+}
+
+.status[data-tone='healthy'] {
+  background: var(--success-10);
+  color: var(--success-text-muted);
+}
+
+.status[data-tone='warning'] {
+  background: var(--warning-10);
+  color: var(--warning-text);
+}
+
+.status[data-tone='danger'] {
+  background: var(--danger-10);
+  color: var(--danger-text);
+}
+
+.detailsGauge {
+  display: flex;
+  gap: var(--space-3xs);
+  height: 8px;
+}
+
+.contextNumbers {
+  margin-top: calc(-1 * var(--space-xs));
+  color: var(--text-subtle);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.billingHeader {
+  padding-top: var(--space-m);
+  border-top: 1px solid var(--overlay-10);
+}
+
+.billingHeader strong {
+  color: var(--text-bright);
+  font-size: var(--text-m);
+  font-variant-numeric: tabular-nums;
+}
+
+.usageGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-xs);
+  margin: 0;
+}
+
+.usageGrid > div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-xs);
+  padding: var(--space-xs);
+  border-radius: var(--radius-sm);
+  background: var(--overlay-5);
+}
+
+.usageGrid dt {
+  color: var(--text-subtle);
+  font-size: var(--text-3xs);
+}
+
+.usageGrid dd {
+  margin: 0;
+  color: var(--text-bright);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+}
+
+.pricing {
+  align-items: flex-start;
+  color: var(--text-subtle);
+  font-size: var(--text-3xs);
+}
+
+.pricing strong {
+  color: var(--text-muted);
+  font-size: var(--text-2xs);
+  font-variant-numeric: tabular-nums;
+  text-align: right;
 }

--- a/src/admin/pages/site/panels/AgentPanel/ContextMeter.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/ContextMeter.tsx
@@ -1,71 +1,159 @@
-/**
- * ContextMeter — a compact "context used / window" indicator for the chat
- * composer.
- *
- * Two halves from two sources:
- *   - `windowTokens` (prop) — the active model's max context window, resolved
- *     by AgentPanel from the model catalogue. Known as soon as a model is
- *     selected, so the meter appears *before* the first turn.
- *   - "used" — `agentContextTokens` from the store: the provider-normalised
- *     total input the model processed on the latest turn. Hydrated from the
- *     persisted conversation on reload, updated live from each `usage` event,
- *     and 0 for a fresh conversation.
- *
- * Renders nothing when the window is unknown (Ollama / uncatalogued model).
- * Display only (no compaction yet): it surfaces how full the window is so the
- * user can see a long thread approaching the model's limit.
- */
-
-import { type CSSProperties } from 'react'
 import { useAgentStore } from '@admin/ai/useAgentStore'
+import { formatCost, formatNumber } from '@admin/ai/usageFormat'
+import { Button } from '@ui/components/Button'
+import { Tooltip } from '@ui/components/Tooltip'
+import {
+  CONTEXT_METER_SEGMENT_COUNT,
+  getContextMeterMetrics,
+  type ContextMeterTone,
+} from './contextMeterMetrics'
 import styles from './ContextMeter.module.css'
 
-/** Token count → compact label. `840`, `12K`, `1.5M`. */
-function formatTokens(tokens: number): string {
-  if (tokens >= 1_000_000) return `${Math.round((tokens / 1_000_000) * 10) / 10}M`
+interface ContextMeterProps {
+  /** Active selection, used to reject a snapshot measured by another provider/model. */
+  credentialId: string | null
+  modelId: string | null
+  /** Active model's max context window, or null when unknown (hides the meter). */
+  windowTokens: number | null
+  pricing: {
+    inputPerMTok: number
+    outputPerMTok: number
+  } | null
+}
+
+function compactTokens(tokens: number): string {
+  if (tokens >= 1_000_000) {
+    return `${Math.round((tokens / 1_000_000) * 10) / 10}M`
+  }
   if (tokens >= 1000) return `${Math.round(tokens / 1000)}K`
   return String(tokens)
 }
 
-interface ContextMeterProps {
-  /** Active model's max context window, or null when unknown (hides the meter). */
-  windowTokens: number | null
+function formatRate(value: number): string {
+  if (value === 0) return '$0'
+  const amount = value < 1 ? value.toFixed(2) : String(Math.round(value * 100) / 100)
+  return `$${amount}`
 }
 
-export function ContextMeter({ windowTokens }: ContextMeterProps) {
-  const storedUsed = useAgentStore((s) => s.agentContextTokens)
+function toneLabel(tone: ContextMeterTone): string {
+  if (tone === 'healthy') return 'Comfortable'
+  if (tone === 'warning') return 'Getting full'
+  if (tone === 'danger') return 'Nearly full'
+  return 'Not measured'
+}
 
-  // No window (Ollama / uncatalogued / model not yet resolved) → hide.
+function Segments({ filled }: { filled: number }) {
+  return Array.from({ length: CONTEXT_METER_SEGMENT_COUNT }, (_, index) => (
+    <span
+      key={index}
+      data-context-segment=""
+      data-filled={index < filled ? 'true' : 'false'}
+    />
+  ))
+}
+
+export function ContextMeter({ credentialId, modelId, windowTokens, pricing }: ContextMeterProps) {
+  const usage = useAgentStore((state) => state.agentUsage)
+
   if (windowTokens === null || windowTokens <= 0) return null
 
-  // Pre-turn / fresh conversation → 0 used against the known window.
-  const used = storedUsed ?? 0
-  const ratio = Math.min(1, Math.max(0, used / windowTokens))
-  const pct = Math.round(ratio * 100)
-  // Color is state: amber as the window fills, red when nearly full.
-  const tone = ratio >= 0.9 ? 'danger' : ratio >= 0.75 ? 'warning' : 'normal'
+  const selectionOwnsContext = usage.contextCredentialId === credentialId
+    && usage.contextModelId === modelId
+  const conversationIsEmpty = usage.promptTokens === 0
+    && usage.completionTokens === 0
+    && usage.cacheReadTokens === 0
+    && usage.cacheCreationTokens === 0
+    && usage.costUsd === 0
+  const currentContext = selectionOwnsContext && usage.contextTokens !== null
+    ? usage.contextTokens
+    : conversationIsEmpty
+      ? 0
+      : null
+  const metrics = getContextMeterMetrics(currentContext, windowTokens)
+  const valueText = metrics.measured
+    ? `${formatNumber(metrics.remainingTokens)} of ${formatNumber(windowTokens)} context tokens available (${metrics.remainingPercentage}%)`
+    : `Context has not been measured for this model yet; ${formatNumber(windowTokens)} token window`
+
+  const details = (
+    <div className={styles.details}>
+      <div className={styles.detailsHeader}>
+        <div>
+          <span className={styles.eyebrow}>Context remaining</span>
+          <strong className={styles.contextHeadline}>
+            {metrics.measured ? `${metrics.remainingPercentage}% available` : 'Waiting for a response'}
+          </strong>
+        </div>
+        <span className={styles.status} data-tone={metrics.tone}>
+          {toneLabel(metrics.tone)}
+        </span>
+      </div>
+
+      <div className={styles.detailsGauge} data-tone={metrics.tone} aria-hidden="true">
+        <Segments filled={metrics.filledSegments} />
+      </div>
+
+      <div className={styles.contextNumbers}>
+        {metrics.measured ? (
+          <>
+            <span>{compactTokens(metrics.usedTokens)} used</span>
+            <span>{compactTokens(metrics.remainingTokens)} available</span>
+          </>
+        ) : (
+          <>
+            <span>Updates after the next response</span>
+            <span>{compactTokens(windowTokens)} window</span>
+          </>
+        )}
+      </div>
+
+      <div className={styles.billingHeader}>
+        <span className={styles.eyebrow}>Conversation billing</span>
+        <strong>{formatCost(usage.costUsd)}</strong>
+      </div>
+      <dl className={styles.usageGrid}>
+        <div>
+          <dt>Input</dt>
+          <dd>{formatNumber(usage.promptTokens)}</dd>
+        </div>
+        <div>
+          <dt>Output</dt>
+          <dd>{formatNumber(usage.completionTokens)}</dd>
+        </div>
+        <div>
+          <dt>Cache read</dt>
+          <dd>{formatNumber(usage.cacheReadTokens)}</dd>
+        </div>
+        <div>
+          <dt>Cache write</dt>
+          <dd>{formatNumber(usage.cacheCreationTokens)}</dd>
+        </div>
+      </dl>
+
+      {pricing && (
+        <div className={styles.pricing}>
+          <span>Current model · per 1M tokens</span>
+          <strong>
+            {formatRate(pricing.inputPerMTok)} in · {formatRate(pricing.outputPerMTok)} out
+          </strong>
+        </div>
+      )}
+    </div>
+  )
 
   return (
-    <div
-      className={styles.meter}
-      role="progressbar"
-      aria-valuemin={0}
-      aria-valuemax={windowTokens}
-      aria-valuenow={used}
-      aria-label={`Context used: ${formatTokens(used)} of ${formatTokens(windowTokens)} tokens (${pct}%)`}
-    >
-      <span className={styles.label}>Context</span>
-      <span
-        className={styles.track}
-        data-tone={tone}
-        // Dynamic fill width — module reads it back via var(--ctx-fill).
-        style={{ '--ctx-fill': `${pct}%` } as CSSProperties}
+    <Tooltip content={details} side="top" align="end" size="wide" openOnFocus>
+      <Button
+        variant="ghost"
+        size="xs"
+        className={styles.meter}
+        data-tone={metrics.tone}
+        data-filled-segments={metrics.filledSegments}
+        aria-label={`AI context remaining: ${valueText}`}
       >
-        <span className={styles.fill} />
-      </span>
-      <span className={styles.count}>
-        {formatTokens(used)} / {formatTokens(windowTokens)}
-      </span>
-    </div>
+        <span className={styles.battery} aria-hidden="true">
+          <Segments filled={metrics.filledSegments} />
+        </span>
+      </Button>
+    </Tooltip>
   )
 }

--- a/src/admin/pages/site/panels/AgentPanel/contextMeterMetrics.ts
+++ b/src/admin/pages/site/panels/AgentPanel/contextMeterMetrics.ts
@@ -1,0 +1,47 @@
+export const CONTEXT_METER_SEGMENT_COUNT = 5
+
+export type ContextMeterTone = 'empty' | 'healthy' | 'warning' | 'danger'
+
+export interface ContextMeterMetrics {
+  measured: boolean
+  usedTokens: number
+  remainingTokens: number
+  usedPercentage: number | null
+  remainingPercentage: number | null
+  progressValue: number
+  filledSegments: number
+  tone: ContextMeterTone
+}
+
+/** Turn a current-context snapshot into the compact five-segment UI state. */
+export function getContextMeterMetrics(
+  usedTokens: number | null,
+  windowTokens: number,
+): ContextMeterMetrics {
+  const measured = usedTokens !== null
+  const safeUsed = measured ? Math.max(0, usedTokens) : 0
+  const usedRatio = safeUsed / windowTokens
+  const remainingTokens = Math.max(0, windowTokens - safeUsed)
+  const remainingRatio = remainingTokens / windowTokens
+  const filledSegments = measured
+    ? Math.ceil(remainingRatio * CONTEXT_METER_SEGMENT_COUNT)
+    : CONTEXT_METER_SEGMENT_COUNT
+  const tone: ContextMeterTone = !measured
+    ? 'empty'
+    : usedRatio > 0.8
+      ? 'danger'
+      : usedRatio > 0.6
+        ? 'warning'
+        : 'healthy'
+
+  return {
+    measured,
+    usedTokens: safeUsed,
+    remainingTokens,
+    usedPercentage: measured ? Math.round(usedRatio * 100) : null,
+    remainingPercentage: measured ? Math.round(remainingRatio * 100) : null,
+    progressValue: remainingTokens,
+    filledSegments,
+    tone,
+  }
+}

--- a/src/admin/pages/site/panels/AgentPanel/index.ts
+++ b/src/admin/pages/site/panels/AgentPanel/index.ts
@@ -1,1 +1,6 @@
 export { AgentPanel } from './AgentPanel'
+export {
+  CONTEXT_METER_SEGMENT_COUNT,
+  getContextMeterMetrics,
+} from './contextMeterMetrics'
+export type { ContextMeterMetrics, ContextMeterTone } from './contextMeterMetrics'

--- a/src/ui/components/Tooltip/Tooltip.module.css
+++ b/src/ui/components/Tooltip/Tooltip.module.css
@@ -49,6 +49,11 @@
     opacity: 1;
 }
 
+.bubbleWide {
+    width: 280px;
+    max-width: calc(100vw - 16px);
+}
+
 /* ── Arrow ──────────────────────────────────────────────────────────────────── */
 /*
  * 6×6px square, rotated 45° to form a diamond ◇.

--- a/src/ui/components/Tooltip/Tooltip.tsx
+++ b/src/ui/components/Tooltip/Tooltip.tsx
@@ -1,18 +1,15 @@
 /**
- * Tooltip — lightweight hover-only tooltip primitive.
+ * Tooltip — lightweight hover/focus tooltip primitive.
  *
  * Renders content through a shared portal (#tooltip-root on document.body).
  * Position is computed by an inline helper — no @floating-ui dependency.
  *
- * Hover only: shows on mouseenter, hides on mouseleave, Escape, scroll, or
- * pointerdown outside the trigger.
+ * Shows while the trigger is hovered, and optionally while focused. Hides after
+ * both interactions leave, or on Escape, scroll, or pointerdown outside.
  *
- * Trigger element: captured from e.currentTarget on mouseenter and stored in
- * state (not a useRef) so that closures passed to cloneElement don't close
- * over a ref value — which is flagged by the react-hooks/refs rule in v7 of
- * eslint-plugin-react-hooks.  bubbleRef (for measuring the portal bubble) is
- * the only useRef; it is read only inside useLayoutEffect (an effect), which
- * is the pattern the rule requires.
+ * Trigger element: captured from e.currentTarget on mouseenter/focus. It is
+ * state because its presence participates in whether the portal renders and
+ * its identity drives position/dismiss effects.
  *
  * Accessibility: the tooltip element carries role="tooltip" and a stable id
  * (from useId). The trigger child receives aria-describedby while the tooltip
@@ -21,8 +18,8 @@
 
 import {
   cloneElement,
-  useCallback,
   useEffect,
+  useEffectEvent,
   useId,
   useLayoutEffect,
   useRef,
@@ -55,6 +52,10 @@ interface TooltipProps {
   align?: TooltipAlign
   /** Gap between trigger and tooltip bubble in px. Default: 8. */
   offset?: number
+  /** Wider bubble for graphical status cards. Default: `default`. */
+  size?: 'default' | 'wide'
+  /** Also show on keyboard focus. Use for status/details not repeated elsewhere. */
+  openOnFocus?: boolean
   /** If true, render children as-is without any tooltip wrapping. */
   disabled?: boolean
   /** Single trigger element. Must accept mouse event handlers. */
@@ -87,6 +88,8 @@ const TOOLTIP_AUTO_PRIORITY = ['top', 'bottom', 'right', 'left'] as const
 interface TriggerChildProps {
   onMouseEnter?: React.MouseEventHandler<HTMLElement>
   onMouseLeave?: React.MouseEventHandler<HTMLElement>
+  onFocus?: React.FocusEventHandler<HTMLElement>
+  onBlur?: React.FocusEventHandler<HTMLElement>
   'aria-describedby'?: string
 }
 
@@ -95,28 +98,28 @@ function TooltipInner({
   side,
   align,
   offset,
+  size,
+  openOnFocus,
   children,
 }: Required<Omit<TooltipProps, 'disabled'>>) {
   const id = useId()
-  const [shown, setShown] = useState(false)
+  const [hovered, setHovered] = useState(false)
+  const [focused, setFocused] = useState(false)
+  const [triggerEl, setTriggerEl] = useState<HTMLElement | null>(null)
+  const shown = (hovered || (openOnFocus && focused)) && triggerEl !== null
   const [position, setPosition] = useState<{
     x: number
     y: number
     arrowOffset: number
     side: ResolvedFloatingSide
   } | null>(null)
-  // State (not useRef) so closures passed to cloneElement never close over a
-  // ref value — which is disallowed during render by react-hooks/refs.
-  const [triggerEl, setTriggerEl] = useState<HTMLElement | null>(null)
-  // bubbleRef is only ever read inside useLayoutEffect (an effect), which is
-  // the safe pattern the react-hooks/refs rule requires.
   const bubbleRef = useRef<HTMLDivElement>(null)
 
-  // useCallback kept: stable identity for the [hide] useEffect dep array (exhaustive-deps).
-  const hide = useCallback(() => {
-    setShown(false)
+  const hide = useEffectEvent(() => {
+    setHovered(false)
+    setFocused(false)
     setPosition(null)
-  }, [])
+  })
 
   // Measure bubble and compute position after it enters the DOM.
   useLayoutEffect(() => {
@@ -142,40 +145,64 @@ function TooltipInner({
 
     const onScroll = () => hide()
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') hide()
+      if (e.key !== 'Escape') return
+      e.preventDefault()
+      e.stopPropagation()
+      hide()
     }
     const onPointerDown = (e: PointerEvent) => {
       if (!triggerEl.contains(e.target as Node)) hide()
     }
 
     window.addEventListener('scroll', onScroll, { capture: true, passive: true })
-    window.addEventListener('keydown', onKeyDown)
+    // Capture lets the tooltip consume Escape before a parent panel's document
+    // handler sees it and closes the whole surface.
+    window.addEventListener('keydown', onKeyDown, { capture: true })
     window.addEventListener('pointerdown', onPointerDown)
 
     return () => {
       window.removeEventListener('scroll', onScroll, { capture: true })
-      window.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('keydown', onKeyDown, { capture: true })
       window.removeEventListener('pointerdown', onPointerDown)
     }
-  }, [shown, triggerEl, hide])
+  }, [shown, triggerEl])
 
   // Compose with the child's existing handlers; inject aria-describedby.
   // Closures here capture only state setters and callbacks — no useRef values.
   const childTyped = children as ReactElement<TriggerChildProps>
   const existingMouseEnter = childTyped.props.onMouseEnter
   const existingMouseLeave = childTyped.props.onMouseLeave
+  const existingFocus = childTyped.props.onFocus
+  const existingBlur = childTyped.props.onBlur
+  const existingDescribedBy = childTyped.props['aria-describedby']
+  const describedBy = [existingDescribedBy, shown ? id : null]
+    .filter(Boolean)
+    .join(' ') || undefined
 
   const cloned = cloneElement(childTyped, {
-    'aria-describedby': shown ? id : undefined,
+    'aria-describedby': describedBy,
     onMouseEnter(e: React.MouseEvent<HTMLElement>) {
       existingMouseEnter?.(e)
       // Capture the trigger element from the event (event handler, not render).
       setTriggerEl(e.currentTarget)
-      setShown(true)
+      setHovered(true)
     },
     onMouseLeave(e: React.MouseEvent<HTMLElement>) {
       existingMouseLeave?.(e)
-      hide()
+      setHovered(false)
+      if (!focused) setPosition(null)
+    },
+    onFocus(e: React.FocusEvent<HTMLElement>) {
+      existingFocus?.(e)
+      if (!openOnFocus) return
+      setTriggerEl(e.currentTarget)
+      setFocused(true)
+    },
+    onBlur(e: React.FocusEvent<HTMLElement>) {
+      existingBlur?.(e)
+      if (!openOnFocus) return
+      setFocused(false)
+      if (!hovered) setPosition(null)
     },
   })
 
@@ -194,7 +221,11 @@ function TooltipInner({
             ref={bubbleRef}
             id={id}
             role="tooltip"
-            className={cn(styles.bubble, position !== null && styles.visible)}
+            className={cn(
+              styles.bubble,
+              size === 'wide' && styles.bubbleWide,
+              position !== null && styles.visible,
+            )}
             data-side={position?.side ?? 'top'}
             style={bubbleStyle}
           >
@@ -211,6 +242,7 @@ function TooltipInner({
 
 /**
  * Tooltip wraps a single trigger element and shows a floating label on hover.
+ * Set `openOnFocus` when the detail must also be available to keyboard users.
  *
  * When `disabled` is true the children are returned untouched — no portal,
  * no event handlers, no aria injection.
@@ -220,6 +252,8 @@ export function Tooltip({
   side = 'auto',
   align = 'center',
   offset = 8,
+  size = 'default',
+  openOnFocus = false,
   content,
   children,
 }: TooltipProps) {
@@ -227,7 +261,14 @@ export function Tooltip({
   if (disabled) return children
 
   return (
-    <TooltipInner content={content} side={side} align={align} offset={offset}>
+    <TooltipInner
+      content={content}
+      side={side}
+      align={align}
+      offset={offset}
+      size={size}
+      openOnFocus={openOnFocus}
+    >
       {children}
     </TooltipInner>
   )


### PR DESCRIPTION
## What changed

- replace the full-width context bar with a five-segment remaining-capacity meter beside the composer actions
- add a hover/focus tooltip with exact context, cumulative conversation token usage, authoritative spend, and current-model rates
- tag context snapshots to the model that measured them, leaving a switched model indeterminate until its next response
- make the shared Tooltip optionally focus-open, preserve existing descriptions, and consume Escape before parent panels
- expose server-priced terminal usage cost and share AI usage formatting between the composer and Audit

## Why

This keeps the composer compact while making context headroom and billing detail accurate, keyboard-accessible, and safe across model switches.

## Verification

- `bun test`
- `bun run build`
- `bun run lint`
- `bunx react-doctor --verbose --diff origin/main --no-score`