### PR TITLE
docs(deployment): add DeployHQ static-output publishing guide

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -104,6 +104,7 @@ SQLite installs also need the SQLite database file on persistent storage. On pla
 | [tls-caddy.md](tls-caddy.md) | Caddy TLS overlay for VPS Compose installs |
 | [backup-restore.md](backup-restore.md) | Database and uploads backup/restore |
 | [release-workflow.md](release-workflow.md) | Maintainer image publishing workflow |
+| [deployhq.md](deployhq.md) | Publish the static output to a bucket or web server with DeployHQ |
 
 ## Related
 

--- a/docs/deployment/deployhq.md
+++ b/docs/deployment/deployhq.md
@@ -14,24 +14,24 @@ which is how you run the CMS server itself.
 
 ## Site compatibility — read first
 
-Serving the published output from a **different origin than the CMS** works cleanly
-for fully static sites, but two Instatic behaviours need attention first:
+The `published/current` slot is self-contained HTML, CSS, and runtime assets (plus a
+`404.html`). Two things it references still resolve **against the CMS origin**, so
+serving the slot from a different origin needs a plan for them:
 
-- **Dynamic "hole" nodes.** Pages that contain request-dependent nodes export as a
-  shell whose runtime script fetches `/_instatic/hole/<nodeId>` **from the page's own
-  origin** (`server/publish/holeRuntime.ts`). On a separate static host that endpoint
-  does not exist, so the placeholder never resolves. Use this pattern only if your
-  site is hole-free, **or** proxy `/_instatic/hole/*` (and `/_instatic/hole-runtime.js`)
-  from the public origin back to the CMS, forwarding the request cookies the hole
-  depends on.
-- **Local uploads live outside the publish slot.** The slot under `published/current`
-  is HTML plus generated CSS/runtime assets; media stays referenced as raw
-  `/uploads/…` paths (`server/publish/mediaPrefetch.ts`). Those files are **not**
-  inside `published/current`, so you must ship them too or route `/uploads/*` to the
-  CMS (Step 1 and Step 3/4 below).
-
-If your site uses external object storage for media and has no dynamic holes, both
-caveats fall away.
+- **Media / uploads.** With the default local adapter, media is served at
+  `/uploads/<path>` from the CMS `UPLOADS_DIR` (`server/router.ts` strips `/uploads`
+  and resolves against that dir), and plugin bundles live under `/uploads/plugins/…`.
+  Object-storage adapters that use `servingMode: 'signed-redirect'` instead serve
+  `/_instatic/media/<adapterId>/<path>` via CMS-generated signed redirects. In both
+  cases those URLs 404 on a separate origin unless you **route them to the CMS**
+  (Step 3/4). Only a `public-url` object-storage adapter — whose media already lives
+  on its own public CDN URL — removes this entirely.
+- **Dynamic "hole" nodes.** Pages with request-dependent nodes export as a shell
+  whose runtime fetches `/_instatic/hole/<nodeId>` **from the page's own origin**
+  (`server/publish/holeRuntime.ts`). On a separate static host that endpoint does not
+  exist, so the placeholder never resolves. Use this pattern only if your site is
+  hole-free, **or** proxy `/_instatic/hole/*` (and `/_instatic/hole-runtime.js`) from
+  the public origin to the CMS, forwarding the request cookies the hole depends on.
 
 ## TL;DR
 
@@ -40,58 +40,58 @@ caveats fall away.
 | Your own web server | You run nginx/Caddy on a VPS; the robust default | Native (`try_files … .html`) | [SSH/SFTP deployment](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-link) |
 | S3 / R2 / Spaces + CDN | Lowest ops, CDN-served | Requires a CDN rewrite (below) | [Static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-link) |
 
-Both deploy from the same Git repository of published files and both support
-post-deploy hooks (for example, purging a CDN cache).
+Both deploy the `published/current` slot from a Git repository, route media to the
+CMS, and support post-deploy hooks (for example, purging a CDN cache).
 
 ## How it fits
 
 ```txt
-Instatic (private)              Git repo                    Public host
-┌──────────────────────┐       ┌────────────────┐          ┌────────────────────┐
-│ publish →            │ push  │ published/     │ DeployHQ  │ web server (nginx) │
-│   published/current  ├──────▶│ current + any  ├─────────▶│   or bucket + CDN  │
-│ UPLOADS_DIR (media)  │       │ /uploads media │          │                    │
-└──────────────────────┘       └────────────────┘          └────────────────────┘
+Instatic (private CMS)            Git repo             Public host
+┌────────────────────┐   push    ┌────────────┐ DeployHQ ┌──────────────────────┐
+│ published/current  ├──────────▶│ deploy repo├─────────▶│ web server / bucket  │
+│ UPLOADS_DIR media  │           └────────────┘          │  + CDN               │
+└─────────┬──────────┘                                   └───────────┬──────────┘
+          │              /uploads/* and /_instatic/media/*           │
+          └───────────────────  routed back to CMS  ◀────────────────┘
 ```
 
-DeployHQ deploys **from Git**, so the glue you provide is assembling the deploy
-artifact — the publish slot plus the public uploads it references — into a
-repository.
+DeployHQ deploys the publish slot; media stays on the CMS and is reached by routing
+`/uploads/*` (and `/_instatic/media/*` for signed-redirect adapters) at the public
+origin.
 
 ## Prerequisites
 
 - An Instatic instance that publishes to `published/current` (any of the
   [deployment](README.md) targets).
-- You know whether the site uses dynamic hole nodes (see Site compatibility).
-- A Git repository (GitHub, GitLab, Bitbucket, or self-hosted) to hold the deploy
-  artifact. Keep it separate from your application repo.
+- You know whether the site uses dynamic hole nodes, and which media adapter it uses
+  (see Site compatibility).
+- A Git repository (GitHub, GitLab, Bitbucket, or self-hosted) to hold the publish
+  slot. Keep it separate from your application repo.
 - A DeployHQ account and one of:
   - a server you can reach over SSH/SFTP, or
   - an S3-compatible bucket (AWS S3, Cloudflare R2, DigitalOcean Spaces).
 
-## Step 1 — Assemble the deploy artifact
+## Step 1 — Push the publish slot to Git
 
