### PR TITLE
fix(data): stop forcing every new table to kind 'data'

### DIFF
--- a/src/admin/pages/data/hooks/useDataWorkspace.ts
+++ b/src/admin/pages/data/hooks/useDataWorkspace.ts
@@ -246,7 +246,7 @@ export function useDataWorkspace({ shouldLoadRows }: DataWorkspaceOptions): Data
 
   const createTable = async (input: CreateDataTableInput): Promise<DataTable> => {
     setTablesError(null)
-    const table = await createCmsDataTable({ ...input, kind: 'data' })
+    const table = await createCmsDataTable(input)
     // Newly created table has no rows yet.
     setTables((current) => [...current, { ...table, rowCount: 0 }])
     setSelectedTableId(table.id)


### PR DESCRIPTION
## Summary
- `createTable` in `src/admin/pages/data/hooks/useDataWorkspace.ts` unconditionally spread `{ ...input, kind: 'data' }` into `createCmsDataTable`, overriding whatever `kind` the New Table dialog actually sent.
- Result: choosing "Post type" in the New Table dialog silently created a plain `data` table instead — no title/slug/body fields, no routing, and (per `TableSettings.tsx`) table kind can't be changed after creation, so the only fix is deleting and recreating the table.
- Found while building custom post-type collections for a real site — reproduced by selecting "Post type" in the dialog and inspecting the resulting row's `kind` column.

## Fix
Pass `input` straight through instead of overriding `kind`. The server (`server/handlers/cms/data/tables.ts`) already validates `body.kind` correctly, so no other changes needed.

## Test plan
- [x] `bunx tsc -b --noEmit` passes
- [x] `bun test` passes (no existing coverage for this path — none broken)
- [x] Manually verified: creating a table with Kind = "Post type" now persists `kind: 'postType'`, gets `title`/`slug`/`body`/`featuredMedia`/`seoTitle`/`seoDescription` fields, and an auto-set `/<slug>` route base