### PR TITLE
fix(editor): registry-reactive module metadata for late-registering plugin packs

### DIFF
--- a/docs/features/modules.md
+++ b/docs/features/modules.md
@@ -245,6 +245,8 @@ registry.generation()                          // monotonic counter — pair wit
 
 The registry is type-erased — every module is held as `AnyModuleDefinition` (props typed as `Record<string, unknown>`). The narrow → erased cast happens once at the registry boundary so user code never needs to widen its types.
 
+**Reading the registry from React render code:** always go through `useModuleDefinition(moduleId)` / `useModuleList()` (`src/admin/pages/site/useModuleRegistry.ts`), never call `registry.get()`/`registry.list()` directly in render. Plugin module packs register asynchronously after the editor mounts, and the React Compiler memoizes a raw `registry.get(node.moduleId)` keyed only on `node.moduleId` — a subscription that merely triggers a re-render (e.g. subscribing to `generation()` and discarding the value) still replays the stale cached lookup. The hooks return the resolved value out of a `useSyncExternalStore` snapshot so the compiler tracks it as a real dependency. Event handlers may keep reading the raw singleton — they always execute against live state.
+
 `register()` throws if the id is already taken (duplicate module guard). `registerOrReplace()` silently overwrites — used by every first-party module because each module's `index.ts` self-registers at import time and hot module reload will re-run the import.
 
 ### Boot-time registration

--- a/src/admin/modals/ImportHtml/ImportHtmlModal.tsx
+++ b/src/admin/modals/ImportHtml/ImportHtmlModal.tsx
@@ -27,11 +27,11 @@ import { pushToast } from '@ui/components/Toast'
 import { importHtml, type ImportFragment, type ImportResult } from '@core/htmlImport'
 import { cssToStyleRules } from '@core/siteImport'
 import { useEditorStore, selectActiveCanvasPage } from '@site/store/store'
-import { registry } from '@core/module-engine'
 import { getNodeDisplayName, getNodeHtmlTag } from '@core/page-tree'
 import type { PageNode } from '@core/page-tree'
 import { TreeContainer, TreeRow } from '@site/ui/Tree'
 import { useEditorPreference } from '@site/preferences/editorPreferences'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 import { LayerTreeNodeContent } from '@site/panels/DomPanel'
 import styles from './ImportHtmlModal.module.css'
 import { getErrorMessage } from '@core/utils/errorMessage'
