### PR TITLE
fix(templates): stop leaking the template's title into published pages

### DIFF
--- a/server/handlers/cms/data/preview.ts
+++ b/server/handlers/cms/data/preview.ts
@@ -94,6 +94,9 @@ export async function handleRowPreview(
     return jsonResponse({ error: 'No entry template found for this collection' }, { status: 404 })
   }
   const merged = composeTemplateChain(chain, { kind: 'entry' })
+  // The template chain has no Page for the entry, so composeTemplateChain
+  // can't know its title — the entry's own (draft) title is the real document title.
+  if (typeof draftCells.title === 'string') merged.title = draftCells.title
 
   // Build a synthetic PublishedDataRow with the draft cells merged in.
   // Bindings inside the template (`{currentEntry.body}`, featured-media

--- a/server/publish/publicRenderer.ts
+++ b/server/publish/publicRenderer.ts
@@ -176,6 +176,9 @@ export async function renderPublishedDataRowTemplate(
   const chain = resolveTemplateChain(snapshot.site, { kind: 'entry', tableSlug: row.tableSlug })
   if (chain.length === 0) return null // no entry template → 404 (unchanged behaviour)
   const merged = composeTemplateChain(chain, { kind: 'entry' })
+  // The template chain has no Page for the entry, so composeTemplateChain
+  // can't know its title — the entry's own title is the real document title.
+  if (typeof row.cells.title === 'string') merged.title = row.cells.title
 
   // Seed the entry stack with the published row + route frame from the request
   // URL. Loop interceptors push/pop iteration items on top of this stack;

--- a/src/core/templates/templateCompose.ts
+++ b/src/core/templates/templateCompose.ts
@@ -140,7 +140,11 @@ export function composeTemplateChain(chain: Page[], terminal: TerminalContent): 
   return {
     id: innermost.id, // identifies "what was rendered" for the publish.html filter
     slug: innermost.slug,
-    title: innermost.title,
+    // The terminal page's own title is the document's real title — the
+    // wrapping template's title is chrome, never `<title>` content. Entry
+    // terminals have no Page here; their caller overrides `title` from the
+    // published row after composing.
+    title: terminal.kind === 'page' ? terminal.page.title : innermost.title,
     rootNodeId: acc.rootId,
     nodes: acc.nodes,
   }


### PR DESCRIPTION
## Summary
- `composeTemplateChain` (`src/core/templates/templateCompose.ts`) always returned `title: innermost.title` — the title of the innermost **template** in the chain, never the title of the actual page or entry being rendered.
- Observed impact: every published page's `<title>` and derived `<head>` metadata came from whichever template wrapped it.
  - Ordinary pages (Home, About, Contact, ...) all rendered `<title>` as the site's "everywhere" template's own title (e.g. "Site Template" for every single page).
  - Post-type entries rendered `<title>` as the postType template's title (e.g. every blog post showed "Post Template", every event showed "Event Template") instead of the entry's own title.
- Found while building out a real multi-page site with custom post types — reproduced by comparing `<title>` across `/`, `/about`, an entry page, and its listing page after publish.

## Fix
- For a `page` terminal, `terminal.page` is already passed into `composeTemplateChain` — use its `title` instead of the template's.
- For an `entry` terminal there's no `Page` object at that layer (the entry's body flows in via `dynamicBindings`, not a spliced `Page`), so the two callers that resolve entry routes (`renderPublishedDataRowTemplate` in `server/publish/publicRenderer.ts`, and the row preview handler in `server/handlers/cms/data/preview.ts`) now set `merged.title` from the row's own `title` cell immediately after composing, before the page is rendered — following the same `typeof cells.title === 'string'` pattern already used in `src/core/data/pageFromRow.ts`.

## Test plan
- [x] `bunx tsc -b --noEmit` passes
- [x] `bun test` passes, including `src/core/templates/__tests__/templateCompose.test.ts`
- [x] Manually verified end-to-end on a real site: published every page/entry type (plain page, postType index, postType entry) and confirmed `<title>` now matches the actual page/entry title rather than the wrapping template's title