### PR TITLE
fix(svg): preserve text path references

### DIFF
--- a/src/__tests__/base-modules-shared-render.editor.test.tsx
+++ b/src/__tests__/base-modules-shared-render.editor.test.tsx
@@ -156,4 +156,37 @@ describe('SvgEditor canvas root', () => {
     expect(root?.getAttribute('style')).toContain('height: 50%')
     expect(root?.getAttribute('style')).toContain('color: red')
   })
+
+  it('renders circular text references authored for inline HTML SVG', () => {
+    const { container, queryByText } = renderEditor(
+      SvgModule,
+      {
+        svg: [
+          '<svg class="seal-ring" viewBox="0 0 100 100">',
+          '<defs><path id="sealE" d="M50,50 m-39,0 a39,39 0 1,1 78,0 a39,39 0 1,1 -78,0"/></defs>',
+          '<text><textPath href="#sealE" xlink:href="#sealE">',
+          '★ OPEN SOURCE · 4K STARS · ',
+          '</textPath></text>',
+          '</svg>',
+        ].join(''),
+      },
+    )
+
+    const textPath = container.querySelector('textPath')
+    expect(queryByText('No SVG')).toBeNull()
+    expect(textPath?.getAttribute('href')).toBe('#sealE')
+    expect(textPath?.getAttribute('xlink:href')).toBe('#sealE')
+    expect(textPath?.textContent).toContain('OPEN SOURCE')
+  })
+
+  it('keeps rejecting markup with more than one SVG root', () => {
+    const { queryByText } = renderEditor(
+      SvgModule,
+      {
+        svg: '<svg viewBox="0 0 10 10"><path d="M0 0"/></svg><svg viewBox="0 0 10 10"><path d="M1 1"/></svg>',
+      },
+    )
+
+    expect(queryByText('No SVG')).not.toBeNull()
+  })
 })

--- a/src/__tests__/core/sanitizeSvg.test.ts
+++ b/src/__tests__/core/sanitizeSvg.test.ts
@@ -21,6 +21,37 @@ describe('sanitizeSvg', () => {
     expect(out).toContain('currentColor')
   })
 
