### PR TITLE
fix(editor): let link and button URLs take data tokens and relative p…

### DIFF
--- a/src/__tests__/property-controls/bindingCompatibility.test.ts
+++ b/src/__tests__/property-controls/bindingCompatibility.test.ts
@@ -106,8 +106,16 @@ describe('isFieldBindable', () => {
     expect(isFieldBindable('url', metaField('f', 'email'))).toBe(true)
   })
 
+  it('url + text → true (a slug composes into an href token)', () => {
+    expect(isFieldBindable('url', metaField('f', 'text'))).toBe(true)
+  })
+
   it('url + boolean → false', () => {
     expect(isFieldBindable('url', metaField('f', 'boolean'))).toBe(false)
+  })
+
+  it('url + richText → false (markup is not a URL fragment)', () => {
+    expect(isFieldBindable('url', metaField('f', 'richText'))).toBe(false)
   })
 
   it('group + text → false (group has no bindings)', () => {

--- a/src/__tests__/utils/urlValidation.test.ts
+++ b/src/__tests__/utils/urlValidation.test.ts
@@ -60,17 +60,48 @@ describe('isValidUrl', () => {
     })
   })
 
+  describe('relative references', () => {
+    it('accepts a root-relative path', () => {
+      expect(isValidUrl('/relative/path')).toBe(true)
+    })
+
+    it('accepts document-relative paths', () => {
+      expect(isValidUrl('./sibling.html')).toBe(true)
+      expect(isValidUrl('../parent/page')).toBe(true)
+      expect(isValidUrl('page.html')).toBe(true)
+    })
+
+    it('accepts in-page anchors and query-only references', () => {
+      expect(isValidUrl('#section')).toBe(true)
+      expect(isValidUrl('?q=1')).toBe(true)
+    })
+
+    it('accepts protocol-relative URLs', () => {
+      expect(isValidUrl('//example.com')).toBe(true)
+    })
+  })
+
+  describe('data tokens', () => {
+    it('accepts a bare token', () => {
+      expect(isValidUrl('{currentEntry.permalink}')).toBe(true)
+    })
+
+    it('accepts a token composed into a relative path', () => {
+      expect(isValidUrl('/blog/{currentEntry.slug}')).toBe(true)
+    })
+
+    it('accepts a token composed into an absolute URL', () => {
+      expect(isValidUrl('https://example.com/{currentEntry.slug}')).toBe(true)
+    })
+  })
+
   describe('malformed input', () => {
-    it('rejects plain text without protocol', () => {
+    it('rejects plain text containing spaces', () => {
       expect(isValidUrl('not a url')).toBe(false)
     })
 
-    it('rejects relative paths', () => {
-      expect(isValidUrl('/relative/path')).toBe(false)
-    })
-
-    it('rejects protocol-relative URLs', () => {
-      expect(isValidUrl('//example.com')).toBe(false)
+    it('rejects a relative path containing whitespace', () => {
+      expect(isValidUrl('/relative/pa th')).toBe(false)
     })
   })
 })
@@ -175,6 +206,12 @@ describe('isValidImageUrl', () => {
       const url = 'data:image/png;base64,abc='
       expect(isValidUrl(url)).toBe(false)
       expect(isValidImageUrl(url)).toBe(true)
+    })
+
+    it('relative references are valid for isValidUrl but not isValidImageUrl', () => {
+      const url = '/images/photo.png'
+      expect(isValidUrl(url)).toBe(true)
+      expect(isValidImageUrl(url)).toBe(false)
     })
   })
 })

