### PR TITLE
fix(mcp): advertise the open-workspace requirement on browser tools

### DIFF
--- a/docs/features/mcp-connectors.md
+++ b/docs/features/mcp-connectors.md
@@ -135,7 +135,7 @@ MCP exposes the full deduplicated tool catalog, filtered by the connection's cap
 
 Server-resolved tools work without an editor open. They include content reads, `get_context`, `site_list_documents`, `site_read_styles`, `site_list_breakpoints`, and explicit `site_publish`. Publishing requires `ai.tools.write` plus `pages.publish`, runs the canonical full-site pipeline, swaps the static slot atomically, and records the connection id in the publish audit event.
 
-Browser tools run against the connection owner's live workspace. Site structure, HTML/CSS, page lifecycle, design-token, content mutation, code-asset, and live-DOM tools route to the matching open Site or Content workspace. If that workspace is not open, the tool returns a scope-specific error while headless tools remain available.
+Browser tools run against the connection owner's live workspace. Site structure, HTML/CSS, page lifecycle, design-token, content mutation, code-asset, and live-DOM tools route to the matching open Site or Content workspace. If that workspace is not open, the tool returns a scope-specific error while headless tools remain available. `tools/list` states that requirement in each browser tool's description, so a client learns the precondition when it picks the tool rather than from a failed call.
 
 There is intentionally no headless page-tree mutation path. The open editor store is the single source of truth for draft edits; a second DB mutation path would desynchronize node state and risk autosave overwrites. Successful relayed edits flush the draft before returning, so a following headless read or explicit publish sees the saved result.
 

--- a/server/ai/mcp/server.test.ts
+++ b/server/ai/mcp/server.test.ts
@@ -95,6 +95,23 @@ describe('mcp server', () => {
     await client.close()
   })
 
+  it('advertises the open-workspace requirement on browser tools, not on headless ones', async () => {
+    const client = await connectClient(db, ['ai.chat', 'ai.tools.write', 'site.structure.edit', 'content.manage'])
+    const { tools } = await client.listTools()
+
+    const sitePage = tools.find((t) => t.name === 'site_add_page')
+    expect(sitePage?.description).toContain('Requires the Instatic Site editor to be open')
+
+    const contentTool = tools.find((t) => t.name === 'content_set_document_field')
+    expect(contentTool?.description).toContain('Requires the Instatic Content workspace to be open')
+
+    // Headless tools must stay free of the hint — they work with no editor open.
+    const headless = tools.find((t) => t.name === 'site_read_styles')
+    expect(headless?.description).not.toContain('Requires the Instatic')
+
+    await client.close()
+  })
+
   it('routes Site and Content browser tools to their matching workspace bridges', async () => {
     const userId = 'u1-scoped-workspaces'
     const siteCtrl = new AbortController()

--- a/server/ai/mcp/server.ts
+++ b/server/ai/mcp/server.ts
@@ -46,6 +46,29 @@ const NO_WORKSPACE_MESSAGE: Record<EditorBridgeScope, string> = {
   content: 'This tool runs in the Instatic Content workspace. Open the Content workspace in a browser (signed in as the connector owner) and try again.',
 }
 
+/**
+ * Same requirement as `NO_WORKSPACE_MESSAGE`, stated up front.
+ *
+ * An MCP client picks its tools from `tools/list` and nothing else, so a
+ * browser tool that reads like a headless one gets called blind: the model
+ * only learns the editor has to be open by burning a turn on the failure. That
+ * is the wrong end of the loop to teach it from — it can neither open the
+ * editor itself nor tell from the error whether retrying is worthwhile, so it
+ * retries anyway. Advertising the precondition alongside the description lets
+ * the model ask the user to open the workspace before it spends anything.
+ */
+const BROWSER_WORKSPACE_REQUIREMENT: Record<EditorBridgeScope, string> = {
+  site: 'Requires the Instatic Site editor to be open in a browser, signed in as the connector owner; this tool edits that live workspace and cannot run headlessly.',
+  content: 'Requires the Instatic Content workspace to be open in a browser, signed in as the connector owner; this tool edits that live workspace and cannot run headlessly.',
+}
+
+/** Tool description as advertised over MCP — browser tools carry their precondition. */
+function advertisedDescription(tool: AiTool): string {
+  if (tool.execution !== 'browser') return tool.description
+  if (tool.scope !== 'site' && tool.scope !== 'content') return tool.description
+  return `${tool.description}\n\n${BROWSER_WORKSPACE_REQUIREMENT[tool.scope]}`
+}
+
 export function buildMcpServer(ctx: McpServerContext): Server {
   const server = new Server(
     { name: 'instatic', version: '1.0.0' },
@@ -63,7 +86,7 @@ export function buildMcpServer(ctx: McpServerContext): Server {
   server.setRequestHandler(ListToolsRequestSchema, async () => ({
     tools: tools.map((t) => ({
       name: t.name,
-      description: t.description,
+      description: advertisedDescription(t),
       // Our TypeBox object schema IS a valid JSON-Schema tool definition. The
       // `AiTool.inputSchema` field is the general `TSchema`, so we adapt it to
       // the SDK's object-schema shape (a type-level adaptation, not a runtime


### PR DESCRIPTION
## Summary

#235 reports `site_add_page` failing over MCP with the open-editor error, and a single
"create a page" turn burning millions of tokens.

The execution model is deliberate and this PR does not change it: browser tools are
relayed to the connector owner's live Site or Content workspace, because the open
editor store is the single source of truth for draft edits and a headless page-tree
mutation path would desync from it. That part of the report is working as designed.

What is not working as designed is discovery. `tools/list` advertised browser tools
with a description indistinguishable from a headless tool's, and an MCP client picks
its tools from that listing and nothing else. So the model calls the tool blind and
only learns the precondition from a failed turn — the worst place to learn it, since it
cannot open the editor itself and cannot tell from the error whether a retry is worth
anything, so it retries.

`tools/list` now appends the precondition to each browser tool's advertised description,
scoped to Site or Content, mirroring the existing `NO_WORKSPACE_MESSAGE`. Headless tools
are untouched.

Refs #235

## Verification

- [x] `bun run build`
- [x] `bun test`
- [x] `bun run lint`
- [ ] Docker/deployment check, if relevant — not applicable

`tsc -b` and `vite build` clean; `eslint` clean on the changed files. New test in
`server/ai/mcp/server.test.ts` asserts the hint appears on a Site browser tool
(`site_add_page`) and a Content browser tool (`content_set_document_field`) and does
*not* appear on a headless one (`site_read_styles`). The full `server/ai/mcp` suite
passes (64 tests).

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.