### PR TITLE
fix(security): parse URL schemes instead of prefix-matching in isSafeUrl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## Unreleased
 
+## 0.0.14 - 2026-07-25
+
+### Security
+
+- Fixed a URL-scheme filter bypass in `isSafeUrl()` ([GHSA-pqcp-872g-gmp8](https://github.com/CoreBunch/Instatic/security/advisories/GHSA-pqcp-872g-gmp8)). The guard normalised input with `String.prototype.trim()`, which does not strip U+0000–U+0008 or U+000E–U+001F, while browsers strip the whole U+0000–U+0020 range before reading a URL scheme. A `javascript:` URL behind a leading control character was therefore reported safe and emitted verbatim into `href` / `src` / `action` attributes. Reported by [@overgrowncarrot1](https://github.com/overgrowncarrot1).
+- Replaced the three-entry scheme denylist with an allowlist (`http`, `https`, `mailto`, `tel`, `sms`, plus all relative forms) read through a scheme extractor that follows the WHATWG stripping rules, so the guard cannot disagree with the browser that resolves the value.
+- Consolidated three divergent URL guards into one. The plugin-SDK `safeUrl` was a weaker copy that a plain leading space defeated and that never blocked `data:` at all; the editor input gate now shares the same scheme extractor. An architecture test fails the build if a fourth copy appears.
+
 ## 0.0.13 - 2026-07-24
 
 ### Editor, import, and publishing

--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -41,7 +41,7 @@ src/core/publisher/
 ├── siteCssBundle.ts                — hash-named bundle composition (reset + framework + style)
 ├── sizesResolver.ts                — `<img sizes>` derived from the layout: linear width model (caps, fractions, grid tracks) per viewport tier
 ├── dynamicDetection.ts             — Single walker for the 4 auto-detection rules; powers Layers A and C
-└── utils.ts                        — escapeHtml, isSafeUrl, sanitiseCssValue (re-exported from @core/css-sanitize)
+└── utils.ts                        — escapeHtml, isSafeUrl, safeUrl (re-exported from @core/html-sanitize); sanitiseCssValue (from @core/css-sanitize)
 
 server/publish/
 ├── publicRouter.ts                 — gateway: Layer A disk fast-path → Layer B LRU → live resolver

--- a/docs/reference/module-engine.md
+++ b/docs/reference/module-engine.md
@@ -198,7 +198,7 @@ html: { type: 'richtext', label: 'Content', hidden: true }
 
 | control `type`            | escaper at the publisher boundary                          |
 |---------------------------|------------------------------------------------------------|
-| `url` / `image` / `media` | `isSafeUrl` (blocks `javascript:` etc.; passed raw for the module's `safeUrl`) |
+| `url` / `image` / `media` | `isSafeUrl` (scheme allowlist: `http`, `https`, `mailto`, `tel`, `sms`, plus relative URLs; passed raw for the module's `safeUrl`) |
 | `richtext`                | `sanitizeRichtext` (DOMPurify)                             |
 | `svg`                     | `sanitizeSvg` (DOMPurify SVG profile)                      |
 | everything else, or a prop absent from `schema` | `escapeHtml` (safe default)          |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.13",
+  "version": "0.0.14",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },

--- a/src/__tests__/architecture/single-url-scheme-guard.test.ts
+++ b/src/__tests__/architecture/single-url-scheme-guard.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Architecture Source-Scan — one render-time URL-scheme guard, not three.
+ *
+ * `src/core/html-sanitize/index.ts` owns the decision of whether a URL scheme
+ * is safe to EMIT into an `href` / `src` / `action` attribute. No other module
+ * may declare its own `isSafeUrl` / `safeUrl` / `hasDangerousUrlScheme` /
+ * `urlScheme` — importing and re-exporting the canonical ones is fine.
+ *
+ * WHY THIS MATTERS
+ * ----------------
+ * GHSA-pqcp-872g-gmp8 existed because three implementations had drifted apart:
+ *
+ *   1. `src/core/html-sanitize/index.ts` — a denylist that normalised with
+ *      `.replace(/[\t\n\r]/g, '').trim()`. `trim()` leaves U+0000–U+0008 and
+ *      U+000E–U+001F in place, but the WHATWG URL parser strips the whole
+ *      U+0000–U+0020 range before reading a scheme, so 27 of 32 C0 code points
+ *      slipped a `javascript:` URL past it.
+ *   2. `src/core/plugin-sdk/builders/html.ts` — an independent two-regex
+ *      denylist, strictly weaker still: no whitespace handling at all (a plain
+ *      leading space defeated it) and no `data:` case.
+ *   3. `src/core/utils/urlValidation.ts` — a `new URL().protocol` allowlist
+ *      whose header claimed the publisher guard was "the stricter enforcement
+ *      gate" when it was in fact the loosest of the three.
+ *
+ * Fixing one copy leaves the others open. This gate makes redeclaring one of
+ * those four names fail the build.
+ *
+ * SCOPE — what this gate does NOT cover
+ * -------------------------------------
+ * It is keyed on the four canonical names, so it catches a *copy of the render
+ * guard*, not every scheme check in the repo. Http(s)-only validators that
+ * serve a different purpose exist and are deliberately out of scope:
+ *   - `isHttpUrl` (src/admin/pages/site/property-controls/MediaLibraryControl.tsx)
+ *   - `isValidUrl` (src/core/forms/validation.ts) — submitted form values
+ *   - the SSRF / import guards under `server/` and `src/core/siteImport/`
+ * Those never decide what is safe to emit into an attribute. If one ever grows
+ * that responsibility, route it through `@core/html-sanitize` instead of
+ * widening this list.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { readdirSync, readFileSync, statSync, existsSync } from 'fs'
+import { join, extname, relative } from 'path'
+
+const REPO_ROOT = join(import.meta.dir, '../../../')
+
+const SCAN_ROOTS = ['src/admin', 'src/core', 'src/modules', 'src/ui', 'server']
+
+/** The one module allowed to define scheme-safety predicates. */
+const CANONICAL_GUARD = 'src/core/html-sanitize/index.ts'
+
+/**
+ * Names that must resolve to the canonical implementation everywhere. A file
+ * may `export { safeUrl } from '@core/html-sanitize'` (re-export) or wrap it,
+ * but may not `function safeUrl(...)` its own scheme logic.
+ */
+const GUARD_NAMES = ['isSafeUrl', 'safeUrl', 'hasDangerousUrlScheme', 'urlScheme']
+
+/**
+ * Deliberate exceptions. Extend only with a written justification.
+ *
+ * §1 `src/core/plugin-sdk/builders/html.ts` — declares a `safeUrl` that is a
+ *    thin non-escaping wrapper delegating to the canonical `isSafeUrl` (the
+ *    `html` tag escapes interpolations itself, so escaping there would
+ *    double-encode `&`). It carries no scheme logic of its own.
+ */
+const ALLOWLIST = new Set([CANONICAL_GUARD, 'src/core/plugin-sdk/builders/html.ts'])
+
+function collectFiles(dir: string, exts = ['.ts', '.tsx']): string[] {
+  const results: string[] = []
+  if (!existsSync(dir)) return results
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '__tests__') continue
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) results.push(...collectFiles(full, exts))
+    else if (exts.includes(extname(entry))) results.push(full)
+  }
+  return results
+}
+
+/**
+ * Blank out comment and string-literal content, preserving every newline so
+ * reported line numbers still match the file on disk.
+ *
+ * A regex pass is not sufficient in either direction. Deleting block comments
+ * outright shifts every subsequent line number (most files here open with a
+ * JSDoc header). And a `/*` appearing inside a string literal would open a
+ * fake comment that swallows real code up to the next closing delimiter —
+ * letting a genuine second guard hide behind `const glob = '/*'`. So this
+ * walks the source once, tracking whether it is inside a string, a template
+ * literal, a line comment, or a block comment.
+ */
+function blankCommentsAndStrings(source: string): string {
+  let out = ''
+  let i = 0
+  let state: 'code' | 'line' | 'block' | 'single' | 'double' | 'template' = 'code'
+
+  while (i < source.length) {
+    const ch = source[i]
+    const next = source[i + 1]
+
+    if (ch === '\n') {
+      // Newlines always survive verbatim, and end a line comment.
+      out += '\n'
+      if (state === 'line') state = 'code'
+      i += 1
+      continue
+    }
+
+    if (state === 'code') {
+      if (ch === '/' && next === '/') {
+        state = 'line'
+        out += '  '
+        i += 2
+        continue
+      }
+      if (ch === '/' && next === '*') {
+        state = 'block'
+        out += '  '
+        i += 2
+        continue
+      }
+      if (ch === "'") state = 'single'
+      else if (ch === '"') state = 'double'
+      else if (ch === '`') state = 'template'
+      out += ch
+      i += 1
+      continue
+    }
+
+    if (state === 'block') {
+      if (ch === '*' && next === '/') {
+        state = 'code'
+        out += '  '
+        i += 2
+        continue
+      }
+      out += ' '
+      i += 1
+      continue
+    }
+
+    if (state === 'line') {
+      out += ' '
+      i += 1
+      continue
+    }
+
+    // Inside a string / template literal: blank the content, honour escapes,
+    // and keep the closing quote so the code around it stays parseable.
+    if (ch === '\\') {
+      out += '  '
+      i += 2
+      continue
+    }
+    const closes =
+      (state === 'single' && ch === "'") ||
+      (state === 'double' && ch === '"') ||
+      (state === 'template' && ch === '`')
+    if (closes) {
+      state = 'code'
+      out += ch
+    } else {
+      out += ' '
+    }
+    i += 1
+  }
+
+  return out
+}
+
+describe('URL-scheme safety is defined in exactly one module', () => {
+  it('has no second declaration of a scheme guard', () => {
+    const offenders: string[] = []
+
+    for (const root of SCAN_ROOTS) {
+      for (const filePath of collectFiles(join(REPO_ROOT, root))) {
+        const rel = relative(REPO_ROOT, filePath)
+        if (ALLOWLIST.has(rel)) continue
+
+        const raw = readFileSync(filePath, 'utf8')
+        const scannable = blankCommentsAndStrings(raw).split('\n')
+        const original = raw.split('\n')
+
+        scannable.forEach((line, index) => {
+          for (const name of GUARD_NAMES) {
+            // `function safeUrl(`, `const safeUrl =`, `let safeUrl =` — a
+            // declaration. Import / re-export / call sites are untouched.
+            const declared = new RegExp(
+              `(?:^|\\s)(?:export\\s+)?(?:async\\s+)?(?:function\\s+${name}\\s*\\(|(?:const|let|var)\\s+${name}\\s*[:=])`,
+            )
+            if (declared.test(line)) {
+              offenders.push(`  ${rel}:${index + 1} -> ${original[index].trim().slice(0, 110)}`)
+            }
+          }
+        })
+      }
+    }
+
+    expect(offenders).toEqual([])
+  })
+
+  it('every consumer resolves to the same function instance', async () => {
+    const core = await import('@core/html-sanitize')
+    const publisher = await import('@core/publisher')
+
+    // The publisher barrel re-exports rather than reimplementing.
+    expect(publisher.isSafeUrl).toBe(core.isSafeUrl)
+    expect(publisher.safeUrl).toBe(core.safeUrl)
+  })
+
+  it('does not let a declaration hide behind a string containing a comment opener', () => {
+    // Regression guard for the scanner itself: a naive regex strip treats the
+    // `/*` inside this string as a comment opener and swallows the function.
+    const evasion = ["const globPattern = '/*'", 'export function safeUrl(v) { return v }', "const tail = '*/'"].join(
+      '\n',
+    )
+    const scanned = blankCommentsAndStrings(evasion).split('\n')
+
+    expect(scanned).toHaveLength(3)
+    expect(scanned[1]).toContain('function safeUrl')
+  })
+
+  it('preserves line numbers across block comments', () => {
+    const source = ['/**', ' * Header.', ' */', 'const after = 1'].join('\n')
+    const scanned = blankCommentsAndStrings(source).split('\n')
+
+    expect(scanned).toHaveLength(4)
+    expect(scanned[3]).toContain('const after')
+  })
+})

