### PR TITLE
fix(ui): restore contrast to editor controls

### DIFF
--- a/src/__tests__/ui/neutralInteractiveChrome.test.ts
+++ b/src/__tests__/ui/neutralInteractiveChrome.test.ts
@@ -4,6 +4,7 @@ import { readFileSync } from 'fs'
 const SEGMENTED_CONTROL_CSS = 'src/ui/components/SegmentedControl/SegmentedControl.module.css'
 const RANGE_TABS_CSS = 'src/ui/components/RangeTabs/RangeTabs.module.css'
 const BUTTON_CSS = 'src/ui/components/Button/Button.module.css'
+const SWITCH_CSS = 'src/ui/components/Switch/Switch.module.css'
 const CANVAS_MODE_TOGGLE_CSS =
   'src/admin/pages/site/canvas/CanvasModeToggle.module.css'
 const SECTION_CSS = 'src/ui/components/Section/Section.module.css'
@@ -101,16 +102,30 @@ describe('neutral interactive chrome', () => {
     }
   })
 
-  it('uses overlay states for the canvas mode pill', () => {
+  it('uses the canvas background and overlay states for the canvas mode pill', () => {
     const css = readFileSync(CANVAS_MODE_TOGGLE_CSS, 'utf8')
 
+    const pill = cssRule(css, '.pill')
     const tabHover = cssRule(css, '.tab:hover:not(.tabActive)')
     const tabActive = cssRule(css, '.tabActive')
 
+    expectBackgroundToken(pill, '--bg-body')
     expectBackgroundToken(tabHover, '--overlay-10')
     expectBackgroundToken(tabActive, '--overlay-20')
     expectNoSurfaceBackground(tabHover)
     expectNoSurfaceBackground(tabActive)
+  })
+
+  it('keeps switch states distinct from surrounding editor surfaces', () => {
+    const css = readFileSync(SWITCH_CSS, 'utf8')
+
+    const trackOn = cssRule(css, '.trackOn')
+    const trackOff = cssRule(css, '.trackOff')
+    const thumbOn = cssRule(css, '.thumbOn')
+
+    expectBackgroundToken(trackOn, '--overlay')
+    expectBackgroundToken(trackOff, '--bg-surface-4')
+    expectBackgroundToken(thumbOn, '--bg-surface')
   })
 
   it('keeps flush inspector sections from painting an open group background', () => {

--- a/src/admin/pages/site/canvas/CanvasModeToggle.module.css
+++ b/src/admin/pages/site/canvas/CanvasModeToggle.module.css
@@ -26,7 +26,7 @@
     gap: var(--space-4xs);
     padding: var(--space-4xs);
     border-radius: 12px;
-    background: var(--bg-surface);
+    background: var(--bg-body);
     box-shadow: 0 6px 18px var(--scrim-30);
     pointer-events: auto;
     user-select: none;

--- a/src/ui/components/Switch/Switch.module.css
+++ b/src/ui/components/Switch/Switch.module.css
@@ -1,4 +1,5 @@
-/* Extracted from ToggleControl and Settings PreferencesSection switch styles. */
+/* High-contrast achromatic states: on = foreground track + dark thumb, off =
+ * raised gray track + light thumb, readable on every editor surface. */
 
 .switch {
     display: inline-flex;
@@ -18,6 +19,7 @@
 
 .switch:disabled {
     cursor: not-allowed;
+    opacity: 0.55;
 }
 
 .track {
@@ -32,12 +34,13 @@
 }
 
 .trackOn {
-    background: var(--bg-surface-3);
-    border-color: var(--bg-surface-3);
+    background: var(--overlay);
+    border-color: var(--overlay);
 }
 
 .trackOff {
-    background: transparent;
+    background: var(--bg-surface-4);
+    border-color: var(--bg-surface-4);
 }
 
 .switch[data-hit-area="true"] .track {
@@ -47,14 +50,6 @@
     box-sizing: content-box;
     border: 0;
     border-radius: 10px;
-}
-
-.switch[data-hit-area="true"] .trackOn {
-    background: var(--overlay);
-}
-
-.switch[data-hit-area="true"] .trackOff {
-    background: var(--border-muted);
 }
 
 .thumb {
@@ -68,7 +63,7 @@
 
 .thumbOn {
     left: 18px;
-    background: var(--text);
+    background: var(--bg-surface);
 }
 
 .thumbOff {


### PR DESCRIPTION
## What changed
- match the canvas mode toggle shell to the canvas/body background
- restore the shared Switch primitive's high-contrast checked, unchecked, and disabled states
- add regression coverage for both token choices

## Why
The canvas mode toggle was painted with a raised surface color instead of the black canvas chrome. Separately, a token migration had collapsed the Switch checked track onto a near-identical surface tone, making its state difficult to read on editor cards.

## Impact
Canvas chrome now blends into the intended background, while switches remain clearly distinguishable across dark and light editor surfaces.

## Verification
- `bun test src/__tests__/ui/neutralInteractiveChrome.test.ts src/__tests__/canvas/canvasNotch.test.ts src/__tests__/canvas/canvasMode.test.tsx` (29 passing)
- `bun run lint`
- `bun run build`
- disposable local browser pass covering both checked and unchecked switch states