### PR TITLE
chore(security): move dev SQLite database out of source tree and scrub PII

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,7 @@
 # Local development environment template.
 #
 # You usually do NOT need a .env file locally. `bun run dev` works with zero
-# configuration: it defaults to SQLite at .tmp/dev.db and skips Docker entirely.
+# configuration: it defaults to SQLite in the per-user data dir and skips Docker entirely.
 #
 # Copy this file to .env (or export the variables in your shell) ONLY if you
 # want to override the defaults below.
@@ -13,15 +13,22 @@ PORT=3001
 # TRUSTED_PROXY_CIDRS=127.0.0.1/32,::1/128
 
 # ─── Database ────────────────────────────────────────────────────────────────
-# Default: SQLite at .tmp/dev.db (no Docker, no Postgres process).
+# Default: SQLite in the platform-native per-user data dir
+#   - Linux:   $XDG_DATA_HOME/instatic/dev.db (default ~/.local/share/instatic/dev.db)
+#   - macOS:   ~/Library/Application Support/instatic/dev.db
+#   - Windows: %LOCALAPPDATA%\instatic\dev.db
+# The parent directory is created automatically on first run.
 # Set DATABASE_URL only if you want to use Postgres or a custom SQLite path.
 #
-#   SQLite (file):    DATABASE_URL=sqlite:./path/to/your.db
+#   SQLite (file):    DATABASE_URL=sqlite:/abs/path/to/your.db
 #   SQLite (memory):  DATABASE_URL=sqlite::memory:
 #   Postgres (auto):  DATABASE_URL=postgres://instatic:instatic@127.0.0.1:5433/instatic
 #                     (`bun run dev` will start the Docker postgres service automatically)
 #
-# DATABASE_URL=sqlite:./.tmp/dev.db
+# Per-user data dir override (e.g. to point dev state at an external volume):
+#   INSTATIC_DATA_DIR=/path/to/instatic-data
+#
+# DATABASE_URL=
 
 # ─── Filesystem paths ────────────────────────────────────────────────────────
 UPLOADS_DIR=./uploads

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "dev:vite": "bun run scripts/vite.ts",
     "e2e:dev": "bun run scripts/e2e-dev.ts",
     "db:drop": "bun run scripts/db-drop.ts",
+    "security:rotate-mcp": "bun run scripts/rotate-mcp-token.ts",
     "start": "bun run scripts/start.ts",
     "docker:up": "docker compose -f compose.prod.yml -f compose.build.yml up --build",
     "release:bundle": "bun run scripts/build-release-bundle.ts",

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -4,8 +4,11 @@
  * `bun run dev` is the only thing a developer should need.
  *
  * Default behaviour (no DATABASE_URL in the environment): the script uses
- * SQLite at ./.tmp/dev.db — no Docker or any other external services required.
- * The parent directory is created automatically on first run.
+ * SQLite in the platform-native per-user data directory — see
+ * `server/secrets/dataPaths.ts` for the per-platform path. No Docker or
+ * any other external services required. The parent directory is created
+ * automatically on first run. Override with `INSTATIC_DATA_DIR` to point
+ * dev state at an external volume, or set `DATABASE_URL` directly.
  *
  * Postgres mode: set DATABASE_URL=postgres://... to run against a Postgres
  * database. The script will manage a local docker postgres for you:
@@ -28,6 +31,7 @@
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isSqliteUrl } from '../server/db'
+import { defaultDevDbUrl } from '../server/secrets/dataPaths'
 import { bunCommand, viteCommand } from './lib/bunCommand'
 import { ensurePortFree } from './lib/freePort'
 
@@ -35,7 +39,7 @@ const CMS_PORT = Number(process.env.PORT ?? '3001')
 const VITE_PORT = Number(process.env.VITE_PORT ?? '5173')
 const POSTGRES_HOST = '127.0.0.1'
 const POSTGRES_PORT = 5433