@@ -61,9 +61,11 @@ function PreviewNodeRow({
 }: PreviewNodeRowProps) {
   const node = nodes[nodeId]
   const [expanded, setExpanded] = useState(true)
+  // Registry-reactive lookup (hook precedes the null guard — hooks order).
+  // See `useModuleRegistry.ts` for why this must come from the snapshot.
+  const definition = useModuleDefinition(node?.moduleId)
   if (!node) return null
 
-  const definition = registry.get(node.moduleId)
   const displayName = getNodeDisplayName(node, definition, undefined)
   const htmlTag = getNodeHtmlTag(node, definition)
   const hasChildren = node.children.length > 0

--- a/src/admin/pages/site/canvas/CanvasNotch.tsx
+++ b/src/admin/pages/site/canvas/CanvasNotch.tsx
@@ -1,6 +1,6 @@
 import { useState, type MouseEvent, type ReactNode, type SyntheticEvent } from "react";
 import { createPortal } from "react-dom";
-import { registry } from "@core/module-engine";
+import { useModuleList } from "@site/useModuleRegistry";
 import type { VisualComponent } from "@core/visualComponents";
 import type { SavedLayout } from "@core/layouts";
 import { useInsertModule } from "@site/hooks/useInsertModule";
@@ -137,6 +137,10 @@ interface FavoriteMenuState {
 }
 
 function FavoriteNotchActions() {
+  // Registry-reactive module list — favorites must recompute when plugin
+  // packs register, so the list flows from the hook's snapshot rather than
+  // the raw registry singleton. See `useModuleRegistry.ts`.
+  const allModules = useModuleList();
   const insertModule = useInsertModule();
   const { favorites, setFavorites, toggleFavorite } = useModuleInserterPreference();
   const insertionContext = useModuleInsertionContext();
@@ -149,7 +153,7 @@ function FavoriteNotchActions() {
   const [menu, setMenu] = useState<FavoriteMenuState | null>(null);
 
   const { allItems } = buildModuleInserterItems({
-    modules: registry.list(),
+    modules: allModules,
     context: insertionContext,
     savedLayouts,
     visualComponents,

--- a/src/admin/pages/site/canvas/CanvasTreeLadderRowButton.tsx
+++ b/src/admin/pages/site/canvas/CanvasTreeLadderRowButton.tsx
@@ -1,5 +1,4 @@
 import type { CSSProperties } from 'react'
-import { registry } from '@core/module-engine'
 import {
   getNodeClassNames,
   getNodeDisplayName,
@@ -9,6 +8,7 @@ import {
 } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
 import { Button } from '@ui/components/Button'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 import type { CanvasTreeLadderRow } from './canvasTreeLadder'
 import styles from './BreakpointSelectionOverlay.module.css'
 
@@ -33,7 +33,9 @@ export function CanvasTreeLadderRowButton({
   onHighlight,
   onCommit,
 }: CanvasTreeLadderRowButtonProps) {
-  const definition = registry.get(node.moduleId)
+  // Registry-reactive lookup — see `useModuleRegistry.ts` for why this must
+  // come out of the hook's snapshot rather than a raw `registry.get()`.
+  const definition = useModuleDefinition(node.moduleId)
   const displayName = getNodeDisplayName(node, definition, visualComponents)
   const htmlTag = getNodeHtmlTag(node, definition)
   const classNames = getNodeClassNames(node, styleRules)

--- a/src/admin/pages/site/canvas/NodeRenderer.tsx
+++ b/src/admin/pages/site/canvas/NodeRenderer.tsx
@@ -19,12 +19,12 @@
  *   stay referentially stable for unchanged data.
  */
 
-import { memo, use, useLayoutEffect, useRef, useSyncExternalStore } from 'react'
+import { memo, use, useLayoutEffect, useRef } from 'react'
 import type { InlineEditBinding } from '@core/module-engine'
 import { readInlineEditableText, seedInlineEditableContent } from '@modules/base/shared/inlineText'
 import { useEditorStore, selectActiveCanvasPage } from '@site/store/store'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 import { resolveProps } from '@core/page-tree'
-import { registry } from '@core/module-engine'
 import type { NodeWrapperProps as NodeWrapperPropsType } from '@core/module-engine'
 import { resolveDynamicProps, effectiveNodeBindings, type TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import type { PageNode } from '@core/page-tree'
@@ -158,14 +158,13 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
     onNodeHover(hoveredNodeId, breakpointId)
   }
 
-  // Subscribe to module registry changes so plugin module packs that activate
+  // Registry-reactive definition lookup so plugin module packs that activate
   // after the canvas mounted trigger a re-render — otherwise the canvas would
   // freeze on `Unknown module` even after the registry receives the module.
-  useSyncExternalStore(
-    registry.subscribe.bind(registry),
-    registry.generation.bind(registry),
-    registry.generation.bind(registry),
-  )
+  // The value must flow from the hook's snapshot (not a raw `registry.get()`)
+  // or the React Compiler replays the stale memoized lookup — see
+  // `useModuleRegistry.ts`.
+  const definition = useModuleDefinition(node?.moduleId)
 
   // On session start, seed the editable element's content imperatively (React
   // does NOT own it — see inlineEditableElementProps), then focus and drop the
@@ -197,7 +196,6 @@ export const NodeRenderer = memo(function NodeRenderer({ nodeId }: NodeRendererP
   if (!node) return null
   if (node.hidden) return null
 
-  const definition = registry.get(node.moduleId)
   if (!definition) {
     return (
       <div

--- a/src/admin/pages/site/canvas/pluginModuleComponentFactory.tsx
+++ b/src/admin/pages/site/canvas/pluginModuleComponentFactory.tsx
@@ -16,11 +16,27 @@
  * keeping the canvas in sync means the editor preview matches what visitors
  * will see — no more "styled on the frontend, unstyled in canvas" surprises.
  *
+ * The canvas itself renders through `createPortal` into each breakpoint
+ * iframe's own `contentDocument` (`IframeFrameSurface.tsx`) — this component
+ * tree executes in the PARENT window's React reconciler, but the DOM it
+ * produces lives inside one of those iframes. Injecting CSS via the bare
+ * global `document` therefore targets the wrong document entirely: the
+ * style tag lands in the admin app's own `<head>`, not the iframe's, so the
+ * portaled module HTML renders with zero applied CSS. Fixed by injecting
+ * into the rendered node's own `ownerDocument` (read via a ref, after
+ * mount — before mount the node isn't attached anywhere yet, so there's no
+ * correct document to target). There are also multiple iframes (one per
+ * breakpoint) with independent documents, so the injected-hash dedupe guard
+ * is keyed per-document (`WeakMap<Document, Set<string>>`), not globally —
+ * a global Set would skip injecting into the second and third iframe once
+ * the first had already "claimed" that CSS hash.
+ *
  * This file deliberately exports only the factory function (a regular
  * function, not a React component) so React Fast Refresh stays happy. Each
  * call returns a fresh anonymous component class — those don't enter
  * Fast Refresh boundaries because they're not module-level exports.
  */
+import { useEffect, useRef } from 'react'
 import type {
   ModuleComponentProps,
 } from '@core/module-engine'
@@ -31,10 +47,11 @@ import type { PluginModuleComponentFactory } from '@core/plugins/moduleAdapter'
 
 /**
  * Track which (moduleId, css-content-hash) pairs we've already injected,
- * so re-rendering an instance doesn't keep appending `<style>` elements.
- * Keyed by the data-css-hash attribute the `<style>` element carries.
+ * per target document — a breakpoint iframe's document needs its own copy
+ * of the style tag; injecting once and skipping the rest (a flat global
+ * Set) would leave every iframe but the first unstyled.
  */
-const injectedCssHashes = new Set<string>()
+const injectedCssHashesByDocument = new WeakMap<Document, Set<string>>()
 
 /**
  * Tiny non-crypto hash — DJB2. Used purely to key the injected `<style>`
@@ -51,34 +68,39 @@ function hashCss(s: string): string {
   return (h >>> 0).toString(36)
 }
 
-function injectModuleCss(moduleId: string, css: string): void {
-  if (typeof document === 'undefined') return
+function injectModuleCss(targetDocument: Document, moduleId: string, css: string): void {
   const trimmed = css.trim()
   if (!trimmed) return
   const hash = hashCss(trimmed)
   const key = `${moduleId}:${hash}`
-  if (injectedCssHashes.has(key)) return
+  let injectedHashes = injectedCssHashesByDocument.get(targetDocument)
+  if (!injectedHashes) {
+    injectedHashes = new Set()
+    injectedCssHashesByDocument.set(targetDocument, injectedHashes)
+  }
+  if (injectedHashes.has(key)) return
   // Defensive — another instance may have injected the same hash before
   // this one ran (e.g. during concurrent first renders of two instances
   // of the same module).
-  if (document.querySelector(
+  if (targetDocument.querySelector(
     `style[data-plugin-module="${CSS.escape(moduleId)}"][data-css-hash="${CSS.escape(hash)}"]`,
   )) {
-    injectedCssHashes.add(key)
+    injectedHashes.add(key)
     return
   }
-  const style = document.createElement('style')
+  const style = targetDocument.createElement('style')
   style.setAttribute('data-plugin-module', moduleId)
   style.setAttribute('data-css-hash', hash)
   style.textContent = trimmed
-  document.head.appendChild(style)
-  injectedCssHashes.add(key)
+  targetDocument.head.appendChild(style)
+  injectedHashes.add(key)
 }
 
 export const editorPluginModuleComponentFactory: PluginModuleComponentFactory = (definition: PluginModuleDefinition) => {
   const renderForEditor = definition.preview ?? definition.render
   const canHaveChildren = Boolean(definition.canHaveChildren)
   return function PluginCanvasModule(props: ModuleComponentProps) {
+    const rootRef = useRef<HTMLDivElement | null>(null)
     const childList: string[] = []
     // Defensive wrap — a throwing plugin preview()/render() is caught by the
     // per-node ErrorBoundary above us, but that boundary swaps the entire
@@ -96,14 +118,20 @@ export const editorPluginModuleComponentFactory: PluginModuleComponentFactory = 
       console.error(`[plugin-module:${definition.id}] preview/render() threw:`, err)
       html = `<!-- instatic: plugin module "${definition.id}" render failed -->`
     }
-    if (css) injectModuleCss(definition.id, css)
+    // Runs after commit, when rootRef.current is attached to its real
+    // document (the portaled-into iframe) — ownerDocument is only
+    // meaningful once the node is actually in a document.
+    useEffect(() => {
+      if (!css || !rootRef.current) return
+      injectModuleCss(rootRef.current.ownerDocument, definition.id, css)
+    }, [css])
     if (canHaveChildren) {
       // dangerouslySetInnerHTML and children are mutually exclusive in React.
       // Plugins with `canHaveChildren: true` need both: rendered HTML + a
       // slot for nested React subtrees. Render the static HTML in one
       // sibling div, mount children in another, outside the dangerous boundary.
       return (
-        <div className={props.mcClassName} data-plugin-canvas-module="true">
+        <div ref={rootRef} className={props.mcClassName} data-plugin-canvas-module="true">
           <div dangerouslySetInnerHTML={{ __html: html }} />
           <div data-plugin-children="true">{props.children}</div>
         </div>
@@ -111,6 +139,7 @@ export const editorPluginModuleComponentFactory: PluginModuleComponentFactory = 
     }
     return (
       <div
+        ref={rootRef}
         className={props.mcClassName}
         data-plugin-canvas-module="true"
         dangerouslySetInnerHTML={{ __html: html }}

--- a/src/admin/pages/site/module-picker/ModuleInserterDialog.tsx
+++ b/src/admin/pages/site/module-picker/ModuleInserterDialog.tsx
@@ -8,7 +8,7 @@ import {
   type PointerEvent as ReactPointerEvent,
 } from 'react'
 import { createPortal } from 'react-dom'
-import { registry } from '@core/module-engine'
+import { useModuleList } from '@site/useModuleRegistry'
 import { pluginRuntime } from '@core/plugins/runtime'
 import type { SavedLayout } from '@core/layouts'
 import type { VisualComponent } from '@core/visualComponents'
@@ -99,6 +99,10 @@ export function ModuleInserterDialog({
   onClose,
   onInsertItem,
 }: ModuleInserterDialogProps) {
+  // Registry-reactive module list — inserter items must recompute when
+  // plugin packs register, so the list flows from the hook's snapshot rather
+  // than the raw registry singleton. See `useModuleRegistry.ts`.
+  const allModules = useModuleList()
   const prefs = readModuleInserterPrefs()
   const [query, setQuery] = useState('')
   const [section, setSection] = useState<ModuleInserterSectionId>('modules')
@@ -130,7 +134,7 @@ export function ModuleInserterDialog({
     componentItems,
     allItems,
   } = buildModuleInserterItems({
-    modules: registry.list(),
+    modules: allModules,
     context: insertionContext,
     savedLayouts,
     visualComponents,

--- a/src/admin/pages/site/module-picker/ModulePicker.tsx
+++ b/src/admin/pages/site/module-picker/ModulePicker.tsx
@@ -23,7 +23,7 @@ import {
   type RefObject,
 } from 'react'
 import { useEditorStore } from '@site/store/store'
-import { registry } from '@core/module-engine'
+import { useModuleList } from '@site/useModuleRegistry'
 import type { AnyModuleDefinition } from '@core/module-engine'
 import type { VisualComponent } from '@core/visualComponents'
 import { BracesIcon } from 'pixel-art-icons/icons/braces'
@@ -60,6 +60,10 @@ export function ModulePicker({
   autoFocusSearch = true,
   containerRef,
 }: ModulePickerProps) {
+  // Registry-reactive module list — the picker's groups must recompute when
+  // plugin packs register, so the list flows from the hook's snapshot rather
+  // than the raw registry singleton. See `useModuleRegistry.ts`.
+  const allModules = useModuleList()
   const [query, setQuery] = useState('')
   const searchRef = useRef<HTMLInputElement>(null)
 
@@ -80,8 +84,14 @@ export function ModulePicker({
   // hides auto-materialized internals (body, VC refs, slot instances; slot
   // outlets outside VC mode) and disables context-bound modules (e.g. Content
   // Outlet outside a template) with a reason rendered as a tooltip.
+  const modulesByCategory = new Map<string, AnyModuleDefinition[]>()
+  for (const mod of allModules) {
+    const group = modulesByCategory.get(mod.category)
+    if (group) group.push(mod)
+    else modulesByCategory.set(mod.category, [mod])
+  }
   const moduleGroups: AnyModuleDefinition[][] = []
-  for (const mods of Object.values(registry.listByCategory())) {
+  for (const mods of modulesByCategory.values()) {
     const visible = mods.filter(
       (m) => moduleAvailability(m, insertionContext).kind !== 'hidden',
     )

--- a/src/admin/pages/site/panels/DomPanel/DomPanel.tsx
+++ b/src/admin/pages/site/panels/DomPanel/DomPanel.tsx
@@ -39,7 +39,7 @@ import { createPortal } from 'react-dom'
 import { useEditorStore, selectActiveCanvasPage } from '@site/store/store'
 import { flattenSubtree } from '@core/page-tree'
 import { getAncestorIds } from '@site/hooks/useTreeWalkOrder'
-import { registry } from '@core/module-engine'
+import { useModuleList } from '@site/useModuleRegistry'
 import {
   getNodeDisplayName,
   getNodeHtmlTag,
@@ -154,6 +154,13 @@ function DomPanelInner({ editable = true }: { editable?: boolean }) {
   // searchable haystack and the chip text shown in results).
   const classes = useEditorStore((s) => s.site?.styleRules)
   const visualComponents = useEditorStore((s) => s.site?.visualComponents)
+  // Registry-reactive module list — the search haystack resolves display
+  // names and tags per node, and plugin module packs register asynchronously
+  // after mount. Reading through the hook's snapshot (not the raw registry
+  // singleton) keeps the React Compiler's memoization of `searchRows`
+  // invalidating when the registry changes. See `useModuleRegistry.ts`.
+  const modules = useModuleList()
+  const moduleById = new Map(modules.map((m) => [m.id, m]))
 
   // Tag / class display preferences. The SEARCH FILTER itself always considers
   // tag and class names regardless of these prefs — toggling visibility of
@@ -340,7 +347,7 @@ function DomPanelInner({ editable = true }: { editable?: boolean }) {
 
         const node = page.nodes[nodeId]
         if (!node) return []
-        const def = registry.get(node.moduleId)
+        const def = moduleById.get(node.moduleId)
         const displayName = getNodeDisplayName(node, def, visualComponents)
         const htmlTag = getNodeHtmlTag(node, def)
         const classNames = getNodeClassNames(node, classes)

--- a/src/admin/pages/site/panels/DomPanel/LayerNodeContextMenu.tsx
+++ b/src/admin/pages/site/panels/DomPanel/LayerNodeContextMenu.tsx
@@ -43,13 +43,13 @@ import {
 } from '@ui/components/ContextMenu'
 import { useEditorStore, selectActiveCanvasPage } from '@site/store/store'
 import { useShallow } from 'zustand/react/shallow'
-import { registry } from '@core/module-engine'
 import { useInsertModule } from '@site/hooks/useInsertModule'
 import { resolveInsertLocation } from '@site/store/insertLocation'
 import { ModulePicker } from '@site/module-picker'
 import { canComponentizeNode } from '@site/componentization'
 import { useConfirmDelete } from '@admin/shared/dialogs/ConfirmDeleteDialog'
 import type { AnyModuleDefinition } from '@core/module-engine'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 import { PenSquareSolidIcon } from 'pixel-art-icons/icons/pen-square-solid'
 import { CopyPlusSolidIcon } from 'pixel-art-icons/icons/copy-plus-solid'
 import { CopySolidIcon } from 'pixel-art-icons/icons/copy-solid'
@@ -168,16 +168,18 @@ export function LayerNodeContextMenu({
   // Whether the right-clicked node accepts children (root or canHaveChildren).
   // Used to gate the "Paste HTML here…" item — only offered when the target
   // is a genuine container so the import lands where the user expects it.
-  const isContainer = useEditorStore((s) => {
+  const isRootNode = useEditorStore((s) => {
     if (isMulti || !nodeId) return false
-    const tree = selectActiveCanvasPage(s)
-    if (!tree) return false
-    const isRoot = tree.rootNodeId === nodeId
-    const node = tree.nodes[nodeId]
-    if (!node) return false
-    const def = registry.get(node.moduleId)
-    return isRoot || def?.canHaveChildren === true
+    return selectActiveCanvasPage(s)?.rootNodeId === nodeId
   })
+  const targetModuleId = useEditorStore((s) => {
+    if (isMulti || !nodeId) return undefined
+    return selectActiveCanvasPage(s)?.nodes[nodeId]?.moduleId
+  })
+  // Registry-reactive lookup — see `useModuleRegistry.ts` for why this must
+  // come out of the hook's snapshot rather than a raw `registry.get()`.
+  const targetDefinition = useModuleDefinition(targetModuleId)
+  const isContainer = isRootNode || targetDefinition?.canHaveChildren === true
 
   const canComponentize = useEditorStore((s) => {
     if (isMulti || !nodeId) return false

--- a/src/admin/pages/site/panels/DomPanel/TreeNode.tsx
+++ b/src/admin/pages/site/panels/DomPanel/TreeNode.tsx
@@ -23,7 +23,6 @@
 import { memo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
 import { useEditorStore, selectActiveCanvasPage } from '@site/store/store'
-import { registry } from '@core/module-engine'
 import {
   getNodeDisplayName,
   getNodeHtmlTag,
@@ -42,6 +41,7 @@ import {
 import { getKeybindingForCommand } from '@admin/spotlight/keybindings'
 import { useEditorPreference } from '@site/preferences/editorPreferences'
 import { useConfirmDelete } from '@admin/shared/dialogs/ConfirmDeleteDialog'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 import { LayerTreeNodeContent } from './LayerTreeNodeContent'
 import { isNarrowEditorChromeViewport } from '@site/layout/responsiveChrome'
 import styles from './TreeNode.module.css'
@@ -79,6 +79,12 @@ export const TreeNode = memo(function TreeNode({ nodeId, depth, editable = true 
   // references it. The reference is stable across unrelated edits because
   // siteSlice mutations only swap classes when class state actually changes.
   const classes = useEditorStore((s) => s.site?.styleRules)
+
+  // Registry-reactive definition lookup — plugin module packs register
+  // asynchronously after the tree mounts, and the resolved value must come
+  // out of the hook's snapshot (not a raw `registry.get()` in render) so the
+  // React Compiler tracks it. See `useModuleRegistry.ts`.
+  const definition = useModuleDefinition(node?.moduleId)
 
   // User preferences — controls visibility of the tag pill, class chip, and
   // module icon beside each row. Re-evaluated on storage / preferences-changed
@@ -147,7 +153,6 @@ export const TreeNode = memo(function TreeNode({ nodeId, depth, editable = true 
   // ── Guard against unmounted nodes ─────────────────────────────────────────
   if (!node) return null
 
-  const definition = registry.get(node.moduleId)
   const displayName = getNodeDisplayName(node, definition, visualComponents)
   const htmlTag = getNodeHtmlTag(node, definition)
   const classNames = getNodeClassNames(node, classes)

--- a/src/admin/pages/site/panels/PropertiesPanel/ComponentParamsOverview.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/ComponentParamsOverview.tsx
@@ -12,7 +12,7 @@
 
 import { useEditorStore } from '@site/store/store'
 import { findParamOrigin } from '@core/visualComponents'
-import { registry } from '@core/module-engine'
+import { useModuleList } from '@site/useModuleRegistry'
 import type { VisualComponent, VCParam } from '@core/visualComponents'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
@@ -79,6 +79,11 @@ function summarizeParamDefault(param: VCParam): string {
 // ---------------------------------------------------------------------------
 
 export function ComponentParamsOverview({ vc }: ComponentParamsOverviewProps) {
+  // Registry-reactive module index — origin-node names resolve per param,
+  // and the lookup must flow from the hook's snapshot so the React Compiler
+  // recomputes it when plugin packs register. See `useModuleRegistry.ts`.
+  const modules = useModuleList()
+  const moduleById = new Map(modules.map((m) => [m.id, m]))
   const selectNode = useEditorStore((s) => s.selectNode)
   const removeParamWithCleanup = useEditorStore((s) => s.removeParamWithCleanup)
 
@@ -103,7 +108,7 @@ export function ComponentParamsOverview({ vc }: ComponentParamsOverviewProps) {
             const origin = findParamOrigin(vc, param.id)
             const originNode = origin ? vc.tree.nodes[origin.nodeId] ?? null : null
             const moduleName = originNode
-              ? (originNode.label || registry.get(originNode.moduleId)?.name || originNode.moduleId)
+              ? (originNode.label || moduleById.get(originNode.moduleId)?.name || originNode.moduleId)
               : null
             const sourceLabel = origin && moduleName
               ? `from ${moduleName}.${origin.propKey}`

--- a/src/admin/pages/site/panels/PropertiesPanel/MultiSelectionInspector.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/MultiSelectionInspector.tsx
@@ -33,7 +33,7 @@ import {
   useEditorStore,
   selectActiveCanvasPage,
 } from '@site/store/store'
-import { registry } from '@core/module-engine'
+import { useModuleList } from '@site/useModuleRegistry'
 import {
   getNodeDisplayName,
   getNodeHtmlTag,
@@ -69,6 +69,11 @@ interface MultiSelectionInspectorProps {
 export function MultiSelectionInspector({
   selectedNodeIds,
 }: MultiSelectionInspectorProps) {
+  // Registry-reactive module index — row labels and tags resolve per node,
+  // and the lookup must flow from the hook's snapshot so the React Compiler
+  // recomputes it when plugin packs register. See `useModuleRegistry.ts`.
+  const modules = useModuleList()
+  const moduleById = new Map(modules.map((m) => [m.id, m]))
   const removeFromSelection = useEditorStore((s) => s.removeFromSelection)
   const duplicateNodes = useEditorStore((s) => s.duplicateNodes)
   const deleteNodes = useEditorStore((s) => s.deleteNodes)
@@ -96,7 +101,7 @@ export function MultiSelectionInspector({
             classChip: null as string | null,
           }
         }
-        const def = registry.get(node.moduleId)
+        const def = moduleById.get(node.moduleId)
         const classNames = getNodeClassNames(node, classes)
         return {
           id,

--- a/src/admin/pages/site/panels/PropertiesPanel/usePropertiesPanelData.ts
+++ b/src/admin/pages/site/panels/PropertiesPanel/usePropertiesPanelData.ts
@@ -16,6 +16,7 @@ import { useState } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 import { useEditorStore, selectSelectedNode } from '@site/store/store'
 import { registry } from '@core/module-engine'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 import { getAncestors, resolveProps } from '@core/page-tree'
 import { loopSourceRegistry } from '@core/loops/registry'
 import { buildClassTokenUsageMap, buildSelectorUsageMap, resolveSelectorUsage } from '../selectorUsage'
@@ -122,6 +123,7 @@ export function usePropertiesPanelData(): PropertiesPanelData {
 
   const [statusMessage, setStatusMessage] = useState('')
 
+
   // ─── Derivations ────────────────────────────────────────────────────────
   const isMultiSelect = selectedNodeIds.length > 1
   const isSelectorMultiSelect = selectedSelectorClassIds.length > 0
@@ -131,9 +133,10 @@ export function usePropertiesPanelData(): PropertiesPanelData {
     ? site?.visualComponents?.find((v) => v.id === activeDocument.vcId) ?? null
     : null
 
-  const definition: AnyModuleDefinition | null = selectedNode
-    ? registry.get(selectedNode.moduleId) ?? null
-    : null
+  // Registry-reactive lookup — see `useModuleRegistry.ts` for why this must
+  // come out of the hook's snapshot rather than a raw `registry.get()`.
+  const definition: AnyModuleDefinition | null =
+    useModuleDefinition(selectedNode?.moduleId) ?? null
   const resolvedPropsForBreakpoint = selectedNode
     ? resolveProps(
         selectedNode,

--- a/src/admin/pages/site/ui/ModuleIcon/ModuleIcon.tsx
+++ b/src/admin/pages/site/ui/ModuleIcon/ModuleIcon.tsx
@@ -12,10 +12,10 @@
  * Pass either `moduleId` (preferred — handles unknown ids gracefully) or
  * `module` directly when the caller already has the resolved definition.
  */
-import { registry } from '@core/module-engine'
 import type { AnyModuleDefinition } from '@core/module-engine'
 import type { IconProps } from 'pixel-art-icons/types'
 import { SquareSolidIcon } from 'pixel-art-icons/icons/square-solid'
+import { useModuleDefinition } from '@site/useModuleRegistry'
 
 interface ModuleIconProps extends IconProps {
   /** Module id to resolve from the registry. Ignored when `module` is set. */
@@ -29,8 +29,10 @@ export function ModuleIcon({
   module: explicitModule,
   ...iconProps
 }: ModuleIconProps) {
-  const definition =
-    explicitModule ?? (moduleId ? registry.get(moduleId) ?? null : null)
+  // Registry-reactive lookup — see `useModuleRegistry.ts` for why this must
+  // come out of the hook's snapshot rather than a raw `registry.get()`.
+  const fromRegistry = useModuleDefinition(explicitModule ? undefined : moduleId)
+  const definition = explicitModule ?? fromRegistry ?? null
   const ResolvedIcon = definition?.icon ?? SquareSolidIcon
   return <ResolvedIcon {...iconProps} />
 }

--- a/src/admin/pages/site/useModuleRegistry.ts
+++ b/src/admin/pages/site/useModuleRegistry.ts
@@ -1,0 +1,65 @@
+/**
+ * useModuleDefinition / useModuleList — React bindings for the module
+ * registry.
+ *
+ * The module registry (`@core/module-engine`) is a plain mutable singleton,
+ * not a React store. Plugin module packs register asynchronously after the
+ * editor mounts (`useInstalledEditorPlugins` → dynamic import →
+ * `activatePluginModulePack`), so any component that reads
+ * `registry.get()`/`registry.list()` during render can execute before the
+ * plugin modules exist — layer rows fall back to raw module ids, tag pills
+ * and icons go missing, the module picker omits plugin modules.
+ *
+ * IMPORTANT — React Compiler interaction: it is NOT enough to subscribe to
+ * the registry and keep calling `registry.get(...)` in render. The compiler
+ * memoizes `registry.get(node.moduleId)` keyed on `node.moduleId` (it
+ * assumes module-level singletons are immutable), so a subscription-driven
+ * re-render still replays the stale cached lookup. The resolved value must
+ * flow OUT of a `useSyncExternalStore` snapshot so the data dependency is
+ * visible to the compiler. That's what these hooks do — always read module
+ * metadata through them in render paths. Event handlers can keep using the
+ * raw singleton; they always execute against live state.
+ */
+import { useSyncExternalStore } from 'react'
+import { registry, type AnyModuleDefinition } from '@core/module-engine'
+
+const subscribe = (listener: () => void) => registry.subscribe(listener)
+
+/**
+ * Resolve one module definition, re-rendering when the registry changes.
+ * Accepts `undefined` so callers with an optional node can call the hook
+ * unconditionally (hooks-order rule) and guard afterwards.
+ */
+export function useModuleDefinition(
+  moduleId: string | undefined,
+): AnyModuleDefinition | undefined {
+  // `Map.get` returns a stable reference per (id, registration), so the
+  // snapshot only changes identity when the module is actually (re)registered.
+  return useSyncExternalStore(
+    subscribe,
+    () => (moduleId ? registry.get(moduleId) : undefined),
+    () => (moduleId ? registry.get(moduleId) : undefined),
+  )
+}
+
+// `registry.list()` builds a fresh array per call; useSyncExternalStore
+// requires a stable snapshot between changes, so cache one array per
+// registry generation.
+let listCache: { generation: number; list: AnyModuleDefinition[] } | null = null
+function listSnapshot(): AnyModuleDefinition[] {
+  const generation = registry.generation()
+  if (!listCache || listCache.generation !== generation) {
+    listCache = { generation, list: registry.list() }
+  }
+  return listCache.list
+}
+
+/**
+ * All registered modules, re-rendering when the registry changes. The array
+ * identity is stable per registry generation, so downstream derivations
+ * (grouping, `Map` indexes, picker item lists) recompute exactly when the
+ * registry changes.
+ */
+export function useModuleList(): AnyModuleDefinition[] {
+  return useSyncExternalStore(subscribe, listSnapshot, listSnapshot)
+}


### PR DESCRIPTION
## What changed

Plugin module packs register into the module registry **asynchronously** after the editor mounts (`useInstalledEditorPlugins` → dynamic import → `activatePluginModulePack`). Any component that read `registry.get()`/`registry.list()` during render before activation completed was frozen on stale data — and, with the React Compiler enabled, **subscribing to registry changes is not enough to fix it**: the compiler memoizes `registry.get(node.moduleId)` keyed only on `node.moduleId`, so a subscription-driven re-render replays the stale cached lookup. (Empirically verified: a discarded `generation()` subscription left layer rows showing raw `dfdez.*` module ids across every reload; forcing a compiler bailout "fixed" them.)

- New `src/admin/pages/site/useModuleRegistry.ts` with `useModuleDefinition(moduleId)` / `useModuleList()` — `useSyncExternalStore` snapshots (list cached per registry generation) so the resolved value is a dependency the compiler tracks.
- Converted every render-path registry reader: layers tree rows + search + context menu, canvas breadcrumb ladder, `ModuleIcon`, properties panel (single/multi-select/component params), module picker, inserter dialog, canvas notch favorites, HTML-import preview, and `NodeRenderer` (whose existing inline `useSyncExternalStore` subscription had the same latent flaw, masked by iframe boot timing). Event handlers keep reading the raw singleton — they always see live state.
- Canvas CSS fix for plugin modules: `pluginModuleComponentFactory` now injects module CSS into the portaled breakpoint iframe's `ownerDocument` (deduped per document via `WeakMap<Document, Set>`), not the admin document — plugin module CSS previously never applied inside any breakpoint frame.
- Documented the rule in `docs/features/modules.md`.

## Why

With an installed plugin exposing canvas modules (tested with a 6-module manifest-driven section pack), the layers panel showed raw module ids with no tag pills or icons, search couldn't find components by name, and canvas previews rendered unstyled — the components loaded but never appeared as *components*.

## Impact

Plugin modules now behave identically to base modules everywhere in the editor: named rows with tag pills and icons in the layers tree, searchable, listed in the picker/notch, styled in every breakpoint frame — regardless of activation timing.

## Verification

- `bun run build`, `bun run lint`, `bun test` (5910 pass) all green.
- Playwright against the live dev editor with the plugin installed: 5/5 fresh loads with zero raw-id layer rows (previously 7 every load); all six plugin modules searchable in the inserter; per-breakpoint iframes each receive the module `<style>` tags; external Astro consumer renders the same manifest end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)