-Sync the publish slot **and the public uploads it references** into a clean deploy
-repository, then push. On the box that runs Instatic (or a CI job with access to the
-CMS `UPLOADS_DIR`):
+Sync the slot into a clean deploy repository and push. Exclude `.git` so the
+`--delete` pass does not wipe the repository's own metadata. On the box that runs
+Instatic (or a CI job with access to the CMS `UPLOADS_DIR`):
 
 ```bash
 # one-time
 git clone git@github.com:you/your-site-published.git deploy && cd deploy
 
 # each publish
-rsync -a --delete "$UPLOADS_DIR/published/current/" ./            # pages, CSS, runtime, 404.html
-rsync -a          "$UPLOADS_DIR/uploads/"           ./uploads/    # media referenced as /uploads/...
+rsync -a --delete --exclude='.git' "$UPLOADS_DIR/published/current/" ./
 git add -A
 git commit -m "Publish $(date -u +%FT%TZ)" || echo "nothing changed"
 git push
 ```
 
-The exported slot includes a `404.html` (the Netlify/GitHub-Pages convention) so
-hosts that fall back on 404 keep working. Adjust the `uploads/` source to wherever
-your CMS stores media; the goal is that every `/uploads/…` path the pages reference
-resolves at the public origin. If you'd rather not copy media at all, skip the second
-`rsync` and instead route `/uploads/*` to the CMS at the public origin (Step 3/4).
+The slot includes a `404.html` (the Netlify/GitHub-Pages convention) so hosts that
+fall back on 404 keep working. Media is **not** copied here — it is served from the
+CMS via routing (Step 3/4), which avoids shipping non-public objects from
+`UPLOADS_DIR`.
 
 > Want to build assets on the way out (minify, fingerprint, generate a sitemap)?
 > Add those steps to a
@@ -112,8 +112,8 @@ server in DeployHQ with the deploy path your web server serves (for example
 `/var/www/site`). Deployments are atomic — the new release is assembled and swapped
 in, so visitors never see a half-written directory.
 
-A web server resolves Instatic's `about.html` / `posts/hello.html` layout natively.
-With nginx:
+A web server resolves Instatic's `about.html` / `posts/hello.html` layout natively
+and can proxy media to the CMS. With nginx:
 
 ```txt
 location / {
@@ -121,12 +121,13 @@ location / {
 }
 error_page 404 /404.html;
 
-# only if you did NOT copy media in Step 1:
-# location /uploads/ { proxy_pass https://cms.internal; }
+# route media to the CMS (skip if you use a public-url object-storage adapter)
+location /uploads/         { proxy_pass https://cms.internal; }
+location /_instatic/media/ { proxy_pass https://cms.internal; }   # signed-redirect adapters
 ```
 
 Caddy: `try_files {path} {path}.html {path}/index.html` with `handle_errors` serving
-`/404.html`.
+`/404.html`, plus `reverse_proxy /uploads/* /_instatic/media/* https://cms.internal`.
 
 ## Step 4 — Or deploy to a bucket + CDN
 
@@ -135,16 +136,14 @@ Configure a
 destination pointing at your S3, R2, or Spaces bucket, front it with a CDN, and point
 your public domain at the CDN. DeployHQ uploads only the changed files.
 