+  it('preserves safe fragment references used by text paths', () => {
+    const out = sanitizeSvg(
+      '<svg viewBox="0 0 100 100"><defs><path id="ring" d="M10 50a40 40 0 1 1 80 0"/></defs><text><textPath href="#ring" xlink:href="#ring">Around the ring</textPath></text></svg>',
+    )
+
+    expect(out).toContain('<textPath')
+    expect(out).toContain('href="#ring"')
+    expect(out).toContain('xlink:href="#ring"')
+    expect(out).toContain('Around the ring')
+  })
+
+  it('strips unsafe URI schemes from SVG reference attributes', () => {
+    const out = sanitizeSvg(
+      '<svg><text><textPath href="javascript:alert(1)" xlink:href="javascript:alert(2)">Unsafe</textPath></text></svg>',
+    )
+
+    expect(out).toContain('<textPath')
+    expect(out).not.toContain('href=')
+    expect(out.toLowerCase()).not.toContain('javascript:')
+  })
+
+  it('strips data-URI SVG reuse payloads', () => {
+    const out = sanitizeSvg(
+      '<svg><use href="data:image/svg+xml,%3Csvg%20onload%3Dalert(1)%3E"></use></svg>',
+    )
+
+    expect(out.toLowerCase()).not.toContain('<use')
+    expect(out.toLowerCase()).not.toContain('data:image')
+    expect(out.toLowerCase()).not.toContain('onload')
+  })
+
   it('strips <script> inside the SVG', () => {
     const out = sanitizeSvg('<svg><script>alert(1)</script><path d="M0 0"/></svg>')
     expect(out.toLowerCase()).not.toContain('<script')

--- a/src/__tests__/htmlImport/svgMapping.test.ts
+++ b/src/__tests__/htmlImport/svgMapping.test.ts
@@ -46,6 +46,18 @@ describe('inline <svg> → base.svg', () => {
     const node = single('<svg aria-label="Company logo" viewBox="0 0 24 24"><path d="M1 1"/></svg>')
     expect(node.props.title).toBe('Company logo')
   })
+
+  it('preserves circular text paths and their fragment references', () => {
+    const node = single(
+      '<svg class="seal-ring" viewBox="0 0 100 100"><defs><path id="sealE" d="M50,50 m-39,0 a39,39 0 1,1 78,0 a39,39 0 1,1 -78,0"></path></defs><text><textPath href="#sealE" xlink:href="#sealE" startOffset="0" textLength="245" lengthAdjust="spacing">★ OPEN SOURCE · 4K STARS · </textPath></text></svg>',
+    )
+    const markup = String(node.props.svg)
+
+    expect(markup).toContain('<textPath')
+    expect(markup).toContain('href="#sealE"')
+    expect(markup).toContain('xlink:href="#sealE"')
+    expect(markup).toContain('★ OPEN SOURCE · 4K STARS ·')
+  })
 })
 
 describe('anchor recursion preserves nested icons', () => {

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -227,9 +227,10 @@ export function isRichtextPropKey(key: string): boolean {
 const SVG_CONFIG: Config = {
   USE_PROFILES: { svg: true, svgFilters: true },
   // Defence in depth — DOMPurify's svg profile already excludes these, but be
-  // explicit: no HTML embedding, no script, no nested anchors carrying hrefs.
+  // explicit: no HTML embedding, no script, and no nested anchors. URI-bearing
+  // attributes stay under DOMPurify's scheme validation so safe same-document
+  // references such as <textPath href="#ring"> can resolve their SVG geometry.
   FORBID_TAGS: ['script', 'foreignObject', 'a'],
-  FORBID_ATTR: ['xlink:href', 'href'],
   RETURN_DOM: false,
   RETURN_DOM_FRAGMENT: false,
 }

--- a/src/modules/base/svg/svgCanvasRoot.ts
+++ b/src/modules/base/svg/svgCanvasRoot.ts
@@ -44,9 +44,25 @@ function reactSvgAttributeName(name: string): string {
  * editor component.
  */
 export function parseSvgCanvasRoot(markup: string): SvgCanvasRoot | null {
-  const doc = new DOMParser().parseFromString(markup, 'image/svg+xml')
-  const root = doc.documentElement
-  if (root.localName.toLowerCase() !== 'svg' || doc.querySelector('parsererror')) return null
+  // Published SVG markup lives inside an HTML document, where common legacy
+  // references such as `xlink:href` do not require an explicit xmlns:xlink
+  // declaration. Parsing as strict XML rejects that valid inline-HTML shape
+  // wholesale and makes the editor show "No SVG" while publish still works.
+  // Use the same HTML parsing context as the public page, then retain the
+  // module's one-SVG-root invariant explicitly.
+  const doc = new DOMParser().parseFromString(markup, 'text/html')
+  const root = doc.body.firstElementChild
+  const hasSignificantRootText = Array.from(doc.body.childNodes).some(
+    (node) => node.nodeType === 3 && Boolean(node.textContent?.trim()),
+  )
+  if (
+    !root ||
+    doc.body.children.length !== 1 ||
+    hasSignificantRootText ||
+    root.localName.toLowerCase() !== 'svg'
+  ) {
+    return null
+  }
 
   const attributes: Record<string, string> = {}
   let className: string | undefined


### PR DESCRIPTION
## What changed

- preserve DOMPurify-validated `href` and `xlink:href` attributes required by inline SVG fragment references such as `<textPath href="#ring">`
- parse the editor canvas SVG root in the same HTML context as the published page while continuing to enforce exactly one SVG root
- add sanitizer, Super Import, and editor regressions for circular text paths and unsafe URI schemes

## Why

Super Import correctly mapped the SVG element, but the shared SVG sanitizer blanket-removed both reference attributes, disconnecting `<textPath>` from its `<path>`. Once those safe references were preserved, live testing exposed a second mismatch: the canvas used strict XML parsing and rejected common inline-HTML SVG that uses `xlink:href` without an explicit namespace declaration. Published pages parse that markup as HTML, so the canvas now matches the real rendering context.

## Impact

Circular SVG text now survives Super Import, editor save/reload, responsive canvas rendering, and publish. DOMPurify remains responsible for URI-scheme validation, and script, `foreignObject`, nested anchors, JavaScript URIs, and data-URI `<use>` payloads remain blocked.

## Verification

- `bun test` — 6,279 passed, 0 failed
- focused SVG/import/editor suites — 154 passed, 0 failed
- `bun run lint`
- `bun run build`
- live Chrome audit from a fresh disposable install: imported the reported seal fixture through Super Import, verified the text and both fragment references at mobile/tablet/desktop canvas widths, saved and reloaded, published through the UI, and verified the same animated circular text on the anonymous `/seal` page