### PR TITLE
fix(publisher): preserve window scroll container

### DIFF
--- a/src/core/publisher/reset.ts
+++ b/src/core/publisher/reset.ts
@@ -46,11 +46,14 @@ export const PUBLISHER_RESET_CSS = [
   // canvas reset so the design view and the published page agree on spacing.
   ':where(*) { margin: 0; padding: 0; }',
 
-  // Sensible body baseline. font-family pinned to system-ui so the published
-  // page picks the OS native font (matches what most modern stacks ship). Users
-  // who want a custom default can set it on `body` via a class or framework
-  // typography settings.
-  ':where(html, body) { height: 100%; }',
+  // Keep the document's natural height. Constraining both roots to 100% makes
+  // an authored `overflow-x: hidden` turn <body> into a viewport-height scroll
+  // container, so window-level scroll listeners never observe page scrolling.
+  //
+  // font-family is pinned to system-ui so the published page picks the OS
+  // native font (matches what most modern stacks ship). Users who want a
+  // custom default can set it on `body` via a class or framework typography
+  // settings.
   ':where(body) {' +
     ' line-height: 1.5;' +
     ' font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;' +


### PR DESCRIPTION
## What changed

Removed the publisher reset's fixed `height: 100%` declaration from `html` and `body`, leaving published documents at their natural height.

## Why

When authored CSS sets `overflow-x: hidden`, the fixed root/body height can make `<body>` a viewport-height scroll container. Window-level scroll runtimes then continue to observe `window.scrollY === 0`, so scroll-triggered elements remain in their hidden initial state even while the visitor scrolls the page.

## Impact

Published pages keep `window` as the document scroll container, restoring window-based scroll effects and matching the canvas behavior. The rest of the publisher reset is unchanged.

## Verification

- `bun test src/__tests__/publisher` — 392 passed
- `./node_modules/.bin/eslint src/core/publisher/reset.ts`
- `bun run build`