--- a/src/__tests__/publisher/utils.test.ts
+++ b/src/__tests__/publisher/utils.test.ts
@@ -110,6 +110,60 @@ describe('isSafeUrl', () => {
     expect(isSafeUrl('data:text/html,<script>alert(1)</script>')).toBe(false)
     expect(isSafeUrl('data:image/png;base64,abc')).toBe(false)
   })
+
+  // GHSA-pqcp-872g-gmp8 — the old guard normalised with
+  // `.replace(/[\t\n\r]/g, '').trim()`, which leaves U+0000–U+0008 and
+  // U+000E–U+001F in place. The WHATWG URL parser strips the whole
+  // U+0000–U+0020 range before reading a scheme, so 27 of 32 C0 code points
+  // made isSafeUrl() return true while the browser resolved `javascript:`.
+  it('blocks javascript: behind every C0 control prefix (GHSA-pqcp-872g-gmp8)', () => {
+    const leaked: string[] = []
+    for (let code = 0; code < 0x20; code++) {
+      if (isSafeUrl(`${String.fromCharCode(code)}javascript:alert(1)`)) {
+        leaked.push(`0x${code.toString(16).padStart(2, '0')}`)
+      }
+    }
+    expect(leaked).toEqual([])
+  })
+
+  it('blocks vbscript: and data: behind a C0 control prefix', () => {
+    expect(isSafeUrl('\u0001vbscript:MsgBox(1)')).toBe(false)
+    expect(isSafeUrl('\u001Fdata:text/html,<script>alert(1)</script>')).toBe(false)
+  })
+
+  it('blocks mixed leading/trailing/embedded disguises', () => {
+    expect(isSafeUrl('\u0001\u000Ejava\tscript:alert(1)\u0000')).toBe(false)
+    expect(isSafeUrl(' \u0001 javascript:alert(1)')).toBe(false)
+  })
+
+  it('is an allowlist — non-web schemes collapse without any disguise', () => {
+    expect(isSafeUrl('blob:https://example.com/8f1a')).toBe(false)
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false)
+    expect(isSafeUrl('ftp://example.com/x')).toBe(false)
+    expect(isSafeUrl('intent://x#Intent;scheme=http;end')).toBe(false)
+    expect(isSafeUrl('view-source:https://example.com/')).toBe(false)
+  })
+
+  it('keeps every legitimate URL shape the publisher must emit', () => {
+    for (const url of [
+      'https://example.com/a?b=1&c=2',
+      'http://example.com',
+      'mailto:user@example.com',
+      'tel:+420123456789',
+      'sms:+420123456789',
+      '/about',
+      './page.html',
+      '../up.html',
+      'page.html',
+      'uploads/img.png',
+      '#anchor',
+      '?q=1',
+      '//cdn.example.com/a.png',
+      '',
+    ]) {
+      expect(isSafeUrl(url)).toBe(true)
+    }
+  })
 })
 
 // ===========================================================================

