### PR TITLE
feat(deploy): add self-contained Dokploy Compose files

### DIFF
--- a/compose.dokploy-postgres.yml
+++ b/compose.dokploy-postgres.yml
@@ -1,0 +1,67 @@
+# compose.dokploy-postgres.yml
+# Self-contained Dokploy Compose deployment: bundled Postgres, source-built
+# from the repo's Dockerfile. Set this file as the Compose Path in the
+# Dokploy UI and add your domain in the app's Domains tab — Dokploy injects
+# Traefik labels and attaches the service to `dokploy-network` for you.
+#
+# Set in the Dokploy environment panel:
+#   POSTGRES_PASSWORD    REQUIRED — a long random secret, e.g. `openssl rand -hex 24`
+#   PUBLIC_ORIGIN        REQUIRED — https://<your Dokploy domain>
+#   INSTATIC_SECRET_KEY  output of `bun run scripts/generate-secret-key.ts`
+#
+# See docs/deployment/dokploy.md for the full walkthrough.
+
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-instatic}
+      POSTGRES_USER: ${POSTGRES_USER:-instatic}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in the Dokploy environment panel}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    networks:
+      - dokploy-network
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U "$${POSTGRES_USER}" -d "$${POSTGRES_DB}"']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    expose:
+      - '3001'
+    environment:
+      PORT: '3001'
+      DATABASE_URL: postgres://${POSTGRES_USER:-instatic}:${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in the Dokploy environment panel}@postgres:5432/${POSTGRES_DB:-instatic}
+      UPLOADS_DIR: /app/uploads
+      STATIC_DIR: /app/dist
+      PUBLIC_ORIGIN: ${PUBLIC_ORIGIN:?Set PUBLIC_ORIGIN to https://<your Dokploy domain> in the Dokploy environment panel}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-172.16.0.0/12}
+      INSTATIC_SECRET_KEY: ${INSTATIC_SECRET_KEY:-}
+    volumes:
+      - uploads:/app/uploads
+    networks:
+      - dokploy-network
+    depends_on:
+      postgres:
+        condition: service_healthy
+    healthcheck:
+      test: ['CMD', 'bun', 'run', 'server/healthcheck.ts']
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
+volumes:
+  postgres_data:
+  uploads:
+
+networks:
+  dokploy-network:
+    external: true

--- a/compose.dokploy.yml
+++ b/compose.dokploy.yml
@@ -1,0 +1,47 @@
+# compose.dokploy.yml
+# Self-contained Dokploy Compose deployment: SQLite, source-built from the
+# repo's Dockerfile. Set this file as the Compose Path in the Dokploy UI and
+# add your domain in the app's Domains tab — Dokploy injects Traefik labels
+# and attaches the service to `dokploy-network` for you.
+#
+# Set in the Dokploy environment panel:
+#   PUBLIC_ORIGIN        REQUIRED — https://<your Dokploy domain>
+#   INSTATIC_SECRET_KEY  output of `bun run scripts/generate-secret-key.ts`
+#
+# See docs/deployment/dokploy.md for the full walkthrough.
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    restart: unless-stopped
+    expose:
+      - '3001'
+    environment:
+      PORT: '3001'
+      DATABASE_URL: sqlite:/app/data/cms.db
+      UPLOADS_DIR: /app/uploads
+      STATIC_DIR: /app/dist
+      PUBLIC_ORIGIN: ${PUBLIC_ORIGIN:?Set PUBLIC_ORIGIN to https://<your Dokploy domain> in the Dokploy environment panel}
+      TRUSTED_PROXY_CIDRS: ${TRUSTED_PROXY_CIDRS:-172.16.0.0/12}
+      INSTATIC_SECRET_KEY: ${INSTATIC_SECRET_KEY:-}
+    volumes:
+      - data:/app/data
+      - uploads:/app/uploads
+    networks:
+      - dokploy-network
+    healthcheck:
+      test: ['CMD', 'bun', 'run', 'server/healthcheck.ts']
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
+
+volumes:
+  data:
+  uploads:
+
+networks:
+  dokploy-network:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,15 @@
 # `DATABASE_URL=postgres://...` in your environment if you want to develop
 # against the Postgres mode instead.
 #
+# NOT A DEPLOY TARGET. This file starts only a bare Postgres container with a
+# hardcoded password — there is no `app` service here. Do not point a hosting
+# platform (Dokploy, etc.) at this file as its Compose Path; it will deploy an
+# unauthenticated database with nothing serving the CMS.
+#
 # For a fully-containerized stack (closer to production), use:
 #   docker compose -f compose.prod.yml -f compose.build.yml up --build
+# For Dokploy specifically, use compose.dokploy.yml or
+# compose.dokploy-postgres.yml — see docs/deployment/dokploy.md.
 
 services:
   postgres:

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -15,6 +15,7 @@ Instatic is one Bun server packaged by the root `Dockerfile`. The server reads r
 | Render SQLite template | Managed Docker install outside Railway | SQLite file | One Render disk mounted at `/app/storage` | [render.md](render.md) |
 | Render Postgres template | Managed Postgres install outside Railway | Render Postgres | Render disk for uploads, Render Postgres storage for DB | [render.md](render.md) |
 | VPS Docker Compose | Self-hosted server, full control | SQLite or bundled Postgres | Docker named volumes | [vps.md](vps.md) |
+| Dokploy | Self-hosted PaaS with Traefik/TLS built in | SQLite or bundled Postgres | Docker named volumes | [dokploy.md](dokploy.md) |
 | Generic Docker host | Any platform that runs the Dockerfile/image | SQLite or external Postgres | A mounted directory/volume for DB/uploads | [docker-image.md](docker-image.md) |
 | VPS HTTPS | Public domain on a VPS | Unchanged | Caddy cert volume plus app volumes | [tls-caddy.md](tls-caddy.md) |
 
@@ -100,6 +101,7 @@ SQLite installs also need the SQLite database file on persistent storage. On pla
 | [railway.md](railway.md) | Railway templates for SQLite and Postgres |
 | [render.md](render.md) | Render Blueprint templates for SQLite and Postgres |
 | [vps.md](vps.md) | Docker Compose on a VPS, both SQLite and Postgres |
+| [dokploy.md](dokploy.md) | Dokploy Docker Compose deploy, both SQLite and Postgres |
 | [docker-image.md](docker-image.md) | Generic Docker image contract and `docker run` examples |
 | [tls-caddy.md](tls-caddy.md) | Caddy TLS overlay for VPS Compose installs |
 | [backup-restore.md](backup-restore.md) | Database and uploads backup/restore |
@@ -112,4 +114,5 @@ SQLite installs also need the SQLite database file on persistent storage. On pla
 - `server/index.ts` — migrations, media storage, and server boot
 - `Dockerfile` — production image contract
 - `compose.prod.yml`, `compose.sqlite.yml`, `compose.tls.yml`, `compose.build.yml` — VPS Compose files
+- `compose.dokploy.yml`, `compose.dokploy-postgres.yml` — Dokploy Compose files
 - `docs/deployment/render/sqlite/render.yaml`, `docs/deployment/render/postgres/render.yaml` — Render Blueprint templates

--- a/docs/deployment/dokploy.md
+++ b/docs/deployment/dokploy.md
@@ -1,0 +1,80 @@
+# Dokploy Deployment
+
+This guide covers deploying Instatic on [Dokploy](https://dokploy.com) using its Docker Compose application type, building from source.
+
+Dokploy takes a single Compose file path per application — it cannot stack the `-f compose.prod.yml -f compose.sqlite.yml` overlay chain the VPS guide uses. `compose.dokploy.yml` and `compose.dokploy-postgres.yml` are self-contained files built specifically for this: each defines the whole stack (`app`, plus `postgres` for the Postgres variant) with `build:` pointed at the repo's `Dockerfile`, `expose:` instead of a published host port, and an external `dokploy-network` attachment so Dokploy's Traefik proxy can route to it.
+
+---
+
+## TL;DR
+
+| Variant | Compose Path | Containers | Persistent volumes |
+|---|---|---|---|
+| SQLite | `compose.dokploy.yml` | `app` | `data`, `uploads` |
+| Postgres | `compose.dokploy-postgres.yml` | `app`, `postgres` | `postgres_data`, `uploads` |
+
+SQLite is the default for single-site installs. Postgres is for multiple simultaneous admin writers or operators who already standardize on Postgres.
+
+## Create the Application
+
+1. In Dokploy, create a new **Application** of type **Docker Compose**.
+2. Point it at this repository and the branch you want to deploy.
+3. Set **Compose Path** to `compose.dokploy.yml` (SQLite) or `compose.dokploy-postgres.yml` (Postgres).
+4. Leave the build type as **Dockerfile** / source build — Dokploy builds the image from the repo on each deploy.
+
+## Environment Variables
+
+Set these in the application's **Environment** panel before the first deploy:
+
+```txt
+PUBLIC_ORIGIN=https://cms.example.com
+INSTATIC_SECRET_KEY=<output of bun run scripts/generate-secret-key.ts>
+```
+
+`PUBLIC_ORIGIN` is required by both compose files (`${PUBLIC_ORIGIN:?...}`) — the deploy fails fast with a clear error if it's missing rather than booting with a broken CSRF check. Dokploy's Traefik terminates TLS and forwards plain HTTP to the container, so the app cannot infer its own public origin from the request URL.
+
+`INSTATIC_SECRET_KEY` is required before adding AI provider credentials, saving plugin secret settings, or enabling TOTP MFA in production. The admin still loads without it.
+
+Postgres deployments additionally require:
+
+```txt
+POSTGRES_PASSWORD=<output of: openssl rand -hex 24>
+```
+
+`compose.dokploy-postgres.yml` guards this with `${POSTGRES_PASSWORD:?...}` on both the `postgres` and `app` services — the deploy fails rather than starting with a guessable password.
+
+## Domain and TLS
+
+Add your domain in the application's **Domains** tab, pointed at container port `3001`. Dokploy auto-generates the Traefik labels and provisions a Let's Encrypt certificate — do not add a separate TLS proxy (`compose.tls.yml`'s Caddy overlay is for the plain-VPS path and is redundant here; running it alongside Dokploy's Traefik would fight over ports 80/443).
+
+## Persistent Data
+
+| Volume | Mount path | Contents |
+|---|---|---|
+| `data` (SQLite only) | `/app/data` | SQLite database |
+| `postgres_data` (Postgres only) | `/var/lib/postgresql/data` | Postgres data directory |
+| `uploads` | `/app/uploads` | Media, fonts, plugins, published artefacts |
+
+These are Docker named volumes managed by Dokploy. Back up both the database and `uploads` — see [backup-restore.md](backup-restore.md).
+
+## Updates
+
+Trigger a redeploy from the Dokploy UI, or configure a Git webhook/auto-deploy on push to the tracked branch. Each deploy rebuilds the image from the current source and re-runs database migrations on boot (`server/index.ts`).
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Deploy fails immediately with a `Set PUBLIC_ORIGIN...` error | Set `PUBLIC_ORIGIN` in the Environment panel to `https://` plus your Dokploy domain. |
+| Deploy fails immediately with a `Set POSTGRES_PASSWORD...` error | Postgres variant only — set `POSTGRES_PASSWORD` in the Environment panel. |
+| Admin loads but every save fails with `Forbidden: invalid origin` | `PUBLIC_ORIGIN` doesn't match the domain you're visiting. |
+| Domain returns a Traefik 404 / bad gateway | Confirm the Domains tab points at container port `3001` and that the deploy succeeded (container attaches to `dokploy-network` automatically — no manual network config needed). |
+| Adding an AI provider credential or enabling TOTP MFA returns 500 | Set `INSTATIC_SECRET_KEY` to the output of `bun run scripts/generate-secret-key.ts`. |
+
+## Related
+
+- [deployment/README.md](README.md) — deployment overview
+- [vps.md](vps.md) — the analogous plain Docker Compose path (no Dokploy)
+- [backup-restore.md](backup-restore.md) — backup and restore procedures
+- `compose.dokploy.yml` — SQLite Dokploy Compose file
+- `compose.dokploy-postgres.yml` — Postgres Dokploy Compose file

--- a/scripts/build-release-bundle.ts
+++ b/scripts/build-release-bundle.ts
@@ -19,9 +19,12 @@ const bundleFiles = [
   'compose.prod.yml',
   'compose.sqlite.yml',
   'compose.tls.yml',
+  'compose.dokploy.yml',
+  'compose.dokploy-postgres.yml',
   '.env.production.example',
   'docs/deployment/README.md',
   'docs/deployment/vps.md',
+  'docs/deployment/dokploy.md',
   'docs/deployment/docker-image.md',
   'docs/deployment/tls-caddy.md',
   'docs/deployment/backup-restore.md',
@@ -104,6 +107,12 @@ PUBLIC_ORIGIN=https://\${{RAILWAY_PUBLIC_DOMAIN}}
 \`\`\`
 
 Read \`docs/deployment/railway.md\`, \`docs/deployment/vps.md\`, and \`docs/deployment/backup-restore.md\` before running a public site.
+
+## Dokploy install
+
+In Dokploy, create a Docker Compose application from this repository and set the Compose Path to \`compose.dokploy.yml\` (SQLite) or \`compose.dokploy-postgres.yml\` (Postgres). Set \`PUBLIC_ORIGIN\` and \`INSTATIC_SECRET_KEY\` (and \`POSTGRES_PASSWORD\` for the Postgres variant) in the Environment panel, then add your domain in the Domains tab.
+
+Read \`docs/deployment/dokploy.md\` before running a public site.
 
 ## Render Blueprint install
 

--- a/src/__tests__/server/dockerConfig.test.ts
+++ b/src/__tests__/server/dockerConfig.test.ts
@@ -97,4 +97,54 @@ describe('self-host docker config', () => {
     expect(compose).toContain('INSTATIC_SECRET_KEY:')
     expect(compose).toContain('TRUSTED_PROXY_CIDRS:')
   })
+
+  describe('Dokploy compose files', () => {
+    // Dokploy takes a single Compose file path per application — it can't stack
+    // overrides the way `docker compose -f a -f b` does. Both Dokploy variants
+    // are therefore self-contained (`build:` inlined, no compose.build.yml /
+    // compose.sqlite.yml overlay) and must stay structurally in sync on the
+    // shared `app` service: same build, network, expose, and required env keys.
+    const sqlite = readFileSync('compose.dokploy.yml', 'utf8')
+    const postgres = readFileSync('compose.dokploy-postgres.yml', 'utf8')
+
+    it('builds from the repo Dockerfile instead of pulling an image', () => {
+      for (const compose of [sqlite, postgres]) {
+        expect(compose).toContain('dockerfile: Dockerfile')
+        expect(compose).not.toContain('ghcr.io/corebunch/instatic')
+      }
+    })
+
+    it('attaches the app service to the external dokploy-network and never publishes a host port', () => {
+      for (const compose of [sqlite, postgres]) {
+        expect(compose).toContain('dokploy-network')
+        expect(compose).toContain('external: true')
+        expect(compose).toContain("expose:\n      - '3001'")
+        expect(compose).not.toContain('ports:')
+      }
+    })
+
+    it('requires PUBLIC_ORIGIN at load time instead of silently booting with a broken CSRF check', () => {
+      for (const compose of [sqlite, postgres]) {
+        expect(compose).toContain('${PUBLIC_ORIGIN:?')
+      }
+    })
+
+    it('persists uploads on a named volume in both variants', () => {
+      for (const compose of [sqlite, postgres]) {
+        expect(compose).toContain('uploads:/app/uploads')
+      }
+    })
+
+    it('points SQLite at a persisted data volume and disables Postgres entirely', () => {
+      expect(sqlite).toContain('DATABASE_URL: sqlite:/app/data/cms.db')
+      expect(sqlite).toContain('data:/app/data')
+      expect(sqlite).not.toContain('postgres')
+    })
+
+    it('requires POSTGRES_PASSWORD at load time and wires the app to the bundled postgres service', () => {
+      expect(postgres).toContain('${POSTGRES_PASSWORD:?')
+      expect(postgres).toContain('condition: service_healthy')
+      expect(postgres).toContain('DATABASE_URL: postgres://')
+    })
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `compose.dokploy.yml` (SQLite) and `compose.dokploy-postgres.yml` (Postgres) — self-contained Docker Compose files for deploying Instatic on [Dokploy](https://dokploy.com), which takes a single Compose file path per application and can't stack the `compose.prod.yml` + `compose.sqlite.yml`/`compose.build.yml` overlay chain the existing VPS guide relies on.
- Each file builds from the repo's `Dockerfile`, uses `expose:` instead of publishing a host port, and attaches to the external `dokploy-network` so Dokploy's Traefik proxy can route to it (labels/TLS are then configured via the Dokploy Domains tab, not written by hand).
- `PUBLIC_ORIGIN` (both variants) and `POSTGRES_PASSWORD` (Postgres variant) use `${VAR:?...}` guards so a deploy with a missing required value fails immediately with a clear message, instead of booting with a broken CSRF check or a guessable database password.
- Adds a warning comment to `docker-compose.yml` — it's a dev-only bare Postgres container with no app service and a hardcoded password; pointing a hosting platform at it as a Compose Path would silently deploy an unauthenticated database with nothing serving the CMS.
- Adds `docs/deployment/dokploy.md` and links it from `docs/deployment/README.md`.
- Wires the two new compose files and the new doc into `scripts/build-release-bundle.ts` so release tarballs carry them.
- Adds a parity gate test (`src/__tests__/server/dockerConfig.test.ts`) asserting both Dokploy compose files stay structurally in sync on the shared `app` service (build source, network, expose, required env guards, volumes).

## Why

Deploying via Dokploy through GitHub currently has no working path: the root `docker-compose.yml` that a naive Dokploy setup would default to is dev-only and starts a bare database with no app in it, and the production `compose.prod.yml` stack assumes multi-file overlay stacking and host-port publishing that Dokploy's single-Compose-path, Traefik-routed model doesn't support.

## Verification

- `docker compose -f compose.dokploy.yml config` and `docker compose -f compose.dokploy-postgres.yml config` — both resolve correctly with required env vars set.
- Confirmed both files fail closed (non-zero exit, clear error) when `PUBLIC_ORIGIN` / `POSTGRES_PASSWORD` are unset.
- **`bun test` / `bun run build` / `bun run lint` were not run locally** — Bun is not installed in the environment this PR was authored in. These are covered by this repo's CI workflow, which runs on PRs to `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)