-Buckets do **exact object-key lookup**, so extensionless routes (`/about`) will not
-resolve against `about.html` on their own. Add a CDN rewrite (CloudFront Function,
+Buckets do **exact object-key lookup**, so add a CDN rewrite (CloudFront Function,
 Cloudflare Worker, or equivalent):
 
 - `/` and paths ending `/` → append `index.html`
 - any other extensionless path → append `.html`
 - unmatched → serve `404.html`
-
-Media copied in Step 1 lands under `uploads/` in the bucket; otherwise add a CDN rule
-routing `/uploads/*` to the CMS origin.
+- `/uploads/*` and `/_instatic/media/*` → route to the CMS origin (skip only for a
+  `public-url` object-storage adapter, whose media is already on a public URL)
 
 ## Step 5 — Post-deploy hooks (optional)
 
@@ -168,9 +167,8 @@ instant pointer swap, not a re-upload.
   CMS configures the origins its CSRF check trusts (where you reach the admin) — it is
   not the public URL of the static site. After the first publish, open the deployed
   site and confirm links, images, and any sitemap resolve against the public host.
-- **Dynamic holes and uploads** are the two things that break silently across origins
-  — re-read Site compatibility if a page renders but a region stays blank or an image
-  404s.
+- **Media and dynamic holes** are what break silently across origins — re-read Site
+  compatibility if an image 404s or a region stays blank.
 
 ## Troubleshooting
 
@@ -178,7 +176,7 @@ instant pointer swap, not a re-upload.
 |---|---|
 | Nothing deploys after publish | Step 1 actually committed and pushed; DeployHQ is watching that branch |
 | Pages 404 on a bucket, homepage works | Extensionless routes need the Step 4 CDN rewrite to `.html` |
-| Images / fonts 404 | Public `/uploads/…` objects not shipped (Step 1) or not routed to the CMS |
+| Images / fonts / plugin assets 404 | `/uploads/*` (and `/_instatic/media/*` for signed-redirect) not routed to the CMS |
 | A region renders blank / stuck on placeholder | Dynamic hole node calling `/_instatic/hole/*` on an origin with no CMS — see Site compatibility |
 | Old pages still served | CDN cache not purged — add the Step 5 post-deploy hook |
 

--- a/docs/deployment/deployhq.md
+++ b/docs/deployment/deployhq.md
@@ -100,9 +100,10 @@ else
 fi
 ```
 
-The slot includes a `404.html` (the Netlify/GitHub-Pages convention) so hosts that
-fall back on 404 keep working. Dynamic endpoints are **not** copied here — they are
-served from the CMS via routing (Step 3/4).
+The slot includes a `404.html` **only if you have published a not-found template**
+(`publishSite` skips it otherwise) — so if you rely on the 404 fallback in Step 3/4,
+create and publish a not-found template first. Dynamic endpoints are **not** copied
+here — they are served from the CMS via routing (Step 3/4).
 
 > Want to build assets on the way out (minify, fingerprint, generate a sitemap)?
 > Add those steps to a
@@ -130,7 +131,7 @@ and can proxy the dynamic endpoints to the CMS. With nginx:
 location / {
     try_files $uri $uri.html $uri/index.html =404;
 }
-error_page 404 /404.html;
+error_page 404 /404.html;   # requires a published not-found template (see Step 1)
 
 # keep the editor/admin surface private
 location = /_instatic/mcp { return 404; }
@@ -159,7 +160,7 @@ Cloudflare Worker, or equivalent):
 
 - `/` and paths ending `/` → append `index.html`
 - any other extensionless path → append `.html`
-- unmatched → serve `404.html`
+- unmatched → serve `404.html` (only if a not-found template was published; see Step 1)
 - `/uploads/*` and the public `/_instatic/*` runtime routes → route to the CMS origin
   (skip `/uploads` for a `public-url` adapter; skip `/_instatic` for a fully static
   site). **Do not** route `/admin/*` or `/_instatic/mcp` to the public CDN.
@@ -182,11 +183,13 @@ instant pointer swap, not a re-upload.
 
 - **This deploys output, not state.** Your Instatic database and uploads volume still
   live with the CMS server — back them up per [backup-restore.md](backup-restore.md).
-- **The CMS host and the public host are different origins.** `PUBLIC_ORIGIN` on the
-  CMS configures the origins its CSRF check trusts (where you reach the admin) — it is
-  not the public URL of the static site. After the first publish, open the deployed
-  site and confirm links, images, forms, and any sitemap resolve against the public
-  host.
+- **`PUBLIC_ORIGIN` and proxied forms.** `PUBLIC_ORIGIN` is the CMS's comma-separated
+  list of CSRF-trusted origins — it is not by itself the public URL of the static
+  site. But if you proxy CSRF-checked endpoints (forms) from the public origin to the
+  CMS, you **must add the deployed public origin to `PUBLIC_ORIGIN`** alongside the
+  admin origin, or proxied form challenge/submit requests return 403. After the first
+  publish, open the deployed site and confirm links, images, forms, and any sitemap
+  resolve against the public host.
 - **Dynamic endpoints are what break silently across origins** — re-read Site
   compatibility if an image 404s, a form fails to submit, or a region stays blank.
 
@@ -198,6 +201,7 @@ instant pointer swap, not a re-upload.
 | Pages 404 on a bucket, homepage works | Extensionless routes need the Step 4 CDN rewrite to `.html` |
 | Images / fonts / plugin assets 404 | `/uploads/*` (or `/_instatic/media/*` for signed-redirect) not routed to the CMS |
 | Forms don't submit / load-more does nothing | `/_instatic/form/*` and `/_instatic/loop/*` not routed to the CMS |
+| Forms return 403 | The deployed public origin isn't in the CMS `PUBLIC_ORIGIN` list — add it (comma-separated) |
 | A region renders blank / stuck on placeholder | Dynamic hole node calling `/_instatic/hole/*` on an origin with no CMS — see Site compatibility |
 | Old pages still served | CDN cache not purged — add the Step 5 post-deploy hook |
 

--- a/docs/deployment/deployhq.md
+++ b/docs/deployment/deployhq.md
@@ -15,7 +15,8 @@ which is how you run the CMS server itself.
 ## Site compatibility — read first
 
 The `published/current` slot is self-contained HTML, CSS, and runtime assets (plus a
-`404.html`), but exported pages call **CMS-backed endpoints at runtime**. Served from
+`404.html` when a not-found template is published), but exported pages call
+**CMS-backed endpoints at runtime**. Served from
 a different origin than the CMS, those requests 404 unless you route them back.
 
 - **Best case — fully static.** A site with no forms, no dynamic "hole" nodes, no
@@ -133,15 +134,18 @@ location / {
 }
 error_page 404 /404.html;   # requires a published not-found template (see Step 1)
 
-# keep the editor/admin surface private
+# non-root trailing slash → canonical path (pages are baked as <path>.html)
+location ~ ^(.+)/$ { return 301 $1$is_args$args; }
+
+# keep the editor/admin surface private (^~ so the redirect regex above can't intercept)
 location = /_instatic/mcp { return 404; }
-location /admin/          { return 404; }
+location ^~ /admin/       { return 404; }
 
 # route dynamic endpoints to the CMS
 # (skip /uploads if you use a public-url object-storage adapter,
 #  and skip /_instatic entirely if the site is fully static)
-location /uploads/   { proxy_pass https://cms.internal; }
-location /_instatic/ { proxy_pass https://cms.internal; }
+location ^~ /uploads/   { proxy_pass https://cms.internal; }
+location ^~ /_instatic/ { proxy_pass https://cms.internal; }
 ```
 
 Caddy is equivalent: `try_files {path} {path}.html {path}/index.html`, `handle_errors`
@@ -158,8 +162,11 @@ your public domain at the CDN. DeployHQ uploads only the changed files.
 Buckets do **exact object-key lookup**, so add a CDN rewrite (CloudFront Function,
 Cloudflare Worker, or equivalent):
 
-- `/` and paths ending `/` → append `index.html`
-- any other extensionless path → append `.html`
+- root `/` → serve `index.html`
+- non-root path ending `/` → 301 to the same path without the trailing slash (pages
+  are baked as `<path>.html`, not `<path>/index.html`)
+- any other extensionless path → serve `<path>.html`, falling back to
+  `<path>/index.html` for real directory pages
 - unmatched → serve `404.html` (only if a not-found template was published; see Step 1)
 - `/uploads/*` and the public `/_instatic/*` runtime routes → route to the CMS origin
   (skip `/uploads` for a `public-url` adapter; skip `/_instatic` for a fully static
@@ -178,6 +185,12 @@ If a publish ships broken markup, use
 [one-click rollback](https://www.deployhq.com/features/one-click-rollback?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=rollback-target)
 to redeploy the previous release. Because deployments are atomic, rollback is an
 instant pointer swap, not a re-upload.
+
+Rollback restores the deployed **files** only. For a fully static site that is a
+complete recovery. If the site uses dynamic endpoints, the CMS's published snapshot
+and `publishVersion` are unchanged, so a rolled-back shell can go stale — holes serve
+sentinels for an obsolete `?v=`, while forms and module JS resolve against the latest
+CMS snapshot. Pair a rollback of a dynamic site with a coordinated CMS rollback.
 
 ## Runtime notes
 

--- a/docs/deployment/deployhq.md
+++ b/docs/deployment/deployhq.md
@@ -1,98 +1,152 @@
 # Publish Static Output with DeployHQ
 
-Instatic runs the editor and content engine on your own server, but everything a
-visitor sees is plain static HTML and CSS written to `published/current`. That
-output is a perfect fit for a separate, fast public host: keep the CMS private
-(behind auth, on a small box) and serve the published site from a CDN-backed
-bucket or a hardened web server.
+Instatic runs the editor and content engine on your own server, but the public site
+is plain static HTML and CSS written to `published/current`. That output is a good
+fit for a separate, fast public host: keep the CMS private (behind auth, on a small
+box) and serve the published site from a hardened web server or a CDN-backed bucket.
 
 [DeployHQ](https://www.deployhq.com/?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=intro-link)
 automates that last hop. It watches a Git repository, uploads only the files that
 changed, and gives you [atomic, zero-downtime deployments](https://www.deployhq.com/features/zero-downtime-deployments?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=zero-downtime-link)
-with [one-click rollback](https://www.deployhq.com/features/one-click-rollback?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=rollback-link)
-if a publish goes wrong. This guide covers the static-output path — it does **not**
-replace [vps.md](vps.md), which is how you run the CMS server itself.
+with [one-click rollback](https://www.deployhq.com/features/one-click-rollback?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=rollback-link).
+This guide covers the static-output path — it does **not** replace [vps.md](vps.md),
+which is how you run the CMS server itself.
+
+## Site compatibility — read first
+
+Serving the published output from a **different origin than the CMS** works cleanly
+for fully static sites, but two Instatic behaviours need attention first:
+
+- **Dynamic "hole" nodes.** Pages that contain request-dependent nodes export as a
+  shell whose runtime script fetches `/_instatic/hole/<nodeId>` **from the page's own
+  origin** (`server/publish/holeRuntime.ts`). On a separate static host that endpoint
+  does not exist, so the placeholder never resolves. Use this pattern only if your
+  site is hole-free, **or** proxy `/_instatic/hole/*` (and `/_instatic/hole-runtime.js`)
+  from the public origin back to the CMS, forwarding the request cookies the hole
+  depends on.
+- **Local uploads live outside the publish slot.** The slot under `published/current`
+  is HTML plus generated CSS/runtime assets; media stays referenced as raw
+  `/uploads/…` paths (`server/publish/mediaPrefetch.ts`). Those files are **not**
+  inside `published/current`, so you must ship them too or route `/uploads/*` to the
+  CMS (Step 1 and Step 3/4 below).
+
+If your site uses external object storage for media and has no dynamic holes, both
+caveats fall away.
 
 ## TL;DR
 
-| Target | Use when | DeployHQ mode | Persistent storage |
+| Target | Use when | Clean-URL routing | DeployHQ mode |
 |---|---|---|---|
-| S3 / R2 / Spaces bucket | Public site served from a CDN, lowest ops | [Static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-link) | Bucket (managed) |
-| Your own web server | You already run nginx/Caddy on a VPS | [SSH/SFTP deployment](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-link) | Server disk |
+| Your own web server | You run nginx/Caddy on a VPS; the robust default | Native (`try_files … .html`) | [SSH/SFTP deployment](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-link) |
+| S3 / R2 / Spaces + CDN | Lowest ops, CDN-served | Requires a CDN rewrite (below) | [Static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-link) |
 
-Both paths deploy from the same Git repository of published files and both support
+Both deploy from the same Git repository of published files and both support
 post-deploy hooks (for example, purging a CDN cache).
 
 ## How it fits
 
 ```txt
-Instatic (private)          Git repo                 Public host
-┌──────────────────┐        ┌──────────────┐         ┌──────────────────┐
-│ edit + publish   │  push  │ published    │ DeployHQ│ S3 / R2 / Spaces │
-│ published/current├───────▶│ static files ├────────▶│  or  web server  │
-└──────────────────┘        └──────────────┘         └──────────────────┘
+Instatic (private)              Git repo                    Public host
+┌──────────────────────┐       ┌────────────────┐          ┌────────────────────┐
+│ publish →            │ push  │ published/     │ DeployHQ  │ web server (nginx) │
+│   published/current  ├──────▶│ current + any  ├─────────▶│   or bucket + CDN  │
+│ UPLOADS_DIR (media)  │       │ /uploads media │          │                    │
+└──────────────────────┘       └────────────────┘          └────────────────────┘
 ```
 
-DeployHQ deploys **from Git**, so the one piece of glue you provide is getting the
-contents of `published/current` into a repository. That is a small, boring step —
-see below.
+DeployHQ deploys **from Git**, so the glue you provide is assembling the deploy
+artifact — the publish slot plus the public uploads it references — into a
+repository.
 
 ## Prerequisites
 
 - An Instatic instance that publishes to `published/current` (any of the
   [deployment](README.md) targets).
-- A Git repository (GitHub, GitLab, Bitbucket, or self-hosted) to hold the
-  published output. Keep it separate from your application repo.
+- You know whether the site uses dynamic hole nodes (see Site compatibility).
+- A Git repository (GitHub, GitLab, Bitbucket, or self-hosted) to hold the deploy
+  artifact. Keep it separate from your application repo.
 - A DeployHQ account and one of:
-  - an S3-compatible bucket (AWS S3, Cloudflare R2, DigitalOcean Spaces), or
-  - a server you can reach over SSH/SFTP.
+  - a server you can reach over SSH/SFTP, or
+  - an S3-compatible bucket (AWS S3, Cloudflare R2, DigitalOcean Spaces).
 
-## Step 1 — Get the published output into Git
+## Step 1 — Assemble the deploy artifact
 
-Sync `published/current` into a clean deploy repository and push. On the box that
-runs Instatic (or a CI job that has access to the published volume):
+Sync the publish slot **and the public uploads it references** into a clean deploy
+repository, then push. On the box that runs Instatic (or a CI job with access to the
+CMS `UPLOADS_DIR`):
 
 ```bash
 # one-time
 git clone git@github.com:you/your-site-published.git deploy && cd deploy
 
 # each publish
-rsync -a --delete /path/to/instatic/published/current/ ./
+rsync -a --delete "$UPLOADS_DIR/published/current/" ./            # pages, CSS, runtime, 404.html
+rsync -a          "$UPLOADS_DIR/uploads/"           ./uploads/    # media referenced as /uploads/...
 git add -A
 git commit -m "Publish $(date -u +%FT%TZ)" || echo "nothing changed"
 git push
 ```
 
-Run it on a schedule, on a webhook after you publish in Instatic, or by hand — the
-mechanism does not matter to DeployHQ, only that new commits land on the branch it
-watches.
+The exported slot includes a `404.html` (the Netlify/GitHub-Pages convention) so
+hosts that fall back on 404 keep working. Adjust the `uploads/` source to wherever
+your CMS stores media; the goal is that every `/uploads/…` path the pages reference
+resolves at the public origin. If you'd rather not copy media at all, skip the second
+`rsync` and instead route `/uploads/*` to the CMS at the public origin (Step 3/4).
 
-> Prefer to build assets on the way out (minify, fingerprint, generate a sitemap)?
-> Point DeployHQ at this repo and add those steps to a
+> Want to build assets on the way out (minify, fingerprint, generate a sitemap)?
+> Add those steps to a
 > [build pipeline](https://www.deployhq.com/features/build-pipelines?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=build-pipeline-link),
 > which runs in an isolated container before anything is uploaded.
 
 ## Step 2 — Connect the repository to DeployHQ
 
-1. Create a new DeployHQ project and connect the published repository.
+1. Create a new DeployHQ project and connect the deploy repository.
 2. Set the branch DeployHQ deploys from (for example, `main`).
 3. Enable automatic deployments so every push publishes without a manual click.
 
-## Step 3 — Choose a deployment target
+## Step 3 — Deploy to your own web server (recommended)
 
-**Bucket + CDN (recommended for public sites).** Configure a
-[static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-target)
-destination pointing at your S3, R2, or Spaces bucket. DeployHQ uploads only the
-changed files, so publishes stay fast even on a large site. Front it with a CDN and
-point your public domain at the CDN.
-
-**Your own web server.** Add an
+Add an
 [SSH/SFTP](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-target)
-server in DeployHQ with the deploy path your web server serves (for example,
+server in DeployHQ with the deploy path your web server serves (for example
 `/var/www/site`). Deployments are atomic — the new release is assembled and swapped
 in, so visitors never see a half-written directory.
 
-## Step 4 — Post-deploy hooks (optional)
+A web server resolves Instatic's `about.html` / `posts/hello.html` layout natively.
+With nginx:
+
+```txt
+location / {
+    try_files $uri $uri.html $uri/index.html =404;
+}
+error_page 404 /404.html;
+
+# only if you did NOT copy media in Step 1:
+# location /uploads/ { proxy_pass https://cms.internal; }
+```
+
+Caddy: `try_files {path} {path}.html {path}/index.html` with `handle_errors` serving
+`/404.html`.
+
+## Step 4 — Or deploy to a bucket + CDN
+
+Configure a
+[static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-target)
+destination pointing at your S3, R2, or Spaces bucket, front it with a CDN, and point
+your public domain at the CDN. DeployHQ uploads only the changed files.
+
+Buckets do **exact object-key lookup**, so extensionless routes (`/about`) will not
+resolve against `about.html` on their own. Add a CDN rewrite (CloudFront Function,
+Cloudflare Worker, or equivalent):
+
+- `/` and paths ending `/` → append `index.html`
+- any other extensionless path → append `.html`
+- unmatched → serve `404.html`
+
+Media copied in Step 1 lands under `uploads/` in the bucket; otherwise add a CDN rule
+routing `/uploads/*` to the CMS origin.
+
+## Step 5 — Post-deploy hooks (optional)
 
 To purge a CDN cache or ping a health check after each publish, add a
 [post-deploy SSH command](https://www.deployhq.com/support/ssh-commands?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-commands-link).
@@ -108,25 +162,25 @@ instant pointer swap, not a re-upload.
 
 ## Runtime notes
 
-- **This deploys output, not state.** Your Instatic database and uploads volume
-  still live with the CMS server — back them up per [backup-restore.md](backup-restore.md).
-- **The CMS host and the public host are different origins.** `PUBLIC_ORIGIN` on
-  the CMS configures the origins its CSRF check trusts (where you reach the admin) —
-  it is not the public URL of the static site. After the first publish, open the
-  deployed site and confirm internal links, assets, and any sitemap resolve against
-  your public host; fix absolute URLs at their source in Instatic, not in DeployHQ.
-- **Uploaded media** under the published output ships with the static files; media
-  you reference from outside `published/current` must be reachable from the public
-  origin.
+- **This deploys output, not state.** Your Instatic database and uploads volume still
+  live with the CMS server — back them up per [backup-restore.md](backup-restore.md).
+- **The CMS host and the public host are different origins.** `PUBLIC_ORIGIN` on the
+  CMS configures the origins its CSRF check trusts (where you reach the admin) — it is
+  not the public URL of the static site. After the first publish, open the deployed
+  site and confirm links, images, and any sitemap resolve against the public host.
+- **Dynamic holes and uploads** are the two things that break silently across origins
+  — re-read Site compatibility if a page renders but a region stays blank or an image
+  404s.
 
 ## Troubleshooting
 
 | Symptom | Check |
 |---|---|
-| Nothing deploys after publish | The sync step in Step 1 actually committed and pushed; DeployHQ is watching that branch |
-| Old pages still served | CDN cache not purged — add the post-deploy hook in Step 4 |
-| Links or assets point at the wrong host | Absolute URLs in the output reference the CMS origin — correct them at the source in Instatic |
-| Deploy uploads everything every time | Line-ending or timestamp churn in the deploy repo; commit only real content changes |
+| Nothing deploys after publish | Step 1 actually committed and pushed; DeployHQ is watching that branch |
+| Pages 404 on a bucket, homepage works | Extensionless routes need the Step 4 CDN rewrite to `.html` |
+| Images / fonts 404 | Public `/uploads/…` objects not shipped (Step 1) or not routed to the CMS |
+| A region renders blank / stuck on placeholder | Dynamic hole node calling `/_instatic/hole/*` on an origin with no CMS — see Site compatibility |
+| Old pages still served | CDN cache not purged — add the Step 5 post-deploy hook |
 
 ## Related
 

--- a/docs/deployment/deployhq.md
+++ b/docs/deployment/deployhq.md
@@ -15,23 +15,29 @@ which is how you run the CMS server itself.
 ## Site compatibility — read first
 
 The `published/current` slot is self-contained HTML, CSS, and runtime assets (plus a
-`404.html`). Two things it references still resolve **against the CMS origin**, so
-serving the slot from a different origin needs a plan for them:
+`404.html`), but exported pages call **CMS-backed endpoints at runtime**. Served from
+a different origin than the CMS, those requests 404 unless you route them back.
 
-- **Media / uploads.** With the default local adapter, media is served at
-  `/uploads/<path>` from the CMS `UPLOADS_DIR` (`server/router.ts` strips `/uploads`
-  and resolves against that dir), and plugin bundles live under `/uploads/plugins/…`.
-  Object-storage adapters that use `servingMode: 'signed-redirect'` instead serve
-  `/_instatic/media/<adapterId>/<path>` via CMS-generated signed redirects. In both
-  cases those URLs 404 on a separate origin unless you **route them to the CMS**
-  (Step 3/4). Only a `public-url` object-storage adapter — whose media already lives
-  on its own public CDN URL — removes this entirely.
-- **Dynamic "hole" nodes.** Pages with request-dependent nodes export as a shell
-  whose runtime fetches `/_instatic/hole/<nodeId>` **from the page's own origin**
-  (`server/publish/holeRuntime.ts`). On a separate static host that endpoint does not
-  exist, so the placeholder never resolves. Use this pattern only if your site is
-  hole-free, **or** proxy `/_instatic/hole/*` (and `/_instatic/hole-runtime.js`) from
-  the public origin to the CMS, forwarding the request cookies the hole depends on.
+- **Best case — fully static.** A site with no forms, no dynamic "hole" nodes, no
+  load-more loops, no dynamic modules, and `public-url` object-storage media deploys
+  with **zero proxying**. This is the clean path.
+- **Anything dynamic must be routed to the CMS.** Exported pages reference these
+  CMS-backed routes:
+  - **Media** — `/uploads/*` (default local adapter; `server/router.ts` strips
+    `/uploads` and resolves against `UPLOADS_DIR`), or `/_instatic/media/*` for
+    object-storage adapters using `servingMode: 'signed-redirect'`.
+  - **Runtime endpoints under `/_instatic/*`** — holes (`/_instatic/hole/*` +
+    `/_instatic/hole-runtime.js`), forms (`/_instatic/form/*`), load-more loops
+    (`/_instatic/loop/*`), dynamic module JS (`/_instatic/module-js/*`), and shared
+    `/_instatic/runtime|css|assets/*`.
+  - **Holes additionally** need the request cookies forwarded, since the response is
+    request-dependent.
+- **Never expose the editor/admin surface** on the public origin — keep `/admin/*`
+  and the MCP editor bridge `/_instatic/mcp` private (Step 3/4 block them).
+
+If your site leans heavily on these dynamic features, note that every one erodes the
+"static site, private CMS" split — the more you must proxy, the more running behind
+the CMS (or the [vps.md](vps.md) setup) may be simpler.
 
 ## TL;DR
 
@@ -40,8 +46,9 @@ serving the slot from a different origin needs a plan for them:
 | Your own web server | You run nginx/Caddy on a VPS; the robust default | Native (`try_files … .html`) | [SSH/SFTP deployment](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-link) |
 | S3 / R2 / Spaces + CDN | Lowest ops, CDN-served | Requires a CDN rewrite (below) | [Static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-link) |
 
-Both deploy the `published/current` slot from a Git repository, route media to the
-CMS, and support post-deploy hooks (for example, purging a CDN cache).
+Both deploy the `published/current` slot from a Git repository, route any dynamic
+endpoints to the CMS, and support post-deploy hooks (for example, purging a CDN
+cache).
 
 ## How it fits
 
@@ -49,22 +56,21 @@ CMS, and support post-deploy hooks (for example, purging a CDN cache).
 Instatic (private CMS)            Git repo             Public host
 ┌────────────────────┐   push    ┌────────────┐ DeployHQ ┌──────────────────────┐
 │ published/current  ├──────────▶│ deploy repo├─────────▶│ web server / bucket  │
-│ UPLOADS_DIR media  │           └────────────┘          │  + CDN               │
+│ dynamic endpoints  │           └────────────┘          │  + CDN               │
 └─────────┬──────────┘                                   └───────────┬──────────┘
-          │              /uploads/* and /_instatic/media/*           │
-          └───────────────────  routed back to CMS  ◀────────────────┘
+          │        /uploads/* and public /_instatic/* routed         │
+          └────────────────────  back to CMS  ◀─────────────────────-┘
 ```
 
-DeployHQ deploys the publish slot; media stays on the CMS and is reached by routing
-`/uploads/*` (and `/_instatic/media/*` for signed-redirect adapters) at the public
-origin.
+DeployHQ deploys the publish slot; anything dynamic stays on the CMS and is reached
+by routing the relevant endpoints at the public origin.
 
 ## Prerequisites
 
 - An Instatic instance that publishes to `published/current` (any of the
   [deployment](README.md) targets).
-- You know whether the site uses dynamic hole nodes, and which media adapter it uses
-  (see Site compatibility).
+- You know which dynamic features the site uses (forms, holes, loops, dynamic
+  modules) and which media adapter it uses (see Site compatibility).
 - A Git repository (GitHub, GitLab, Bitbucket, or self-hosted) to hold the publish
   slot. Keep it separate from your application repo.
 - A DeployHQ account and one of:
@@ -74,24 +80,29 @@ origin.
 ## Step 1 — Push the publish slot to Git
 
 Sync the slot into a clean deploy repository and push. Exclude `.git` so the
-`--delete` pass does not wipe the repository's own metadata. On the box that runs
-Instatic (or a CI job with access to the CMS `UPLOADS_DIR`):
+`--delete` pass does not wipe the repository's own metadata, and let real commit
+failures abort the job instead of silently deploying the previous release. On the box
+that runs Instatic (or a CI job with access to the CMS `UPLOADS_DIR`):
 
 ```bash
 # one-time
 git clone git@github.com:you/your-site-published.git deploy && cd deploy
 
 # each publish
+set -euo pipefail
 rsync -a --delete --exclude='.git' "$UPLOADS_DIR/published/current/" ./
 git add -A
-git commit -m "Publish $(date -u +%FT%TZ)" || echo "nothing changed"
-git push
+if git diff --cached --quiet; then
+  echo "nothing to publish"
+else
+  git commit -m "Publish $(date -u +%FT%TZ)"
+  git push
+fi
 ```
 
 The slot includes a `404.html` (the Netlify/GitHub-Pages convention) so hosts that
-fall back on 404 keep working. Media is **not** copied here — it is served from the
-CMS via routing (Step 3/4), which avoids shipping non-public objects from
-`UPLOADS_DIR`.
+fall back on 404 keep working. Dynamic endpoints are **not** copied here — they are
+served from the CMS via routing (Step 3/4).
 
 > Want to build assets on the way out (minify, fingerprint, generate a sitemap)?
 > Add those steps to a
@@ -113,7 +124,7 @@ server in DeployHQ with the deploy path your web server serves (for example
 in, so visitors never see a half-written directory.
 
 A web server resolves Instatic's `about.html` / `posts/hello.html` layout natively
-and can proxy media to the CMS. With nginx:
+and can proxy the dynamic endpoints to the CMS. With nginx:
 
 ```txt
 location / {
@@ -121,13 +132,20 @@ location / {
 }
 error_page 404 /404.html;
 
-# route media to the CMS (skip if you use a public-url object-storage adapter)
-location /uploads/         { proxy_pass https://cms.internal; }
-location /_instatic/media/ { proxy_pass https://cms.internal; }   # signed-redirect adapters
+# keep the editor/admin surface private
+location = /_instatic/mcp { return 404; }
+location /admin/          { return 404; }
+
+# route dynamic endpoints to the CMS
+# (skip /uploads if you use a public-url object-storage adapter,
+#  and skip /_instatic entirely if the site is fully static)
+location /uploads/   { proxy_pass https://cms.internal; }
+location /_instatic/ { proxy_pass https://cms.internal; }
 ```
 
-Caddy: `try_files {path} {path}.html {path}/index.html` with `handle_errors` serving
-`/404.html`, plus `reverse_proxy /uploads/* /_instatic/media/* https://cms.internal`.
+Caddy is equivalent: `try_files {path} {path}.html {path}/index.html`, `handle_errors`
+serving `/404.html`, `respond /_instatic/mcp* 404`, and
+`reverse_proxy /uploads/* /_instatic/* https://cms.internal`.
 
 ## Step 4 — Or deploy to a bucket + CDN
 
@@ -142,8 +160,9 @@ Cloudflare Worker, or equivalent):
 - `/` and paths ending `/` → append `index.html`
 - any other extensionless path → append `.html`
 - unmatched → serve `404.html`
-- `/uploads/*` and `/_instatic/media/*` → route to the CMS origin (skip only for a
-  `public-url` object-storage adapter, whose media is already on a public URL)
+- `/uploads/*` and the public `/_instatic/*` runtime routes → route to the CMS origin
+  (skip `/uploads` for a `public-url` adapter; skip `/_instatic` for a fully static
+  site). **Do not** route `/admin/*` or `/_instatic/mcp` to the public CDN.
 
 ## Step 5 — Post-deploy hooks (optional)
 
@@ -166,9 +185,10 @@ instant pointer swap, not a re-upload.
 - **The CMS host and the public host are different origins.** `PUBLIC_ORIGIN` on the
   CMS configures the origins its CSRF check trusts (where you reach the admin) — it is
   not the public URL of the static site. After the first publish, open the deployed
-  site and confirm links, images, and any sitemap resolve against the public host.
-- **Media and dynamic holes** are what break silently across origins — re-read Site
-  compatibility if an image 404s or a region stays blank.
+  site and confirm links, images, forms, and any sitemap resolve against the public
+  host.
+- **Dynamic endpoints are what break silently across origins** — re-read Site
+  compatibility if an image 404s, a form fails to submit, or a region stays blank.
 
 ## Troubleshooting
 
@@ -176,7 +196,8 @@ instant pointer swap, not a re-upload.
 |---|---|
 | Nothing deploys after publish | Step 1 actually committed and pushed; DeployHQ is watching that branch |
 | Pages 404 on a bucket, homepage works | Extensionless routes need the Step 4 CDN rewrite to `.html` |
-| Images / fonts / plugin assets 404 | `/uploads/*` (and `/_instatic/media/*` for signed-redirect) not routed to the CMS |
+| Images / fonts / plugin assets 404 | `/uploads/*` (or `/_instatic/media/*` for signed-redirect) not routed to the CMS |
+| Forms don't submit / load-more does nothing | `/_instatic/form/*` and `/_instatic/loop/*` not routed to the CMS |
 | A region renders blank / stuck on placeholder | Dynamic hole node calling `/_instatic/hole/*` on an origin with no CMS — see Site compatibility |
 | Old pages still served | CDN cache not purged — add the Step 5 post-deploy hook |
 

--- a/docs/deployment/deployhq.md
+++ b/docs/deployment/deployhq.md
@@ -1,0 +1,136 @@
+# Publish Static Output with DeployHQ
+
+Instatic runs the editor and content engine on your own server, but everything a
+visitor sees is plain static HTML and CSS written to `published/current`. That
+output is a perfect fit for a separate, fast public host: keep the CMS private
+(behind auth, on a small box) and serve the published site from a CDN-backed
+bucket or a hardened web server.
+
+[DeployHQ](https://www.deployhq.com/?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=intro-link)
+automates that last hop. It watches a Git repository, uploads only the files that
+changed, and gives you [atomic, zero-downtime deployments](https://www.deployhq.com/features/zero-downtime-deployments?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=zero-downtime-link)
+with [one-click rollback](https://www.deployhq.com/features/one-click-rollback?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=rollback-link)
+if a publish goes wrong. This guide covers the static-output path — it does **not**
+replace [vps.md](vps.md), which is how you run the CMS server itself.
+
+## TL;DR
+
+| Target | Use when | DeployHQ mode | Persistent storage |
+|---|---|---|---|
+| S3 / R2 / Spaces bucket | Public site served from a CDN, lowest ops | [Static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-link) | Bucket (managed) |
+| Your own web server | You already run nginx/Caddy on a VPS | [SSH/SFTP deployment](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-link) | Server disk |
+
+Both paths deploy from the same Git repository of published files and both support
+post-deploy hooks (for example, purging a CDN cache).
+
+## How it fits
+
+```txt
+Instatic (private)          Git repo                 Public host
+┌──────────────────┐        ┌──────────────┐         ┌──────────────────┐
+│ edit + publish   │  push  │ published    │ DeployHQ│ S3 / R2 / Spaces │
+│ published/current├───────▶│ static files ├────────▶│  or  web server  │
+└──────────────────┘        └──────────────┘         └──────────────────┘
+```
+
+DeployHQ deploys **from Git**, so the one piece of glue you provide is getting the
+contents of `published/current` into a repository. That is a small, boring step —
+see below.
+
+## Prerequisites
+
+- An Instatic instance that publishes to `published/current` (any of the
+  [deployment](README.md) targets).
+- A Git repository (GitHub, GitLab, Bitbucket, or self-hosted) to hold the
+  published output. Keep it separate from your application repo.
+- A DeployHQ account and one of:
+  - an S3-compatible bucket (AWS S3, Cloudflare R2, DigitalOcean Spaces), or
+  - a server you can reach over SSH/SFTP.
+
+## Step 1 — Get the published output into Git
+
+Sync `published/current` into a clean deploy repository and push. On the box that
+runs Instatic (or a CI job that has access to the published volume):
+
+```bash
+# one-time
+git clone git@github.com:you/your-site-published.git deploy && cd deploy
+
+# each publish
+rsync -a --delete /path/to/instatic/published/current/ ./
+git add -A
+git commit -m "Publish $(date -u +%FT%TZ)" || echo "nothing changed"
+git push
+```
+
+Run it on a schedule, on a webhook after you publish in Instatic, or by hand — the
+mechanism does not matter to DeployHQ, only that new commits land on the branch it
+watches.
+
+> Prefer to build assets on the way out (minify, fingerprint, generate a sitemap)?
+> Point DeployHQ at this repo and add those steps to a
+> [build pipeline](https://www.deployhq.com/features/build-pipelines?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=build-pipeline-link),
+> which runs in an isolated container before anything is uploaded.
+
+## Step 2 — Connect the repository to DeployHQ
+
+1. Create a new DeployHQ project and connect the published repository.
+2. Set the branch DeployHQ deploys from (for example, `main`).
+3. Enable automatic deployments so every push publishes without a manual click.
+
+## Step 3 — Choose a deployment target
+
+**Bucket + CDN (recommended for public sites).** Configure a
+[static hosting](https://www.deployhq.com/features/static-hosting?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=static-hosting-target)
+destination pointing at your S3, R2, or Spaces bucket. DeployHQ uploads only the
+changed files, so publishes stay fast even on a large site. Front it with a CDN and
+point your public domain at the CDN.
+
+**Your own web server.** Add an
+[SSH/SFTP](https://www.deployhq.com/features/ssh-deployment?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-deployment-target)
+server in DeployHQ with the deploy path your web server serves (for example,
+`/var/www/site`). Deployments are atomic — the new release is assembled and swapped
+in, so visitors never see a half-written directory.
+
+## Step 4 — Post-deploy hooks (optional)
+
+To purge a CDN cache or ping a health check after each publish, add a
+[post-deploy SSH command](https://www.deployhq.com/support/ssh-commands?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=ssh-commands-link).
+DeployHQ can run commands before files change, after upload but before the release
+goes live, and after the release is live.
+
+## Rollback
+
+If a publish ships broken markup, use
+[one-click rollback](https://www.deployhq.com/features/one-click-rollback?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=rollback-target)
+to redeploy the previous release. Because deployments are atomic, rollback is an
+instant pointer swap, not a re-upload.
+
+## Runtime notes
+
+- **This deploys output, not state.** Your Instatic database and uploads volume
+  still live with the CMS server — back them up per [backup-restore.md](backup-restore.md).
+- **The CMS host and the public host are different origins.** `PUBLIC_ORIGIN` on
+  the CMS configures the origins its CSRF check trusts (where you reach the admin) —
+  it is not the public URL of the static site. After the first publish, open the
+  deployed site and confirm internal links, assets, and any sitemap resolve against
+  your public host; fix absolute URLs at their source in Instatic, not in DeployHQ.
+- **Uploaded media** under the published output ships with the static files; media
+  you reference from outside `published/current` must be reachable from the public
+  origin.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| Nothing deploys after publish | The sync step in Step 1 actually committed and pushed; DeployHQ is watching that branch |
+| Old pages still served | CDN cache not purged — add the post-deploy hook in Step 4 |
+| Links or assets point at the wrong host | Absolute URLs in the output reference the CMS origin — correct them at the source in Instatic |
+| Deploy uploads everything every time | Line-ending or timestamp churn in the deploy repo; commit only real content changes |
+
+## Related
+
+- [vps.md](vps.md) — run the Instatic CMS server itself
+- [backup-restore.md](backup-restore.md) — protect database and uploads
+- [Deploy a static site with DeployHQ](https://www.deployhq.com/guides/hugo?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=related-guide) — worked example (Hugo, same pattern)
+- [Start deploying free](https://www.deployhq.com/signup?utm_source=instatic-docs&utm_medium=referral&utm_campaign=instatic-integration&utm_content=signup-cta) — create a DeployHQ account


### PR DESCRIPTION
Add a deployment guide for publishing Instatic's static output with DeployHQ.

Instatic writes clean static HTML/CSS to `published/current`. This adds
`docs/deployment/deployhq.md`, a guide for serving that output from a separate
public host — an S3/R2/Spaces bucket behind a CDN, or your own web server over
SSH/SFTP — while the CMS stays private. It complements `vps.md` (which runs the CMS
server) rather than replacing it, and it slots into the existing
`docs/deployment/` format (TL;DR table → steps → Runtime notes → Troubleshooting →
Related).

It also registers the guide in the deployment index (`README.md` → Docs Inventory).

The guide is honest about the one seam DeployHQ needs: it deploys from Git, so
there's a small sync step to get `published/current` into a deploy repo. No claims
are made about Instatic internals beyond the documented runtime contract.

Disclosure: I work on DeployHQ. Happy to adjust scope, wording, or placement — or
drop it entirely if it's not a fit for the docs.