--- a/src/__tests__/security/urlSchemeBypass.test.ts
+++ b/src/__tests__/security/urlSchemeBypass.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Security regression tests: URL-scheme guard bypass via control characters
+ * (GHSA-pqcp-872g-gmp8).
+ *
+ * `isSafeUrl()` normalised with `url.replace(/[\t\n\r]/g, '').trim()` and then
+ * prefix-matched a three-entry denylist. `String.prototype.trim()` does not
+ * strip U+0000–U+0008 or U+000E–U+001F, but the WHATWG URL parser strips the
+ * whole U+0000–U+0020 range before reading a scheme — so 27 of 32 C0 code
+ * points produced `isSafeUrl(v) === true` while `new URL(v).protocol` was
+ * `javascript:`. `escapeHtml()` escapes only & < > " ', so the raw control byte
+ * survived into the emitted attribute.
+ *
+ * The guard is now an allowlist over a scheme read with the WHATWG stripping
+ * rules, plus a dangerous-scheme predicate for free-text attribute values.
+ * These tests are the differential gate: whatever a browser's URL parser
+ * resolves to a dangerous scheme, the guard must reject.
+ *
+ * Deliberately covers all three implementations that existed at report time —
+ * the core guard, the custom-htmlAttributes gate, and the plugin-SDK helper —
+ * so a future change cannot repair one and leave the others open.
+ */
+
+import { describe, it, expect } from 'bun:test'
+import { escapeHtml, hasDangerousUrlScheme, isSafeUrl, safeUrl } from '@core/html-sanitize'
+import { sanitizeRenderableHtmlAttribute } from '@core/htmlAttributes'
+import { safeUrl as sdkSafeUrl } from '@core/plugin-sdk'
+
+const PARSE_BASE = 'https://instatic.invalid/'
+const DANGEROUS_SCHEMES = new Set(['javascript:', 'vbscript:', 'data:'])
+
+function browserScheme(value: string): string | null {
+  try {
+    return new URL(value, PARSE_BASE).protocol
+  } catch {
+    return null
+  }
+}
+
+/** Every C0 code point and space, every dangerous scheme, prefix and suffix. */
+function bypassCorpus(): string[] {
+  const payloads = [
+    'javascript:alert(1)',
+    'vbscript:MsgBox(1)',
+    'data:text/html,<script>alert(1)</script>',
+  ]
+  const out: string[] = []
+  for (const payload of payloads) {
+    out.push(payload, payload.toUpperCase())
+    for (let code = 0; code <= 0x20; code++) {
+      const ch = String.fromCharCode(code)
+      out.push(ch + payload, ch + ch + payload, ch + payload + ch)
+    }
+  }
+  return out
+}
+
+describe('isSafeUrl agrees with the WHATWG URL parser (differential)', () => {
+  it('never accepts a value the URL parser resolves to a dangerous scheme', () => {
+    const leaked: string[] = []
+    for (const value of bypassCorpus()) {
+      const scheme = browserScheme(value)
+      if (scheme !== null && DANGEROUS_SCHEMES.has(scheme) && isSafeUrl(value)) {
+        leaked.push(JSON.stringify(value))
+      }
+    }
+    expect(leaked).toEqual([])
+  })
+
+  it('collapses every disguised payload to "#" in safeUrl', () => {
+    const leaked = bypassCorpus().filter((value) => safeUrl(value) !== '#')
+    expect(leaked).toEqual([])
+  })
+})
+
+describe('escapeHtml does not neutralise control characters — the guard must', () => {
+  it('passes C0 bytes through untouched (documents why the guard is load-bearing)', () => {
+    expect(escapeHtml('\u0001javascript:alert(1)')).toBe('\u0001javascript:alert(1)')
+  })
+})
+
+describe('custom-htmlAttributes gate — the single shared value check', () => {
+  it('drops attributes carrying a control-disguised dangerous scheme', () => {
+    for (const name of ['href', 'src', 'formaction', 'xlink:href', 'ping', 'action', 'poster']) {
+      expect(sanitizeRenderableHtmlAttribute(name, '\u0001javascript:alert(1)')).toBeNull()
+      expect(
+        sanitizeRenderableHtmlAttribute(name, '\u001Fdata:text/html,<script>alert(1)</script>'),
+      ).toBeNull()
+    }
+  })
+
+  it('keeps ordinary prose that happens to contain a colon', () => {
+    // `Notes: draft` parses as scheme `notes:` — not dangerous, must survive.
+    expect(sanitizeRenderableHtmlAttribute('title', 'Notes: draft')).toBe('Notes: draft')
+    expect(sanitizeRenderableHtmlAttribute('viewBox', '0 0 24 24')).toBe('0 0 24 24')
+    expect(sanitizeRenderableHtmlAttribute('aria-label', 'Chapter 3: the end')).toBe(
+      'Chapter 3: the end',
+    )
+    expect(sanitizeRenderableHtmlAttribute('href', '/about')).toBe('/about')
+  })
+
+  it('hasDangerousUrlScheme is the predicate behind that split', () => {
+    expect(hasDangerousUrlScheme('\u0001javascript:alert(1)')).toBe(true)
+    expect(hasDangerousUrlScheme('Notes: draft')).toBe(false)
+    expect(hasDangerousUrlScheme('blob:https://example.com/x')).toBe(false)
+  })
+})
+
+describe('plugin-SDK safeUrl is the shared guard, not a weaker copy', () => {
+  it('blocks the payloads the standalone SDK denylist used to pass', () => {
+    for (const value of [
+      ' javascript:alert(1)',
+      '\tjavascript:alert(1)',
+      '\njavascript:alert(1)',
+      'java\tscript:alert(1)',
+      '\u0001javascript:alert(1)',
+      'data:text/html,<script>alert(1)</script>',
+    ]) {
+      expect(sdkSafeUrl(value)).toBe('#')
+    }
+  })
+
+  it('does not HTML-escape — the `html` tag escapes interpolations already', () => {
+    expect(sdkSafeUrl('https://example.com/?a=1&b=2')).toBe('https://example.com/?a=1&b=2')
+  })
+})

