### PR TITLE
fix(image): editor canvas ignores node inline styles on images

### DIFF
--- a/src/modules/base/image/ImageEditor.tsx
+++ b/src/modules/base/image/ImageEditor.tsx
@@ -87,13 +87,18 @@ export const ImageEditor: React.FC<ModuleComponentProps<ImageStoredProps>> = ({ 
     )
   }
 
+  // Merge the BlurHash backdrop with the node's inline styles carried by
+  // nodeWrapperProps.style — an explicit `style` prop after the spread would
+  // otherwise clobber them (even `style={undefined}` wins over the spread),
+  // making the canvas ignore inline styles the published render honours.
   const style = responsive.blurUrl
     ? ({
+        ...nodeWrapperProps?.style,
         backgroundImage: `url(${responsive.blurUrl})`,
         backgroundSize: 'cover',
         backgroundPosition: 'center',
       } as React.CSSProperties)
-    : undefined
+    : nodeWrapperProps?.style
 
   return (
     <img


### PR DESCRIPTION
Fixes #252

## Problem

In the design canvas, `base.image` nodes ignore their `inlineStyles` once the media asset resolves — e.g. a header logo with `height: 1.75rem; width: auto` renders at intrinsic size and fills the frame. The published page is correct; this is an editor-only WYSIWYG break.

## Cause

In `ImageEditor.tsx` (resolved-asset branch) the explicit `style={style}` prop comes after the `{...nodeWrapperProps}` spread, so it always overrides `nodeWrapperProps.style` — the channel that carries `node.inlineStyles` into the canvas. This happens both when `style` is the BlurHash backdrop object and when it is `undefined` (an explicit `style={undefined}` still wins over a spread value in React). The raw-src fallback branch has no explicit `style` prop, which is why inline styles briefly apply until the asset cache resolves, then vanish.

## Fix

Merge instead of clobber: spread `nodeWrapperProps?.style` into the backdrop object (backdrop keys win — they only touch `background-*`), and pass `nodeWrapperProps?.style` through when there is no backdrop.

## Verification

- `tsc --noEmit` clean, `eslint` clean on the changed file.
- Reproduced on a live site: logo node with `inlineStyles` `height: 1.75rem; width: auto; display: block` rendered at ~2000px wide in the canvas before the change; published output was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)