### PR TITLE
fix(canvas): hide empty chrome for ambient styles

### DIFF
--- a/src/__tests__/canvas/classStyleInjector.test.ts
+++ b/src/__tests__/canvas/classStyleInjector.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import {
   createCanvasClassCssMemo,
+  generateAmbientPlaceholderSuppressionCSS,
   generateCanvasClassCSS,
   generateForcedStateCSS,
 } from '@site/canvas/canvasClassCss'
@@ -40,6 +41,25 @@ function resolvedMedia(path = '/uploads/hero.png'): RenderResolvedMedia {
       { width: 2048, height: 1024, format: 'webp', path: '/uploads/hero-w2048.webp', sizeBytes: 190_000 },
     ],
     posterPath: null,
+  }
+}
+
+function makeAmbient(
+  id: string,
+  selector: string,
+  styles: StyleRule['styles'],
+  contextStyles: StyleRule['contextStyles'] = {},
+): StyleRule {
+  return {
+    id,
+    name: selector,
+    kind: 'ambient',
+    selector,
+    order: 0,
+    styles,
+    contextStyles,
+    createdAt: 0,
+    updatedAt: 0,
   }
 }
 
@@ -198,6 +218,63 @@ describe('generateCanvasClassCSS', () => {
     expect(css).toContain('--primary: hsla(238, 100%, 62%, 1);')
     expect(css).toContain('.text-primary')
     expect(css).toContain('color: var(--primary);')
+  })
+})
+
+describe('generateAmbientPlaceholderSuppressionCSS', () => {
+  it('suppresses empty-container chrome for a matching ambient descendant selector', () => {
+    const css = generateAmbientPlaceholderSuppressionCSS({
+      dots: makeAmbient('dots', '.dots i', {
+        width: '12px',
+        height: '12px',
+        backgroundColor: 'red',
+      }),
+    })
+
+    expect(css).toBe(
+      ':is(.dots i) > [data-canvas-module-placeholder] { display: none; }',
+    )
+  })
+
+  it('keeps comma-separated selectors scoped before appending the placeholder child', () => {
+    const css = generateAmbientPlaceholderSuppressionCSS({
+      dots: makeAmbient('dots', '.dots i, .status-dot', { width: '12px' }),
+    })
+
+    expect(css).toContain(
+      ':is(.dots i, .status-dot) > [data-canvas-module-placeholder]',
+    )
+    expect(css).not.toContain('.dots i, .status-dot >')
+  })
+
+  it('matches :empty against the authored element rather than its canvas-only child', () => {
+    const css = generateAmbientPlaceholderSuppressionCSS({
+      empty: makeAmbient('empty', '.dots i:empty', { width: '12px' }),
+    })
+
+    expect(css).toContain(
+      '.dots i:has(> [data-canvas-module-placeholder]:only-child)',
+    )
+  })
+
+  it('ignores ambient entries that do not emit selector declarations', () => {
+    const rawRule = makeAmbient('keyframes', '@keyframes pulse', {})
+    rawRule.rawCss = '@keyframes pulse { from { opacity: 0; } }'
+
+    expect(generateAmbientPlaceholderSuppressionCSS({
+      empty: makeAmbient('empty', '.empty', {}),
+      raw: rawRule,
+    })).toBe('')
+  })
+
+  it('suppresses for context-only authored styling', () => {
+    const css = generateAmbientPlaceholderSuppressionCSS({
+      responsive: makeAmbient('responsive', '.dots i', {}, {
+        mobile: { width: '8px' },
+      }),
+    })
+
+    expect(css).toContain(':is(.dots i)')
   })
 })
 

--- a/src/admin/pages/site/canvas/ClassStyleInjector.tsx
+++ b/src/admin/pages/site/canvas/ClassStyleInjector.tsx
@@ -44,7 +44,12 @@ import { styleRuleSelector, type ConditionDef, type StyleRule } from '@core/page
 import { collectBackgroundImagePaths, collectSiteStyleBackgroundImagePaths } from '@core/publisher'
 import { useResponsiveEditorMediaAssets } from '@admin/pages/media/hooks/useResponsiveBackgroundStyle'
 import { selectorStatePseudo } from '@site/cssStatePseudo'
