### PR TITLE
feat(loops): support contextual entry field iteration

### DIFF
--- a/docs/features/loops.md
+++ b/docs/features/loops.md
@@ -10,6 +10,7 @@ Loop sources are pluggable: built-in sources (`data.rows`, `site.pages`, `site.m
 
 - Loop source registry: `loopSourceRegistry` in `src/core/loops/registry.ts`. First-party sources self-register from `src/core/loops/sources/index.ts` at boot.
 - `LoopEntitySource` shape: `{ id, label, fields, filterSchema?, orderByOptions?, fetch, preview? }` in `src/core/loops/types.ts`.
+- `entry.field` is the contextual exception: it resolves an array on the closest `currentEntry` separately for every outer iteration, so a Project's multi-media `gallery` field can drive an inner loop.
 - The `base.loop` module's children are **variants** — different per-item layouts (e.g. "Card", "Featured"). The walker round-robins across them as it iterates.
 - At publish time, `loopPrefetch.ts` calls each loop's `fetch()` and stores results on the render context. The walker is then purely synchronous.
 - Each iteration renders against a fresh `entryStack` snapshot (`[...baseStack, item]`) carried in a child `RenderConfig`; nodes inside the loop resolve `currentEntry.<field>` against that item via dynamic bindings. The stack is never mutated in place.
@@ -26,6 +27,7 @@ src/core/loops/
 └── sources/
     ├── index.ts             — register the three built-ins at boot
     ├── dataRows.ts          — data.rows (any data_table)
+    ├── entryField.ts        — entry.field (array field on currentEntry)
     ├── sitePages.ts         — site.pages (+ shared helpers re-exported via barrel)
     └── siteMedia.ts         — site.media
 
@@ -144,6 +146,30 @@ Used by galleries.
 
 Its author-facing `fields` list exposes filename, path/URL/source URL, MIME type, and upload date. Internal uploader ids stay in `LoopItem.fields` for code that needs them, but they are not binding-picker rows.
 
+### `entry.field`
+
+Iterates an array-valued field on the closest enclosing entry. It is resolved
+inside the synchronous render walk rather than prefetched once by loop node id,
+because the value can differ for every outer iteration:
+
+```text
+Projects loop
+  Project A → gallery [a1, a2] → inner loop renders a1, a2
+  Project B → gallery [b1]     → inner loop renders b1
+```
+
+The Properties panel offers collection fields from the current entry table:
+multi-media, multi-relation, and multi-select fields. Primitive items are
+available as `currentEntry.value`; object-array members are exposed by key.
+Media ids are resolved through the publisher's batched media prefetch and
+provide `currentEntry.src`, `url`, `path`, `altText`, `mimeType`, `width`, and
+`height`.
+
+Contextual loops preserve authored order by default, can reverse/slice with
+direction/offset/limit, and do not support infinite pagination. Infinite
+fragments are independent requests and cannot recover an arbitrary outer
+entry stack safely.
+
 ### Plugin-registered sources
 
 A plugin with `loops.register` registers a custom source via the SDK at activation. The source runs inside the **QuickJS sandbox** — it can use `api.cms.storage.collection(...)` to fetch plugin-owned data or `fetch(...)` (with `network.outbound` permission) for external APIs.
@@ -243,7 +269,10 @@ See [docs/features/publisher.md](publisher.md) → "renderLoop" for the broader 
 
 ## Prefetch
 
-The walker is **purely synchronous** — async data (loop sources, media) is resolved up-front so the publisher doesn't have to `await` per node.
+The walker is **purely synchronous**. Async data (prefetched loop sources and
+media) is resolved up-front so the publisher doesn't have to `await` per node.
+`entry.field` stays synchronous by deriving its items from the already-present
+entry stack.
 
 `server/publish/loopPrefetch.ts`:
 
@@ -304,6 +333,18 @@ Subscription granularity: the hook never subscribes to the whole `site` document
    - Drop a `base.container` as the loop's first child — this is variant A.
    - Add nodes inside: a heading bound to `currentEntry.title`, content bound to `currentEntry.body`, an image bound to `currentEntry.featuredMedia`.
 6. Publish. Each iteration renders the variant with the item's fields substituted.
+
+### Build a per-project media gallery
+
+1. Add a Media field named `gallery` to the Projects post type and enable
+   **Allow multiple**.
+2. On the Project entry template, insert a Loop.
+3. Set Source to **Current entry field** and Field to **Gallery**.
+4. Add an Image as the loop's child template.
+5. Bind the Image source to **Current entry field → Media source** and,
+   optionally, its alt text to **Alt text**.
+6. Publish the site and a Project entry. Each project route renders only that
+   project's gallery items, in the field's authored order.
 
 ### Build a loop with the AI agent
 

--- a/server/handlers/cms/data/preview.ts
+++ b/server/handlers/cms/data/preview.ts
@@ -103,20 +103,21 @@ export async function handleRowPreview(
   // resolution, etc.) operate against this seed.
   const draftPublishedRow: PublishedDataRow = synthesisePublishedRow(row, table, draftCells)
 
-  const [loopData, mediaAssets] = await Promise.all([
-    prefetchLoopData(merged, snapshot.site, db),
-    prefetchMediaAssets(merged, snapshot.site, registry, db),
-  ])
-  const cssBundle = buildSiteCssBundle(snapshot.site, registry, merged, { mediaAssets })
-
   const publicPath = buildEntryPublicPath(table.routeBase, draftPublishedRow.slug)
   const syntheticUrl = new URL(`http://localhost${publicPath}`)
+  const templateContext = {
+    entryStack: [publishedDataRowToLoopItem(draftPublishedRow)],
+    route: buildRouteFrame(syntheticUrl.toString()),
+  }
+  const loopData = await prefetchLoopData(merged, snapshot.site, db)
+  const mediaAssets = await prefetchMediaAssets(merged, snapshot.site, registry, db, {
+    templateContext,
+    loopData,
+  })
+  const cssBundle = buildSiteCssBundle(snapshot.site, registry, merged, { mediaAssets })
 
   const published = publishPage(merged, snapshot.site, registry, {
-    templateContext: {
-      entryStack: [publishedDataRowToLoopItem(draftPublishedRow)],
-      route: buildRouteFrame(syntheticUrl.toString()),
-    },
+    templateContext,
     runtimeAssets: snapshot.runtimeAssets,
     runtimePackageImportmap: snapshot.runtimePackageImportmap,
     cssEmission: 'external',

--- a/server/handlers/cms/loop.ts
+++ b/server/handlers/cms/loop.ts
@@ -97,6 +97,9 @@ export async function handleLoopRequest(
   if (!source) {
     return jsonResponse({ error: 'Source not registered' }, { status: 404 })
   }
+  if (source.kind === 'contextual') {
+    return jsonResponse({ error: 'Contextual loops do not support infinite pagination' }, { status: 400 })
+  }
 
   // Fetch the requested page slice.
   const offset = props.offset + (pageNumber - 1) * props.pageSize

--- a/server/publish/loopPrefetch.ts
+++ b/server/publish/loopPrefetch.ts
@@ -12,9 +12,9 @@
 
 import type { Page, PageNode, SiteDocument } from '@core/page-tree'
 import type {
-  LoopEntitySource,
   LoopFetchResult,
   LoopItem,
+  PrefetchedLoopEntitySource,
   SourceFetchContext,
   SourceRequestContext,
 } from '@core/loops/types'
@@ -219,7 +219,7 @@ function readPageNumber(url: URL | undefined, loopNodeId: string): number {
  */
 async function resolveOneLoop(
   node: PageNode,
-  source: LoopEntitySource,
+  source: PrefetchedLoopEntitySource,
   ctx: { db: DbClient; site: SiteDocument; url?: URL; request?: SourceRequestContext },
 ): Promise<ResolvedLoopData> {
   const props = readLoopProps(node)
@@ -288,7 +288,7 @@ export async function prefetchLoopData(
     nodes.map(async (node) => {
       const props = readLoopProps(node)
       const source = props.sourceId ? loopSourceRegistry.get(props.sourceId) : undefined
-      if (!source) {
+      if (!source || source.kind === 'contextual') {
         return [
           node.id,
           { items: [], totalItems: 0, pageNumber: 1, hasMore: false },

--- a/server/publish/mediaPrefetch.ts
+++ b/server/publish/mediaPrefetch.ts
@@ -19,7 +19,12 @@
 
 import type { Page, SiteDocument } from '@core/page-tree'
 import type { IModuleRegistry } from '@core/module-engine'
-import { collectNodeBackgroundImagePaths, collectSiteStyleBackgroundImagePaths } from '@core/publisher'
+import {
+  collectNodeBackgroundImagePaths,
+  collectSiteStyleBackgroundImagePaths,
+  type ResolvedLoopRenderData,
+} from '@core/publisher'
+import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { walkRenderTree } from './renderTreeWalk'
 import type { DbClient } from '../db/client'
 import type { MediaAsset } from '../repositories/media'
@@ -32,6 +37,11 @@ import { materializeAssetMapForClient } from './mediaPresentation'
 
 /** Map keyed by the asset's `public_path` for O(1) lookup at render time. */
 type MediaAssetMap = Map<string, MediaAsset>
+
+interface MediaPrefetchOptions {
+  templateContext?: TemplateRenderDataContext
+  loopData?: ReadonlyMap<string, ResolvedLoopRenderData>
+}
 
 /**
  * Collect every `/uploads/...` path referenced by an image/media-typed prop
@@ -72,32 +82,62 @@ export async function prefetchMediaAssets(
   site: SiteDocument,
   registry: IModuleRegistry,
   db: DbClient,
+  options: MediaPrefetchOptions = {},
 ): Promise<MediaAssetMap> {
   const map = new Map<string, MediaAsset>()
   const paths = collectMediaPaths(page, site, registry)
-  if (paths.size === 0) return map
+  const entryReferences = collectEntryArrayReferences(options)
+  if (paths.size === 0 && entryReferences.size === 0) return map
 
-  // `collectMediaPaths` already returns a Set, so the paths are unique.
+  // `collectMediaPaths` and `collectEntryArrayReferences` both return Sets,
+  // so the lookup values are unique. Entry references are queried against
+  // both `id` and `public_path`: multi-media cells store ids, while plugin or
+  // imported entry arrays may already carry public paths.
   const pathsToFetch = [...paths]
-  const placeholders = pathsToFetch.map((_, i) =>
-    db.dialect === 'postgres' ? `$${i + 1}` : '?'
-  ).join(', ')
+  const entryReferencesToFetch = [...entryReferences]
+  const allReferences = [...new Set([...pathsToFetch, ...entryReferencesToFetch])]
   // Bespoke batched-by-`public_path` SELECT (the render path resolves by stored
   // URL, not asset id, and legitimately skips the folder-id join). It maps
   // through the SAME canonical `mapMediaAssetRow` as the repository, so the
   // published page and the admin see one identical asset shape — including
   // storageAdapterId, externallyHosted, and the variants' storagePath /
   // storageAdapterId derivation.
-  const { rows } = await db.unsafe<MediaAssetRow>(
-    `select ${MEDIA_ASSET_COLUMNS}
-     from media_assets
-     where public_path in (${placeholders}) and deleted_at is null`,
-    pathsToFetch,
-  )
+  let rows: MediaAssetRow[]
+  if (entryReferencesToFetch.length === 0) {
+    const placeholders = pathsToFetch.map((_, i) =>
+      db.dialect === 'postgres' ? `$${i + 1}` : '?'
+    ).join(', ')
+    const result = await db.unsafe<MediaAssetRow>(
+      `select ${MEDIA_ASSET_COLUMNS}
+       from media_assets
+       where public_path in (${placeholders}) and deleted_at is null`,
+      pathsToFetch,
+    )
+    rows = result.rows
+  } else {
+    const pathPlaceholders = allReferences.map((_, i) =>
+      db.dialect === 'postgres' ? `$${i + 1}` : '?'
+    ).join(', ')
+    const idPlaceholders = allReferences.map((_, i) =>
+      db.dialect === 'postgres' ? `$${allReferences.length + i + 1}` : '?'
+    ).join(', ')
+    const result = await db.unsafe<MediaAssetRow>(
+      `select ${MEDIA_ASSET_COLUMNS}
+       from media_assets
+       where (public_path in (${pathPlaceholders}) or id in (${idPlaceholders}))
+         and deleted_at is null`,
+      [...allReferences, ...allReferences],
+    )
+    rows = result.rows
+  }
   const byPath = new Map(rows.map(r => [r.public_path, r]))
-  for (const path of pathsToFetch) {
-    const row = byPath.get(path)
-    if (row) map.set(path, mapMediaAssetRow(row))
+  const byId = new Map(rows.map(r => [r.id, r]))
+  for (const reference of allReferences) {
+    const row = byPath.get(reference) ?? byId.get(reference)
+    if (!row) continue
+    const asset = mapMediaAssetRow(row)
+    map.set(reference, asset)
+    map.set(asset.publicPath, asset)
   }
   // Apply the `media.url.transform` filter chain to every asset's URLs
   // (publicPath + variants[*].path). The map KEY stays the page tree's
@@ -105,4 +145,30 @@ export async function prefetchMediaAssets(
   // rewritten so transformer plugins (passive CDN, image-CDN) take effect
   // on the published page AND the editor preview iframe in one place.
   return materializeAssetMapForClient(map)
+}
+
+function collectEntryArrayReferences(options: MediaPrefetchOptions): Set<string> {
+  const references = new Set<string>()
+  const visit = (value: unknown, insideArray: boolean): void => {
+    if (typeof value === 'string') {
+      if (insideArray && value) references.add(value)
+      return
+    }
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, true)
+      return
+    }
+    if (!value || typeof value !== 'object') return
+    for (const child of Object.values(value as Record<string, unknown>)) {
+      visit(child, insideArray)
+    }
+  }
+
+  for (const entry of options.templateContext?.entryStack ?? []) {
+    visit(entry.fields, false)
+  }
+  for (const data of options.loopData?.values() ?? []) {
+    for (const item of data.items) visit(item.fields, false)
+  }
+  return references
 }

--- a/server/publish/publicRenderer.ts
+++ b/server/publish/publicRenderer.ts
@@ -93,10 +93,11 @@ async function renderMergedTemplate(
 ): Promise<{ html: string; jsModuleIds: string[]; publishVersion: number; cssBundle: SiteCssBundle }> {
   const publishVersion = ctx.publishVersion ?? getPublishVersion()
   const moduleJsMap = buildPublishedSiteModuleJsMap(snapshot.site, registry)
-  const [loopData, mediaAssets] = await Promise.all([
-    prefetchLoopData(merged, snapshot.site, ctx.db, ctx.url),
-    prefetchMediaAssets(merged, snapshot.site, registry, ctx.db),
-  ])
+  const loopData = await prefetchLoopData(merged, snapshot.site, ctx.db, ctx.url)
+  const mediaAssets = await prefetchMediaAssets(merged, snapshot.site, registry, ctx.db, {
+    templateContext,
+    loopData,
+  })
   const cssBundle = buildPublishedSiteCssBundle(snapshot.site, registry, merged, publishVersion, { mediaAssets })
   const published = publishPage(merged, snapshot.site, registry, {
     templateContext,

--- a/server/publish/runtime/previewRuntime.ts
+++ b/server/publish/runtime/previewRuntime.ts
@@ -76,12 +76,15 @@ export async function buildRuntimePreviewDocument(
       runtimePackageImportmap = { body: serialized.body, sha256: serialized.sha256 }
     }
   }
-  const [loopData, mediaAssets] = input.db
-    ? await Promise.all([
-        prefetchLoopData(input.page, input.site, input.db),
-        prefetchMediaAssets(input.page, input.site, input.registry, input.db),
-      ])
-    : [undefined, undefined]
+  const loopData = input.db
+    ? await prefetchLoopData(input.page, input.site, input.db)
+    : undefined
+  const mediaAssets = input.db
+    ? await prefetchMediaAssets(input.page, input.site, input.registry, input.db, {
+        templateContext: input.templateContext,
+        loopData,
+      })
+    : undefined
   const baseHtml = publishPage(input.page, input.site, input.registry, {
     breakpointId: input.breakpointId,
     templateContext: input.templateContext,

--- a/src/__tests__/loops/entryField.test.ts
+++ b/src/__tests__/loops/entryField.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test'
+import { resolveEntryFieldItems } from '@core/loops'
+
+describe('current-entry-field loop items', () => {
+  it('keeps primitive array values in authored order', () => {
+    const result = resolveEntryFieldItems(['first', 'second'], {
+      direction: 'asc',
+      limit: 10,
+    })
+
+    expect(result.totalItems).toBe(2)
+    expect(result.items.map((item) => item.fields.value)).toEqual(['first', 'second'])
+    expect(result.items.map((item) => item.fields.index)).toEqual([0, 1])
+  })
+
+  it('projects object members while preserving the original value', () => {
+    const object = { id: 'shot-1', caption: 'Evening light' }
+    const result = resolveEntryFieldItems([object])
+
+    expect(result.items[0]?.id).toBe('shot-1')
+    expect(result.items[0]?.fields.caption).toBe('Evening light')
+    expect(result.items[0]?.fields.value).toEqual(object)
+  })
+
+  it('enriches media ids with renderable media fields', () => {
+    const result = resolveEntryFieldItems(['media-1'], {
+      mediaByReference: new Map([
+        ['media-1', {
+          publicPath: '/uploads/portfolio-1.webp',
+          mimeType: 'image/webp',
+          width: 1600,
+          height: 1067,
+          altText: 'Portrait in a studio',
+        }],
+      ]),
+    })
+
+    expect(result.items[0]?.fields).toMatchObject({
+      id: 'media-1',
+      value: '/uploads/portfolio-1.webp',
+      src: '/uploads/portfolio-1.webp',
+      url: '/uploads/portfolio-1.webp',
+      path: '/uploads/portfolio-1.webp',
+      altText: 'Portrait in a studio',
+      mimeType: 'image/webp',
+      width: 1600,
+      height: 1067,
+    })
+  })
+
+  it('returns an empty result for non-array fields', () => {
+    expect(resolveEntryFieldItems('not-an-array')).toEqual({
+      items: [],
+      totalItems: 0,
+    })
+  })
+})

--- a/src/__tests__/publisher/loopRender.test.ts
+++ b/src/__tests__/publisher/loopRender.test.ts
@@ -308,6 +308,44 @@ describe('publisher loop renderer', () => {
       const footerIdx = html.lastIndexOf('<p>OUTER</p>')
       expect(footerIdx).toBeGreaterThan(html.indexOf('<p>Beta</p>'))
     })
+
+    it('resolves an entry-field loop separately for every outer item', () => {
+      const page = makePage({
+        root: { moduleId: 'base.body', children: ['outer'] },
+        outer: { moduleId: 'base.loop', children: ['inner'], props: { sourceId: 'outer' } },
+        inner: {
+          moduleId: 'base.loop',
+          children: ['card'],
+          props: {
+            sourceId: 'entry.field',
+            filters: { fieldId: 'gallery' },
+            direction: 'asc',
+            limit: 10,
+          },
+        },
+        card: {
+          moduleId: 'test.pair',
+          props: { parent: '', current: '' },
+          dynamicBindings: {
+            parent: { source: 'parentEntry', field: 'title' },
+            current: { source: 'currentEntry', field: 'value' },
+          },
+        },
+      })
+      const outerItems: LoopItem[] = [
+        { id: 'p1', fields: { title: 'Project 1', gallery: ['p1-a', 'p1-b'] } },
+        { id: 'p2', fields: { title: 'Project 2', gallery: ['p2-a'] } },
+      ]
+      const html = publishPage(page, makeSite(), baseRegistry, {
+        loopData: new Map([['outer', loopData(outerItems)]]),
+      }).html
+
+      expect(html).toContain('<p>Project 1/p1-a</p>')
+      expect(html).toContain('<p>Project 1/p1-b</p>')
+      expect(html).toContain('<p>Project 2/p2-a</p>')
+      expect(html).not.toContain('Project 1/p2-a')
+      expect(html).not.toContain('Project 2/p1-a')
+    })
   })
 
   it('attaches data attrs and registers infinite mode', () => {

--- a/src/__tests__/server/mediaBatchResolution.test.ts
+++ b/src/__tests__/server/mediaBatchResolution.test.ts
@@ -270,4 +270,33 @@ describe('prefetchMediaAssets (Finding 2)', () => {
       await cleanup()
     }
   })
+
+  it('resolves media ids stored in entry array fields and keys them by id and path', async () => {
+    const { db, cleanup } = await createTestDb()
+    try {
+      await insertMediaAsset(db, 'gallery-1', '/uploads/gallery-1.png')
+      const page = makePageWithImageProp('n1', 'content', 'no static media path')
+      const registry = { get: () => ({ id: 'base.text', schema: {} }) } as unknown as IModuleRegistry
+
+      const map = await prefetchMediaAssets(
+        page as never,
+        { visualComponents: [] } as never,
+        registry,
+        db,
+        {
+          templateContext: {
+            entryStack: [{
+              id: 'project-1',
+              fields: { gallery: ['gallery-1'] },
+            }],
+          },
+        },
+      )
+
+      expect(map.get('gallery-1')?.publicPath).toBe('/uploads/gallery-1.png')
+      expect(map.get('/uploads/gallery-1.png')?.id).toBe('gallery-1')
+    } finally {
+      await cleanup()
+    }
+  })
 })

--- a/src/admin/pages/site/canvas/NodeRenderer.tsx
+++ b/src/admin/pages/site/canvas/NodeRenderer.tsx
@@ -457,7 +457,7 @@ interface LoopIterationsPreviewProps {
  * arrives the component re-renders with real iterations.
  */
 function LoopIterationsPreview({ node, baseTemplateContext }: LoopIterationsPreviewProps) {
-  const items = useLoopPreviewItems(node)
+  const items = useLoopPreviewItems(node, baseTemplateContext)
   if (items.length === 0) return null
 
   const baseStack = baseTemplateContext?.entryStack ?? []

--- a/src/admin/pages/site/canvas/useLoopPreviewItems.ts
+++ b/src/admin/pages/site/canvas/useLoopPreviewItems.ts
@@ -37,9 +37,18 @@
 import { use, useEffect, useState } from 'react'
 import { useEditorStore } from '@site/store/store'
 import { loopSourceRegistry } from '@core/loops/registry'
-import { type LoopItem, pageToLoopItem, filterPagesForLoop } from '@core/loops'
+import {
+  ENTRY_FIELD_FILTER_KEY,
+  ENTRY_FIELD_SOURCE_ID,
+  filterPagesForLoop,
+  pageToLoopItem,
+  resolveEntryFieldItems,
+  type EntryFieldMedia,
+  type LoopItem,
+} from '@core/loops'
 import type { DataTable } from '@core/data/schemas'
 import type { Page, PageNode } from '@core/page-tree'
+import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { getCmsDataTable, previewCmsDataLoopItems } from '@core/persistence/cmsData'
 import { listCmsMediaAssets, type CmsMediaAsset } from '@core/persistence/cmsMedia'
 import { dataTablePreviewToLoopItem } from '@core/templates/templatePreviewData'
@@ -224,9 +233,17 @@ export function selectSitePagesLoopItems(node: PageNode, pages: readonly Page[] 
 // Hook
 // ---------------------------------------------------------------------------
 
-const BUILT_IN_SOURCE_IDS = new Set(['data.rows', 'site.media', 'site.pages'])
+const BUILT_IN_SOURCE_IDS = new Set([
+  'data.rows',
+  'site.media',
+  'site.pages',
+  ENTRY_FIELD_SOURCE_ID,
+])
 
-export function useLoopPreviewItems(node: PageNode): LoopItem[] {
+export function useLoopPreviewItems(
+  node: PageNode,
+  templateContext?: TemplateRenderDataContext,
+): LoopItem[] {
   const previewReadiness = use(CanvasPreviewReadinessContext)
   // `readLoopProps()` reuses the shared `EMPTY_FILTERS` sentinel when the
   // node has no filters set, so `filters` identity is stable across renders
@@ -298,7 +315,7 @@ export function useLoopPreviewItems(node: PageNode): LoopItem[] {
 
   // ── Async fetch: site.media ─────────────────────────────────────────
   useEffect(() => {
-    if (sourceId !== 'site.media') return
+    if (sourceId !== 'site.media' && sourceId !== ENTRY_FIELD_SOURCE_ID) return
     let cancelled = false
     const request = listCmsMediaAssets()
       .then((assets) => {
@@ -339,13 +356,31 @@ export function useLoopPreviewItems(node: PageNode): LoopItem[] {
     return sorted.slice(offset, offset + limit).map(mediaAssetToLoopItem)
   }
 
+  if (sourceId === ENTRY_FIELD_SOURCE_ID) {
+    const fieldId = filters[ENTRY_FIELD_FILTER_KEY]
+    if (typeof fieldId !== 'string' || !fieldId) return EMPTY_ITEMS
+    const stack = templateContext?.entryStack ?? []
+    const entry = stack[stack.length - 1]
+    const mediaByReference = new Map<string, EntryFieldMedia>()
+    for (const asset of asyncMedia) {
+      mediaByReference.set(asset.id, asset)
+      mediaByReference.set(asset.publicPath, asset)
+    }
+    return resolveEntryFieldItems(entry?.fields[fieldId], {
+      offset,
+      limit,
+      direction,
+      mediaByReference,
+    }).items
+  }
+
   if (sourceId === 'site.pages') return sitePagesItems
 
   // Plugin source fallback — synchronous preview() with no client-side
   // sort. Plugins that need ordering should apply it inside their own
   // preview() implementation.
   const source = loopSourceRegistry.get(sourceId)
-  if (!source || !pluginSite) return EMPTY_ITEMS
+  if (!source || source.kind === 'contextual' || !pluginSite) return EMPTY_ITEMS
   try {
     return source.preview({ site: pluginSite, filters, limit }).slice(offset, offset + limit)
   } catch {

--- a/src/admin/pages/site/panels/PropertiesPanel/LoopPropertiesView.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/LoopPropertiesView.tsx
@@ -16,9 +16,12 @@
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { useEditorStore } from '@site/store/store'
 import { loopSourceRegistry } from '@core/loops/registry'
+import { ENTRY_FIELD_FILTER_KEY, ENTRY_FIELD_SOURCE_ID } from '@core/loops'
 import type { LoopEntitySource } from '@core/loops/types'
+import type { DataTableListItem } from '@core/data/schemas'
 import type { PropertyControl, PropertySchema } from '@core/module-engine'
 import { listCmsDataTables } from '@core/persistence/cmsData'
+import { getAncestors, type Page } from '@core/page-tree'
 import { PropertyControlRenderer } from '@site/property-controls/PropertyControlRenderer'
 import {
   CUSTOM_HTML_TAG_VALUE,
@@ -29,9 +32,10 @@ import {
 interface LoopPropertiesViewProps {
   nodeId: string
   props: Record<string, unknown>
+  activePage: Page | null
 }
 
-export function LoopPropertiesView({ nodeId, props }: LoopPropertiesViewProps) {
+export function LoopPropertiesView({ nodeId, props, activePage }: LoopPropertiesViewProps) {
   const updateNodeProps = useEditorStore((s) => s.updateNodeProps)
 
   const sources = loopSourceRegistry.list()
@@ -46,8 +50,12 @@ export function LoopPropertiesView({ nodeId, props }: LoopPropertiesViewProps) {
   // Data table list — fetched lazily for the data.rows source's tableId picker.
   // Other sources resolve to `null` (no fetch); a failed load resolves to an
   // empty list so the picker degrades gracefully.
-  const { data: tables } = useAsyncResource<Array<{ id: string; name: string }> | null>(
-    () => (sourceId === 'data.rows' ? listCmsDataTables().catch(() => []) : Promise.resolve(null)),
+  const { data: tables } = useAsyncResource<DataTableListItem[] | null>(
+    () => (
+      sourceId === 'data.rows' || sourceId === ENTRY_FIELD_SOURCE_ID
+        ? listCmsDataTables().catch(() => [])
+        : Promise.resolve(null)
+    ),
     [sourceId],
   )
 
@@ -64,6 +72,21 @@ export function LoopPropertiesView({ nodeId, props }: LoopPropertiesViewProps) {
             options: [
               { label: '— Choose a table —', value: '' },
               ...tables.map((t) => ({ label: t.name, value: t.id })),
+            ],
+          },
+        }
+      }
+    }
+    if (source.id === ENTRY_FIELD_SOURCE_ID && tables) {
+      const fieldControl = source.filterSchema[ENTRY_FIELD_FILTER_KEY]
+      if (fieldControl?.type === 'select') {
+        return {
+          ...source.filterSchema,
+          [ENTRY_FIELD_FILTER_KEY]: {
+            ...fieldControl,
+            options: [
+              { label: '— Choose an array field —', value: '' },
+              ...entryCollectionFieldOptions(activePage, nodeId, tables),
             ],
           },
         }
@@ -91,6 +114,8 @@ export function LoopPropertiesView({ nodeId, props }: LoopPropertiesViewProps) {
       sourceId: nextId,
       filters: {},
       orderBy: next?.orderByOptions[0]?.id ?? '',
+      direction: next?.kind === 'contextual' ? 'asc' : 'desc',
+      pagination: next?.kind === 'contextual' ? 'none' : props.pagination,
     })
   }
 
@@ -151,23 +176,34 @@ export function LoopPropertiesView({ nodeId, props }: LoopPropertiesViewProps) {
 
       {source ? (
         <>
-          <PropertyControlRenderer
-            propKey="orderBy"
-            control={orderOptions}
-            value={typeof props.orderBy === 'string' ? props.orderBy : ''}
-            onChange={handleScalarChange}
-          />
+          {source.kind !== 'contextual' ? (
+            <PropertyControlRenderer
+              propKey="orderBy"
+              control={orderOptions}
+              value={typeof props.orderBy === 'string' ? props.orderBy : ''}
+              onChange={handleScalarChange}
+            />
+          ) : null}
           <PropertyControlRenderer
             propKey="direction"
             control={{
               type: 'select',
               label: 'Direction',
-              options: [
-                { label: 'Descending (newest first)', value: 'desc' },
-                { label: 'Ascending (oldest first)', value: 'asc' },
-              ],
+              options: source.kind === 'contextual'
+                ? [
+                    { label: 'Original order', value: 'asc' },
+                    { label: 'Reverse order', value: 'desc' },
+                  ]
+                : [
+                    { label: 'Descending (newest first)', value: 'desc' },
+                    { label: 'Ascending (oldest first)', value: 'asc' },
+                  ],
             }}
-            value={typeof props.direction === 'string' ? props.direction : 'desc'}
+            value={
+              typeof props.direction === 'string'
+                ? props.direction
+                : source.kind === 'contextual' ? 'asc' : 'desc'
+            }
             onChange={handleScalarChange}
           />
           <PropertyControlRenderer
@@ -182,29 +218,78 @@ export function LoopPropertiesView({ nodeId, props }: LoopPropertiesViewProps) {
             value={typeof props.offset === 'number' ? props.offset : 0}
             onChange={handleScalarChange}
           />
-          <PropertyControlRenderer
-            propKey="pagination"
-            control={{
-              type: 'select',
-              label: 'Pagination',
-              options: [
-                { label: 'None', value: 'none' },
-                { label: 'Infinite scroll', value: 'infinite' },
-              ],
-            }}
-            value={typeof props.pagination === 'string' ? props.pagination : 'none'}
-            onChange={handleScalarChange}
-          />
-          {props.pagination === 'infinite' ? (
-            <PropertyControlRenderer
-              propKey="pageSize"
-              control={{ type: 'number', label: 'Page size', min: 1, max: 100, step: 1 }}
-              value={typeof props.pageSize === 'number' ? props.pageSize : 10}
-              onChange={handleScalarChange}
-            />
+          {source.kind !== 'contextual' ? (
+            <>
+              <PropertyControlRenderer
+                propKey="pagination"
+                control={{
+                  type: 'select',
+                  label: 'Pagination',
+                  options: [
+                    { label: 'None', value: 'none' },
+                    { label: 'Infinite scroll', value: 'infinite' },
+                  ],
+                }}
+                value={typeof props.pagination === 'string' ? props.pagination : 'none'}
+                onChange={handleScalarChange}
+              />
+              {props.pagination === 'infinite' ? (
+                <PropertyControlRenderer
+                  propKey="pageSize"
+                  control={{ type: 'number', label: 'Page size', min: 1, max: 100, step: 1 }}
+                  value={typeof props.pageSize === 'number' ? props.pageSize : 10}
+                  onChange={handleScalarChange}
+                />
+              ) : null}
+            </>
           ) : null}
         </>
       ) : null}
     </>
   )
+}
+
+function entryCollectionFieldOptions(
+  activePage: Page | null,
+  nodeId: string,
+  tables: DataTableListItem[],
+): Array<{ label: string; value: string }> {
+  if (!activePage) return []
+
+  const enclosingDataRowsLoop = [...getAncestors(activePage, nodeId)]
+    .reverse()
+    .find((node) => node.moduleId === 'base.loop' && node.props.sourceId === 'data.rows')
+  const filters = enclosingDataRowsLoop?.props.filters
+  const enclosingTableId =
+    filters && typeof filters === 'object' && !Array.isArray(filters)
+      ? (filters as Record<string, unknown>).tableId
+      : null
+
+  let contextTables: DataTableListItem[]
+  if (typeof enclosingTableId === 'string' && enclosingTableId) {
+    contextTables = tables.filter((table) => table.id === enclosingTableId)
+  } else if (activePage.template?.target.kind === 'postTypes') {
+    const slugs = new Set(activePage.template.target.tableSlugs)
+    contextTables = tables.filter((table) => slugs.has(table.slug))
+  } else {
+    contextTables = []
+  }
+
+  const showTableName = contextTables.length > 1
+  const seen = new Set<string>()
+  const options: Array<{ label: string; value: string }> = []
+  for (const table of contextTables) {
+    for (const field of table.fields) {
+      const isCollection =
+        field.type === 'multiSelect' ||
+        ((field.type === 'media' || field.type === 'relation') && field.allowMultiple === true)
+      if (!isCollection || seen.has(field.id)) continue
+      seen.add(field.id)
+      options.push({
+        label: showTableName ? `${table.name} → ${field.label}` : field.label,
+        value: field.id,
+      })
+    }
+  }
+  return options
 }

--- a/src/admin/pages/site/panels/PropertiesPanel/renderModuleTabContent.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/renderModuleTabContent.tsx
@@ -81,6 +81,7 @@ export function renderModuleTabContent(args: ModuleTabContentArgs): React.ReactN
       <LoopPropertiesView
         nodeId={selectedNodeId}
         props={selectedNode.props as Record<string, unknown>}
+        activePage={activePage}
       />
     )
   }

--- a/src/core/loops/index.ts
+++ b/src/core/loops/index.ts
@@ -11,3 +11,9 @@
 
 export type { LoopItem } from './types'
 export { pageToLoopItem, filterPagesForLoop } from './sources/sitePages'
+export {
+  ENTRY_FIELD_FILTER_KEY,
+  ENTRY_FIELD_SOURCE_ID,
+  resolveEntryFieldItems,
+  type EntryFieldMedia,
+} from './sources/entryField'

--- a/src/core/loops/sources/entryField.ts
+++ b/src/core/loops/sources/entryField.ts
@@ -1,0 +1,137 @@
+/**
+ * Contextual current-entry-field loop source.
+ *
+ * Unlike database/site/plugin sources, this source is resolved synchronously
+ * for every enclosing render iteration. A Project template can therefore
+ * iterate `currentEntry.gallery`, while the same loop nested inside a
+ * `data.rows` project listing resolves the gallery belonging to each project.
+ */
+
+import type {
+  ContextualLoopEntitySource,
+  LoopFetchResult,
+  LoopItem,
+} from '../types'
+
+export const ENTRY_FIELD_SOURCE_ID = 'entry.field'
+export const ENTRY_FIELD_FILTER_KEY = 'fieldId'
+
+export interface EntryFieldMedia {
+  publicPath: string
+  mimeType?: string
+  width?: number | null
+  height?: number | null
+  altText?: string
+}
+
+export interface ResolveEntryFieldItemsOptions {
+  offset?: number
+  limit?: number
+  direction?: 'asc' | 'desc'
+  mediaByReference?: ReadonlyMap<string, EntryFieldMedia>
+}
+
+function itemId(value: unknown, index: number): string {
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    const candidate = (value as Record<string, unknown>).id
+    if (typeof candidate === 'string' && candidate) return candidate
+  }
+  if (typeof value === 'string' && value) return value
+  return `entry-item-${index}`
+}
+
+function projectItem(
+  value: unknown,
+  index: number,
+  mediaByReference: ReadonlyMap<string, EntryFieldMedia> | undefined,
+): LoopItem {
+  const id = itemId(value, index)
+
+  if (typeof value === 'string') {
+    const media = mediaByReference?.get(value)
+    if (media) {
+      return {
+        id,
+        fields: {
+          id,
+          value: media.publicPath,
+          src: media.publicPath,
+          url: media.publicPath,
+          path: media.publicPath,
+          altText: media.altText ?? '',
+          mimeType: media.mimeType ?? '',
+          width: media.width ?? null,
+          height: media.height ?? null,
+          index,
+        },
+      }
+    }
+    return { id, fields: { id, value, index } }
+  }
+
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    return {
+      id,
+      fields: {
+        ...(value as Record<string, unknown>),
+        id,
+        value,
+        index,
+      },
+    }
+  }
+
+  return { id, fields: { id, value, index } }
+}
+
+/**
+ * Turn an array-valued entry field into ordinary LoopItems.
+ *
+ * Media ids are enriched when the caller supplies the publisher/canvas media
+ * map. Other primitives remain available as `currentEntry.value`; object
+ * members are exposed directly while the original object remains at `value`.
+ */
+export function resolveEntryFieldItems(
+  value: unknown,
+  options: ResolveEntryFieldItemsOptions = {},
+): LoopFetchResult {
+  if (!Array.isArray(value)) return { items: [], totalItems: 0 }
+
+  const direction = options.direction === 'desc' ? 'desc' : 'asc'
+  const ordered = direction === 'desc' ? [...value].reverse() : value
+  const offset = Math.max(0, Math.floor(options.offset ?? 0))
+  const limit = Math.max(1, Math.floor(options.limit ?? (ordered.length || 1)))
+  const slice = ordered.slice(offset, offset + limit)
+
+  return {
+    items: slice.map((item, index) =>
+      projectItem(item, offset + index, options.mediaByReference)),
+    totalItems: value.length,
+  }
+}
+
+export const EntryFieldSource: ContextualLoopEntitySource = {
+  kind: 'contextual',
+  id: ENTRY_FIELD_SOURCE_ID,
+  label: 'Current entry field',
+  description: 'Iterate an array field on the closest enclosing entry.',
+  filterSchema: {
+    [ENTRY_FIELD_FILTER_KEY]: {
+      type: 'select',
+      label: 'Field',
+      options: [{ label: '— Choose an array field —', value: '' }],
+    },
+  },
+  orderByOptions: [],
+  fields: [
+    { id: 'value', label: 'Value' },
+    { id: 'index', label: 'Index' },
+    { id: 'src', label: 'Media source', format: 'media' },
+    { id: 'url', label: 'Media URL', format: 'url' },
+    { id: 'path', label: 'Media path', format: 'media' },
+    { id: 'altText', label: 'Alt text' },
+    { id: 'mimeType', label: 'MIME type' },
+    { id: 'width', label: 'Width' },
+    { id: 'height', label: 'Height' },
+  ],
+}

--- a/src/core/loops/sources/index.ts
+++ b/src/core/loops/sources/index.ts
@@ -11,7 +11,9 @@ import { loopSourceRegistry } from '@core/loops/registry'
 import { DataRowsSource } from './dataRows'
 import { SitePagesSource } from './sitePages'
 import { SiteMediaSource } from './siteMedia'
+import { EntryFieldSource } from './entryField'
 
 loopSourceRegistry.registerOrReplace(DataRowsSource)
 loopSourceRegistry.registerOrReplace(SitePagesSource)
 loopSourceRegistry.registerOrReplace(SiteMediaSource)
+loopSourceRegistry.registerOrReplace(EntryFieldSource)

--- a/src/core/loops/types.ts
+++ b/src/core/loops/types.ts
@@ -170,13 +170,14 @@ export interface LoopFetchResult {
 }
 
 /**
- * Pluggable entity source.
+ * Properties shared by every loop source.
  *
- * Built-in sources live under `src/core/loops/sources/*` and self-register
- * on import. Plugins register additional sources via the plugin SDK
- * (see `src/core/plugin-sdk`).
+ * Most sources are prefetched: their items come from the database, site
+ * document, or a plugin fetch hook before the synchronous render walk starts.
+ * Contextual sources are different: they derive their items from the active
+ * render entry (for example a multi-media field on the current Project).
  */
-export interface LoopEntitySource {
+interface LoopEntitySourceBase {
   /** Namespaced ID, e.g. `data.rows`, `site.pages`, `acme.products`. */
   id: string
   /** Human label for the source picker. */
@@ -223,11 +224,39 @@ export interface LoopEntitySource {
   orderByOptions: { id: string; label: string }[]
   /** Fields available for `dynamicBindings` inside the loop. */
   fields: LoopSourceField[]
+}
+
+/**
+ * A source whose data is resolved before the publisher's synchronous walk.
+ *
+ * `kind` is optional so existing first-party and plugin sources remain the
+ * concise default. Contextual sources opt into their distinct behavior with
+ * the explicit `kind: 'contextual'` discriminant.
+ */
+export interface PrefetchedLoopEntitySource extends LoopEntitySourceBase {
+  kind?: 'prefetched'
   /** Server-side: produce items + totalItems for the resolved filters/page. */
   fetch(ctx: SourceFetchContext): Promise<LoopFetchResult>
   /** Editor-side: synthesise representative items without DB access. */
   preview(ctx: SourcePreviewContext): LoopItem[]
 }
+
+/**
+ * A source resolved against the current render entry for each enclosing loop
+ * iteration. It performs no I/O and therefore has no fetch/preview callbacks;
+ * the shared loop engine owns its deterministic projection.
+ */
+export interface ContextualLoopEntitySource extends LoopEntitySourceBase {
+  kind: 'contextual'
+}
+
+/**
+ * Pluggable entity source.
+ *
+ * Built-in sources live under `src/core/loops/sources/*` and self-register
+ * on import. Plugins register prefetched sources via the plugin SDK.
+ */
+export type LoopEntitySource = PrefetchedLoopEntitySource | ContextualLoopEntitySource
 
 // ---------------------------------------------------------------------------
 // Registry interface

--- a/src/core/publisher/renderLoop.ts
+++ b/src/core/publisher/renderLoop.ts
@@ -12,7 +12,13 @@
  */
 
 import type { PageNode } from '@core/page-tree'
-import type { LoopItem } from '@core/loops/types'
+import {
+  ENTRY_FIELD_FILTER_KEY,
+  ENTRY_FIELD_SOURCE_ID,
+  resolveEntryFieldItems,
+  type EntryFieldMedia,
+  type LoopItem,
+} from '@core/loops'
 import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { resolveHtmlTag } from '@modules/base/utils/htmlTag'
 import { injectNodeClassIds, injectNodeId, injectNodeInlineStyles } from './classInjection'
@@ -57,7 +63,7 @@ export function renderLoop(
   renderNode: RenderNodeFn,
 ): string {
   const loopId = node.id
-  const data = config.loopData?.get(loopId)
+  const data = resolveLoopData(node, config)
   // No pre-fetched data — most likely an editor preview or a test that did
   // not seed loopData. Emit a marker comment rather than an empty string so
   // diagnostics in the rendered output are visible.
@@ -121,4 +127,34 @@ export function renderLoop(
   const withClasses = injectNodeClassIds(html, node.classIds, config.site)
   const withStyles = injectNodeInlineStyles(withClasses, node.inlineStyles, config.mediaAssets)
   return config.annotateNodeIds ? injectNodeId(withStyles, node.id) : withStyles
+}
+
+function resolveLoopData(node: PageNode, config: RenderConfig) {
+  if (node.props.sourceId !== ENTRY_FIELD_SOURCE_ID) {
+    return config.loopData?.get(node.id)
+  }
+
+  const filters = node.props.filters
+  const fieldId =
+    filters && typeof filters === 'object' && !Array.isArray(filters)
+      ? (filters as Record<string, unknown>)[ENTRY_FIELD_FILTER_KEY]
+      : undefined
+  if (typeof fieldId !== 'string' || !fieldId) {
+    return { items: [], totalItems: 0, pageNumber: 1, hasMore: false }
+  }
+
+  const stack = config.templateContext?.entryStack ?? []
+  const entry = stack[stack.length - 1]
+  const value = entry?.fields[fieldId]
+  const resolved = resolveEntryFieldItems(value, {
+    offset: typeof node.props.offset === 'number' ? node.props.offset : 0,
+    limit: typeof node.props.limit === 'number' ? node.props.limit : 10,
+    direction: node.props.direction === 'desc' ? 'desc' : 'asc',
+    mediaByReference: config.mediaAssets as ReadonlyMap<string, EntryFieldMedia> | undefined,
+  })
+  return {
+    ...resolved,
+    pageNumber: 1,
+    hasMore: false,
+  }
 }

--- a/src/modules/base/utils/ReadOnlyNodeTree.tsx
+++ b/src/modules/base/utils/ReadOnlyNodeTree.tsx
@@ -300,7 +300,7 @@ function ReadOnlyLoopIterationsPreview({
   readonlyMarkers,
   templateContext,
 }: ReadOnlyLoopIterationsPreviewProps) {
-  const items = useLoopPreviewItems(node)
+  const items = useLoopPreviewItems(node, templateContext)
   if (items.length === 0) return null
 
   const baseStack = templateContext?.entryStack ?? []


### PR DESCRIPTION
## Summary

- add a built-in `entry.field` loop source for iterating array-valued fields on the closest current entry
- resolve contextual loop data independently for every enclosing iteration in the editor preview and publisher
- enrich multi-media field values with their resolved asset URLs and metadata
- expose eligible multi-select, multi-media, and multi-relation fields in the Loop properties UI
- document the per-entry gallery workflow and add focused regression coverage

## Why

Loop nodes could be nested structurally, but every loop source was prefetched globally once per node ID. An inner loop therefore could not depend on the current outer entry, making per-project galleries and other entry-owned collections impossible to render correctly.

## Impact

Authors can now select **Current entry field** as a Loop source and iterate an array such as a Project's Gallery. The same template renders a different inner collection for each outer entry, with original/reverse ordering, offset, and limit controls. Contextual collections intentionally do not expose infinite pagination.

## Verification

- `bun test` — 6,303 passed across 677 files
- `bun run lint`
- `bun run build`
- `bun run doctor` — completed with the repository's existing warning-only diagnostics; no error-tier failure
- live disposable browser test: created Projects with a multi-media Gallery, uploaded two images, configured `Current entry field → Gallery`, published the entry and site, and verified two distinct loaded images on the public project route