### PR TITLE
fix(data): keep the page-tree "Open editor" button enabled on system tables

### DIFF
--- a/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.test.tsx
+++ b/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.test.tsx
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { createNode } from '@core/page-tree'
+import { PageTreeCell } from './PageTreeCell'
+import type { DataField } from '@core/data/schemas'
+
+afterEach(cleanup)
+
+const bodyField: Extract<DataField, { type: 'pageTree' }> = {
+  type: 'pageTree',
+  id: 'body',
+  label: 'Body',
+  builtIn: true,
+}
+
+const rootNode = createNode('base.body')
+const tree = { rootNodeId: rootNode.id, nodes: { [rootNode.id]: rootNode } }
+
+function renderCell(props: { readOnly?: boolean; onOpenEditor?: () => void }) {
+  return render(
+    <PageTreeCell
+      field={bodyField}
+      value={tree}
+      onChange={() => {}}
+      context="detail"
+      readOnly={props.readOnly}
+      onOpenEditor={props.onOpenEditor}
+    />,
+  )
+}
+
+function button(): HTMLButtonElement {
+  return screen.getByRole('button') as HTMLButtonElement
+}
+
+describe('PageTreeCell', () => {
+  // A `pageTree` cell on a system table is ALWAYS readOnly — every built-in
+  // field of `pages` / `components` / `layouts` is value-locked. The button
+  // navigates to the visual editor rather than editing the cell, so gating it
+  // on readOnly disabled it on exactly the rows it exists for.
+  it('stays enabled on a read-only cell when a handler is wired', async () => {
+    let opened = 0
+    renderCell({ readOnly: true, onOpenEditor: () => { opened += 1 } })
+
+    expect(button().disabled).toBe(false)
+
+    await userEvent.click(button())
+    expect(opened).toBe(1)
+  })
+
+  it('is disabled when no handler is wired', () => {
+    renderCell({ readOnly: false })
+    expect(button().disabled).toBe(true)
+  })
+
+  it('labels the button for the row it can open', () => {
+    renderCell({ readOnly: true, onOpenEditor: () => {} })
+    expect(button().getAttribute('aria-label')).toBe('Body: Open editor')
+  })
+})

--- a/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.tsx
+++ b/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.tsx
@@ -8,6 +8,13 @@
  *
  * The optional `onOpenEditor` prop follows the same extra-prop threading
  * pattern that `RelationCell` uses for `onOpenPicker`.
+ *
+ * `readOnly` deliberately does NOT gate the button. It means "this value is
+ * not editable in the grid", which is always true for a `pageTree` cell on a
+ * system table (`isBuiltInValueLocked` holds for every built-in field of
+ * `pages` / `components` / `layouts`). The button edits nothing — it navigates
+ * to the visual editor, which enforces its own permissions. Gating it on
+ * `readOnly` disabled it on exactly the rows it exists for.
  */
 import type { ReactElement } from 'react'
 import { Button } from '@ui/components/Button'
@@ -27,7 +34,6 @@ export interface PageTreeCellProps extends CellEditorProps<PageTreeField> {
 export function PageTreeCell({
   field,
   value,
-  readOnly,
   ariaLabel,
   onOpenEditor,
 }: PageTreeCellProps): ReactElement {
@@ -40,7 +46,7 @@ export function PageTreeCell({
       <Button
         variant="secondary"
         size="sm"
-        disabled={readOnly || !onOpenEditor}
+        disabled={!onOpenEditor}
         aria-label={ariaLabel ?? `${field.label}: ${hasTree ? 'Open editor' : 'No content'}`}
         onClick={() => onOpenEditor?.()}
         align="start"


### PR DESCRIPTION
## What

`PageTreeCell` gated its "Open editor →" button on `readOnly`:

```ts
disabled={readOnly || !onOpenEditor}
```

That disabled the button on every row it exists for. `RowDetail` computes `readOnly` as `!canEdit || isBuiltInValueLocked(table, field)`, and `isBuiltInValueLocked` returns `true` for any built-in field of a system table whose kind isn't `postType` — which covers the `body` field of `pages`, `components`, and `layouts`. There is no combination of state where a `pageTree` cell on those tables is not read-only.

## Why

`readOnly` means "this value can't be edited in the grid", which is correct — a page tree is not editable in a text cell. But the button doesn't edit the value; it navigates to the visual editor.

The inconsistency is visible inside `RowDetail` itself: the row header renders an **"Open in Site editor"** action wired to the same `onOpenInSiteEditor` handler with no `readOnly` check, and that one works. Two entry points to one action, one of them dead.

## Impact

Data → Pages → select a row → **Body → "Open editor →"** now navigates to the visual editor instead of doing nothing. No change for any other cell type: `readOnly` still governs the editors that actually mutate values.

## How

Gate on `onOpenEditor` alone. `RowDetail` only threads the handler for `page` and `component` table kinds, so its presence already encodes "this row has a visual editor to open", and the editor enforces its own permissions on arrival.

## Tests

Adds `PageTreeCell.test.tsx` — the component had no coverage. The first case fails on `main` and passes here:

- stays enabled on a read-only cell when a handler is wired, and fires it on click
- is disabled when no handler is wired
- keeps the aria-label describing the row it opens

## Verification

- `bun test` — 6301 pass, 0 fail (677 files)
- `bun run build` — clean
- `bun run lint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018b38iXmvtzaNzuYyv2TMib