### PR TITLE
fix(svg): render canvas styles on svg root

### DIFF
--- a/src/__tests__/base-modules-shared-render.editor.test.tsx
+++ b/src/__tests__/base-modules-shared-render.editor.test.tsx
@@ -16,6 +16,7 @@ import { LinkModule } from '@modules/base/link'
 import { ButtonModule } from '@modules/base/button'
 import { ListModule } from '@modules/base/list'
 import { ContainerModule } from '@modules/base/container'
+import { SvgModule } from '@modules/base/svg'
 import { anchorRel } from '@modules/base/shared/anchorTarget'
 import { parseItems } from '@modules/base/list/items'
 
@@ -102,5 +103,57 @@ describe('ContainerEditor empty-state placeholder', () => {
     expect(root?.getAttribute('style')).toContain('min-height: 120px')
     expect(root?.getAttribute('data-canvas-empty-container')).toBeNull()
     expect(queryByText('Empty container')).toBeNull()
+  })
+})
+
+describe('SvgEditor canvas root', () => {
+  it('uses the authored svg as the canvas root instead of adding a sizing wrapper', () => {
+    const { container } = renderEditor(
+      SvgModule,
+      { svg: '<svg viewBox="0 0 24 24"><path d="M2 2h20v20H2z"/></svg>' },
+      {
+        mcClassName: 'seal-mark',
+        nodeWrapperProps: {
+          'data-node-id': 'svg-node',
+          style: { width: '50%', height: '50%' },
+        },
+      },
+    )
+
+    const root = container.firstElementChild
+    expect(root?.tagName.toLowerCase()).toBe('svg')
+    expect(root?.parentElement).toBe(container)
+    expect(root?.classList.contains('seal-mark')).toBe(true)
+    expect(root?.getAttribute('data-node-id')).toBe('svg-node')
+    expect(root?.getAttribute('style')).toContain('width: 50%')
+    expect(root?.getAttribute('style')).toContain('height: 50%')
+    expect(root?.querySelector('path')).not.toBeNull()
+  })
+
+  it('preserves authored root attributes while node classes and styles win in publisher order', () => {
+    const { container } = renderEditor(
+      SvgModule,
+      {
+        svg: [
+          '<svg class="source-mark" viewBox="0 0 24 24"',
+          ' style="width: 12px; height: 13px; color: red">',
+          '<circle cx="12" cy="12" r="10" fill="currentColor"/>',
+          '</svg>',
+        ].join(''),
+      },
+      {
+        mcClassName: 'seal-mark',
+        nodeWrapperProps: {
+          style: { width: '50%', height: '50%' },
+        },
+      },
+    )
+
+    const root = container.querySelector('svg')
+    expect(root?.getAttribute('viewBox')).toBe('0 0 24 24')
+    expect(root?.getAttribute('class')?.split(' ')).toEqual(['seal-mark', 'source-mark'])
+    expect(root?.getAttribute('style')).toContain('width: 50%')
+    expect(root?.getAttribute('style')).toContain('height: 50%')
+    expect(root?.getAttribute('style')).toContain('color: red')
   })
 })

--- a/src/__tests__/base-modules.test.ts
+++ b/src/__tests__/base-modules.test.ts
@@ -913,13 +913,13 @@ describe('base.svg — render() specifics', () => {
       } as never),
     )
 