--- a/src/admin/pages/site/property-controls/DynamicBindingControl/helpers.ts
+++ b/src/admin/pages/site/property-controls/DynamicBindingControl/helpers.ts
@@ -44,7 +44,10 @@ export function loopFieldMatchesControl(
     case 'textarea':
       return field.format !== 'media' && field.format !== 'html'
     case 'url':
-      return field.format === 'url' || field.format === 'media'
+      // Same reasoning as BINDING_COMPATIBILITY.url: token insertion builds the
+      // href as a string, so plain-text synthetics (`slug`, `publishedAt`, …)
+      // are valid path segments. Only html is excluded.
+      return field.format !== 'html'
     case 'number':
     case 'toggle':
     case 'color':

--- a/src/admin/pages/site/property-controls/bindingCompatibility.ts
+++ b/src/admin/pages/site/property-controls/bindingCompatibility.ts
@@ -48,7 +48,12 @@ export const BINDING_COMPATIBILITY: Record<PropertyControlKind, readonly DataFie
   // to a data field.
   svg:      [],
   number:   ['number'],
-  url:      ['url', 'email'],
+  // url binds in token mode: the picker inserts `{source.field}` into the href
+  // string, so any scalar that reads as a path segment is a legitimate source —
+  // linking a loop row to its template page means composing the URL out of the
+  // row's `slug` (a plain text field). richText is excluded (markup is not a
+  // URL fragment), as are multiSelect (comma-joined) and boolean.
+  url:      ['url', 'email', 'text', 'longText', 'select', 'relation', 'number', 'date', 'dateTime'],
   color:    [],
   toggle:   ['boolean'],
   select:   [],

--- a/src/core/utils/urlValidation.ts
+++ b/src/core/utils/urlValidation.ts
@@ -12,7 +12,8 @@
  * scheme is — they differ only in which schemes they accept.
  *
  * Allowlists:
- *   isValidUrl()       — https, http, mailto
+ *   isValidUrl()       — https, http, mailto, plus every schemeless (relative)
+ *                        form, matching what `isSafeUrl()` lets through
  *   isValidImageUrl()  — https, http, data:image/* (inline base64 images)
  */
 
@@ -44,15 +45,31 @@ function parses(v: string): boolean {
  * Returns true if `v` is a safe general-purpose URL for storing in site
  * props (e.g. a link href, a button href).
  *
- * Allows:  https:, http:, mailto:
- * Rejects: javascript:, data:, ftp:, blob:, custom schemes, schemeless values,
- *          and malformed absolute URLs (`http://`, `https://exa mple.com`)
+ * Allows:  https:, http:, mailto:, and every schemeless (relative) reference —
+ *          `/a`, `./a`, `../a`, `a.html`, `#anchor`, `?q=1`, `//cdn/x` — plus
+ *          values carrying `{source.field}` tokens the publisher interpolates
+ *          (`/blog/{currentEntry.slug}`)
+ * Rejects: javascript:, data:, ftp:, blob:, custom schemes, malformed absolute
+ *          URLs (`http://`, `https://exa mple.com`), and any value containing
+ *          whitespace
+ *
+ * Relative references are accepted because `isSafeUrl()` — the enforcement gate
+ * this one is the input-side counterpart to — accepts every relative form, and
+ * internal links, in-page anchors and data-token hrefs are all schemeless by
+ * nature. Rejecting them here left those values unsavable in the editor even
+ * though the publisher would happily emit them.
  */
 export function isValidUrl(v: string): boolean {
   if (!v) return true
   const scheme = urlScheme(v)
-  if (scheme !== 'https:' && scheme !== 'http:' && scheme !== 'mailto:') return false
-  return parses(v)
+  if (scheme !== null) {
+    if (scheme !== 'https:' && scheme !== 'http:' && scheme !== 'mailto:') return false
+    return parses(v)
+  }
+  // Schemeless — a relative reference. `new URL()` cannot parse one without a
+  // base, and there is no scheme to decide on, so the only well-formedness
+  // check left is whitespace, which is always a typo in a URL.
+  return !/\s/.test(v)
 }
 
 /**


### PR DESCRIPTION
## Summary

Linking a loop row to its entry page is currently impossible (#237). Two independent
gates on the `url` property control block it.

**1. The binding picker hides every text field.** `BINDING_COMPATIBILITY.url` accepted
only `url` and `email` field types, and `loopFieldMatchesControl` only the `url` and
`media` loop formats. But `getDynamicBindingMode` puts `url` in **token** mode: the
picker inserts a `{source.field}` token into the href *string*. Restricting the source
to URL-typed fields has no basis in that model, and it filters out the one field a row
detail link is built from — `slug`, a plain `text` field — leaving the author with
nothing clickable in the picker.

**2. `isValidUrl()` drops relative values.** It is the only gate `UrlControl` runs on
typed input, and it required an absolute `http`/`https`/`mailto` URL. `/about`,
`#section`, `?q=1` and `/blog/{currentEntry.slug}` all failed it, and `handleUrlChange`
only calls `onChange` when the value is valid — so the href was silently never written,
which is what the reporter saw as "the href field stays empty". The publisher's
`isSafeUrl()` accepts every relative form, so the input-boundary gate was stricter than
the enforcement gate it fronts, and its own docblock already claimed relative URLs were
supported.

Both are widened:

- `url` now accepts any scalar that reads as a path segment — `text`, `longText`,
  `select`, `relation`, `number`, `date`, `dateTime` alongside `url`/`email`.
  `richText` (markup), `multiSelect` (comma-joined) and `boolean` stay out.
  `loopFieldMatchesControl` excludes only `html` for the same reason.
- `isValidUrl` accepts schemeless references. It still rejects unsafe schemes,
  malformed absolute URLs, and any value containing whitespace — so `not a url` and
  `https://exa mple.com` remain invalid.

Closes #237

## Verification

- [x] `bun run build`
- [x] `bun test`
- [x] `bun run lint`
- [ ] Docker/deployment check, if relevant — not applicable

`tsc -b` and `vite build` clean; `eslint` clean on the changed files. 13 new unit tests
across `urlValidation.test.ts` and `bindingCompatibility.test.ts`; the publisher,
architecture, property-controls, templates and loops suites all pass, including
`single-url-scheme-guard` and `binding-compatibility-coverage`.

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed — no doc describes this matrix; the rationale is in the code comments.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.