### PR TITLE
fix(dashboard): stop onboarding calling a seeded site's page step Not started

### DIFF
--- a/docs/e2e/feature-matrix.md
+++ b/docs/e2e/feature-matrix.md
@@ -97,7 +97,7 @@ DASH-001 note: `dashboard.e2e.ts` verifies the default owner dashboard route, Ov
 
 DASH-002 note: `dashboard.e2e.ts` verifies customize mode, the Block library, adding the built-in AI usage widget, server-backed `dashboard-layout` preference persistence, reload restoration, grid drag move, right-edge resize, drag-to-library removal, final reload absence, and 390px customize/library containment. DEF-20260623-DASH002-01 fixed invalid nested buttons in Block library live previews by rendering preview widget chrome in edit mode.
 
-DASH-003 note: `dashboard.e2e.ts` runs in a dedicated post-setup, pre-persona project and verifies onboarding progress from genuinely clean E2E state (1/5: identity complete; framework in progress; first page, plugin, and team not started), all five step labels/actions, the Settings modal action, workspace routes for New page/Browse plugins/Add members, 390px mobile containment, and server-backed dismiss persistence through `dashboard-layout`.
+DASH-003 note: `dashboard.e2e.ts` runs in a dedicated post-setup, pre-persona project and verifies onboarding progress from genuinely clean E2E state (1/5: identity complete; framework and first page in progress; plugin and team not started), all five step labels/actions, the Settings modal action, workspace routes for New page/Browse plugins/Add members, 390px mobile containment, and server-backed dismiss persistence through `dashboard-layout`.
 
 ## Capabilities And Access Control
 

--- a/docs/features/dashboard.md
+++ b/docs/features/dashboard.md
@@ -265,11 +265,11 @@ Each CMS hook fetches on mount through `useAsyncResource` + `apiRequest`, valida
 
 - [ ] Set site identity
 - [ ] Choose Core Framework import
-- [ ] Create your first page
+- [ ] Add a page of your own
 - [ ] Install a plugin
 - [ ] Invite your team
 
-State lives in `useOnboardingState(...)`. It reads the current site, installed plugins, and users concurrently. The seed Home page does not satisfy "Create your first page"; that step flips done when the site has at least two pages. Framework import defaults to `active` until the user picks a framework mode.
+State lives in `useOnboardingState(...)`. It reads the current site, installed plugins, and users concurrently. The seeded Home page does not satisfy "Add a page of your own"; that step flips done when the site has at least two pages, and reads `active` while only the seed exists so the checklist never reports "Not started" for a site that already has a live page. Framework import defaults to `active` until the user picks a framework mode.
 
 The panel is dismissible per-user and persisted with the dashboard layout preference (`dashboard-layout`). `useDashboardLayout.restoreOnboarding()` flips the same preference flag back to visible.
 

--- a/src/admin/pages/dashboard/components/OnboardingPanel.tsx
+++ b/src/admin/pages/dashboard/components/OnboardingPanel.tsx
@@ -83,9 +83,9 @@ const STEPS: readonly StepDef[] = [
   },
   {
     id: 'firstPage',
-    title: 'Create your first page',
+    title: 'Add a page of your own',
     desc:
-      'Start from a blank canvas, a starter layout, or import HTML and we will scaffold a tree.',
+      'Beyond the starter Home page — begin from a blank canvas, a starter layout, or import HTML and we will scaffold a tree.',
     cta: 'New page',
     icon: FileTextSolidIcon,
     action: { kind: 'navigate', to: '/admin/site' },

--- a/src/admin/pages/dashboard/hooks/useOnboardingState.ts
+++ b/src/admin/pages/dashboard/hooks/useOnboardingState.ts
@@ -7,8 +7,10 @@
  *   • Framework import — derived from `site.settings.framework` being
  *     populated. Defaults to `'active'` so the user is nudged to make a
  *     deliberate decision; once they pick a mode the step flips to done.
- *   • First page — done when ≥ 2 pages exist (the seed Home page
- *     doesn't count).
+ *   • First page — done when ≥ 2 pages exist (the seeded Home page
+ *     doesn't count). While only the seed exists the step reads
+ *     'active', not 'todo': the site already has a page, so "Not
+ *     started" would contradict the Pages widget's published count.
  *   • First plugin — done when any plugin is installed.
  *   • Team — done when more than the owner is in the users table.
  *
@@ -71,7 +73,7 @@ export function useOnboardingState(): OnboardingStateResult {
       loading: false,
       identity: hasIdentity || hasFavicon ? 'done' : 'active',
       framework: hasFramework ? 'done' : 'active',
-      firstPage: pageCount >= 2 ? 'done' : 'todo',
+      firstPage: pageCount >= 2 ? 'done' : pageCount >= 1 ? 'active' : 'todo',
       plugin: plugins.length > 0 ? 'done' : 'todo',
       team: users.length > 1 ? 'done' : 'todo',
     }

--- a/tests/e2e/dashboard.e2e.ts
+++ b/tests/e2e/dashboard.e2e.ts
@@ -212,7 +212,7 @@ test.describe('dashboard', () => {
 
     await expectOnboardingStep(panel, 'Set site identity', 'Completed', 'Open settings')
     await expectOnboardingStep(panel, 'Choose Core Framework import', 'In progress', 'Import')
-    await expectOnboardingStep(panel, 'Create your first page', 'Not started', 'New page')
+    await expectOnboardingStep(panel, 'Add a page of your own', 'In progress', 'New page')
     await expectOnboardingStep(panel, 'Install a plugin', 'Not started', 'Browse plugins')
     await expectOnboardingStep(panel, 'Invite your team', 'Not started', 'Add members')
 


### PR DESCRIPTION
## Summary

On a fresh install Instatic seeds a Home page, so `site.pages.length` is 1. The
onboarding checklist's third step flips to done only at 2 pages — the seeded page
deliberately does not count — but it was labelled **"Create your first page"** and
reported **"Not started"**. A user who edited and published the seeded Home page
therefore saw the Pages widget report `1 Published` next to a checklist step
insisting no page existed (#223).

The two-page rule itself is right: the step's intent is a page the user made. What
was wrong was that neither the label nor the state said so.

- `OnboardingPanel` step 3 now reads **"Add a page of your own"** and its description
  says the starter Home page does not count.
- `useOnboardingState` reports `active` ("In progress") instead of `todo`
  ("Not started") while the seed is the only page, matching how the identity and
  framework steps already use `active` as their nudge state.

No change to when the step completes, so the "N of 5 steps complete" count is
unaffected.

Closes #223

## Verification

- [x] `bun run build`
- [x] `bun test`
- [x] `bun run lint`
- [ ] Docker/deployment check, if relevant — not applicable

`tsc -b` and `vite build` clean; `eslint` clean on the changed files; the dashboard,
admin, editor and panel suites pass. `dashboard.e2e.ts` (DASH-003) is updated to
expect the new label and state — that assertion is the behaviour coverage — but the
Playwright run itself is left to CI.

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.