-    const wrapper = container.querySelector('span')
-    expect(wrapper?.getAttribute('role')).toBe('img')
-    expect(wrapper?.getAttribute('aria-label')).toBe('Preview mark')
-    expect(wrapper?.classList.contains('ist-svg')).toBe(true)
-    expect(wrapper?.querySelector('svg')).not.toBeNull()
-    expect(wrapper?.innerHTML.toLowerCase()).not.toContain('<script')
-    expect(wrapper?.innerHTML.toLowerCase()).not.toContain('onload')
+    const svg = container.querySelector('svg')
+    expect(container.querySelector('span')).toBeNull()
+    expect(svg?.getAttribute('role')).toBe('img')
+    expect(svg?.getAttribute('aria-label')).toBe('Preview mark')
+    expect(svg?.classList.contains('ist-svg')).toBe(true)
+    expect(svg?.innerHTML.toLowerCase()).not.toContain('<script')
+    expect(svg?.innerHTML.toLowerCase()).not.toContain('onload')
   })
 
   it('does not access DOM globals during publish render', () => {

--- a/src/modules/base/svg/SvgEditor.tsx
+++ b/src/modules/base/svg/SvgEditor.tsx
@@ -12,8 +12,10 @@ import React from 'react'
 import type { ModuleComponentProps } from '@core/module-engine'
 import { sanitizeSvg } from '@core/sanitize'
 import { CanvasModulePlaceholder } from '@ui/components/CanvasModulePlaceholder'
+import { cn } from '@ui/cn'
 import { ImageSolidIcon } from 'pixel-art-icons/icons/image-solid'
 import type { SvgStoredProps } from './props'
+import { parseSvgCanvasRoot } from './svgCanvasRoot'
 
 export const SvgEditor: React.FC<ModuleComponentProps<SvgStoredProps>> = ({
   props,
@@ -21,8 +23,9 @@ export const SvgEditor: React.FC<ModuleComponentProps<SvgStoredProps>> = ({
   nodeWrapperProps,
 }) => {
   const markup = sanitizeSvg(props.svg)
+  const svgRoot = markup ? parseSvgCanvasRoot(markup) : null
 
-  if (!markup) {
+  if (!svgRoot) {
     return (
       <CanvasModulePlaceholder
         {...nodeWrapperProps}
@@ -34,12 +37,17 @@ export const SvgEditor: React.FC<ModuleComponentProps<SvgStoredProps>> = ({
   }
 
   const label = String(props.title ?? '').trim()
-  return (
-    <span
-      {...nodeWrapperProps}
-      className={mcClassName}
-      {...(label ? { role: 'img', 'aria-label': label } : {})}
-      dangerouslySetInnerHTML={{ __html: markup }}
-    />
-  )
+  const { style: nodeStyle, ...editorRootProps } = nodeWrapperProps ?? {}
+  const mergedStyle = svgRoot.style || nodeStyle
+    ? { ...svgRoot.style, ...nodeStyle }
+    : undefined
+
+  return React.createElement('svg', {
+    ...svgRoot.attributes,
+    ...editorRootProps,
+    className: cn(mcClassName, svgRoot.className) || undefined,
+    style: mergedStyle,
+    ...(label ? { role: 'img', 'aria-label': label } : {}),
+    dangerouslySetInnerHTML: { __html: svgRoot.innerHtml },
+  })
 }

--- a/src/modules/base/svg/svgCanvasRoot.ts
+++ b/src/modules/base/svg/svgCanvasRoot.ts
@@ -1,0 +1,81 @@
+import type { CSSProperties } from 'react'
+import { readCssDeclarationBag } from '@core/css-substitution'
+import { bagToReactStyle } from '@core/publisher'
+
+interface SvgCanvasRoot {
+  attributes: Record<string, string>
+  className?: string
+  style?: CSSProperties
+  innerHtml: string
+}
+
+const SVG_ATTRIBUTE_NAME_OVERRIDES: Record<string, string> = {
+  class: 'className',
+  tabindex: 'tabIndex',
+  'xml:base': 'xmlBase',
+  'xml:lang': 'xmlLang',
+  'xml:space': 'xmlSpace',
+  'xmlns:xlink': 'xmlnsXlink',
+  'xlink:actuate': 'xlinkActuate',
+  'xlink:arcrole': 'xlinkArcrole',
+  'xlink:href': 'xlinkHref',
+  'xlink:role': 'xlinkRole',
+  'xlink:show': 'xlinkShow',
+  'xlink:title': 'xlinkTitle',
+  'xlink:type': 'xlinkType',
+}
+
+function reactSvgAttributeName(name: string): string {
+  if (name.startsWith('aria-') || name.startsWith('data-')) return name
+  const override = SVG_ATTRIBUTE_NAME_OVERRIDES[name]
+  if (override) return override
+  return name.replace(/-([a-z])/g, (_match, letter: string) => letter.toUpperCase())
+}
+
+/**
+ * Split already-sanitized SVG markup into the root element React must own and
+ * the safe inner markup it may inject.
+ *
+ * The publisher injects node classes and inline styles onto the SVG root. The
+ * editor must own that same root so percentage sizing, selector matching, and
+ * selection geometry resolve against identical DOM. Root presentation
+ * attributes are converted to React's SVG prop spelling; authored inline
+ * styles pass through the publisher's CSS gate before being merged by the
+ * editor component.
+ */
+export function parseSvgCanvasRoot(markup: string): SvgCanvasRoot | null {
+  const doc = new DOMParser().parseFromString(markup, 'image/svg+xml')
+  const root = doc.documentElement
+  if (root.localName.toLowerCase() !== 'svg' || doc.querySelector('parsererror')) return null
+
+  const attributes: Record<string, string> = {}
+  let className: string | undefined
+  let style: CSSProperties | undefined
+
+  for (const attribute of Array.from(root.attributes)) {
+    if (attribute.name === 'class') {
+      className = attribute.value.trim() || undefined
+      continue
+    }
+    if (attribute.name === 'style') {
+      // XML-parsed SVG elements do not expose a consistently populated
+      // CSSStyleDeclaration across browser/test DOM implementations. Let an
+      // HTML element parse the already-sanitized declaration text, then pass
+      // the result through the publisher's property/value gate.
+      const styleProbe = document.createElement('div')
+      styleProbe.setAttribute('style', attribute.value)
+      style = bagToReactStyle(
+        readCssDeclarationBag(styleProbe.style),
+      ) as CSSProperties | undefined
+      continue
+    }
+    attributes[reactSvgAttributeName(attribute.name)] = attribute.value
+  }
+
+  return {
+    attributes,
+    className,
+    style,
+    innerHtml: root.innerHTML,
+  }
+}


### PR DESCRIPTION
## What changed

- removed the editor-only `<span>` wrapper around resolved SVG markup
- reconstructed the sanitized SVG root as the React-owned canvas element while preserving authored attributes, classes, and styles
- merged editor node classes and styles in the same order as the publisher
- added regressions for direct-root rendering, class targeting, percentage sizing, and authored root attributes

## Why

The editor applied a selected class and its width/height to a wrapper, while published output applied them directly to the SVG. Percentage dimensions therefore resolved against different elements and could look as if sizing was applied twice.

## User impact

SVG class and inline sizing now target the actual SVG in the canvas, so its DOM, selector matching, selection geometry, and sizing behavior match published output.

## Verification

- `bun test` — 6,264 pass, 0 fail
- `bun run lint`
- `bun run build`
- focused SVG/base-module regressions — 138 pass, 0 fail
- React Doctor diff scan (the only changed-file warning is the intentional sanitized SVG `dangerouslySetInnerHTML` boundary)
- disposable-site browser E2E: inserted SVG, assigned `.seal-mark`, set width/height to 50%, saved/reloaded, published, and confirmed the actual SVG is the direct root with no nested SVG or wrapper across all editor frames and the public page