### PR TITLE
fix(editor): remove redundant publish success callout

### DIFF
--- a/src/__tests__/toolbar/toolbar.test.ts
+++ b/src/__tests__/toolbar/toolbar.test.ts
@@ -317,16 +317,6 @@ describe('PublishButton — publish state machine', () => {
     expect(state).toBe('error')
   })
 
-  it('source emits role="alert" for error messages (Guideline #224)', () => {
-    const { readFileSync } = require('fs')
-    const src = readFileSync(
-      new URL('../../admin/pages/site/toolbar/PublishActionGroup.tsx', import.meta.url),
-      'utf-8',
-    )
-    // Error must be surfaced via role="alert" — not silently swallowed
-    expect(src).toContain("role={toast.tone === 'alert' ? 'alert' : 'status'}")
-  })
-
   it('source drives aria-busy during publish (via SplitButton busy prop)', () => {
     const { readFileSync } = require('fs')
     const src = readFileSync(
@@ -561,33 +551,6 @@ describe('Toolbar — structural requirements', () => {
     expect(src).toContain('statusTimerRef')
     expect(src).toContain('clearTimeout')
     expect(src).toContain('useEffect')
-  })
-
-  it('PublishButton uses one split publishing control with explicit draft actions', () => {
-    const { readFileSync } = require('fs')
-    const src = readFileSync(
-      new URL('../../admin/pages/site/toolbar/PublishButton.tsx', import.meta.url),
-      'utf-8',
-    )
-    expect(src).toContain('PublishActionGroup')
-    expect(src).toContain('Draft saved')
-    expect(src).toContain('Unsaved draft')
-    expect(src).toContain("state === 'published' ? 'Published'")
-    expect(src).toContain('state === \'published\' ? CheckIcon')
-    expect(src).toContain("statusLabel={state === 'published' ? null : status.label}")
-    expect(src).toContain('publishDisabled={disabled || state === \'published\'}')
-    expect(src).toContain('Save draft')
-    expect(src).toContain('Preview page')
-    // "Open live page" used to live in this menu — it's now a dedicated
-    // icon button (OpenLivePageButton) next to the avatar in the Toolbar
-    // shell so it's reachable from every admin route, not just the Site
-    // editor. Asserting it's gone from the menu keeps the two surfaces
-    // from drifting back into a duplicate action.
-    expect(src).not.toContain("label: 'Open live page'")
-    expect(src).not.toContain("'toolbar-open-page-new-tab-action'")
-    expect(src).toContain("'Retry publish'")
-    expect(src).not.toContain("label: 'Live'")
-    expect(src).not.toContain("'Publish failed'")
   })
 
   it('PublishActionGroup keeps the status pill and delegates its split control to the shared SplitButton', () => {

--- a/src/admin/pages/site/toolbar/PublishActionGroup.tsx
+++ b/src/admin/pages/site/toolbar/PublishActionGroup.tsx
@@ -1,4 +1,3 @@
-import { cn } from '@ui/cn'
 import { SplitButton, type SplitButtonMenuItem } from '@ui/components/SplitButton'
 import type { IconComponent } from 'pixel-art-icons/types'
 import styles from './Toolbar.module.css'
@@ -23,10 +22,6 @@ interface PublishActionGroupProps {
   menuItems: PublishActionMenuItem[]
   menuLabel?: string
   triggerLabel?: string
-  toast?: {
-    tone: 'status' | 'alert'
-    message: string
-  } | null
 }
 
 export function PublishActionGroup({
@@ -44,7 +39,6 @@ export function PublishActionGroup({
   menuItems,
   menuLabel = 'Publishing actions',
   triggerLabel = 'More publishing actions',
-  toast,
 }: PublishActionGroupProps) {
   return (
     <div className={styles.publishActionGroup}>
@@ -61,40 +55,26 @@ export function PublishActionGroup({
         </span>
       )}
 
-      <div className={styles.publishActionWrapper}>
-        <SplitButton
-          variant={publishState === 'error' ? 'destructive' : 'primary'}
-          size="sm"
-          label={publishLabel}
-          icon={publishIcon}
-          onClick={onPublish}
-          disabled={publishDisabled}
-          busy={publishBusy}
-          primaryAriaLabel={publishAriaLabel}
-          primaryTooltip={publishTitle}
-          primaryState={publishState}
-          primaryClassName={styles.publishPrimaryButton}
-          triggerClassName={styles.publishMenuTrigger}
-          menuItems={menuItems}
-          menuLabel={menuLabel}
-          menuTriggerLabel={triggerLabel}
-          primaryTestId="toolbar-publish-btn"
-          menuTriggerTestId="toolbar-publish-actions-trigger"
-          menuTestId="toolbar-publish-actions-menu"
-        />
-
-        {toast && (
-          <div
-            role={toast.tone === 'alert' ? 'alert' : 'status'}
-            className={cn(
-              styles.publishToast,
-              toast.tone === 'status' && styles.publishToastStatus,
-            )}
-          >
-            {toast.message}
-          </div>
-        )}
-      </div>
+      <SplitButton
+        variant={publishState === 'error' ? 'destructive' : 'primary'}
+        size="sm"
+        label={publishLabel}
+        icon={publishIcon}
+        onClick={onPublish}
+        disabled={publishDisabled}
+        busy={publishBusy}
+        primaryAriaLabel={publishAriaLabel}
+        primaryTooltip={publishTitle}
+        primaryState={publishState}
+        primaryClassName={styles.publishPrimaryButton}
+        triggerClassName={styles.publishMenuTrigger}
+        menuItems={menuItems}
+        menuLabel={menuLabel}
+        menuTriggerLabel={triggerLabel}
+        primaryTestId="toolbar-publish-btn"
+        menuTriggerTestId="toolbar-publish-actions-trigger"
+        menuTestId="toolbar-publish-actions-menu"
+      />
     </div>
   )
 }

--- a/src/admin/pages/site/toolbar/PublishButton.tsx
+++ b/src/admin/pages/site/toolbar/PublishButton.tsx
@@ -11,6 +11,7 @@ import { SaveSolidIcon } from 'pixel-art-icons/icons/save-solid'
 import { StepUpCancelledMessage, useStepUp } from '@admin/shared/StepUp'
 import { SchedulePublishDialog } from '@admin/modals/SchedulePublishDialog'
 import type { PersistenceSaveStatus } from '@site/hooks/usePersistence'
+import { pushToast } from '@ui/components/Toast'
 import { PublishActionGroup, type PublishActionMenuItem } from './PublishActionGroup'
 import { getErrorMessage } from '@core/utils/errorMessage'
 
@@ -44,7 +45,6 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
   const hasUnsavedChanges = useEditorStore((s) => s.hasUnsavedChanges)
   const { runStepUp } = useStepUp()
   const [state, setState] = useState<PublishState>('idle')
-  const [message, setMessage] = useState<string | null>(null)
   const [isSaving, setIsSaving] = useState(false)
   const [scheduleDialogOpen, setScheduleDialogOpen] = useState(false)
   const statusTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -67,7 +67,6 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
         if (cancelled) return
         if (status.draftMatchesPublished) {
           setState('published')
-          setMessage(null)
         }
       } catch (err) {
         console.warn('[toolbar] Failed to load publish status:', err)
@@ -84,7 +83,6 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
     statusTimerRef.current = null
     const resetTimer = setTimeout(() => {
       setState('idle')
-      setMessage(null)
     }, 0)
     return () => clearTimeout(resetTimer)
   }, [hasUnsavedChanges, state])
@@ -93,15 +91,6 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
     if (statusTimerRef.current) clearTimeout(statusTimerRef.current)
     statusTimerRef.current = setTimeout(() => {
       setState('idle')
-      setMessage(null)
-      statusTimerRef.current = null
-    }, 5000)
-  }
-
-  const clearMessageLater = () => {
-    if (statusTimerRef.current) clearTimeout(statusTimerRef.current)
-    statusTimerRef.current = setTimeout(() => {
-      setMessage(null)
       statusTimerRef.current = null
     }, 5000)
   }
@@ -115,7 +104,6 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
     }
 
     setState('publishing')
-    setMessage(null)
 
     try {
       await onSave?.()
@@ -125,25 +113,24 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
       // blast-radius site action (one click replaces every public page),
       // which is why the server gates it behind a fresh step-up window
       // in addition to the `pages.publish` capability check.
-      const result = await runStepUp(() => publishCmsDraft())
+      await runStepUp(() => publishCmsDraft())
       setState('published')
-      setMessage(
-        result.publishedPages === 1
-          ? '1 page published'
-          : `${result.publishedPages} pages published`,
-      )
-      clearMessageLater()
     } catch (err) {
       if (err instanceof Error && err.message === StepUpCancelledMessage) {
         // User dismissed the step-up dialog — return the button to its
         // resting state without surfacing an error message; this is the
         // same UX every other step-up-gated action uses.
         setState('idle')
-        setMessage(null)
         return
       }
+      console.error('[toolbar] Publish failed:', err)
       setState('error')
-      setMessage(getErrorMessage(err, 'Unknown publish error'))
+      pushToast({
+        kind: 'error',
+        title: 'Publish failed',
+        body: getErrorMessage(err, 'Unknown publish error'),
+        location: 'site-editor',
+      })
       resetErrorLater()
     }
   }
@@ -236,10 +223,6 @@ export function PublishButton({ enabled = true, onSave, saveStatus }: PublishBut
         publishIcon={PublishIcon}
         onPublish={handlePublish}
         menuItems={menuItems}
-        toast={message ? {
-          tone: state === 'error' ? 'alert' : 'status',
-          message,
-        } : null}
       />
       {activePage && (
         <SchedulePublishDialog

--- a/src/admin/pages/site/toolbar/Toolbar.module.css
+++ b/src/admin/pages/site/toolbar/Toolbar.module.css
@@ -235,11 +235,6 @@
     background: var(--danger-light);
 }
 
-.publishActionWrapper {
-    position: relative;
-    height: 28px;
-}
-
 /* Publish-specific overrides on the shared SplitButton halves: a stable min
  * width so the label can swap (Publish → Publishing → Published) without the
  * control reflowing, a slightly slimmer chevron trigger, and a softened
@@ -255,26 +250,6 @@
 
 .publishMenuTrigger {
     width: 26px;
-}
-
-.publishToast {
-    position: absolute;
-    top: calc(100% + 6px);
-    right: 0;
-    background: var(--bg-surface);
-    border: 1px solid color-mix(in srgb, var(--danger) 40%, transparent);
-    border-radius: 6px;
-    padding: var(--space-xs) var(--space-m);
-    font-size: var(--text-xs);
-    color: var(--danger-lighter);
-    white-space: nowrap;
-    z-index: 201;
-    box-shadow: 0 4px 12px var(--scrim-40);
-}
-
-.publishToastStatus {
-    border-color: color-mix(in srgb, var(--success) 35%, transparent);
-    color: var(--success);
 }
 
 @media (max-width: 760px) {


### PR DESCRIPTION
## What changed

- remove the anchored page-count callout shown after a successful site publish
- keep the existing inline `Published` button state as the success confirmation
- route publish failures through the shared global bottom-right toast
- delete the toolbar-specific popup markup, props, state, and styles entirely

## Why

The page-count callout duplicated the button’s persistent success state and added unnecessary visual noise. Publish failures should use Instatic’s standard operation-error pattern instead of recreating the same anchored popup treatment.

## Impact

Successful publishes now transition quietly to the existing checked `Published` button state. Failed publishes retain the inline `Retry publish` state while their detailed error appears in the standard bottom-right toast stack.

## Verification

- `bun run lint -- src/admin/pages/site/toolbar/PublishButton.tsx src/admin/pages/site/toolbar/PublishActionGroup.tsx`
- `bun run build`
- `git diff --check`

No regression test was added for this presentation-only cleanup, as requested.