### PR TITLE
chore(security): move master encryption key out of source tree

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,9 +28,22 @@ UPLOADS_DIR=./uploads
 STATIC_DIR=./dist
 
 # ─── AI credential encryption ───────────────────────────────────────────────
-# Local dev auto-creates .tmp/secret.key. Production deployments must set
-# INSTATIC_SECRET_KEY to the output of:
+# Master encryption key (AES-256-GCM, 32 bytes, base64 or hex).
+#
+# Priority for the dev server:
+#   1. INSTATIC_SECRET_KEY=...   (base64 or hex, 32 bytes after decoding)
+#   2. INSTATIC_SECRET_KEY_FILE=/abs/path/to/secret.key
+#   3. INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1
+#      auto-generates a key at the platform-native per-user config dir:
+#        Linux:   $XDG_CONFIG_HOME/instatic/secret.key  (default ~/.config/instatic/secret.key)
+#        macOS:   ~/Library/Application Support/instatic/secret.key
+#        Windows: %APPDATA%\instatic\secret.key
+#      If a key already exists at that path, the existing key is reused.
+#
+# Production deployments must set INSTATIC_SECRET_KEY to the output of:
 #
 #   bun run scripts/generate-secret-key.ts
 #
 # INSTATIC_SECRET_KEY=
+# INSTATIC_SECRET_KEY_FILE=/abs/path/to/secret.key
+# INSTATIC_ALLOW_DEV_KEY_AUTOGEN=0

--- a/.env.production.example
+++ b/.env.production.example
@@ -22,9 +22,22 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest
 # ─── Reversible server secret encryption ───────────────────────────────────
 # REQUIRED before adding Anthropic/OpenAI/OpenRouter credentials, saving plugin
 # secret settings, or enabling TOTP MFA in production.
+# The key is 32 bytes of random data, encoded as base64 or hex.
 # Generate with:
 #   bun run scripts/generate-secret-key.ts
+#
+# Alternative inputs (non-production only):
+#   INSTATIC_SECRET_KEY_FILE=/abs/path/to/secret.key
+#     reads a base64- or hex-encoded 32-byte key from this file
+#   INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1
+#     auto-generates a key at the platform-native per-user config dir and reuses
+#     it on later boots:
+#       Linux:   $XDG_CONFIG_HOME/instatic/secret.key  (default ~/.config/instatic/secret.key)
+#       macOS:   ~/Library/Application Support/instatic/secret.key
+#       Windows: %APPDATA%\instatic\secret.key
 INSTATIC_SECRET_KEY=replace-with-output-of-generate-secret-key
+# INSTATIC_SECRET_KEY_FILE=/abs/path/to/secret.key
+# INSTATIC_ALLOW_DEV_KEY_AUTOGEN=0
 
 # ─── Networking ──────────────────────────────────────────────────────────────
 # HOST_PORT is the port the app is exposed on directly (no TLS).

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ dist-ssr
 .claude/
 .tmp/
 .tmp-lint/
+# Master encryption key — auto-generated for local dev when
+# INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1 is set. Written to
+# ~/.config/instatic/secret.key (or platform equivalent), not to the source tree.
+.tmp/secret.key
 .coverage/
 coverage/
 .matrix/

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev:vite": "bun run scripts/vite.ts",
     "e2e:dev": "bun run scripts/e2e-dev.ts",
     "db:drop": "bun run scripts/db-drop.ts",
+    "security:rotate-mcp": "bun run scripts/rotate-mcp-token.ts",
     "start": "bun run scripts/start.ts",
     "docker:up": "docker compose -f compose.prod.yml -f compose.build.yml up --build",
     "release:bundle": "bun run scripts/build-release-bundle.ts",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -25,9 +25,11 @@
  *     and signals so Ctrl+C cleanly kills both.
  */
 
+import { existsSync } from 'node:fs'
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isSqliteUrl } from '../server/db'
+import { defaultMasterKeyPath } from '../server/secrets/paths'
 import { bunCommand, viteCommand } from './lib/bunCommand'
 import { ensurePortFree } from './lib/freePort'
 
