### PR TITLE
chore(release): prepare 0.0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,42 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## Unreleased
 
+## 0.0.11 - 2026-07-11
+
+### AI and integrations
+
+- Added multi-image AI conversations with paste and picker flows, compact galleries and previews, private history persistence, model capability checks, and optional Save to Media actions.
+- Added a compact context meter with remaining-context, token, cache, cost, and model-pricing details.
+- Made render snapshots faithfully capture authored backgrounds and breakpoint-specific layouts without changing the visible canvas state.
+- Expanded `site_apply_css` with explicit merge, replace, property-removal, and delete operations, preserved `!important` priorities, and an Anthropic-compatible provider schema.
+- Expanded MCP connectors with headless document listing, scoped Site and Content workspace bridges, and explicit capability-gated publishing after saved draft edits.
+
+### Editor, content, and publishing
+
+- Added a light admin theme and UI text-size preferences alongside the existing density setting.
+- Added editors for custom content fields, including structured, media, and relation values, directly in the Content settings panel.
+- Added middle-mouse canvas panning and improved Layers visibility, scrolling, and empty-container presentation.
+- Derived font-weight choices from installed variants, tolerated malformed stored font settings, and fixed stale selection or focus after undo, redo, and assistant-panel interactions.
+
+### Import and publishing
+
+- Imported YouTube iframes and HTML `<video>` elements as native Video modules, preserving playback and accessibility settings.
+- Optimized media-library background images into responsive variant fallbacks and `image-set()` output in both the editor and published CSS.
+- Made whole-site saves transactional with explicit deletes and a serialized save queue, preventing partial or interleaved saves before publishing.
+
+### Security and data safety
+
+- Hardened custom HTML attributes and tags against stored script injection by rejecting dangerous URL schemes, `srcdoc`, and unsafe embedded elements.
+- Applied shared magic-byte, MIME, extension, SVG-sanitization, traversal, and reserved-path validation to JSON and archive media imports.
+- Added `base-uri 'self'` and `object-src 'none'` to the admin Content Security Policy.
+
+### Platform and reliability
+
+- Fixed Postgres JSON text-column hydration and made static publish-slot swaps reliable on Windows.
+- Made Windows development startup use the active Bun runtime with safer Vite launching and stale-port recovery.
+- Recovered interrupted AI browser-tool turns as terminal, retryable failures instead of leaving conversations stuck or replaying malformed history.
+- Cleaned up disconnected MCP, editor, and plugin streams and bounded orphaned connection lifetimes so abandoned connections cannot exhaust the development proxy.
+
 ## 0.0.10 - 2026-07-01
 
 ### AI and integrations

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.10 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.11 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.10
+docker pull ghcr.io/corebunch/instatic:0.0.11
 ```
 
-The v0.0.10 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.11 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.10
+ghcr.io/corebunch/instatic:0.0.11
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.10` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.11` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.10
+Image=ghcr.io/corebunch/instatic:0.0.11
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.10
+ghcr.io/corebunch/instatic:0.0.11
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.10` |
+| Image | `ghcr.io/corebunch/instatic:0.0.11` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.10` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.11` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/docs/deployment/release-workflow.md
+++ b/docs/deployment/release-workflow.md
@@ -28,9 +28,13 @@ Release flow:
 
 ## Pre-Tag Template Updates
 
-Before tagging a release, update every checked-in deployment surface that intentionally pins the release image:
+Before tagging a release, update the package/changelog version and every checked-in deployment surface that intentionally pins the release image:
 
 ```txt
+package.json
+CHANGELOG.md
+docs/deployment/README.md
+docs/deployment/docker-image.md
 docs/deployment/railway.md
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.10",
+  "version": "0.0.11",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },


### PR DESCRIPTION
## What changed
- bump the package version and add the 0.0.11 changelog
- update every intentional deployment image pin to 0.0.11
- make the maintainer checklist enumerate all release version surfaces

## Why
Prepare the verified main line for the v0.0.11 tag, GHCR image, and portable deployment bundle.

## Release verification
- bun install --frozen-lockfile
- bun run build
- bun test (6,233 passed, 0 failed)
- bun run lint
- bunx tsc -b --pretty false
- bun run test:e2e (159 passed, 0 failed)
- fresh SQLite owner lifecycle from merged main: setup, sign-out/sign-in, edit, save/reload, password-step-up publish, anonymous public render, and unpublished-draft isolation
- bun run release:bundle -- 0.0.11
- bundle SHA-256: f2d169a2be08a5af90a936504cd2a4f8a90d8cf1ddffc4aa62519cce0da4e337