--- a/src/core/html-sanitize/index.ts
+++ b/src/core/html-sanitize/index.ts
@@ -25,22 +25,88 @@ export function escapeHtml(value: unknown): string {
 }
 
 /**
- * Return true when a URL is safe for href/src/action attributes.
- * Blocks javascript:, vbscript:, and data: schemes after the same tab/newline
- * normalisation browsers apply during URL parsing.
+ * Schemes safe to place in an `href` / `src` / `action`. Everything else —
+ * including `javascript:`, `vbscript:`, `data:`, `blob:`, `file:` and any
+ * custom app scheme — is rejected. Relative URLs carry no scheme at all and
+ * are always allowed.
  */
-export function isSafeUrl(url: string): boolean {
-  const normalized = url.replace(/[\t\n\r]/g, '').trim().toLowerCase()
-  return (
-    !normalized.startsWith('javascript:') &&
-    !normalized.startsWith('vbscript:') &&
-    !normalized.startsWith('data:')
-  )
+const SAFE_URL_SCHEMES = new Set(['http:', 'https:', 'mailto:', 'tel:', 'sms:'])
+
+/**
+ * Schemes that execute script or substitute a whole document, and so must not
+ * survive into ANY rendered attribute value — URL-bearing or not.
+ */
+const DANGEROUS_URL_SCHEMES = new Set(['javascript:', 'vbscript:', 'data:'])
+
+/**
+ * Extract the scheme the way the WHATWG URL parser does, so this guard cannot
+ * disagree with the browser that ultimately resolves the value:
+ *
+ *   1. strip leading and trailing C0 controls and space (U+0000–U+0020);
+ *   2. remove every ASCII tab / LF / CR from anywhere in the string;
+ *   3. read `ALPHA *( ALPHA / DIGIT / "+" / "-" / "." ) ":"` off the front.
+ *
+ * Step 1 is what the previous implementation got wrong: it used
+ * `String.prototype.trim()`, which strips only U+0009–U+000D, U+0020 and the
+ * Unicode space separators — leaving U+0000–U+0008 and U+000E–U+001F in place.
+ * A browser strips all of them, so `"javascript:…"` read as safe here
+ * while resolving to the `javascript:` scheme in the page (GHSA-pqcp-872g-gmp8).
+ *
+ * Returns the lowercased scheme including its colon, or `null` when the value
+ * carries no scheme — a relative URL, or ordinary prose.
+ *
+ * Deliberately does NOT use `new URL()`. This module is bundled into plugin
+ * module packs that execute inside the QuickJS-WASM sandbox, whose `URL`
+ * polyfill (`server/plugins/quickjs/bootstrap/`) is a regex approximation that
+ * requires `scheme://authority` and strips no control characters. A pure-string
+ * implementation behaves identically in Bun, in browsers, and in the sandbox.
+ */
+export function urlScheme(value: string): string | null {
+  // Matching control characters is the entire point of this function — the C0
+  // range is what the URL parser strips and what the old `trim()`-based guard
+  // missed, so `no-control-regex` is inverted here.
+  /* eslint-disable no-control-regex */
+  const normalized = value
+    .replace(/^[\u0000-\u0020]+/, '')
+    .replace(/[\u0000-\u0020]+$/, '')
+    .replace(/[\t\n\r]/g, '')
+  /* eslint-enable no-control-regex */
+  const match = /^([a-zA-Z][a-zA-Z0-9+.-]*):/.exec(normalized)
+  return match ? `${match[1].toLowerCase()}:` : null
 }
 
 /**
- * Validate a URL and HTML-escape it for safe interpolation into an attribute.
- * Unsafe values collapse to "#".
+ * Return true when a URL is safe for an href/src/action attribute.
+ *
+ * Allowlist: http, https, mailto, tel, sms, plus every relative form
+ * (`/a`, `./a`, `../a`, `a.html`, `#anchor`, `?q=1`, `//cdn.example/x`, `''`).
+ */
+export function isSafeUrl(url: string): boolean {
+  const scheme = urlScheme(String(url ?? ''))
+  return scheme === null || SAFE_URL_SCHEMES.has(scheme)
+}
+
+/**
+ * Return true when an arbitrary attribute VALUE — which may be prose, an ARIA
+ * label, a `viewBox`, or a URL — carries a scheme that executes script or
+ * substitutes a document.
+ *
+ * This is the predicate for the custom-`htmlAttributes` gate, which checks every
+ * attribute value regardless of whether the attribute is URL-bearing. It cannot
+ * use `isSafeUrl`: `title="Notes: draft"` parses as scheme `notes:` and must
+ * survive, while `javascript:` under any control-character disguise must not.
+ */
+export function hasDangerousUrlScheme(value: string): boolean {
+  const scheme = urlScheme(String(value ?? ''))
+  return scheme !== null && DANGEROUS_URL_SCHEMES.has(scheme)
+}
+
+/**
+ * Validate a URL and HTML-escape it for safe interpolation into an attribute
+ * inside a template string. Unsafe values collapse to "#".
+ *
+ * Do NOT use at a React prop boundary — React escapes on its own, so escaping
+ * here double-encodes `&`. Use `isSafeUrl(v) ? v : '#'` there instead.
  */
 export function safeUrl(value: unknown): string {
   const str = String(value ?? '')

--- a/src/core/htmlAttributes/attributes.ts
+++ b/src/core/htmlAttributes/attributes.ts
@@ -1,4 +1,4 @@
-import { isSafeUrl } from '@core/html-sanitize'
+import { hasDangerousUrlScheme } from '@core/html-sanitize'
 
 const HTML_ATTRIBUTE_NAME_RE = /^[a-z][a-z0-9_.:-]*$/i
 const RESERVED_DATA_PREFIX_RE = /^data-(instatic|canvas)-/i
@@ -14,8 +14,9 @@ const RESERVED_HTML_ATTRIBUTE_NAMES = new Set(['class', 'style'])
  * be made safe by a URL-scheme check: `srcdoc` runs its value as an `<iframe>`
  * document, executing any `<script>` inside it on load. URL-bearing attributes
  * (`href`, `src`, `formaction`, `xlink:href`, …) are handled by the
- * value-level `isSafeUrl` check in `sanitizeRenderableHtmlAttribute` instead of
- * a name denylist, so new URL attributes are covered without enumerating them.
+ * value-level `hasDangerousUrlScheme` check in `sanitizeRenderableHtmlAttribute`
+ * instead of a name denylist, so new URL attributes are covered without
+ * enumerating them.
  */
 const RAW_HTML_SINK_ATTRIBUTE_NAMES = new Set(['srcdoc'])
 
@@ -53,16 +54,19 @@ export function isRenderableHtmlAttributeName(name: string): boolean {
  *   - non-renderable / event-handler / reserved / raw-HTML-sink names
  *     (via `isRenderableHtmlAttributeName`);
  *   - values carrying a dangerous URL scheme — `javascript:` / `vbscript:` /
- *     `data:` (via `isSafeUrl`). This blocks e.g. a custom
+ *     `data:` (via `hasDangerousUrlScheme`). This blocks e.g. a custom
  *     `href="javascript:…"` that would otherwise shadow a module's own checked
  *     href and execute in the page — on the published site AND, more
  *     seriously, inside the admin editor canvas (same-origin as `/admin`).
  *
- * `isSafeUrl` returns true for ordinary non-URL text, so plain attribute values
- * (titles, ARIA labels, `viewBox`, …) pass through unchanged.
+ * `hasDangerousUrlScheme` is deliberately used here rather than `isSafeUrl`:
+ * this gate sees EVERY attribute value, not just URL-bearing ones, and
+ * `isSafeUrl` is an allowlist that would drop ordinary prose (`title="Notes:
+ * draft"` parses as scheme `notes:`). Only genuinely executable schemes are
+ * rejected, so titles, ARIA labels and `viewBox` pass through unchanged.
  */
 export function sanitizeRenderableHtmlAttribute(name: string, value: string): string | null {
   if (!isRenderableHtmlAttributeName(name)) return null
-  if (!isSafeUrl(value)) return null
+  if (hasDangerousUrlScheme(value)) return null
   return value
 }

--- a/src/core/markdown/renderMarkdown.ts
+++ b/src/core/markdown/renderMarkdown.ts
@@ -71,8 +71,11 @@ marked.use({
 })
 
 function safeMarkdownUrl(value: string): string {
-  const trimmed = (value ?? '').trim()
-  return isSafeUrl(trimmed) ? escapeHtml(trimmed) : '#'
+  // No pre-trim: `isSafeUrl` performs the full WHATWG leading/trailing strip
+  // itself. A `.trim()` here would look protective while leaving exactly the
+  // control characters that mattered (GHSA-pqcp-872g-gmp8).
+  const raw = value ?? ''
+  return isSafeUrl(raw) ? escapeHtml(raw) : '#'
 }
 
 export function renderMarkdownToHtml(markdown: string): string {

--- a/src/core/plugin-sdk/builders/html.ts
+++ b/src/core/plugin-sdk/builders/html.ts
@@ -18,6 +18,7 @@
  * Numbers and booleans are stringified. Objects with `__raw` are emitted
  * verbatim (used by `raw()`).
  */
+import { isSafeUrl } from '@core/html-sanitize'
 
 const HTML_ESCAPE_RE = /[&<>"']/g
 const HTML_ESCAPE_MAP: Record<string, string> = {
@@ -71,12 +72,19 @@ export function html(strings: TemplateStringsArray, ...values: unknown[]): strin
 
 /**
  * Validate a URL value before emitting it into an `href`/`src`/`action`.
- * Returns `'#'` for `javascript:` / `vbscript:` schemes. Use inside `html`:
+ * Returns `'#'` for anything outside the shared scheme allowlist. Use inside
+ * `html`:
  *
  *   html`<a href="${safeUrl(props.href)}">…</a>`
+ *
+ * Delegates to the canonical guard rather than carrying its own scheme logic —
+ * this used to be an independent two-regex denylist that a plain leading space
+ * defeated and that never blocked `data:` at all (GHSA-pqcp-872g-gmp8).
+ *
+ * Does not HTML-escape, unlike `safeUrl` in `@core/html-sanitize`: the `html`
+ * tag already escapes every interpolation, so escaping here double-encodes `&`.
  */
 export function safeUrl(value: unknown): string {
   const s = String(value ?? '')
-  if (/^javascript:/i.test(s) || /^vbscript:/i.test(s)) return '#'
-  return s
+  return isSafeUrl(s) ? s : '#'
 }

--- a/src/core/utils/urlValidation.ts
+++ b/src/core/utils/urlValidation.ts
@@ -3,32 +3,56 @@
  *
  * Centralised allowlist predicates for editor property controls.
  * Both functions follow the same contract: empty string → true (no value is
- * valid for optional fields), non-empty string → validate protocol.
+ * valid for optional fields), non-empty string → validate the scheme.
  *
- * Separate from `isSafeUrl()` in `src/core/publisher/` which is the stricter
- * enforcement gate applied at HTML export time. This module is the
- * input-boundary gate applied at user-input / site-load time.
+ * These are the **input-boundary** gates, applied at user-input / site-load
+ * time. `isSafeUrl()` in `@core/html-sanitize` is the **enforcement** gate,
+ * applied at HTML export time. Both read the scheme through the same
+ * `urlScheme()` extractor so the two can never disagree about what a value's
+ * scheme is — they differ only in which schemes they accept.
  *
  * Allowlists:
  *   isValidUrl()       — https, http, mailto
  *   isValidImageUrl()  — https, http, data:image/* (inline base64 images)
  */
 
+import { urlScheme } from '@core/html-sanitize'
+
+/**
+ * Well-formedness check, kept separate from the scheme decision.
+ *
+ * `urlScheme()` reads only the leading `scheme:` token — it says nothing about
+ * whether the rest of the value parses. These predicates are input-boundary
+ * gates whose job includes catching typos (`https://exa mple.com`, `http://`),
+ * so they need both halves: the shared scheme extractor for the security
+ * decision, and a real parse for well-formedness.
+ *
+ * Unlike `@core/html-sanitize`, this module is admin-only (React property
+ * controls) and never bundled into a QuickJS plugin pack, so `new URL()` is
+ * available here.
+ */
+function parses(v: string): boolean {
+  try {
+    new URL(v)
+    return true
+  } catch {
+    return false
+  }
+}
+
 /**
  * Returns true if `v` is a safe general-purpose URL for storing in site
  * props (e.g. a link href, a button href).
  *
  * Allows:  https:, http:, mailto:
- * Rejects: javascript:, data:, ftp:, blob:, custom schemes, malformed strings
+ * Rejects: javascript:, data:, ftp:, blob:, custom schemes, schemeless values,
+ *          and malformed absolute URLs (`http://`, `https://exa mple.com`)
  */
 export function isValidUrl(v: string): boolean {
   if (!v) return true
-  try {
-    const { protocol } = new URL(v)
-    return protocol === 'https:' || protocol === 'http:' || protocol === 'mailto:'
-  } catch {
-    return false
-  }
+  const scheme = urlScheme(v)
+  if (scheme !== 'https:' && scheme !== 'http:' && scheme !== 'mailto:') return false
+  return parses(v)
 }
 
 /**
@@ -36,21 +60,20 @@ export function isValidUrl(v: string): boolean {
  *
  * Allows:  https:, http:, data:image/* (e.g. data:image/png;base64,…)
  * Rejects: javascript:, data:text/html, data:application/*, blob:, ftp:,
- *          mailto:, custom schemes, malformed strings
+ *          mailto:, custom schemes, schemeless values, and malformed
+ *          absolute URLs
  *
  * Note: `data:image/*` is allowed because base64-encoded inline images are a
  * legitimate use case in the editor (e.g. pasted screenshots, small icons).
  * All other `data:` subtypes are rejected to prevent unexpected content from
- * rendering in the editor preview.
+ * rendering in the editor preview. The publisher's `isSafeUrl()` rejects every
+ * `data:` URL, so such a value renders in the canvas but not on the published
+ * page — a known divergence, tracked separately.
  */
 export function isValidImageUrl(v: string): boolean {
   if (!v) return true
-  try {
-    const { protocol } = new URL(v)
-    if (protocol === 'https:' || protocol === 'http:') return true
-    if (protocol === 'data:') return v.toLowerCase().startsWith('data:image/')
-    return false
-  } catch {
-    return false
-  }
+  const scheme = urlScheme(v)
+  if (scheme === 'https:' || scheme === 'http:') return parses(v)
+  if (scheme === 'data:') return v.trimStart().toLowerCase().startsWith('data:image/')
+  return false
 }


### PR DESCRIPTION
Fixes the URL-scheme filter bypass reported privately in GHSA-pqcp-872g-gmp8. Ships as 0.0.14.

## What was wrong

`isSafeUrl()` normalised with `.replace(/[\t\n\r]/g, '').trim()` and then prefix-matched a three-entry denylist (`javascript:` / `vbscript:` / `data:`).

`String.prototype.trim()` strips only U+0009–U+000D, U+0020 and the Unicode space separators. It leaves **U+0000–U+0008 and U+000E–U+001F** in place. The WHATWG URL parser strips the entire U+0000–U+0020 range before reading a scheme, so **27 of 32 C0 code points** made the guard report "safe" for a URL the browser resolves as `javascript:`. `escapeHtml()` only escapes `& < > " '`, so the raw control byte landed in the attribute intact.

The guard is the single chokepoint for four call sites — `escapeProps.ts:108`, `htmlAttributes/attributes.ts`, `renderMarkdown.ts`, and `render.ts` (favicon) — so patching one would have left the rest open.

## Why not just widen the strip set

The reporter's suggested patch keeps the denylist. That denylist was wrong in both directions: it accepted `blob:`, `file:`, `view-source:` and any custom scheme with no disguise at all, and it over-blocked some harmless values. Per CLAUDE.md ("no band-aids… fix it at the source"), this replaces it with an allowlist over a scheme extractor that follows the WHATWG stripping rules, so the guard cannot disagree with the browser that resolves the value.

Deliberately **not** `new URL()` in the render guard: `@core/html-sanitize` is bundled into plugin module packs that run inside the QuickJS-WASM sandbox, whose `URL` polyfill is a regex approximation requiring `scheme://authority` that strips no control characters. A pure-string implementation behaves identically in Bun, browsers, and the sandbox.

## Three divergent guards, now one

The report surfaced a second, unreported bug: `src/core/plugin-sdk/builders/html.ts` carried an independent copy that was **strictly weaker** — no whitespace handling at all (a plain leading space defeated it) and no `data:` case whatsoever. The editor input gate in `src/core/utils/urlValidation.ts` was a third. All three now read their scheme through one extractor; a new architecture test fails the build if a fourth appears.

The input gate keeps its own `new URL()` well-formedness check on top of the shared scheme decision — it is admin-only, never bundled into a plugin pack, and its job includes catching typos like `https://exa mple.com` that a scheme check alone would pass.

`sanitizeRenderableHtmlAttribute` moves to a new `hasDangerousUrlScheme` predicate rather than `isSafeUrl`. It sees *every* attribute value, not just URL-bearing ones, so an allowlist would have dropped ordinary prose — `title="Notes: draft"` parses as scheme `notes:`.

## Behaviour changes

1. `blob:`, `file:`, `ftp:`, `view-source:` and custom schemes now collapse to `#` in `url` / `image` / `media` props. Intentional; no compat obligation for code.
2. A relative path whose first segment contains a colon (`notes:draft.html`) is now rejected. Write `./notes:draft.html`.
3. `tel:` and `sms:` are now explicitly allowed. They already passed the old denylist, so this is not a regression.

No database or stored-shape changes.

## Tests

- `src/__tests__/publisher/utils.test.ts` — full C0 sweep, allowlist assertions, and every legitimate URL shape the publisher must emit.
- `src/__tests__/security/urlSchemeBypass.test.ts` (new) — differential gate against `new URL().protocol` over a generated corpus, covering all three implementations that existed at report time.
- `src/__tests__/architecture/single-url-scheme-guard.test.ts` (new) — structural gate, including self-tests that its scanner preserves line numbers and cannot be evaded by a `/*` inside a string literal.

Verified the fix accepts 0 of 99 control-prefixed dangerous URLs while every legitimate shape still passes.

## Verification

```
bun run build   # clean
bun test        # 6298 tests, 0 fail (one pre-existing flake in
                # src/__tests__/data/contentAdmin.test.tsx under full-suite
                # load — passes 3/3 in isolation, untouched by this branch)
bun run lint    # clean
```

## Credit

Reported privately by @overgrowncarrot1 via GitHub's private vulnerability reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)