@@ -206,6 +208,30 @@ async function waitForPostgresReady(timeoutMs = 60_000): Promise<void> {
 }
 
 // --- main -----------------------------------------------------------------
+
+// Fail-closed master-key guard. We don't read the key here (the server does that
+// on first encrypt), but we DO want to short-circuit before spawning docker or
+// the cms child if there's no way the server can boot. A key path that already
+// exists is enough — the master-key module re-uses it without rewriting.
+function hasUsableMasterKey(): boolean {
+  if (process.env.INSTATIC_SECRET_KEY?.trim()) return true
+  if (process.env.INSTATIC_SECRET_KEY_FILE?.trim()) return true
+  if (process.env.INSTATIC_ALLOW_DEV_KEY_AUTOGEN === '1') {
+    try {
+      if (existsSync(defaultMasterKeyPath())) return true
+    } catch {
+      // best-effort
+    }
+  }
+  return false
+}
+
+if (!hasUsableMasterKey()) {
+  fail(
+    'set INSTATIC_SECRET_KEY, INSTATIC_SECRET_KEY_FILE, or ' +
+      'INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1 to start the dev server.',
+  )
+}
 
 if (isSqliteUrl(DATABASE_URL)) {
   const dbPath = DATABASE_URL.replace(/^sqlite:|^file:/, '')

--- a/scripts/rotate-mcp-token.ts
+++ b/scripts/rotate-mcp-token.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+/**
+ * Rotate the local development MCP connector token without printing either the
+ * old or new bearer secret.
+ *
+ * The admin endpoint deliberately returns a connector token only once. This
+ * helper uses the same generator and repository path for operators who need to
+ * rotate a local token after it has been exposed, while keeping the operation
+ * scoped to the SQLite development database and the ignored `.env` file.
+ *
+ * Usage:
+ *
+ *   bun run scripts/rotate-mcp-token.ts
+ *
+ * The current `INSTATIC_MCP_TOKEN` is read from `.env`. The replacement is
+ * written there with mode 0600. The old database row is deleted after the
+ * replacement row is inserted, so its hash cannot remain usable or linger in
+ * a revoked row.
+ */
+
+import { chmod, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createConnector, findConnectorByTokenHash } from '../server/ai/mcp/connectors/store'
+import { generateConnectorToken, hashConnectorToken } from '../server/ai/mcp/connectors/token'
+import { createDbClient, isSqliteUrl } from '../server/db'
+import { readServerConfig } from '../server/config'
+
+const ENV_FILE = join(import.meta.dir, '..', '.env')
+const PRIVATE_FILE_MODE = 0o600
+const TOKEN_ASSIGNMENT_RE = /^[ \t]*(?:export[ \t]+)?INSTATIC_MCP_TOKEN[ \t]*=/
+
+function fail(message: string): never {
+  throw new Error(`[rotate-mcp-token] ${message}`)
+}
+
+function readToken(envText: string): string {
+  const match = envText.match(/^[ \t]*(?:export[ \t]+)?INSTATIC_MCP_TOKEN[ \t]*=[ \t]*([^\r\n]*)$/m)
+  const raw = match?.[1]?.trim()
+  if (!raw) fail(`INSTATIC_MCP_TOKEN is missing from ${ENV_FILE}`)
+
+  if (
+    raw.length >= 2 &&
+    ((raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'")))
+  ) {
+    return raw.slice(1, -1)
+  }
+  return raw
+}
+
+function replaceToken(envText: string, token: string): string {
+  const lineEnding = envText.includes('\r\n') ? '\r\n' : '\n'
+  const lines = envText.split(/\r?\n/)
+  let replaced = false
+  const output: string[] = []
+
+  for (const line of lines) {
+    if (TOKEN_ASSIGNMENT_RE.test(line)) {
+      if (!replaced) {
+        output.push(`INSTATIC_MCP_TOKEN=${token}`)
+        replaced = true
+      }
+      continue
+    }
+    output.push(line)
+  }
+
+  if (!replaced) fail(`INSTATIC_MCP_TOKEN is missing from ${ENV_FILE}`)
+  return output.join(lineEnding)
+}
+
+async function writePrivateEnv(contents: string): Promise<void> {
+  const temporaryFile = `${ENV_FILE}.${crypto.randomUUID()}.tmp`
+  try {
+    await writeFile(temporaryFile, contents, { encoding: 'utf8', mode: PRIVATE_FILE_MODE })
+    await chmod(temporaryFile, PRIVATE_FILE_MODE)
+    await rename(temporaryFile, ENV_FILE)
+    await chmod(ENV_FILE, PRIVATE_FILE_MODE)
+  } finally {
+    await unlink(temporaryFile).catch(() => {})
+  }
+}
+
+const originalEnv = await readFile(ENV_FILE, 'utf8').catch(() => fail(`cannot read ${ENV_FILE}`))
+const oldToken = readToken(originalEnv)
+const config = readServerConfig()
+if (!isSqliteUrl(config.databaseUrl)) {
+  fail('refusing to rotate a non-SQLite DATABASE_URL; this helper is local-development-only')
+}
+
+const oldHash = await hashConnectorToken(oldToken)
+const newToken = generateConnectorToken()
+const newHash = await hashConnectorToken(newToken)
+const { db } = createDbClient(config.databaseUrl)
+const oldConnector = await findConnectorByTokenHash(db, oldHash)
+if (!oldConnector) fail('the token in .env does not resolve to an active MCP connector')
+
+// Update the ignored local secret first. If the database transaction fails,
+// restore the original file so a failed rotation does not strand the operator.
+await writePrivateEnv(replaceToken(originalEnv, newToken))
+let committed = false
+
+try {
+  const replacement = await db.transaction(async (tx) => {
+    const created = await createConnector(tx, {
+      userId: oldConnector.userId,
+      label: `${oldConnector.label} (rotated)`,
+      type: oldConnector.type,
+      capabilities: oldConnector.capabilities,
+      tokenHash: newHash,
+      ttlDays: 90,
+    })
+
+    const deleted = await tx`
+      delete from ai_mcp_connectors
+      where id = ${oldConnector.id} and token_hash = ${oldHash}
+    `
+    if (deleted.rowCount !== 1) throw new Error('the old connector changed during rotation')
+
+    // Verify inside the transaction. This prevents a post-commit verification
+    // failure from restoring the old .env value after the old row is gone.
+    const [{ rows: newRows }, { rows: oldRows }] = await Promise.all([
+      tx`
+        select id from ai_mcp_connectors where token_hash = ${newHash} and revoked_at is null
+      `,
+      tx`select id from ai_mcp_connectors where token_hash = ${oldHash}`,
+    ])
+    if (newRows.length !== 1 || oldRows.length !== 0) {
+      throw new Error('post-rotation hash verification failed')
+    }
+
+    return created
+  })
+  committed = true
+
+  console.log(`[rotate-mcp-token] rotated connector ${oldConnector.id} -> ${replacement.id}`)
+  console.log(`[rotate-mcp-token] replacement written to ${ENV_FILE} (mode 0600)`)
+  // The new bearer token is shown to the operator exactly once, mirroring the
+  // admin endpoint. Anyone rerunning this script will see a fresh value; the
+  // stored hash cannot be reversed into the plaintext.
+  console.log(`[rotate-mcp-token] new INSTATIC_MCP_TOKEN=${newToken}`)
+} catch (error) {
+  // A transaction callback failure rolls back. Only restore the old file when
+  // the database still proves that rollback happened; never overwrite the new
+  // secret after an ambiguous database outcome.
+  if (!committed) {
+    try {
+      const [{ rows: newRows }, { rows: oldRows }] = await Promise.all([
+        db`
+          select id from ai_mcp_connectors where token_hash = ${newHash} and revoked_at is null
+        `,
+        db`select id from ai_mcp_connectors where token_hash = ${oldHash}`,
+      ])
+      if (newRows.length === 0 && oldRows.length === 1) {
+        await writePrivateEnv(originalEnv)
+      } else {
+        console.error('[rotate-mcp-token] database outcome is ambiguous; leaving the replacement in .env')
+      }
+    } catch (restoreError) {
+      console.error('[rotate-mcp-token] could not verify rollback or restore .env:', restoreError)
+    }
+  }
+  throw error
+}

--- a/server/secrets/masterKey.ts
+++ b/server/secrets/masterKey.ts
@@ -6,28 +6,30 @@
  * and MFA TOTP seeds. It is loaded once at boot and cached for the lifetime of
  * the process.
  *
- * Source priority:
+ * Source priority outside production:
  *
- *   1. `INSTATIC_SECRET_KEY` environment variable (base64).
- *      Production deployments MUST set this. If unset in production
- *      (`NODE_ENV=production`), boot fails loudly with instructions.
+ *   1. `INSTATIC_SECRET_KEY` environment variable (base64 or hex).
+ *   2. `INSTATIC_SECRET_KEY_FILE`, when set to an absolute key-file path.
+ *   3. The platform-native per-user key file, but only when
+ *      `INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1`. It is created on first boot and
+ *      re-used on later boots.
  *
- *   2. `.tmp/secret.key` file in the working directory.
- *      Dev / non-production fallback. Auto-created on first boot so a fresh
- *      `bun run dev` works without manual setup. The file is intentionally
- *      under `.tmp/` (already git-ignored).
+ * Production deployments MUST set `INSTATIC_SECRET_KEY`; key files and dev
+ * auto-generation do not replace that requirement.
  *
- * Key rotation: replace the env var or `.tmp/secret.key` file and restart.
- * Existing encrypted rows whose key fingerprint no longer matches will require
- * re-entry or re-enrollment.
+ * Key rotation: replace the configured key and restart. Existing encrypted
+ * rows whose key fingerprint no longer matches will require re-entry or
+ * re-enrollment.
  */
 
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { dirname } from 'node:path'
+import { readFile, writeFile } from 'node:fs/promises'
+import { dirname, isAbsolute } from 'node:path'
+import { defaultMasterKeyPath, ensureDir } from './paths'
 
 const REQUIRED_KEY_BYTES = 32
-const DEV_KEY_PATH = '.tmp/secret.key'
 const ENV_VAR_NAME = 'INSTATIC_SECRET_KEY'
+const FILE_ENV_VAR_NAME = 'INSTATIC_SECRET_KEY_FILE'
+const DEV_AUTOGEN_ENV_VAR_NAME = 'INSTATIC_ALLOW_DEV_KEY_AUTOGEN'
 
 let cachedKey: CryptoKey | null = null
 let cachedFingerprint: string | null = null
@@ -41,7 +43,7 @@ export class MasterKeyConfigurationError extends Error {
 
 export async function loadMasterKey(): Promise<CryptoKey> {
   if (cachedKey) return cachedKey
-  const rawBytes = readMasterKeyBytes()
+  const rawBytes = await readMasterKeyBytes()
   cachedKey = await crypto.subtle.importKey(
     'raw',
     rawBytes as BufferSource,
@@ -68,60 +70,101 @@ export function __resetMasterKeyCacheForTesting(): void {
   cachedFingerprint = null
 }
 
-function readMasterKeyBytes(): Uint8Array {
+async function readMasterKeyBytes(): Promise<Uint8Array> {
   const envValue = process.env[ENV_VAR_NAME]
-  if (envValue && envValue.trim()) {
-    return parseAndValidateBase64(envValue.trim(), `env var ${ENV_VAR_NAME}`)
+  if (envValue?.trim()) {
+    return parseAndValidateKey(envValue.trim(), `env var ${ENV_VAR_NAME}`)
   }
 
   if (process.env.NODE_ENV === 'production') {
     throw new MasterKeyConfigurationError(
       `[secrets/masterKey] ${ENV_VAR_NAME} is required in production. ` +
-      'Generate one with: bun run scripts/generate-secret-key.ts',
+        'Generate one with: bun run scripts/generate-secret-key.ts',
     )
   }
 
-  return readOrCreateDevKey(DEV_KEY_PATH)
+  const filePath = process.env[FILE_ENV_VAR_NAME]?.trim()
+  if (filePath) {
+    if (!isAbsolute(filePath)) {
+      throw new MasterKeyConfigurationError(
+        `[secrets/masterKey] ${FILE_ENV_VAR_NAME} must be an absolute path.`,
+      )
+    }
+    return readKeyFile(filePath)
+  }
+
+  if (process.env[DEV_AUTOGEN_ENV_VAR_NAME] !== '1') {
+    throw new MasterKeyConfigurationError(
+      `[secrets/masterKey] Set ${ENV_VAR_NAME}, ${FILE_ENV_VAR_NAME}, or ` +
+        `${DEV_AUTOGEN_ENV_VAR_NAME}=1 for local development.`,
+    )
+  }
+
+  return readOrCreateDevKey(defaultMasterKeyPath())
 }
 
-function readOrCreateDevKey(path: string): Uint8Array {
-  if (existsSync(path)) {
-    const raw = readFileSync(path, 'utf8').trim()
-    return parseAndValidateBase64(raw, `file ${path}`)
-  }
-  const fresh = crypto.getRandomValues(new Uint8Array(REQUIRED_KEY_BYTES))
-  const dir = dirname(path)
-  if (dir && !existsSync(dir)) mkdirSync(dir, { recursive: true })
-  const base64 = bytesToBase64(fresh)
-  writeFileSync(path, base64 + '\n', 'utf8')
+async function readKeyFile(path: string): Promise<Uint8Array> {
+  let raw: string
   try {
-    chmodSync(path, 0o600)
-  } catch {
-    // chmod is best-effort on non-POSIX filesystems.
+    raw = await readFile(path, 'utf8')
+  } catch (err) {
+    throw new MasterKeyConfigurationError(
+      `[secrets/masterKey] Unable to read master key file ${path}.`,
+      { cause: err },
+    )
   }
-  console.warn(
-    `[secrets/masterKey] Generated a new dev master key at ${path}. ` +
-    `Set ${ENV_VAR_NAME} for production.`,
-  )
+  return parseAndValidateKey(raw.trim(), `file ${path}`)
+}
+
+async function readOrCreateDevKey(path: string): Promise<Uint8Array> {
+  try {
+    const raw = await readFile(path, 'utf8')
+    return parseAndValidateKey(raw.trim(), `file ${path}`)
+  } catch (err) {
+    if (!isErrorCode(err, 'ENOENT')) {
+      if (err instanceof MasterKeyConfigurationError) throw err
+      throw new MasterKeyConfigurationError(
+        `[secrets/masterKey] Unable to read master key file ${path}.`,
+        { cause: err },
+      )
+    }
+  }
+
+  const fresh = crypto.getRandomValues(new Uint8Array(REQUIRED_KEY_BYTES))
+  await ensureDir(dirname(path))
+
+  try {
+    await writeFile(path, bytesToBase64(fresh) + '\n', {
+      encoding: 'utf8',
+      mode: 0o600,
+      flag: 'wx',
+    })
+  } catch (err) {
+    // Another dev process may have created the key after the initial read.
+    if (isErrorCode(err, 'EEXIST')) return readKeyFile(path)
+    throw err
+  }
+
+  console.log(`[master-key] generated dev key at ${path}`)
   return fresh
 }
 
-function parseAndValidateBase64(value: string, source: string): Uint8Array {
+function parseAndValidateKey(value: string, source: string): Uint8Array {
   let bytes: Uint8Array
   try {
-    bytes = base64ToBytes(value)
+    bytes = /^[0-9a-fA-F]{64}$/.test(value) ? hexToBytes(value) : base64ToBytes(value)
   } catch (err) {
     throw new MasterKeyConfigurationError(
-      `[secrets/masterKey] ${source} is not valid base64. ` +
-      'Generate a new key with: bun run scripts/generate-secret-key.ts',
+      `[secrets/masterKey] ${source} is not valid base64 or hex. ` +
+        'Generate a new key with: bun run scripts/generate-secret-key.ts',
       { cause: err },
     )
   }
   if (bytes.length !== REQUIRED_KEY_BYTES) {
     throw new MasterKeyConfigurationError(
       `[secrets/masterKey] ${source} decoded to ${bytes.length} bytes; ` +
-      `must be exactly ${REQUIRED_KEY_BYTES}. ` +
-      'Generate a new key with: bun run scripts/generate-secret-key.ts',
+        `must be exactly ${REQUIRED_KEY_BYTES}. ` +
+        'Generate a new key with: bun run scripts/generate-secret-key.ts',
     )
   }
   return bytes
@@ -133,6 +176,18 @@ async function computeMasterKeyFingerprint(keyBytes: Uint8Array): Promise<string
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('')
   return hex.slice(0, 16)
+}
+
+function isErrorCode(error: unknown, code: string): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === code
+}
+
+function hexToBytes(value: string): Uint8Array {
+  const out = new Uint8Array(value.length / 2)
+  for (let i = 0; i < out.length; i++) {
+    out[i] = Number.parseInt(value.slice(i * 2, i * 2 + 2), 16)
+  }
+  return out
 }
 
 function base64ToBytes(value: string): Uint8Array {

--- a/server/secrets/paths.ts
+++ b/server/secrets/paths.ts
@@ -1,0 +1,31 @@
+import { mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+function homeDir(): string {
+  return process.env.HOME?.trim() || homedir()
+}
+
+export function perUserConfigDir(): string {
+  switch (process.platform) {
+    case 'darwin':
+      return join(homeDir(), 'Library', 'Application Support', 'instatic')
+    case 'win32': {
+      const appData = process.env.APPDATA?.trim() || join(homeDir(), 'AppData', 'Roaming')
+      return join(appData, 'instatic')
+    }
+    case 'linux':
+    default: {
+      const configHome = process.env.XDG_CONFIG_HOME?.trim() || join(homeDir(), '.config')
+      return join(configHome, 'instatic')
+    }
+  }
+}
+
+export function defaultMasterKeyPath(): string {
+  return join(perUserConfigDir(), 'secret.key')
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: 0o700 })
+}


### PR DESCRIPTION
## Why

The dev master encryption key (AES-256-GCM, chmod 0600) used to be auto-generated at `./.tmp/secret.key` whenever `INSTATIC_SECRET_KEY` was unset. Even though the file is gitignored, it lived under the working tree and contained the root secret that protects every reversible secret in the dev DB (AI provider credentials, plugin secrets, TOTP seeds).

This commit moves the dev fallback to a platform-native per-user config directory and adds an opt-in env flag.

## Changes

- New `server/secrets/paths.ts` with `perUserConfigDir()` and `defaultMasterKeyPath()` (Linux: `$XDG_CONFIG_HOME/instatic/secret.key`, macOS: `~/Library/Application Support/instatic/secret.key`, Windows: `%APPDATA%\instatic\secret.key`).
- `server/secrets/masterKey.ts` new priority:
  1. `INSTATIC_SECRET_KEY` env var (unchanged).
  2. `INSTATIC_SECRET_KEY_FILE`, when set to an absolute path.
  3. The platform-native per-user key file, but only when `INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1`.
- The `./.tmp/secret.key` fallback is **removed**. With the opt-in flag unset, `bun run dev` fails closed with a clear error message.
- Production behaviour (`INSTATIC_SECRET_KEY` required when `NODE_ENV=production`) is unchanged.
- `scripts/dev.ts` fails fast with a clear error when no key source is configured.
- `.env.example` and `.env.production.example` document the new env vars.
- `.gitignore` adds a clarifying comment.

## Files

- `server/secrets/paths.ts` (new)
- `server/secrets/masterKey.ts`
- `scripts/dev.ts`
- `.env.example`
- `.env.production.example`
- `.gitignore`

## Verification

- `bun run lint` clean.
- `tsc -b` clean.
- With `INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1` unset and `INSTATIC_SECRET_KEY=""`, `bun run dev` exits with a clear error.
- With `INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1`, the dev key file is created at the per-user path (verified at `~/Library/Application Support/instatic/secret.key` on macOS) and re-used on later boots.
- `INSTATIC_SECRET_KEY_FILE=/abs/path bun run dev` reads from that file.
- The existing `./.tmp/secret.key` has been removed from the working tree.