### PR TITLE
fix(admin): keep responsive navigation left-aligned

### DIFF
--- a/src/admin/pages/site/toolbar/Toolbar.module.css
+++ b/src/admin/pages/site/toolbar/Toolbar.module.css
@@ -286,13 +286,6 @@
         padding: var(--space-4xs) var(--space-s);
     }
 
-    .siteName,
-    .siteNameSkeleton,
-    .siteFavicon,
-    .workspaceToolbarItems {
-        order: 1;
-    }
-
     .siteName {
         max-width: 104px;
         margin-right: var(--space-4xs);
@@ -320,7 +313,6 @@
 
     .adminLink,
     .activeSection {
-        order: 2;
         justify-content: center;
         width: 30px;
         min-width: 30px;

--- a/tests/e2e/admin-navigation.e2e.ts
+++ b/tests/e2e/admin-navigation.e2e.ts
@@ -113,6 +113,7 @@ test.describe('admin navigation', () => {
         page.getByTestId('account-menu-trigger'),
         'mobile toolbar account menu trigger',
       )
+      await expectNavigationBeforeToolbarTrailer(page)
     })
   })
 
@@ -506,6 +507,20 @@ async function expectLocatorContained(
   const viewportWidth = await page.evaluate(() => document.documentElement.clientWidth)
   expect(box.x).toBeGreaterThanOrEqual(-1)
   expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth + 1)
+}
+
+async function expectNavigationBeforeToolbarTrailer(page: Page): Promise<void> {
+  const toolbar = page.getByTestId('toolbar')
+  const navigationBox = await toolbar.getByRole('link', { name: 'Site' }).boundingBox()
+  const settingsBox = await toolbar.getByTestId('toolbar-settings-btn').boundingBox()
+  if (!navigationBox || !settingsBox) {
+    throw new Error('mobile toolbar navigation or settings button had no bounding box')
+  }
+
+  const navigationPrecedesSettings =
+    navigationBox.y < settingsBox.y ||
+    (Math.abs(navigationBox.y - settingsBox.y) <= 1 && navigationBox.x < settingsBox.x)
+  expect(navigationPrecedesSettings).toBe(true)
 }
 
 async function expectStoredWorkspaceLayout(


### PR DESCRIPTION
## What changed

- preserve the toolbar DOM order at responsive widths so workspace navigation stays beside the site identity
- keep Settings, Open live, and Account grouped as the right-side toolbar trailer
- add an E2E geometry assertion covering the mobile navigation/trailer order

## Why

The mobile media query assigned workspace links a later flex order than the toolbar trailer. That moved the icon navigation to the far right even though desktop presents navigation on the left.

## Impact

Responsive admin navigation now matches the desktop information hierarchy without changing available actions or toolbar containment.

## Verification

- `bun test src/__tests__/toolbar/toolbar.test.ts`
- `bun run lint`
- `bun run build`
- `E2E_REUSE_SERVER=1 bun run test:e2e -- tests/e2e/admin-navigation.e2e.ts --project=e2e` (9 passed)
- agent-browser visual check at 665x800 with 2x capture
