### PR TITLE
feat(editor): undock and resize sidebar panels

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -451,6 +451,7 @@ Why this matters: selection rings and the floating selection toolbar are portale
 | AgentPanel (floating)                 | 50      | `panels/AgentPanel/AgentPanel.module.css` |
 | PanelRail                             | 55      | `sidebars/PanelRail/PanelRail.module.css` |
 | LeftSidebar, RightSidebar             | 85      | `sidebars/{Left,Right}Sidebar/` |
+| Undocked left-panel host              | 90      | `sidebars/LeftSidebar/LeftSidebar.module.css` |
 | CodeEditorPanel (floats over sidebars)| 95      | `code-editor/CodeEditorPanel.module.css` |
 | Toolbar popovers / dropdowns          | 201     | `toolbar/Toolbar.module.css` |
 | PreviewOverlay                        | 400–401 | `preview/PreviewOverlay.module.css` |
@@ -532,6 +533,21 @@ Opens the rail-selected panel:
 - `DependenciesPanel` — site package.json / `bun install`
 - `PluginEditorPanel` — plugin-provided editor panels
 - `AgentPanel` — AI assistant
+
+Explorer, Selectors, Framework, Dependencies, and plugin panels use the shared
+`Panel` header contract and can be unpinned into one draggable canvas window.
+Switching among those rail items while unpinned replaces the window content
+without redocking it; the same header action docks the active panel back into
+the left sidebar. A keyboard-accessible bottom-right handle resizes the
+floating window in both axes (arrow keys resize by 10px; Shift+arrow by 40px).
+`leftSidebarMode`, the shared floating position, and its user-set width and
+height are persisted through `siteEditorLayoutPersistence` /
+`workspaceLayoutStorage`.
+
+The AI Assistant is an independent draggable and resizable floating window, so
+it can stay open beside Explorer/Layers or any other hosted panel. Its position,
+dimensions, and open state persist separately across reloads. Properties
+follows the same independent floating-window interaction contract on the right.
 
 ### Right sidebar (`RightSidebar`)
 

--- a/src/__tests__/architecture/framework-typography-spacing.test.ts
+++ b/src/__tests__/architecture/framework-typography-spacing.test.ts
@@ -135,6 +135,6 @@ describe('architecture — left sidebar', () => {
   const layoutSource = readSource('admin/pages/site/sidebars/LeftSidebar/LeftSidebar.tsx')
 
   it('mounts the consolidated FrameworkPanel', () => {
-    expect(layoutSource).toContain('<FrameworkPanel />')
+    expect(layoutSource).toMatch(/<FrameworkPanel\b/)
   })
 })

--- a/src/__tests__/layout/editorLayoutPersistence.test.tsx
+++ b/src/__tests__/layout/editorLayoutPersistence.test.tsx
@@ -102,6 +102,7 @@ function resetStore() {
     propertiesPanel: { collapsed: false, x: 0, y: 0, width: 360 },
     propertiesPanelMode: 'docked',
     leftSidebarWidth: 320,
+    leftSidebarMode: 'docked',
     focusedPanel: 'canvas',
     explorerPanelOpen: true,
     explorerPanelTab: 'layers',
@@ -338,7 +339,9 @@ describe('AdminCanvasLayout — persisted panel layout', () => {
             rightWidth: 390,
             rightOpen: true,
             propertiesPanelMode: 'floating',
+            leftSidebarMode: 'floating',
             activeLeftPanel: 'explorer',
+            agentPanelOpen: true,
             explorerPanelTab: 'code',
             codeEditorPanelOpen: true,
             activeEditorFileId: 'file-1',
@@ -356,6 +359,7 @@ describe('AdminCanvasLayout — persisted panel layout', () => {
       expect(state.explorerPanelTab).toBe('code')
       expect(state.propertiesPanel.collapsed).toBe(false)
       expect(state.propertiesPanelMode).toBe('floating')
+      expect(state.leftSidebarMode).toBe('floating')
       expect(state.propertiesPanel.width).toBe(390)
       expect(state.leftSidebarWidth).toBe(410)
       expect(state.codeEditorPanelOpen).toBe(true)
@@ -363,7 +367,7 @@ describe('AdminCanvasLayout — persisted panel layout', () => {
       expect(state.selectorsPanelOpen).toBe(false)
       expect(state.frameworkPanelOpen).toBe(false)
       expect(state.dependenciesPanelOpen).toBe(false)
-      expect(state.isAgentOpen).toBe(false)
+      expect(state.isAgentOpen).toBe(true)
     }, { timeout: 150 })
   })
 })
@@ -531,11 +535,33 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     fireEvent.click(within(rail).getByRole('button', { name: /open ai assistant panel/i }))
 
     expect(sidebar.getAttribute('data-expanded')).toBe('true')
-    expect(sidebar.getAttribute('data-active-panel')).toBe('agent')
+    expect(sidebar.getAttribute('data-active-panel')).toBe('dependencies')
     expect(sidebar.getAttribute('style')).toContain('--left-sidebar-panel-width: 320px')
     expect(useEditorStore.getState().isAgentOpen).toBe(true)
-    expect(useEditorStore.getState().dependenciesPanelOpen).toBe(false)
+    expect(useEditorStore.getState().dependenciesPanelOpen).toBe(true)
     expect(useEditorStore.getState().explorerPanelOpen).toBe(false)
+    const agentPanel = within(sidebar).getByTestId('agent-panel').closest('[data-panel]')
+    expect(agentPanel).not.toBeNull()
+
+    const agentResizeHandle = within(agentPanel as HTMLElement).getByRole('separator', {
+      name: /resize ai assistant panel/i,
+    })
+    fireEvent.keyDown(agentResizeHandle, { key: 'ArrowRight' })
+    fireEvent.keyDown(agentResizeHandle, { key: 'ArrowDown' })
+
+    await waitFor(() => {
+      expect((agentPanel as HTMLElement).style.getPropertyValue('--panel-w')).toBe('330px')
+      expect((agentPanel as HTMLElement).style.getPropertyValue('--panel-h')).toBe('490px')
+      const stored = JSON.parse(localStorage.getItem(LAYOUT_STORAGE_KEY) ?? '{}')
+      expect(stored.panelSizes?.agent).toEqual({ width: 330, height: 490 })
+    }, { timeout: 150 })
+
+    fireEvent.click(within(rail).getByRole('button', { name: /open explorer panel/i }))
+
+    expect(sidebar.getAttribute('data-active-panel')).toBe('explorer')
+    expect(useEditorStore.getState().explorerPanelOpen).toBe(true)
+    expect(useEditorStore.getState().isAgentOpen).toBe(true)
+    expect(within(sidebar).getByTestId('explorer-panel')).toBeDefined()
     expect(within(sidebar).getByTestId('agent-panel')).toBeDefined()
   })
 
@@ -564,6 +590,18 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
 
     const floatingPanel = screen.getByTestId('properties-panel')
     expect(floatingPanel.getAttribute('data-variant')).toBe('floating')
+    const propertiesResizeHandle = within(floatingPanel).getByRole('separator', {
+      name: /resize properties panel/i,
+    })
+    fireEvent.keyDown(propertiesResizeHandle, { key: 'ArrowRight' })
+    fireEvent.keyDown(propertiesResizeHandle, { key: 'ArrowDown', shiftKey: true })
+
+    await waitFor(() => {
+      expect(floatingPanel.style.getPropertyValue('--panel-w')).toBe('370px')
+      expect(floatingPanel.style.getPropertyValue('--panel-h')).toBe('720px')
+      const stored = JSON.parse(localStorage.getItem(LAYOUT_STORAGE_KEY) ?? '{}')
+      expect(stored.panelSizes?.properties).toEqual({ width: 370, height: 720 })
+    }, { timeout: 150 })
 
     fireEvent.click(within(floatingPanel).getByRole('button', { name: /dock properties panel/i }))
 
@@ -571,6 +609,56 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
       expect(useEditorStore.getState().propertiesPanelMode).toBe('docked')
       expect(rightSidebar.getAttribute('data-expanded')).toBe('true')
       expect(within(rightSidebar).getByTestId('properties-panel').getAttribute('data-variant')).toBe('docked')
+    }, { timeout: 150 })
+  })
+
+  it('can unpin hosted left-rail panels and keeps switching in the floating host', async () => {
+    renderEditorLayout()
+
+    const sidebar = await screen.findByTestId('left-sidebar')
+    const rail = within(sidebar).getByRole('navigation', { name: /panel dock/i })
+    const panelSlot = within(sidebar).getByTestId('left-sidebar-panel-slot')
+
+    fireEvent.click(within(sidebar).getByRole('button', { name: /unpin explorer panel/i }))
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().leftSidebarMode).toBe('floating')
+      expect(sidebar.getAttribute('data-expanded')).toBe('false')
+      expect(panelSlot.getAttribute('data-mode')).toBe('floating')
+    }, { timeout: 150 })
+
+    const explorerResizeHandle = within(panelSlot).getByRole('separator', {
+      name: /resize explorer panel/i,
+    })
+    fireEvent.keyDown(explorerResizeHandle, { key: 'ArrowRight' })
+    fireEvent.keyDown(explorerResizeHandle, { key: 'ArrowUp' })
+
+    await waitFor(() => {
+      expect(panelSlot.style.getPropertyValue('--panel-w')).toBe('330px')
+      expect(panelSlot.style.getPropertyValue('--panel-h')).toBe('510px')
+      const stored = JSON.parse(localStorage.getItem(LAYOUT_STORAGE_KEY) ?? '{}')
+      expect(stored.panelSizes?.site).toEqual({ width: 330, height: 510 })
+    }, { timeout: 150 })
+
+    const railTargets = [
+      ['selectors', 'selectors-panel'],
+      ['framework', 'framework-panel'],
+      ['dependencies', 'dependencies-panel'],
+    ] as const
+
+    for (const [label, testId] of railTargets) {
+      fireEvent.click(within(rail).getByRole('button', { name: new RegExp(`open ${label} panel`, 'i') }))
+      expect(within(panelSlot).getByTestId(testId)).toBeDefined()
+      expect(within(panelSlot).getByRole('button', { name: new RegExp(`dock ${label} panel`, 'i') })).toBeDefined()
+      expect(sidebar.getAttribute('data-expanded')).toBe('false')
+    }
+
+    fireEvent.click(within(panelSlot).getByRole('button', { name: /dock dependencies panel/i }))
+
+    await waitFor(() => {
+      expect(useEditorStore.getState().leftSidebarMode).toBe('docked')
+      expect(sidebar.getAttribute('data-expanded')).toBe('true')
+      expect(panelSlot.getAttribute('data-mode')).toBe('docked')
     }, { timeout: 150 })
   })
 