-import { generateCanvasClassCSS, generateForcedStateCSS, generatePreviewClassCSS } from './canvasClassCss'
+import {
+  generateAmbientPlaceholderSuppressionCSS,
+  generateCanvasClassCSS,
+  generateForcedStateCSS,
+  generatePreviewClassCSS,
+} from './canvasClassCss'
 import { resolveViewportUnitsForCanvas, type CanvasViewport } from './resolveViewportUnits'
 
 interface ClassStyleInjectorProps {
@@ -145,9 +150,15 @@ export function ClassStyleInjector({ targetDocument, viewport }: ClassStyleInjec
     // within the layer). User CSS (also @layer user-authored) still wins over the
     // zero-specificity :where() publisher reset — same as before.
     const css = forCanvas(generated)
-    styleEl.textContent = css
+    const authoredCss = css
       ? `@layer user-authored {\n${css}\n}`
       : '/* no classes */'
+    const placeholderSuppressionCss = generateAmbientPlaceholderSuppressionCSS(
+      classes ?? EMPTY_STYLE_RULES,
+    )
+    styleEl.textContent = placeholderSuppressionCss
+      ? `${authoredCss}\n${placeholderSuppressionCss}`
+      : authoredCss
   }, [
     targetDocument,
     viewport,

--- a/src/admin/pages/site/canvas/canvasClassCss.ts
+++ b/src/admin/pages/site/canvas/canvasClassCss.ts
@@ -136,6 +136,55 @@ export function createCanvasClassCssMemo(
  */
 export const generateCanvasClassCSS: CanvasClassCssGenerator = createCanvasClassCssMemo()
 
+const EMPTY_CONTAINER_PLACEHOLDER_SELECTOR = '[data-canvas-module-placeholder]'
+
+function ruleHasAuthoredDeclarations(rule: StyleRule): boolean {
+  if (Object.keys(rule.styles).length > 0) return true
+  return Object.values(rule.contextStyles).some((styles) => Object.keys(styles).length > 0)
+}
+
+/**
+ * Hide the editor-only empty-container placeholder when an ambient selector
+ * styles the authored element.
+ *
+ * Class-assigned and inline-styled empty containers suppress the placeholder
+ * in `ContainerEditor` because that styling is present in the node props.
+ * Ambient rules attach only through selector matching, so the component cannot
+ * see them. These canvas-only rules let the browser perform the same selector
+ * matching it already performs for the authored CSS, including descendant,
+ * sibling, attribute, and state selectors.
+ *
+ * `:is()` keeps comma-separated selector lists scoped as one subject before
+ * the direct-child placeholder suffix is added. `:empty` is rewritten against
+ * the editor-only placeholder child so selectors authored for a genuinely
+ * empty published element still suppress the canvas affordance.
+ */
+export function generateAmbientPlaceholderSuppressionCSS(
+  rules: Record<string, StyleRule>,
+): string {
+  const selectors = Object.values(rules)
+    .filter((rule) =>
+      rule.kind === 'ambient' &&
+      !rule.rawCss &&
+      ruleHasAuthoredDeclarations(rule)
+    )
+    .map((rule) =>
+      styleRuleSelector(rule).replace(
+        /:empty\b/g,
+        `:has(> ${EMPTY_CONTAINER_PLACEHOLDER_SELECTOR}:only-child)`,
+      )
+    )
+
+  if (selectors.length === 0) return ''
+
+  return selectors
+    .map(
+      (selector) =>
+        `:is(${selector}) > ${EMPTY_CONTAINER_PLACEHOLDER_SELECTOR} { display: none; }`,
+    )
+    .join('\n')
+}
+
 /**
  * Generate a higher-specificity preview rule for a single class, used by
  * the canvas style injector while a user is hovering a suggestion. The


### PR DESCRIPTION
## What changed

- generate canvas-only placeholder suppression rules for authored ambient selectors
- scope comma-separated selectors safely with `:is(...)`
- preserve authored `:empty` semantics despite the editor-only placeholder child
- ignore empty ambient entries and raw at-rules while covering context-only declarations

## Why

`ContainerEditor` already removes its empty-state affordance when a node has a directly assigned class or inline styles. Ambient selectors such as `.dots i` attach through CSS matching and are therefore invisible to that component-level check. The authored empty element was correctly styled, but the striped “Empty container” chrome remained visible over it.

The fix lets the browser use the same ambient selector matching as the authored stylesheet and hides only the direct editor-placeholder child. Published markup is unchanged.

## User impact

Empty decorative elements styled through descendant, sibling, attribute, state, selector-list, or `:empty` ambient rules now preview without Instatic’s empty-state chrome. The selectable canvas root remains intact.

## Verification

- `bun test` — 6,262 passed, 0 failed
- `bun run build`
- `bun run lint`
- `bunx tsc -b --noEmit`
- changed-file ESLint
- focused canvas/container tests — 153 passed
- local React Doctor diff scan — no task-specific regression; remote score API unavailable
- browser E2E with disposable SQLite data:
  - created `.dots` parent and empty custom `<i>` child
  - applied `.dots i` ambient width, height, background, and radius
  - verified placeholder computes to `display: none` in mobile, tablet, and desktop canvas frames
  - verified save/reload persistence
  - published and verified the public `<i>` has no children and identical authored styling