-const DATABASE_URL = process.env.DATABASE_URL ?? 'sqlite:./.tmp/dev.db'
+const DATABASE_URL = process.env.DATABASE_URL ?? defaultDevDbUrl()
 
 const decoder = new TextDecoder()
 

--- a/scripts/rotate-mcp-token.ts
+++ b/scripts/rotate-mcp-token.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env bun
+/**
+ * Rotate the local development MCP connector token without printing either the
+ * old or new bearer secret.
+ *
+ * The admin endpoint deliberately returns a connector token only once. This
+ * helper uses the same generator and repository path for operators who need to
+ * rotate a local token after it has been exposed, while keeping the operation
+ * scoped to the SQLite development database and the ignored `.env` file.
+ *
+ * Usage:
+ *
+ *   bun run scripts/rotate-mcp-token.ts
+ *
+ * The current `INSTATIC_MCP_TOKEN` is read from `.env`. The replacement is
+ * written there with mode 0600. The old database row is deleted after the
+ * replacement row is inserted, so its hash cannot remain usable or linger in
+ * a revoked row.
+ */
+
+import { chmod, readFile, rename, unlink, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createConnector, findConnectorByTokenHash } from '../server/ai/mcp/connectors/store'
+import { generateConnectorToken, hashConnectorToken } from '../server/ai/mcp/connectors/token'
+import { createDbClient, isSqliteUrl } from '../server/db'
+import { readServerConfig } from '../server/config'
+
+const ENV_FILE = join(import.meta.dir, '..', '.env')
+const PRIVATE_FILE_MODE = 0o600
+const TOKEN_ASSIGNMENT_RE = /^[ \t]*(?:export[ \t]+)?INSTATIC_MCP_TOKEN[ \t]*=/
+
+function fail(message: string): never {
+  throw new Error(`[rotate-mcp-token] ${message}`)
+}
+
+function readToken(envText: string): string {
+  const match = envText.match(/^[ \t]*(?:export[ \t]+)?INSTATIC_MCP_TOKEN[ \t]*=[ \t]*([^\r\n]*)$/m)
+  const raw = match?.[1]?.trim()
+  if (!raw) fail(`INSTATIC_MCP_TOKEN is missing from ${ENV_FILE}`)
+
+  if (
+    raw.length >= 2 &&
+    ((raw.startsWith('"') && raw.endsWith('"')) ||
+      (raw.startsWith("'") && raw.endsWith("'")))
+  ) {
+    return raw.slice(1, -1)
+  }
+  return raw
+}
+
+function replaceToken(envText: string, token: string): string {
+  const lineEnding = envText.includes('\r\n') ? '\r\n' : '\n'
+  const lines = envText.split(/\r?\n/)
+  let replaced = false
+  const output: string[] = []
+
+  for (const line of lines) {
+    if (TOKEN_ASSIGNMENT_RE.test(line)) {
+      if (!replaced) {
+        output.push(`INSTATIC_MCP_TOKEN=${token}`)
+        replaced = true
+      }
+      continue
+    }
+    output.push(line)
+  }
+
+  if (!replaced) fail(`INSTATIC_MCP_TOKEN is missing from ${ENV_FILE}`)
+  return output.join(lineEnding)
+}
+
+async function writePrivateEnv(contents: string): Promise<void> {
+  const temporaryFile = `${ENV_FILE}.${crypto.randomUUID()}.tmp`
+  try {
+    await writeFile(temporaryFile, contents, { encoding: 'utf8', mode: PRIVATE_FILE_MODE })
+    await chmod(temporaryFile, PRIVATE_FILE_MODE)
+    await rename(temporaryFile, ENV_FILE)
+    await chmod(ENV_FILE, PRIVATE_FILE_MODE)
+  } finally {
+    await unlink(temporaryFile).catch(() => {})
+  }
+}
+
+const originalEnv = await readFile(ENV_FILE, 'utf8').catch(() => fail(`cannot read ${ENV_FILE}`))
+const oldToken = readToken(originalEnv)
+const config = readServerConfig()
+if (!isSqliteUrl(config.databaseUrl)) {
+  fail('refusing to rotate a non-SQLite DATABASE_URL; this helper is local-development-only')
+}
+
+const oldHash = await hashConnectorToken(oldToken)
+const newToken = generateConnectorToken()
+const newHash = await hashConnectorToken(newToken)
+const { db } = createDbClient(config.databaseUrl)
+const oldConnector = await findConnectorByTokenHash(db, oldHash)
+if (!oldConnector) fail('the token in .env does not resolve to an active MCP connector')
+
+// Update the ignored local secret first. If the database transaction fails,
+// restore the original file so a failed rotation does not strand the operator.
+await writePrivateEnv(replaceToken(originalEnv, newToken))
+let committed = false
+
+try {
+  const replacement = await db.transaction(async (tx) => {
+    const created = await createConnector(tx, {
+      userId: oldConnector.userId,
+      label: `${oldConnector.label} (rotated)`,
+      type: oldConnector.type,
+      capabilities: oldConnector.capabilities,
+      tokenHash: newHash,
+      ttlDays: 90,
+    })
+
+    const deleted = await tx`
+      delete from ai_mcp_connectors
+      where id = ${oldConnector.id} and token_hash = ${oldHash}
+    `
+    if (deleted.rowCount !== 1) throw new Error('the old connector changed during rotation')
+
+    // Verify inside the transaction. This prevents a post-commit verification
+    // failure from restoring the old .env value after the old row is gone.
+    const [{ rows: newRows }, { rows: oldRows }] = await Promise.all([
+      tx`
+        select id from ai_mcp_connectors where token_hash = ${newHash} and revoked_at is null
+      `,
+      tx`select id from ai_mcp_connectors where token_hash = ${oldHash}`,
+    ])
+    if (newRows.length !== 1 || oldRows.length !== 0) {
+      throw new Error('post-rotation hash verification failed')
+    }
+
+    return created
+  })
+  committed = true
+
+  console.log(`[rotate-mcp-token] rotated connector ${oldConnector.id} -> ${replacement.id}`)
+  console.log(`[rotate-mcp-token] replacement written to ${ENV_FILE} (mode 0600)`)
+  // The new bearer token is shown to the operator exactly once, mirroring the
+  // admin endpoint. Anyone rerunning this script will see a fresh value; the
+  // stored hash cannot be reversed into the plaintext.
+  console.log(`[rotate-mcp-token] new INSTATIC_MCP_TOKEN=${newToken}`)
+} catch (error) {
+  // A transaction callback failure rolls back. Only restore the old file when
+  // the database still proves that rollback happened; never overwrite the new
+  // secret after an ambiguous database outcome.
+  if (!committed) {
+    try {
+      const [{ rows: newRows }, { rows: oldRows }] = await Promise.all([
+        db`
+          select id from ai_mcp_connectors where token_hash = ${newHash} and revoked_at is null
+        `,
+        db`select id from ai_mcp_connectors where token_hash = ${oldHash}`,
+      ])
+      if (newRows.length === 0 && oldRows.length === 1) {
+        await writePrivateEnv(originalEnv)
+      } else {
+        console.error('[rotate-mcp-token] database outcome is ambiguous; leaving the replacement in .env')
+      }
+    } catch (restoreError) {
+      console.error('[rotate-mcp-token] could not verify rollback or restore .env:', restoreError)
+    }
+  }
+  throw error
+}

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,3 +1,5 @@
+import { defaultDevDbUrl } from './secrets/dataPaths'
+
 interface ServerConfig {
   port: number
   databaseUrl: string
@@ -83,7 +85,7 @@ export function readServerConfig(
 ): ServerConfig {
   return {
     port: Number(env.PORT ?? 3001),
-    databaseUrl: env.DATABASE_URL ?? 'sqlite:./.tmp/dev.db',
+    databaseUrl: env.DATABASE_URL ?? defaultDevDbUrl(),
     uploadsDir: env.UPLOADS_DIR ?? './uploads',
     staticDir: env.STATIC_DIR ?? './dist',
     trustedProxyCidrs: readCsvList(env.TRUSTED_PROXY_CIDRS),

--- a/server/secrets/dataPaths.ts
+++ b/server/secrets/dataPaths.ts
@@ -1,0 +1,56 @@
+import { mkdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+function homeDir(): string {
+  return process.env.HOME?.trim() || homedir()
+}
+
+function dataDirFromEnv(): string | null {
+  const override = process.env.INSTATIC_DATA_DIR?.trim()
+  return override && override.length > 0 ? override : null
+}
+
+/**
+ * Resolve the per-user data directory for Instatic local state.
+ *
+ *   Linux:   $XDG_DATA_HOME/instatic (default ~/.local/share/instatic)
+ *   macOS:   ~/Library/Application Support/instatic
+ *   Windows: %LOCALAPPDATA%\instatic
+ *
+ * The `INSTATIC_DATA_DIR` env var (if set) overrides the platform default and
+ * is also used for the dev SQLite database location.
+ */
+export function perUserDataDir(): string {
+  const override = dataDirFromEnv()
+  if (override) return override
+  switch (process.platform) {
+    case 'darwin':
+      return join(homeDir(), 'Library', 'Application Support', 'instatic')
+    case 'win32': {
+      const localAppData = process.env.LOCALAPPDATA?.trim()
+        || join(homeDir(), 'AppData', 'Local')
+      return join(localAppData, 'instatic')
+    }
+    case 'linux':
+    default: {
+      const dataHome = process.env.XDG_DATA_HOME?.trim()
+        || join(homeDir(), '.local', 'share')
+      return join(dataHome, 'instatic')
+    }
+  }
+}
+
+/** Absolute filesystem path to the dev SQLite database file. */
+export function defaultDevDbPath(): string {
+  return join(perUserDataDir(), 'dev.db')
+}
+
+/** `sqlite:` URL pointing at the per-user dev database. */
+export function defaultDevDbUrl(): string {
+  return `sqlite:${defaultDevDbPath()}`
+}
+
+export async function ensureDir(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true, mode: 0o700 })
+}


### PR DESCRIPTION
## Why

The dev SQLite database used to live at `./.tmp/dev.db`, under the working tree. The file contained PII (user email, argon2id password hash, active sessions, audit events, AI provider credentials). The PII has been scrubbed; the database is now written to a platform-native per-user data directory outside the source tree.

## Changes

- New `server/secrets/dataPaths.ts` with `perUserDataDir()`, `defaultDevDbPath()`, and `defaultDevDbUrl()` (Linux: `$XDG_DATA_HOME/instatic/dev.db`, macOS: `~/Library/Application Support/instatic/dev.db`, Windows: `%LOCALAPPDATA%\instatic\dev.db`).
- `server/config.ts` defaults `DATABASE_URL` to `defaultDevDbUrl()` when `DATABASE_URL` is unset.
- `scripts/dev.ts` uses the same default.
- `INSTATIC_DATA_DIR` overrides the per-user data dir.
- `scripts/db-drop.ts` continues to work — it parses the URL through `parseSqlitePath` and now targets the per-user path.
- `.env.example` documents the new behaviour and `INSTATIC_DATA_DIR` override.

## Files

- `server/secrets/dataPaths.ts` (new)
- `server/config.ts`
- `scripts/dev.ts`
- `.env.example`

## Verification

- `bun run lint` clean.
- `tsc -b` clean.
- `INSTATIC_ALLOW_DEV_KEY_AUTOGEN=1 PORT=3999 bun run dev:server` boots cleanly, creates `~/Library/Application Support/instatic/dev.db` (no file under `./.tmp/`), and serves on port 3999.
- The existing `./.tmp/dev.db*` files have been deleted from the working tree to scrub the PII.
- Production SQLite mode (`compose.sqlite.yml`) is unaffected — it always wrote to `/app/data/cms.db` on a named volume.