--- a/src/__tests__/layout/floatingWindowPosition.test.ts
+++ b/src/__tests__/layout/floatingWindowPosition.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { clampFloatingPanelPosition } from '@admin/shared/FloatingWindow'
+import {
+  clampFloatingPanelPosition,
+  clampFloatingPanelSize,
+} from '@admin/shared/FloatingWindow'
 
 describe('floating window viewport clamp', () => {
   it('keeps a reachable header strip after a far-left drag', () => {
@@ -14,5 +17,35 @@ describe('floating window viewport clamp', () => {
       { x: -770, y: 900 },
       { viewportWidth: 600, viewportHeight: 500, panelWidth: 520 },
     )).toEqual({ x: -470, y: 450 })
+  })
+})
+
+describe('floating window size clamp', () => {
+  it('respects minimum usable dimensions', () => {
+    expect(clampFloatingPanelSize(
+      { width: 80, height: 40 },
+      {
+        viewportWidth: 1_440,
+        viewportHeight: 900,
+        panelLeft: 400,
+        panelTop: 160,
+        minWidth: 280,
+        minHeight: 240,
+      },
+    )).toEqual({ width: 280, height: 240 })
+  })
+
+  it('keeps a resized panel inside the available bottom-right viewport', () => {
+    expect(clampFloatingPanelSize(
+      { width: 2_000, height: 1_200 },
+      {
+        viewportWidth: 1_440,
+        viewportHeight: 900,
+        panelLeft: 400,
+        panelTop: 160,
+        minWidth: 280,
+        minHeight: 240,
+      },
+    )).toEqual({ width: 1_024, height: 724 })
   })
 })

--- a/src/__tests__/layout/workspaceLayoutStorage.test.ts
+++ b/src/__tests__/layout/workspaceLayoutStorage.test.ts
@@ -3,9 +3,11 @@ import {
   EDITOR_LAYOUT_STORAGE_KEY,
   readEditorLayout,
   readStoredPanelPosition,
+  readStoredPanelSize,
   readWorkspaceLayout,
   workspaceFromPathname,
   writeStoredPanelPosition,
+  writeStoredPanelSize,
   writeWorkspaceLayout,
 } from '@admin/state/workspaceLayoutStorage'
 
@@ -34,6 +36,28 @@ describe('workspaceLayoutStorage — floating panel positions', () => {
     writeStoredPanelPosition('agent', { x: 24, y: 180 })
 
     expect(localStorage.getItem('instatic-agent-panel-pos')).toBeNull()
+  })
+})
+
+describe('workspaceLayoutStorage — floating panel sizes', () => {
+  it('stores floating panel dimensions without clobbering its position', () => {
+    writeStoredPanelPosition('site', { x: 420, y: 140 })
+    writeStoredPanelSize('site', { width: 540, height: 460 })
+
+    expect(readStoredPanelPosition('site')).toEqual({ x: 420, y: 140 })
+    expect(readStoredPanelSize('site')).toEqual({ width: 540, height: 460 })
+    expect(readEditorLayout()?.panelSizes?.site).toEqual({ width: 540, height: 460 })
+  })
+
+  it('preserves workspace layout state when updating floating dimensions', () => {
+    writeWorkspaceLayout('site', { leftWidth: 380, leftSidebarMode: 'floating' })
+    writeStoredPanelSize('properties', { width: 480, height: 620 })
+
+    expect(readWorkspaceLayout('site')).toMatchObject({
+      leftWidth: 380,
+      leftSidebarMode: 'floating',
+    })
+    expect(readStoredPanelSize('properties')).toEqual({ width: 480, height: 620 })
   })
 })
 

--- a/src/__tests__/ui/segmentedControlChrome.test.tsx
+++ b/src/__tests__/ui/segmentedControlChrome.test.tsx
@@ -28,9 +28,15 @@ describe('SegmentedControl editor chrome variants', () => {
   it('uses the recessed tab surface and top fade in Explorer Layers chrome', () => {
     const explorerSource = readFileSync('src/admin/pages/site/panels/ExplorerPanel/ExplorerPanel.tsx', 'utf8')
     const domPanelCss = readFileSync('src/admin/pages/site/panels/DomPanel/DomPanel.module.css', 'utf8')
+    const leftSidebarCss = readFileSync(
+      'src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.module.css',
+      'utf8',
+    )
 
     expect(explorerSource).toContain('activeSurface="recessed"')
     expect(domPanelCss).toContain('.searchRow::after')
-    expect(domPanelCss).toContain('linear-gradient(180deg, var(--bg-body) 0%, transparent)')
+    expect(domPanelCss).toContain('linear-gradient(180deg, var(--panel-fade-bg) 0%, transparent)')
+    expect(leftSidebarCss).toContain('--panel-fade-bg: var(--bg-body)')
+    expect(leftSidebarCss).toContain('--panel-fade-bg: var(--bg-surface)')
   })
 })

--- a/src/admin/pages/site/layout/siteEditorLayoutPersistence.ts
+++ b/src/admin/pages/site/layout/siteEditorLayoutPersistence.ts
@@ -5,7 +5,7 @@ import type { ExplorerPanelTab } from '@site/store/slices/uiSlice'
 import {
   readWorkspaceLayout,
   writeWorkspaceLayout,
-  type PropertiesPanelMode,
+  type PanelMode,
   type StoredWorkspaceLayout,
 } from '@admin/state/workspaceLayoutStorage'
 import {
@@ -24,7 +24,8 @@ export type SiteLayoutSelection = readonly [
   codeEditorOpen: boolean,
   agentOpen: boolean,
   explorerTab: ExplorerPanelTab,
-  propertiesMode: PropertiesPanelMode,
+  propertiesMode: PanelMode,
+  leftSidebarMode: PanelMode,
   leftSidebarWidth: number,
   propertiesWidth: number,
   activeEditorFileId: string | null,
@@ -49,10 +50,14 @@ function explorerTab(
 
 function propertiesMode(
   layout: StoredWorkspaceLayout,
-  currentMode: PropertiesPanelMode,
-): PropertiesPanelMode {
+  currentMode: PanelMode,
+): PanelMode {
   const mode = layout.propertiesPanelMode
   return mode === 'floating' || mode === 'docked' ? mode : currentMode
+}
+
+function storedPanelMode(value: unknown, currentMode: PanelMode): PanelMode {
+  return value === 'floating' || value === 'docked' ? value : currentMode
 }
 
 function leftSidebarWidth(layout: StoredWorkspaceLayout, currentWidth: number): number {
@@ -73,6 +78,7 @@ export function selectSiteLayoutState(s: EditorStore): SiteLayoutSelection {
     s.isAgentOpen,
     s.explorerPanelTab,
     s.propertiesPanelMode,
+    s.leftSidebarMode,
     s.leftSidebarWidth,
     s.propertiesPanel.width,
     s.activeEditorFileId,
@@ -90,15 +96,12 @@ function deriveSiteActiveLeftPanel(selection: SiteLayoutSelection): string | nul
     selectorsOpen,
     frameworkOpen,
     dependenciesOpen,
-    ,
-    agentOpen,
   ] = selection
 
   if (explorerOpen) return 'explorer'
   if (selectorsOpen) return 'selectors'
   if (frameworkOpen) return 'framework'
   if (dependenciesOpen) return 'dependencies'
-  if (agentOpen) return 'agent'
   return null
 }
 
@@ -112,9 +115,10 @@ export function siteLayoutFromSelection(
     ,
     ,
     codeEditorOpen,
-    ,
+    agentOpen,
     explorerTab,
     propertiesMode,
+    leftSidebarMode,
     leftSidebarWidth,
     propertiesWidth,
     activeEditorFileId,
@@ -130,6 +134,8 @@ export function siteLayoutFromSelection(
     activeEditorFileId,
     codeEditorPanelOpen: codeEditorOpen,
     propertiesPanelMode: propertiesMode,
+    leftSidebarMode,
+    agentPanelOpen: agentOpen,
   }
 }
 
@@ -141,6 +147,8 @@ export function restoreStoredSiteEditorLayout(
     const propertiesOpen = boolOrCurrent(layout.rightOpen, !state.propertiesPanel.collapsed)
     const storedActivePanel = layout.activeLeftPanel
     const applyLeftPanel = storedActivePanel !== undefined
+    const storedAgentOpen = layout.agentPanelOpen
+      ?? (storedActivePanel === 'agent' ? true : state.isAgentOpen)
 
     const leftPanelPatch = applyLeftPanel
       ? {
@@ -148,7 +156,6 @@ export function restoreStoredSiteEditorLayout(
           selectorsPanelOpen: storedActivePanel === 'selectors',
           frameworkPanelOpen: storedActivePanel === 'framework',
           dependenciesPanelOpen: storedActivePanel === 'dependencies',
-          isAgentOpen: storedActivePanel === 'agent',
         }
       : {}
 
@@ -159,9 +166,11 @@ export function restoreStoredSiteEditorLayout(
         width: finiteNumberOrCurrent(layout.rightWidth, state.propertiesPanel.width),
       },
       propertiesPanelMode: propertiesMode(layout, state.propertiesPanelMode),
+      leftSidebarMode: storedPanelMode(layout.leftSidebarMode, state.leftSidebarMode),
       leftSidebarWidth: leftSidebarWidth(layout, state.leftSidebarWidth),
       explorerPanelTab: explorerTab(layout.explorerPanelTab, state.explorerPanelTab),
       codeEditorPanelOpen: boolOrCurrent(layout.codeEditorPanelOpen, state.codeEditorPanelOpen),
+      isAgentOpen: storedAgentOpen,
       activeEditorFileId: layout.activeEditorFileId !== undefined
         ? layout.activeEditorFileId
         : state.activeEditorFileId,

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.module.css
@@ -2,15 +2,21 @@
 
 /* ── Floating panel outer shell ──────────────────────────────────────────── */
 .floatPanel {
-  position: absolute;
-  /* Position driven by --panel-x / --panel-y CSS vars (useDraggablePanel) */
+  position: fixed;
+  /* Position and size are driven by the shared floating-panel hooks. */
   --panel-x: calc(100% - 336px);
   --panel-y: 200px;
+  --panel-w: 320px;
+  --panel-h: 480px;
   left: var(--panel-x);
   top: var(--panel-y);
   z-index: 50;
-  width: 320px;
-  height: 480px;
+  width: var(--panel-w);
+  height: var(--panel-h);
+  min-width: 280px;
+  min-height: 240px;
+  max-width: calc(100vw - 16px);
+  max-height: calc(100vh - 16px);
   display: flex;
   flex-direction: column;
   background: var(--bg-surface);
@@ -31,6 +37,10 @@
   z-index: auto;
   width: 100%;
   height: 100%;
+  min-width: 0;
+  min-height: 0;
+  max-width: none;
+  max-height: none;
   border: 0;
   border-radius: 0;
   box-shadow: none;

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -36,7 +36,11 @@ import { PanelHeader } from '@admin/shared/PanelHeader'
 import { UserAvatar } from '@admin/shared/UserAvatar'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
-import { useDraggablePanel } from '@admin/shared/FloatingWindow'
+import {
+  PanelResizeHandle,
+  useDraggablePanel,
+  useResizablePanel,
+} from '@admin/shared/FloatingWindow'
 import { cn } from '@ui/cn'
 import { ConversationHistory } from './ConversationHistory'
 import { AgentComposer, type ComposerLockReason } from './AgentComposer'
@@ -59,6 +63,10 @@ const PANEL_HEIGHT = 480
 const AI_SETTINGS_ROUTE = '/admin/ai'
 type PanelVariant = 'floating' | 'docked'
 
+interface AgentPanelProps {
+  variant?: PanelVariant
+}
+
 // ---------------------------------------------------------------------------
 // AgentPanel
 // ---------------------------------------------------------------------------
@@ -70,7 +78,7 @@ type PanelVariant = 'floating' | 'docked'
  * (`.floatPanelClosed`) to preserve Zustand conversation state across open/close cycles.
  * Agent routes via Vite proxy `/admin/api/agent` → local Bun server → Claude SDK.
  */
-export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant }) {
+export function AgentPanel({ variant = 'floating' }: AgentPanelProps) {
   const agentStore = useAgentStoreApi()
   const isOpen = useAgentStore((s) => s.isAgentOpen)
   const isStreaming = useAgentStore((s) => s.isAgentStreaming)
@@ -119,14 +127,27 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
 
   // ── Draggable panel position ───────────────────────────────────────────────
   // Default to bottom-right corner.
-  const { setPanelRef, headerDragProps, panelPositionStyle } = useDraggablePanel(
+  const {
+    panelRef,
+    setPanelRef,
+    headerDragProps,
+    panelPositionStyle,
+  } = useDraggablePanel(
     'agent',
     () => ({
       x: typeof window !== 'undefined' ? window.innerWidth - PANEL_WIDTH - 16 : 16,
       y: typeof window !== 'undefined'
         ? window.innerHeight - PANEL_HEIGHT - 16
         : 200,
-    }),
+      }),
+  )
+  const {
+    panelSizeStyle,
+    resizeHandleProps,
+  } = useResizablePanel(
+    'agent',
+    panelRef,
+    () => ({ width: PANEL_WIDTH, height: PANEL_HEIGHT }),
   )
 
   // Auto-scroll to bottom when new messages arrive
@@ -198,8 +219,11 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
       data-panel=""
       tabIndex={-1}
       onClick={(e) => e.stopPropagation()}
-      // Panel position is drag-driven — CSS var injection from useDraggablePanel
-      style={variant === 'floating' ? panelPositionStyle : undefined}
+      style={
+        variant === 'floating'
+          ? { ...panelPositionStyle, ...panelSizeStyle }
+          : undefined
+      }
       className={cn(
         styles.floatPanel,
         variant === 'docked' && styles.floatPanelDocked,
@@ -301,6 +325,12 @@ export function AgentPanel({ variant = 'floating' }: { variant?: PanelVariant })
       />
       {isOpen && imageMenu && (
         <AgentImageContextMenu request={imageMenu} onClose={closeImageMenu} />
+      )}
+      {variant === 'floating' && (
+        <PanelResizeHandle
+          panelLabel="AI Assistant"
+          resizeHandleProps={resizeHandleProps}
+        />
       )}
     </aside>
   )

--- a/src/admin/pages/site/panels/DependenciesPanel/DependenciesPanel.tsx
+++ b/src/admin/pages/site/panels/DependenciesPanel/DependenciesPanel.tsx
@@ -1,20 +1,24 @@
 import { useRef } from 'react'
 import { useEditorStore } from '@site/store/store'
-import { Panel, useAutoFocusPanel } from '@admin/shared/Panel'
+import {
+  Panel,
+  useAutoFocusPanel,
+  type DockablePanelProps,
+} from '@admin/shared/Panel'
 import { DepsSection } from './DepsSection'
 
-interface DependenciesPanelProps {
-  variant?: 'docked'
-}
-
-export function DependenciesPanel({ variant = 'docked' }: DependenciesPanelProps) {
+export function DependenciesPanel({
+  mode = 'docked',
+  dragHandleProps,
+  onToggleMode,
+}: DockablePanelProps) {
   const isOpen = useEditorStore((s) => s.dependenciesPanelOpen)
   const setDependenciesPanelOpen = useEditorStore((s) => s.setDependenciesPanelOpen)
   const panelRef = useRef<HTMLElement>(null)
 
   useAutoFocusPanel(panelRef, isOpen)
 
-  if (!isOpen || variant !== 'docked') return null
+  if (!isOpen) return null
 
   return (
     <Panel
@@ -23,6 +27,10 @@ export function DependenciesPanel({ variant = 'docked' }: DependenciesPanelProps
       title="Dependencies"
       testId="dependencies-panel"
       onClose={() => setDependenciesPanelOpen(false)}
+      mode={mode}
+      dragHandleProps={dragHandleProps}
+      onToggleMode={onToggleMode}
+      dockLocation="left sidebar"
     >
       <DepsSection />
     </Panel>

--- a/src/admin/pages/site/panels/DomPanel/DomPanel.module.css
+++ b/src/admin/pages/site/panels/DomPanel/DomPanel.module.css
@@ -40,7 +40,7 @@
     top: 100%;
     height: var(--space-2xl);
     pointer-events: none;
-    background: linear-gradient(180deg, var(--bg-body) 0%, transparent);
+    background: linear-gradient(180deg, var(--panel-fade-bg) 0%, transparent);
 }
 
 .searchFill {

--- a/src/admin/pages/site/panels/ExplorerPanel/ExplorerPanel.tsx
+++ b/src/admin/pages/site/panels/ExplorerPanel/ExplorerPanel.tsx
@@ -13,7 +13,7 @@
  * every explorer drag — so they deliberately share one instance + DnD scope.
  */
 import { useEditorStore } from '@site/store/store'
-import { Panel } from '@admin/shared/Panel'
+import { Panel, type DockablePanelProps } from '@admin/shared/Panel'
 import { SegmentedControl } from '@ui/components/SegmentedControl'
 import { DomPanel } from '@site/panels/DomPanel'
 import { SiteExplorerPanel } from '@site/panels/SiteExplorerPanel'
@@ -28,12 +28,17 @@ const TABS: ReadonlyArray<{ value: ExplorerPanelTab; label: string }> = [
   { value: 'media', label: 'Media' },
 ]
 
-interface ExplorerPanelProps {
+interface ExplorerPanelProps extends DockablePanelProps {
   /** Whether the caller can perform structural edits (drives DnD/insert). */
   editable?: boolean
 }
 
-export function ExplorerPanel({ editable = true }: ExplorerPanelProps) {
+export function ExplorerPanel({
+  editable = true,
+  mode,
+  dragHandleProps,
+  onToggleMode,
+}: ExplorerPanelProps) {
   const tab = useEditorStore((s) => s.explorerPanelTab)
   const setTab = useEditorStore((s) => s.setExplorerPanelTab)
   const setOpen = useEditorStore((s) => s.setExplorerPanelOpen)
@@ -44,6 +49,10 @@ export function ExplorerPanel({ editable = true }: ExplorerPanelProps) {
       title="Explorer"
       testId="explorer-panel"
       onClose={() => setOpen(false)}
+      mode={mode}
+      dragHandleProps={dragHandleProps}
+      onToggleMode={onToggleMode}
+      dockLocation="left sidebar"
       body="bare"
     >
       <div className={styles.tabsRow}>

--- a/src/admin/pages/site/panels/FrameworkPanel/FrameworkPanel.tsx
+++ b/src/admin/pages/site/panels/FrameworkPanel/FrameworkPanel.tsx
@@ -8,7 +8,7 @@
  * which is mounted once via FrameworkManagerHost.
  */
 import { useEditorStore } from '@site/store/store'
-import { Panel } from '@admin/shared/Panel'
+import { Panel, type DockablePanelProps } from '@admin/shared/Panel'
 import { SegmentedControl } from '@ui/components/SegmentedControl'
 import { Button } from '@ui/components/Button'
 import { SlidersHorizontalIcon } from 'pixel-art-icons/icons/sliders-horizontal'
@@ -27,7 +27,11 @@ const TABS: ReadonlyArray<{ value: FrameworkPanelTab; label: string }> = [
   { value: 'spacing', label: 'Space' },
 ]
 
-export function FrameworkPanel() {
+export function FrameworkPanel({
+  mode,
+  dragHandleProps,
+  onToggleMode,
+}: DockablePanelProps) {
   const tab = useEditorStore((s) => s.frameworkPanelTab)
   const setTab = useEditorStore((s) => s.setFrameworkPanelTab)
   const setOpen = useEditorStore((s) => s.setFrameworkPanelOpen)
@@ -39,6 +43,10 @@ export function FrameworkPanel() {
       title="Framework"
       testId="framework-panel"
       onClose={() => setOpen(false)}
+      mode={mode}
+      dragHandleProps={dragHandleProps}
+      onToggleMode={onToggleMode}
+      dockLocation="left sidebar"
       headerActions={
         <Button
           variant="ghost"

--- a/src/admin/pages/site/panels/PluginEditorPanel/PluginEditorPanel.tsx
+++ b/src/admin/pages/site/panels/PluginEditorPanel/PluginEditorPanel.tsx
@@ -18,7 +18,7 @@
  */
 import { useEffect, useState } from 'react'
 import { ErrorBoundary } from '@ui/components/ErrorBoundary'
-import { Panel } from '@admin/shared/Panel'
+import { Panel, type DockablePanelProps } from '@admin/shared/Panel'
 import { useEditorStore } from '@site/store/store'
 import { pluginRuntime } from '@core/plugins/runtime'
 import { buildPluginRoutesHelper } from '@core/plugins/adminRuntime'
@@ -28,21 +28,27 @@ import {
 } from '@admin/plugin-host-hooks'
 import styles from './PluginEditorPanel.module.css'
 
-interface PluginEditorPanelProps {
+interface PluginEditorPanelProps extends DockablePanelProps {
   panelId: string
 }
 
-export function PluginEditorPanel({ panelId }: PluginEditorPanelProps) {
+export function PluginEditorPanel(props: PluginEditorPanelProps) {
+  const { panelId } = props
   // ErrorBoundary reset key includes the panel id so navigating away then
   // back clears stuck errors automatically.
   return (
     <ErrorBoundary location="plugin-editor-panel" resetKeys={[panelId]}>
-      <PluginEditorPanelContent panelId={panelId} />
+      <PluginEditorPanelContent {...props} />
     </ErrorBoundary>
   )
 }
 
-function PluginEditorPanelContent({ panelId }: PluginEditorPanelProps) {
+function PluginEditorPanelContent({
+  panelId,
+  mode,
+  dragHandleProps,
+  onToggleMode,
+}: PluginEditorPanelProps) {
   // Subscribe to the runtime so the panel re-renders if the plugin is
   // re-activated (e.g. after a hot reload from `instatic-plugin dev`).
   const [tick, setTick] = useState(0)
@@ -67,6 +73,10 @@ function PluginEditorPanelContent({ panelId }: PluginEditorPanelProps) {
         title="Plugin panel"
         testId={`panel-plugin-${panelId}`}
         onClose={handleClose}
+        mode={mode}
+        dragHandleProps={dragHandleProps}
+        onToggleMode={onToggleMode}
+        dockLocation="left sidebar"
       >
         <div className={styles.unavailable}>
           Panel <code>{panelId}</code> is not currently registered.
@@ -84,6 +94,10 @@ function PluginEditorPanelContent({ panelId }: PluginEditorPanelProps) {
       title={panel.label}
       testId={`panel-plugin-${panel.id}`}
       onClose={handleClose}
+      mode={mode}
+      dragHandleProps={dragHandleProps}
+      onToggleMode={onToggleMode}
+      dockLocation="left sidebar"
     >
       <PluginPanelSubtree
         panelId={panel.id}

--- a/src/admin/pages/site/panels/PropertiesPanel/PropertiesPanel.module.css
+++ b/src/admin/pages/site/panels/PropertiesPanel/PropertiesPanel.module.css
@@ -1,9 +1,9 @@
 /* PropertiesPanel - inspector shell. */
 
 .panel {
-    position: absolute;
+    position: fixed;
     --panel-x: calc(100% - 376px);
-    --panel-y: 16px;
+    --panel-y: 64px;
     /* Background the inner fade gradients (ClassPicker fade, search-bar fade,
        locked-preview teaser) blend into. Floating panel surface is --bg-surface;
        the docked variant is transparent over the --bg-body sidebar, so it
@@ -11,12 +11,16 @@
     --panel-fade-bg: var(--bg-surface);
     left: var(--panel-x);
     top: var(--panel-y);
-    bottom: 12px;
+    bottom: auto;
     z-index: 50;
     display: flex;
     flex-direction: column;
     width: var(--panel-w);
-    max-height: calc(100vh - 28px);
+    height: var(--panel-h);
+    min-width: 280px;
+    min-height: 240px;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 80px);
     overflow: hidden;
     border: 1px solid var(--overlay-10);
     border-radius: var(--panel-radius);
@@ -24,7 +28,6 @@
     backdrop-filter: blur(var(--panel-blur));
     box-shadow: var(--shadow-panel);
     outline: none;
-    transition: width 150ms ease-in-out;
     transform: translateZ(0);
     will-change: transform;
 }
@@ -40,6 +43,9 @@
     z-index: auto;
     width: 100%;
     height: 100%;
+    min-width: 0;
+    min-height: 0;
+    max-width: none;
     max-height: none;
     border: 0;
     border-radius: 0;

--- a/src/admin/pages/site/panels/PropertiesPanel/PropertiesPanel.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/PropertiesPanel.tsx
@@ -42,11 +42,12 @@ import { MultiSelectionHeader } from './MultiSelectionInspector'
 import { MultiSelectorHeader } from './MultiSelectorInspector'
 import { type ClassPickerHandle } from './ClassPicker'
 import { useEditorStore } from '@site/store/store'
-import { PanelHeader } from '@admin/shared/PanelHeader'
-import { useDraggablePanel } from '@admin/shared/FloatingWindow'
-import { Button } from '@ui/components/Button'
-import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
-import { DockSolidIcon } from 'pixel-art-icons/icons/dock-solid'
+import { PanelHeader, PanelModeButton } from '@admin/shared/PanelHeader'
+import {
+  PanelResizeHandle,
+  useDraggablePanel,
+  useResizablePanel,
+} from '@admin/shared/FloatingWindow'
 import { cn } from '@ui/cn'
 import styles from './PropertiesPanel.module.css'
 
@@ -91,7 +92,18 @@ export function PropertiesPanel({ variant = 'floating' }: PropertiesPanelProps) 
     'properties',
     () => ({
       x: typeof window !== 'undefined' ? window.innerWidth - DEFAULT_WIDTH - 16 : 16,
-      y: 16,
+      y: 64,
+    }),
+  )
+  const {
+    panelSizeStyle,
+    resizeHandleProps,
+  } = useResizablePanel(
+    'properties',
+    dragPanelElementRef,
+    () => ({
+      width: data.width,
+      height: typeof window !== 'undefined' ? Math.min(680, window.innerHeight - 80) : 680,
     }),
   )
 
@@ -145,7 +157,7 @@ export function PropertiesPanel({ variant = 'floating' }: PropertiesPanelProps) 
       onClick={(e) => e.stopPropagation()}
       style={
         variant === 'floating'
-          ? { '--panel-w': `${data.width}px`, ...panelPositionStyle } as React.CSSProperties
+          ? { ...panelPositionStyle, ...panelSizeStyle }
           : undefined
       }
       className={cn(styles.panel, variant === 'docked' && styles.panelDocked)}
@@ -179,8 +191,10 @@ export function PropertiesPanel({ variant = 'floating' }: PropertiesPanelProps) 
         dragHandleProps={variant === 'floating' ? headerDragProps : undefined}
       >
         <PanelModeButton
-          variant={variant}
-          onClick={() => data.setPropertiesPanelMode(variant === 'docked' ? 'floating' : 'docked')}
+          mode={variant}
+          panelLabel="Properties"
+          dockLocation="right sidebar"
+          onToggle={() => data.setPropertiesPanelMode(variant === 'docked' ? 'floating' : 'docked')}
         />
       </PanelHeader>
 
@@ -210,6 +224,12 @@ export function PropertiesPanel({ variant = 'floating' }: PropertiesPanelProps) 
         />
       </div>
 
+      {variant === 'floating' && (
+        <PanelResizeHandle
+          panelLabel="Properties"
+          resizeHandleProps={resizeHandleProps}
+        />
+      )}
     </aside>
   )
 }
@@ -277,35 +297,4 @@ function HeaderTitleContent({
     )
   }
   return undefined
-}
-
-// ---------------------------------------------------------------------------
-// PanelModeButton — icon-only toggle between docked and floating modes,
-// rendered as a child of PanelHeader.
-// ---------------------------------------------------------------------------
-
-interface PanelModeButtonProps {
-  variant: PanelVariant
-  onClick: () => void
-}
-
-function PanelModeButton({ variant, onClick }: PanelModeButtonProps) {
-  const label = variant === 'docked' ? 'Unpin Properties panel' : 'Dock Properties panel'
-  const tooltip = variant === 'docked' ? 'Unpin to floating panel' : 'Dock in right sidebar'
-  return (
-    <Button
-      variant="ghost"
-      size="xs"
-      iconOnly
-      onClick={onClick}
-      aria-label={label}
-      tooltip={tooltip}
-    >
-      {variant === 'docked' ? (
-        <OpenSolidIcon size={12} aria-hidden="true" />
-      ) : (
-        <DockSolidIcon size={12} aria-hidden="true" />
-      )}
-    </Button>
-  )
 }

--- a/src/admin/pages/site/panels/PropertiesPanel/usePropertiesPanelData.ts
+++ b/src/admin/pages/site/panels/PropertiesPanel/usePropertiesPanelData.ts
@@ -30,7 +30,7 @@ import type {
 } from '@core/page-tree'
 import type { VisualComponent } from '@core/visualComponents'
 import type { LoopEntitySource } from '@core/loops/types'
-import type { ActiveDocument, PanelState, FocusedPanel, PropertiesPanelMode } from '../../store/slices/uiSlice'
+import type { ActiveDocument, PanelState, FocusedPanel, PanelMode } from '../../store/slices/uiSlice'
 
 const DEFAULT_WIDTH = 360
 const MIN_WIDTH = 280
@@ -82,7 +82,7 @@ interface PropertiesPanelData {
   // ─── Panel chrome actions ──────────────────────────────────────────────
   setStatusMessage: (msg: string) => void
   togglePropertiesPanel: () => void
-  setPropertiesPanelMode: (mode: PropertiesPanelMode) => void
+  setPropertiesPanelMode: (mode: PanelMode) => void
   setFocusedPanel: (panel: FocusedPanel) => void
   renameClass: (classId: string, name: string) => void
   deleteClass: (classId: string) => void

--- a/src/admin/pages/site/panels/SelectorsPanel/SelectorsPanel.tsx
+++ b/src/admin/pages/site/panels/SelectorsPanel/SelectorsPanel.tsx
@@ -18,7 +18,7 @@ import { FilterBar, type FilterBarItem } from '@ui/components/FilterBar'
 import { Skeleton } from '@ui/components/Skeleton'
 import { PaintBucketSolidIcon } from 'pixel-art-icons/icons/paint-bucket-solid'
 import { PlusIcon } from 'pixel-art-icons/icons/plus'
-import { Panel } from '@admin/shared/Panel'
+import { Panel, type DockablePanelProps } from '@admin/shared/Panel'
 import { cn } from '@ui/cn'
 import { DeleteSelectorDialog, SelectorNameDialog } from '../SelectorDialogs'
 import { SelectorContextMenu } from './SelectorContextMenu'
@@ -33,9 +33,7 @@ import {
 } from '../selectorUsage'
 import styles from './SelectorsPanel.module.css'
 
-interface SelectorsPanelProps {
-  variant?: 'docked'
-}
+type SelectorsPanelProps = DockablePanelProps
 
 type SelectorFilter = 'all' | 'user' | 'utility' | 'unused'
 
@@ -81,7 +79,11 @@ function getEmptyFilterMessage(filter: SelectorFilter, query: string): string {
   return 'No selectors match the current filters.'
 }
 
-export function SelectorsPanel({ variant = 'docked' }: SelectorsPanelProps) {
+export function SelectorsPanel({
+  mode = 'docked',
+  dragHandleProps,
+  onToggleMode,
+}: SelectorsPanelProps) {
   const site = useEditorStore((s) => s.site)
   const isOpen = useEditorStore((s) => s.selectorsPanelOpen)
   const selectedSelectorClassId = useEditorStore((s) => s.selectedSelectorClassId)
@@ -201,7 +203,7 @@ export function SelectorsPanel({ variant = 'docked' }: SelectorsPanelProps) {
     return () => observer.disconnect()
   }, [hasMore, showSkeleton, visibleCount])
 
-  if (!isOpen || variant !== 'docked') return null
+  if (!isOpen) return null
 
   function openContextMenu(classId: string, event: MouseEvent<HTMLButtonElement>) {
     event.preventDefault()
@@ -306,6 +308,10 @@ export function SelectorsPanel({ variant = 'docked' }: SelectorsPanelProps) {
         testId="selectors-panel"
         bodyRef={scrollRef}
         onClose={() => setSelectorsPanelOpen(false)}
+        mode={mode}
+        dragHandleProps={dragHandleProps}
+        onToggleMode={onToggleMode}
+        dockLocation="left sidebar"
       >
         <FilterBar<SelectorFilter>
             items={SELECTOR_FILTER_ITEMS}

--- a/src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.module.css
+++ b/src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.module.css
@@ -17,13 +17,14 @@
     width: calc(var(--left-sidebar-rail-width) + var(--left-sidebar-panel-render-width));
     min-width: var(--left-sidebar-rail-width);
     min-height: 0;
-    overflow: hidden;
+    overflow: visible;
     transition:
         flex-basis 180ms ease,
         width 180ms ease;
 }
 
 .panelSlot {
+    --panel-fade-bg: var(--bg-body);
     position: absolute;
     top: 0;
     bottom: 0;
@@ -31,6 +32,29 @@
     width: var(--left-sidebar-panel-render-layout-width);
     min-height: 0;
     overflow: hidden;
+}
+
+.panelSlotFloating {
+    --panel-fade-bg: var(--bg-surface);
+    --panel-w: 320px;
+    --panel-h: 520px;
+    position: fixed;
+    top: var(--panel-y);
+    bottom: auto;
+    left: var(--panel-x);
+    z-index: 90;
+    width: var(--panel-w);
+    height: var(--panel-h);
+    min-width: 280px;
+    min-height: 240px;
+    max-width: calc(100vw - 32px);
+    max-height: calc(100vh - 80px);
+    overflow: hidden;
+    border: 1px solid var(--overlay-10);
+    border-radius: var(--panel-radius);
+    background: var(--bg-surface);
+    backdrop-filter: blur(var(--panel-blur));
+    box-shadow: var(--shadow-panel);
 }
 
 .panelMount {

--- a/src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.tsx
+++ b/src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.tsx
@@ -11,6 +11,12 @@ import { SelectorsPanel } from '@site/panels/SelectorsPanel'
 import { FrameworkChangeConfirmProvider } from '@admin/shared/dialogs/FrameworkChangeConfirmDialog'
 import { VCDeletionConfirmProvider } from '@admin/shared/dialogs/VCDeletionConfirmDialog'
 import { SidebarResizeHandle } from '@admin/shared/SidebarResizeHandle'
+import {
+  PanelResizeHandle,
+  useDraggablePanel,
+  useResizablePanel,
+} from '@admin/shared/FloatingWindow'
+import { cn } from '@ui/cn'
 import styles from './LeftSidebar.module.css'
 
 // Image preparation and provider catalogue code belong to the AI surface, not
@@ -21,7 +27,11 @@ const AgentPanel = lazy(() =>
   import('@site/panels/AgentPanel').then((module) => ({ default: module.AgentPanel })),
 )
 
-function selectActiveLeftSidebarPanel(state: ReturnType<typeof useEditorStore.getState>): LeftSidebarPanelId | null {
+type HostedLeftPanelId = Exclude<LeftSidebarPanelId, 'agent'>
+
+function selectActiveLeftSidebarPanel(
+  state: ReturnType<typeof useEditorStore.getState>,
+): HostedLeftPanelId | null {
   // A plugin panel takes precedence over the built-in `*PanelOpen` flags;
   // the LeftSidebar reads `activePluginPanelId` separately and shows the
   // plugin mount when set.
@@ -30,7 +40,6 @@ function selectActiveLeftSidebarPanel(state: ReturnType<typeof useEditorStore.ge
   if (state.selectorsPanelOpen) return 'selectors'
   if (state.frameworkPanelOpen) return 'framework'
   if (state.dependenciesPanelOpen) return 'dependencies'
-  if (state.isAgentOpen) return 'agent'
   return null
 }
 
@@ -60,6 +69,12 @@ interface LeftSidebarProps {
  * and is dropped from the rail (and its panel mount) when `editable=false`.
  */
 const READ_ONLY_RAIL_IDS: ReadonlySet<LeftSidebarPanelId> = new Set(['explorer'])
+const PANEL_RESIZE_LABELS: Record<HostedLeftPanelId, string> = {
+  explorer: 'Explorer',
+  selectors: 'Selectors',
+  framework: 'Framework',
+  dependencies: 'Dependencies',
+}
 
 export function LeftSidebar({
   workspace = 'site',
@@ -71,7 +86,9 @@ export function LeftSidebar({
   const activePanel = useEditorStore(selectActiveLeftSidebarPanel)
   const activePluginPanelId = useEditorStore((s) => s.activePluginPanelId)
   const leftSidebarWidth = useEditorStore((s) => s.leftSidebarWidth)
+  const leftSidebarMode = useEditorStore((s) => s.leftSidebarMode)
   const setLeftSidebarWidth = useEditorStore((s) => s.setLeftSidebarWidth)
+  const setLeftSidebarMode = useEditorStore((s) => s.setLeftSidebarMode)
   // When the user can't edit structure, drop them onto Layers if they had a
   // hidden-for-them panel active (selectors, colors, …). Plugin panels are
   // editing-only by definition.
@@ -84,8 +101,38 @@ export function LeftSidebar({
   const effectivePluginPanelId = editable ? activePluginPanelId : null
   // Sidebar is "expanded" whenever a built-in OR plugin panel is showing.
   const sidebarOpen = Boolean(effectiveActivePanel) || effectivePluginPanelId !== null
-  const panelExpanded = sidebarOpen && !railOnly
+  const panelFloating = sidebarOpen && leftSidebarMode === 'floating'
+  const panelExpanded = sidebarOpen && leftSidebarMode === 'docked' && !railOnly
+  const panelVisible = panelExpanded || panelFloating
   const panelWidth = panelExpanded ? leftSidebarWidth : 0
+  const panelResizeLabel = effectivePluginPanelId !== null
+    ? 'plugin'
+    : effectiveActivePanel
+      ? PANEL_RESIZE_LABELS[effectiveActivePanel]
+      : 'left sidebar'
+  const {
+    panelRef,
+    setPanelRef,
+    headerDragProps,
+    panelPositionStyle,
+  } = useDraggablePanel('site', () => ({ x: 58, y: 64 }))
+  const {
+    panelSizeStyle,
+    resizeHandleProps,
+  } = useResizablePanel(
+    'site',
+    panelRef,
+    () => ({ width: leftSidebarWidth, height: 520 }),
+  )
+
+  const togglePanelMode = () => {
+    setLeftSidebarMode(leftSidebarMode === 'docked' ? 'floating' : 'docked')
+  }
+  const dockablePanelProps = {
+    mode: leftSidebarMode,
+    dragHandleProps: panelFloating ? headerDragProps : undefined,
+    onToggleMode: togglePanelMode,
+  } as const
 
   const style = {
     '--left-sidebar-panel-width': `${panelWidth}px`,
@@ -114,16 +161,19 @@ export function LeftSidebar({
       <FrameworkChangeConfirmProvider>
       <VCDeletionConfirmProvider>
         <div
-          className={styles.panelSlot}
+          ref={panelFloating ? setPanelRef : undefined}
+          className={cn(styles.panelSlot, panelFloating && styles.panelSlotFloating)}
           data-testid="left-sidebar-panel-slot"
-          inert={panelExpanded ? undefined : true}
+          data-mode={leftSidebarMode}
+          inert={panelVisible ? undefined : true}
+          style={panelFloating ? { ...panelPositionStyle, ...panelSizeStyle } : undefined}
         >
           {/* Read-only-safe panels — always rendered for any role with
               `site.read`. These are navigation/inspection surfaces, not
               editing tools; each respects its own read-only state internally
               (e.g. TreeNode disables drag + context menu via `editable`). */}
           <div className={styles.panelMount} hidden={effectiveActivePanel !== 'explorer'}>
-            <ExplorerPanel editable={editable} />
+            <ExplorerPanel editable={editable} {...dockablePanelProps} />
           </div>
           {/* Editor-only panels — only mounted when the caller can perform
               structural edits. Mounting them for non-editors would expose
@@ -132,45 +182,45 @@ export function LeftSidebar({
           {editable && (
             <>
               <div className={styles.panelMount} hidden={effectiveActivePanel !== 'selectors'}>
-                <SelectorsPanel variant="docked" />
+                <SelectorsPanel {...dockablePanelProps} />
               </div>
               <div className={styles.panelMount} hidden={effectiveActivePanel !== 'framework'}>
-                <FrameworkPanel />
+                <FrameworkPanel {...dockablePanelProps} />
               </div>
               <div className={styles.panelMount} hidden={effectiveActivePanel !== 'dependencies'}>
-                <DependenciesPanel variant="docked" />
+                <DependenciesPanel {...dockablePanelProps} />
               </div>
               {effectivePluginPanelId !== null && (
                 <div
                   className={styles.panelMount}
                   data-testid="left-sidebar-plugin-panel-mount"
                 >
-                  <PluginEditorPanel panelId={effectivePluginPanelId} />
+                  <PluginEditorPanel
+                    panelId={effectivePluginPanelId}
+                    {...dockablePanelProps}
+                  />
                 </div>
               )}
             </>
           )}
-          {canUseAiChat && (
-            <div className={styles.panelMount} hidden={effectiveActivePanel !== 'agent'}>
-              {/* Inject the site editor's store API so AgentPanel +
-                  ModelPicker + ConversationHistory read agent state
-                  from useEditorStore. The same components are mounted
-                  in ContentPage with a different store.
-
-                  The eslint-disable below covers a known Zustand idiom:
-                  `useEditorStore` is the store API AND a hook — we pass
-                  the store API here, never call it as a hook in this
-                  file. The React-Compiler rule keys on the identifier
-                  prefix and can't see through the dual API. */}
-              {/* eslint-disable-next-line react-compiler/react-compiler */}
-              <AgentStoreProvider store={useEditorStore}>
-                <Suspense fallback={null}>
-                  <AgentPanel variant="docked" />
-                </Suspense>
-              </AgentStoreProvider>
-            </div>
+          {panelFloating && (
+            <PanelResizeHandle
+              panelLabel={panelResizeLabel}
+              resizeHandleProps={resizeHandleProps}
+            />
           )}
         </div>
+        {canUseAiChat && (
+          /* The AI assistant stays independent from the hosted left panel so
+             users can keep Layers visible while following a conversation.
+             Keeping it mounted also preserves the current draft. */
+          // eslint-disable-next-line react-compiler/react-compiler
+          <AgentStoreProvider store={useEditorStore}>
+            <Suspense fallback={null}>
+              <AgentPanel />
+            </Suspense>
+          </AgentStoreProvider>
+        )}
       </VCDeletionConfirmProvider>
       </FrameworkChangeConfirmProvider>
 

--- a/src/admin/pages/site/store/slices/uiSlice.ts
+++ b/src/admin/pages/site/store/slices/uiSlice.ts
@@ -4,6 +4,9 @@ import {
   LEFT_SIDEBAR_DEFAULT_WIDTH,
   clampSidebarWidth,
 } from '@admin/state/workspaceLayout'
+import type { PanelMode } from '@admin/state/workspaceLayoutStorage'
+
+export type { PanelMode } from '@admin/state/workspaceLayoutStorage'
 
 export type FocusedPanel = 'canvas' | 'domTree' | 'properties' | null
 type FormPreviewState = 'default' | 'submitting' | 'success' | 'error'
@@ -23,8 +26,6 @@ export type FrameworkPanelTab = 'home' | 'colors' | 'typography' | 'spacing'
  *   - `media`  — asset library (MediaExplorerPanel)
  */
 export type ExplorerPanelTab = 'layers' | 'site' | 'code' | 'media'
-export type PropertiesPanelMode = 'docked' | 'floating'
-
 const PROPERTIES_PANEL_DEFAULT_WIDTH = 360
 
 /**
@@ -77,9 +78,10 @@ export type LayoutNameDialogRequest =
 interface UiSlice {
   // Panel visibility / layout
   propertiesPanel: PanelState
-  propertiesPanelMode: PropertiesPanelMode
+  propertiesPanelMode: PanelMode
   propertiesPanelAutoOpenSuppressed: boolean
   leftSidebarWidth: number
+  leftSidebarMode: PanelMode
   focusedPanel: FocusedPanel
 
   // Settings modal state lives in `settingsSlice` (single source of truth) —
@@ -143,8 +145,9 @@ interface UiSlice {
   // Actions
   setPropertiesPanel: (state: Partial<PanelState>) => void
   consumePropertiesPanelAutoOpenSuppression: () => boolean
-  setPropertiesPanelMode: (mode: PropertiesPanelMode) => void
+  setPropertiesPanelMode: (mode: PanelMode) => void
   setLeftSidebarWidth: (width: number) => void
+  setLeftSidebarMode: (mode: PanelMode) => void
   togglePropertiesPanel: () => void
   setFocusedPanel: (panel: FocusedPanel) => void
   cycleFocusedPanel: () => void
@@ -286,7 +289,6 @@ function getActiveLeftSidebarPanel(state: EditorStore): LeftSidebarPanelId | nul
   if (state.selectorsPanelOpen) return 'selectors'
   if (state.frameworkPanelOpen) return 'framework'
   if (state.dependenciesPanelOpen) return 'dependencies'
-  if (state.isAgentOpen) return 'agent'
   return null
 }
 
@@ -301,6 +303,7 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
   propertiesPanelMode: 'docked',
   propertiesPanelAutoOpenSuppressed: false,
   leftSidebarWidth: LEFT_SIDEBAR_DEFAULT_WIDTH,
+  leftSidebarMode: 'docked',
   focusedPanel: 'canvas',
   previewOpen: false,
   formPreviewStates: {},
@@ -361,6 +364,11 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
     const nextWidth = clampSidebarWidth(width)
     if (Object.is(get().leftSidebarWidth, nextWidth)) return
     set({ leftSidebarWidth: nextWidth })
+  },
+
+  setLeftSidebarMode: (mode) => {
+    if (Object.is(get().leftSidebarMode, mode)) return
+    set({ leftSidebarMode: mode })
   },
 
   togglePropertiesPanel: () =>
@@ -439,16 +447,25 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
 
   setLeftSidebarPanel: (panel) =>
     set((state) => {
+      if (panel === 'agent') {
+        state.isAgentOpen = true
+        return
+      }
       state.explorerPanelOpen = panel === 'explorer'
       state.selectorsPanelOpen = panel === 'selectors'
       state.frameworkPanelOpen = panel === 'framework'
       state.dependenciesPanelOpen = panel === 'dependencies'
-      state.isAgentOpen = panel === 'agent'
       // Built-in panels are mutually exclusive with plugin panels.
       state.activePluginPanelId = null
     }),
 
   toggleLeftSidebarPanel: (panel) => {
+    if (panel === 'agent') {
+      set((state) => {
+        state.isAgentOpen = !state.isAgentOpen
+      })
+      return
+    }
     // Account for the plugin-panel-takes-precedence rule in
     // getActiveLeftSidebarPanel: if a plugin panel is currently active
     // and the user clicks a built-in rail item, that should open the
@@ -466,7 +483,6 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
       state.selectorsPanelOpen = false
       state.frameworkPanelOpen = false
       state.dependenciesPanelOpen = false
-      state.isAgentOpen = false
       state.activePluginPanelId = panelId
     }),
 

--- a/src/admin/shared/FloatingWindow/PanelResizeHandle.module.css
+++ b/src/admin/shared/FloatingWindow/PanelResizeHandle.module.css
@@ -1,0 +1,33 @@
+.handle {
+    position: absolute;
+    right: 0;
+    bottom: 0;
+    z-index: 4;
+    width: 20px;
+    height: 20px;
+    cursor: nwse-resize;
+    outline: none;
+}
+
+.handle::after {
+    content: "";
+    position: absolute;
+    right: 4px;
+    bottom: 4px;
+    width: 7px;
+    height: 7px;
+    border-right: 1px solid var(--overlay-30);
+    border-bottom: 1px solid var(--overlay-30);
+    transition: border-color 120ms ease;
+}
+
+.handle:hover::after,
+.handle:focus-visible::after {
+    border-color: var(--overlay-70);
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .handle::after {
+        transition: none;
+    }
+}

--- a/src/admin/shared/FloatingWindow/PanelResizeHandle.tsx
+++ b/src/admin/shared/FloatingWindow/PanelResizeHandle.tsx
@@ -1,0 +1,24 @@
+import type { PanelResizeHandleProps } from './useResizablePanel'
+import styles from './PanelResizeHandle.module.css'
+
+interface ResizeHandleProps {
+  panelLabel: string
+  resizeHandleProps: PanelResizeHandleProps
+}
+
+/** Bottom-right pointer and keyboard affordance for a floating panel. */
+export function PanelResizeHandle({
+  panelLabel,
+  resizeHandleProps,
+}: ResizeHandleProps) {
+  return (
+    <div
+      {...resizeHandleProps}
+      role="separator"
+      aria-label={`Resize ${panelLabel} panel`}
+      tabIndex={0}
+      className={styles.handle}
+      title={`Resize ${panelLabel} panel`}
+    />
+  )
+}

--- a/src/admin/shared/FloatingWindow/index.ts
+++ b/src/admin/shared/FloatingWindow/index.ts
@@ -1,5 +1,10 @@
 export { FloatingWindow } from './FloatingWindow'
+export { PanelResizeHandle } from './PanelResizeHandle'
 export {
   clampFloatingPanelPosition,
   useDraggablePanel,
 } from './useDraggablePanel'
+export {
+  clampFloatingPanelSize,
+  useResizablePanel,
+} from './useResizablePanel'

--- a/src/admin/shared/FloatingWindow/useDraggablePanel.ts
+++ b/src/admin/shared/FloatingWindow/useDraggablePanel.ts
@@ -112,6 +112,7 @@ export function useDraggablePanel(
 
   useEffect(() => {
     function onResize(): void {
+      if (dragRef.current) return
       setPosition((current) => {
         const clamped = clampToViewport(current, panelRef.current)
         positionRef.current = clamped
@@ -139,6 +140,10 @@ export function useDraggablePanel(
       x: dragRef.current.startPanelX + event.clientX - dragRef.current.startClientX,
       y: dragRef.current.startPanelY + event.clientY - dragRef.current.startClientY,
     }, panelRef.current)
+    // ResizeObserver callbacks and ordinary panel re-renders can run between
+    // pointer events. Keep their imperative source aligned with the pixels on
+    // screen so they cannot restore the pointer-down position mid-drag.
+    positionRef.current = clamped
     panelRef.current?.style.setProperty('--panel-x', `${clamped.x}px`)
     panelRef.current?.style.setProperty('--panel-y', `${clamped.y}px`)
   }

--- a/src/admin/shared/FloatingWindow/useResizablePanel.ts
+++ b/src/admin/shared/FloatingWindow/useResizablePanel.ts
@@ -1,0 +1,237 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type {
+  CSSProperties,
+  KeyboardEvent,
+  PointerEvent,
+  RefObject,
+} from 'react'
+import {
+  readStoredPanelSize,
+  writeStoredPanelSize,
+  type FloatingPanelId,
+  type PanelSize,
+} from '@admin/state/workspaceLayoutStorage'
+
+const VIEWPORT_MARGIN = 16
+const KEYBOARD_STEP = 10
+const LARGE_KEYBOARD_STEP = 40
+
+interface ResizeBounds {
+  viewportWidth: number
+  viewportHeight: number
+  panelLeft: number
+  panelTop: number
+  minWidth: number
+  minHeight: number
+}
+
+interface ResizeState extends ResizeBounds {
+  startClientX: number
+  startClientY: number
+  startWidth: number
+  startHeight: number
+}
+
+interface ResizablePanelOptions {
+  minWidth?: number
+  minHeight?: number
+}
+
+export interface PanelResizeHandleProps {
+  ref: RefObject<HTMLDivElement | null>
+  onPointerDown: (event: PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (event: PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (event: PointerEvent<HTMLDivElement>) => void
+  onPointerCancel: (event: PointerEvent<HTMLDivElement>) => void
+  onKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void
+  'aria-valuemin': number
+  'aria-valuemax': number
+  'aria-valuenow': number
+  'aria-valuetext': string
+}
+
+interface UseResizablePanelResult {
+  panelSizeStyle: CSSProperties
+  resizeHandleProps: PanelResizeHandleProps
+}
+
+/** Keep a floating panel usable while its bottom-right corner is resized. */
+export function clampFloatingPanelSize(
+  size: PanelSize,
+  bounds: ResizeBounds,
+): PanelSize {
+  const availableWidth = Math.max(
+    bounds.minWidth,
+    bounds.viewportWidth - Math.max(bounds.panelLeft, VIEWPORT_MARGIN) - VIEWPORT_MARGIN,
+  )
+  const availableHeight = Math.max(
+    bounds.minHeight,
+    bounds.viewportHeight - Math.max(bounds.panelTop, 0) - VIEWPORT_MARGIN,
+  )
+  return {
+    width: Math.max(bounds.minWidth, Math.min(size.width, availableWidth)),
+    height: Math.max(bounds.minHeight, Math.min(size.height, availableHeight)),
+  }
+}
+
+function sizesEqual(a: PanelSize, b: PanelSize): boolean {
+  return a.width === b.width && a.height === b.height
+}
+
+function viewportBounds(
+  panel: HTMLElement | null,
+  minWidth: number,
+  minHeight: number,
+): ResizeBounds {
+  const rect = panel?.getBoundingClientRect()
+  return {
+    viewportWidth: window.innerWidth,
+    viewportHeight: window.innerHeight,
+    panelLeft: rect?.left ?? VIEWPORT_MARGIN,
+    panelTop: rect?.top ?? 64,
+    minWidth,
+    minHeight,
+  }
+}
+
+function sizeFromPointer(resize: ResizeState, clientX: number, clientY: number): PanelSize {
+  return clampFloatingPanelSize({
+    width: resize.startWidth + clientX - resize.startClientX,
+    height: resize.startHeight + clientY - resize.startClientY,
+  }, resize)
+}
+
+/**
+ * Persisted two-axis resizing for a floating panel. Pointer movement writes
+ * CSS variables directly so resizing stays smooth; React state commits once
+ * the gesture ends.
+ */
+export function useResizablePanel(
+  panelId: FloatingPanelId,
+  panelRef: RefObject<HTMLElement | null>,
+  getDefault: () => PanelSize,
+  {
+    minWidth = 280,
+    minHeight = 240,
+  }: ResizablePanelOptions = {},
+): UseResizablePanelResult {
+  const [size, setSize] = useState<PanelSize>(() => {
+    const initial = readStoredPanelSize(panelId) ?? getDefault()
+    if (typeof window === 'undefined') return initial
+    return clampFloatingPanelSize(initial, viewportBounds(null, minWidth, minHeight))
+  })
+  const sizeRef = useRef(size)
+  const resizeRef = useRef<ResizeState | null>(null)
+  const handleRef = useRef<HTMLDivElement | null>(null)
+
+  // useCallback kept: stable identity for the [applyLiveSize] effect dependency.
+  const applyLiveSize = useCallback((nextSize: PanelSize): void => {
+    sizeRef.current = nextSize
+    panelRef.current?.style.setProperty('--panel-w', `${nextSize.width}px`)
+    panelRef.current?.style.setProperty('--panel-h', `${nextSize.height}px`)
+    handleRef.current?.setAttribute(
+      'aria-valuetext',
+      `${Math.round(nextSize.width)} by ${Math.round(nextSize.height)} pixels`,
+    )
+    handleRef.current?.setAttribute('aria-valuenow', String(Math.round(nextSize.width)))
+  }, [panelRef])
+
+  useEffect(() => {
+    sizeRef.current = size
+    applyLiveSize(size)
+  }, [applyLiveSize, size])
+
+  useEffect(() => {
+    writeStoredPanelSize(panelId, size)
+  }, [panelId, size])
+
+  useEffect(() => {
+    function onResize(): void {
+      if (resizeRef.current) return
+      const clamped = clampFloatingPanelSize(
+        sizeRef.current,
+        viewportBounds(panelRef.current, minWidth, minHeight),
+      )
+      applyLiveSize(clamped)
+      setSize((current) => sizesEqual(current, clamped) ? current : clamped)
+    }
+    window.addEventListener('resize', onResize)
+    return () => window.removeEventListener('resize', onResize)
+  }, [applyLiveSize, minHeight, minWidth, panelRef])
+
+  function onPointerDown(event: PointerEvent<HTMLDivElement>): void {
+    const panel = panelRef.current
+    if (!panel) return
+    const rect = panel.getBoundingClientRect()
+    resizeRef.current = {
+      ...viewportBounds(panel, minWidth, minHeight),
+      startClientX: event.clientX,
+      startClientY: event.clientY,
+      startWidth: rect.width,
+      startHeight: rect.height,
+    }
+    event.currentTarget.setPointerCapture(event.pointerId)
+    event.preventDefault()
+    event.stopPropagation()
+  }
+
+  function onPointerMove(event: PointerEvent<HTMLDivElement>): void {
+    if (!resizeRef.current) return
+    applyLiveSize(sizeFromPointer(resizeRef.current, event.clientX, event.clientY))
+  }
+
+  function commitPointerResize(clientX: number, clientY: number): void {
+    if (!resizeRef.current) return
+    const nextSize = sizeFromPointer(resizeRef.current, clientX, clientY)
+    resizeRef.current = null
+    applyLiveSize(nextSize)
+    setSize(nextSize)
+  }
+
+  function onPointerUp(event: PointerEvent<HTMLDivElement>): void {
+    commitPointerResize(event.clientX, event.clientY)
+  }
+
+  function onPointerCancel(event: PointerEvent<HTMLDivElement>): void {
+    commitPointerResize(event.clientX, event.clientY)
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLDivElement>): void {
+    const step = event.shiftKey ? LARGE_KEYBOARD_STEP : KEYBOARD_STEP
+    const delta = {
+      width: event.key === 'ArrowRight' ? step : event.key === 'ArrowLeft' ? -step : 0,
+      height: event.key === 'ArrowDown' ? step : event.key === 'ArrowUp' ? -step : 0,
+    }
+    if (delta.width === 0 && delta.height === 0) return
+    event.preventDefault()
+    event.stopPropagation()
+    const nextSize = clampFloatingPanelSize({
+      width: sizeRef.current.width + delta.width,
+      height: sizeRef.current.height + delta.height,
+    }, viewportBounds(panelRef.current, minWidth, minHeight))
+    applyLiveSize(nextSize)
+    setSize(nextSize)
+  }
+
+  const maxWidth = typeof window === 'undefined' ? size.width : window.innerWidth
+  const panelSizeStyle = {
+    '--panel-w': `${size.width}px`,
+    '--panel-h': `${size.height}px`,
+  } as CSSProperties
+
+  return {
+    panelSizeStyle,
+    resizeHandleProps: {
+      ref: handleRef,
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel,
+      onKeyDown,
+      'aria-valuemin': minWidth,
+      'aria-valuemax': maxWidth,
+      'aria-valuenow': Math.round(size.width),
+      'aria-valuetext': `${Math.round(size.width)} by ${Math.round(size.height)} pixels`,
+    },
+  }
+}

--- a/src/admin/shared/Panel/Panel.tsx
+++ b/src/admin/shared/Panel/Panel.tsx
@@ -26,11 +26,27 @@
  * @see Guideline #357 — Compact UI density (36px header)
  */
 import type { CSSProperties, ReactNode, Ref } from 'react'
-import { PanelHeader } from '@admin/shared/PanelHeader'
+import {
+  PanelHeader,
+  PanelModeButton,
+  type PanelDragHandleProps,
+} from '@admin/shared/PanelHeader'
+import type { PanelMode } from '@admin/state/workspaceLayoutStorage'
 import { cn } from '@ui/cn'
 import styles from './Panel.module.css'
 
-interface PanelProps {
+export interface DockablePanelProps {
+  /** Enables header dragging when this panel is hosted as a floating window. */
+  dragHandleProps?: PanelDragHandleProps
+  /** Reflected on the root for panel-host styling and interaction tests. */
+  mode?: PanelMode
+  /** Adds the shared dock / unpin action to the header when provided. */
+  onToggleMode?: () => void
+  /** Human-readable sidebar destination used in the dock action tooltip. */
+  dockLocation?: string
+}
+
+interface PanelProps extends DockablePanelProps {
   /** Stable identifier — feeds the `<PanelHeader>` testids and the
    *  `data-testid` on the panel root. */
   panelId: string
@@ -88,6 +104,10 @@ export function Panel({
   onClose,
   headerless = false,
   headerActions,
+  dragHandleProps,
+  mode = 'docked',
+  onToggleMode,
+  dockLocation = 'sidebar',
   body = 'padded',
   bodyClassName,
   bodyRef,
@@ -103,6 +123,7 @@ export function Panel({
       aria-label={ariaLabel ?? title}
       data-panel=""
       data-testid={testId ?? `panel-${panelId}`}
+      data-mode={mode}
       tabIndex={-1}
       onClick={(e) => e.stopPropagation()}
       className={cn(styles.panel, className)}
@@ -113,8 +134,17 @@ export function Panel({
           title={title}
           titleContent={titleContent}
           onClose={onClose}
+          dragHandleProps={dragHandleProps}
         >
           {headerActions}
+          {onToggleMode && (
+            <PanelModeButton
+              mode={mode}
+              panelLabel={title}
+              dockLocation={dockLocation}
+              onToggle={onToggleMode}
+            />
+          )}
         </PanelHeader>
       )}
 

--- a/src/admin/shared/Panel/index.ts
+++ b/src/admin/shared/Panel/index.ts
@@ -1,2 +1,3 @@
 export { Panel } from './Panel'
+export type { DockablePanelProps } from './Panel'
 export { useAutoFocusPanel } from './useAutoFocusPanel'

--- a/src/admin/shared/PanelHeader/PanelHeader.tsx
+++ b/src/admin/shared/PanelHeader/PanelHeader.tsx
@@ -23,6 +23,13 @@ import { CloseIcon } from 'pixel-art-icons/icons/close'
 import { Button } from '@ui/components/Button'
 import styles from './PanelHeader.module.css'
 
+export interface PanelDragHandleProps {
+  onPointerDown: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerMove: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerUp: (event: React.PointerEvent<HTMLDivElement>) => void
+  onPointerCancel: (event: React.PointerEvent<HTMLDivElement>) => void
+}
+
 interface PanelHeaderProps {
   /** Panel title displayed in the header. */
   title: string
@@ -42,12 +49,7 @@ interface PanelHeaderProps {
    * Spread onto the header div to enable drag-to-reposition.
    * Provided by the `useDraggablePanel` hook via its `headerDragProps` field.
    */
-  dragHandleProps?: {
-    onPointerDown: (e: React.PointerEvent<HTMLDivElement>) => void
-    onPointerMove: (e: React.PointerEvent<HTMLDivElement>) => void
-    onPointerUp: (e: React.PointerEvent<HTMLDivElement>) => void
-    onPointerCancel: (e: React.PointerEvent<HTMLDivElement>) => void
-  }
+  dragHandleProps?: PanelDragHandleProps
   /**
    * Optional extra action buttons rendered between the title and the close button.
    * Example: AgentPanel's "clear conversation" button.

--- a/src/admin/shared/PanelHeader/PanelModeButton.tsx
+++ b/src/admin/shared/PanelHeader/PanelModeButton.tsx
@@ -1,0 +1,40 @@
+import { DockSolidIcon } from 'pixel-art-icons/icons/dock-solid'
+import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
+import { Button } from '@ui/components/Button'
+import type { PanelMode } from '@admin/state/workspaceLayoutStorage'
+
+interface PanelModeButtonProps {
+  mode: PanelMode
+  panelLabel: string
+  dockLocation: string
+  onToggle: () => void
+}
+
+/** Shared icon action for moving a panel between its sidebar and the canvas. */
+export function PanelModeButton({
+  mode,
+  panelLabel,
+  dockLocation,
+  onToggle,
+}: PanelModeButtonProps) {
+  const floating = mode === 'floating'
+  const action = floating ? `Dock ${panelLabel} panel` : `Unpin ${panelLabel} panel`
+  const tooltip = floating ? `Dock in ${dockLocation}` : 'Unpin to floating panel'
+
+  return (
+    <Button
+      variant="ghost"
+      size="xs"
+      iconOnly
+      onClick={onToggle}
+      aria-label={action}
+      tooltip={tooltip}
+    >
+      {floating ? (
+        <DockSolidIcon size={12} aria-hidden="true" />
+      ) : (
+        <OpenSolidIcon size={12} aria-hidden="true" />
+      )}
+    </Button>
+  )
+}

--- a/src/admin/shared/PanelHeader/index.ts
+++ b/src/admin/shared/PanelHeader/index.ts
@@ -1,1 +1,3 @@
 export { PanelHeader } from './PanelHeader'
+export type { PanelDragHandleProps } from './PanelHeader'
+export { PanelModeButton } from './PanelModeButton'

--- a/src/admin/state/workspaceLayoutStorage.ts
+++ b/src/admin/state/workspaceLayoutStorage.ts
@@ -1,7 +1,7 @@
 import { Type } from '@sinclair/typebox'
 import { safeParseJson } from '@core/utils/jsonValidate'
 
-export type PropertiesPanelMode = 'docked' | 'floating'
+export type PanelMode = 'docked' | 'floating'
 
 /**
  * Per-workspace editor layout storage.
@@ -26,6 +26,12 @@ export const EDITOR_LAYOUT_STORAGE_KEY = 'instatic-editor-layout-v2'
 export interface PanelPosition {
   x: number
   y: number
+}
+
+/** Persisted dimensions for a user-resizable floating panel. */
+export interface PanelSize {
+  width: number
+  height: number
 }
 
 export type FloatingPanelId =
@@ -83,7 +89,11 @@ export interface StoredWorkspaceLayout {
   /** Whether the floating code editor is visible (site only). */
   codeEditorPanelOpen?: boolean
   /** Properties panel docked vs floating (site only). */
-  propertiesPanelMode?: PropertiesPanelMode
+  propertiesPanelMode?: PanelMode
+  /** Left-rail panel docked vs floating (site only). */
+  leftSidebarMode?: PanelMode
+  /** Whether the independent floating AI assistant is open (site only). */
+  agentPanelOpen?: boolean
 }
 
 interface StoredEditorLayout {
@@ -93,6 +103,8 @@ interface StoredEditorLayout {
    * unique to a single workspace so positions are kept at the top level.
    */
   panelPositions?: Partial<Record<FloatingPanelId, PanelPosition>>
+  /** User-set dimensions for floating panels that support two-axis resizing. */
+  panelSizes?: Partial<Record<FloatingPanelId, PanelSize>>
   /** Per-workspace sidebar / panel state. */
   workspaces?: Partial<Record<EditorWorkspaceId, StoredWorkspaceLayout>>
 }
@@ -111,6 +123,14 @@ const PanelPositionSchema = Type.Object(
   { additionalProperties: true },
 )
 
+const PanelSizeSchema = Type.Object(
+  {
+    width: Type.Number(),
+    height: Type.Number(),
+  },
+  { additionalProperties: true },
+)
+
 const StoredWorkspaceLayoutSchema = Type.Object(
   {
     leftWidth: Type.Optional(Type.Number()),
@@ -121,9 +141,11 @@ const StoredWorkspaceLayoutSchema = Type.Object(
     explorerPanelTab: Type.Optional(Type.String()),
     activeEditorFileId: Type.Optional(Type.Union([Type.String(), Type.Null()])),
     codeEditorPanelOpen: Type.Optional(Type.Boolean()),
-    // PropertiesPanelMode is a string union; keep loose to avoid coupling to
-    // its exact membership here.
+    // Panel modes are string unions; keep them loose to avoid coupling this
+    // persisted boundary to their exact membership.
     propertiesPanelMode: Type.Optional(Type.String()),
+    leftSidebarMode: Type.Optional(Type.String()),
+    agentPanelOpen: Type.Optional(Type.Boolean()),
   },
   { additionalProperties: true },
 )
@@ -133,6 +155,9 @@ const StoredEditorLayoutSchema = Type.Object(
     version: Type.Literal(2),
     panelPositions: Type.Optional(
       Type.Record(Type.String(), PanelPositionSchema),
+    ),
+    panelSizes: Type.Optional(
+      Type.Record(Type.String(), PanelSizeSchema),
     ),
     workspaces: Type.Optional(
       Type.Record(Type.String(), StoredWorkspaceLayoutSchema),
@@ -150,6 +175,13 @@ function isPanelPosition(value: unknown): value is PanelPosition {
   const pos = value as Partial<PanelPosition>
   return typeof pos.x === 'number' && Number.isFinite(pos.x)
     && typeof pos.y === 'number' && Number.isFinite(pos.y)
+}
+
+function isPanelSize(value: unknown): value is PanelSize {
+  if (!value || typeof value !== 'object') return false
+  const size = value as Partial<PanelSize>
+  return typeof size.width === 'number' && Number.isFinite(size.width)
+    && typeof size.height === 'number' && Number.isFinite(size.height)
 }
 
 export function readEditorLayout(): StoredEditorLayout | null {
@@ -221,6 +253,22 @@ export function writeStoredPanelPosition(panelId: FloatingPanelId, position: Pan
     panelPositions: {
       ...layout.panelPositions,
       [panelId]: position,
+    },
+  }))
+}
+
+export function readStoredPanelSize(panelId: FloatingPanelId): PanelSize | null {
+  const size = readEditorLayout()?.panelSizes?.[panelId]
+  return isPanelSize(size) ? size : null
+}
+
+export function writeStoredPanelSize(panelId: FloatingPanelId, size: PanelSize) {
+  updateEditorLayout((layout) => ({
+    ...layout,
+    version: 2,
+    panelSizes: {
+      ...layout.panelSizes,
+      [panelId]: size,
     },
   }))
 }


### PR DESCRIPTION
## Summary

- add the shared dock/unpin control to Explorer, Selectors, Framework, Dependencies, and plugin editor panels
- keep the AI Assistant as an independent draggable and resizable window so it can remain open beside Layers or another left panel
- make floating Properties and left-panel windows resizable in both axes, with pointer and keyboard controls
- persist floating mode, position, dimensions, and the independent AI open state across reloads
- correct the floating Explorer search fade so it uses the host surface instead of leaving a mismatched dark band

## Why

The floating Properties panel had both vertical edges constrained, so dragging changed its measured height and a resize observer repeatedly restored stale coordinates, producing the back-and-forth jump. Left-side panels also shared mutually exclusive open state with the AI Assistant, which prevented the Layers + AI workflow requested in #291.

This change gives floating windows one explicit position and size source, separates AI visibility from the hosted left panel, and centralizes the reusable dock and resize behavior.

## User impact

Users can now:

- keep Explorer/Layers visible while working in the AI Assistant
- undock every hosted editor panel through the same header action
- drag floating panels without position jitter
- resize floating panels horizontally and vertically
- reload the editor without losing panel placement or dimensions

## Verification

- `bun run lint`
- `bun run build`
- `bun test` — 6,302 passed, 0 failed
- real-browser check: Explorer and AI open simultaneously; AI dragged and resized from 320×480 to 420×530; exact position and size restored after reload
- real-browser checks for Explorer and Properties drag/resize persistence
- `git diff --check`

Closes #291