### PR TITLE
fix(loops): resolve custom media fields to URLs in loops

### DIFF
--- a/src/__tests__/loops/dataRowsFetch.test.ts
+++ b/src/__tests__/loops/dataRowsFetch.test.ts
@@ -403,11 +403,12 @@ describe('fetchPublishedDataRowItems — data-kind ordering', () => {
 // ---------------------------------------------------------------------------
 // Custom media fields — id → public URL resolution in loops
 //
-// Built-in `featuredMedia` is resolved above; these lock in that a
-// user-defined `media` field (single) and a multi-value one both resolve to
-// public URLs, and that an unresolved id becomes null rather than leaking the
-// raw media id into an `img src`. Covers both projections: a custom post-type
-// table (rowToLoopItem) and a data-kind table (dataKindRowToLoopItem).
+// Built-in `featuredMedia` is resolved above; these lock in that custom media
+// fields resolve to public URLs without losing their authored shape. Scalar
+// media becomes a URL or null, multi-media stays an ordered array, and media
+// nested in repeater item cells resolves recursively. Covers both projections:
+// a custom post-type table (rowToLoopItem) and a data-kind table
+// (dataKindRowToLoopItem).
 // ---------------------------------------------------------------------------
 
 describe('fetchPublishedDataRowItems — custom media field resolution', () => {
@@ -434,11 +435,31 @@ describe('fetchPublishedDataRowItems — custom media field resolution', () => {
         { id: 'title', label: 'Title', type: 'text' },
         { id: 'logo', label: 'Logo', type: 'media' },
         { id: 'gallery', label: 'Gallery', type: 'media', allowMultiple: true },
+        {
+          id: 'showcase', label: 'Showcase', type: 'repeater',
+          fields: [
+            { id: 'caption', label: 'Caption', type: 'text' },
+            { id: 'cover', label: 'Cover', type: 'media' },
+            { id: 'images', label: 'Images', type: 'media', allowMultiple: true },
+          ],
+        },
       ])})
     `
     await seedDataRow(db, 'clients', {
       rowId: 'client-a', slug: 'a',
-      cells: { title: 'Acme', logo: 'm-logo', gallery: ['m-g1', 'm-g2'] },
+      cells: {
+        title: 'Acme',
+        logo: 'm-logo',
+        gallery: ['m-g1', 'm-g2'],
+        showcase: [{
+          id: 'showcase-1',
+          cells: {
+            caption: 'Launch set',
+            cover: 'm-g2',
+            images: ['m-g1', 'missing-media', 'm-g2'],
+          },
+        }],
+      },
       createdAt: '2026-03-01T00:00:00.000Z', updatedAt: '2026-03-01T00:00:00.000Z',
     })
     await seedDataRow(db, 'clients', {
@@ -486,14 +507,28 @@ describe('fetchPublishedDataRowItems — custom media field resolution', () => {
     expect((await clientFields('client-a'))['logo']).toBe('/uploads/logo.png')
   })
 
-  it('flattens a multi-value media cell to the first element URL', async () => {
-    expect((await clientFields('client-a'))['gallery']).toBe('/uploads/g1.png')
+  it('preserves a multi-value media cell as an ordered URL array', async () => {
+    expect((await clientFields('client-a'))['gallery']).toEqual([
+      '/uploads/g1.png',
+      '/uploads/g2.png',
+    ])
   })
 
-  it('resolves empty / null media cells to null', async () => {
+  it('keeps empty multi-media as an array and resolves empty scalar media to null', async () => {
     const b = await clientFields('client-b')
     expect(b['logo']).toBeNull()
-    expect(b['gallery']).toBeNull()
+    expect(b['gallery']).toEqual([])
+  })
+
+  it('resolves scalar and multi-media recursively inside repeater item cells', async () => {
+    expect((await clientFields('client-a'))['showcase']).toEqual([{
+      id: 'showcase-1',
+      cells: {
+        caption: 'Launch set',
+        cover: '/uploads/g2.png',
+        images: ['/uploads/g1.png', '/uploads/g2.png'],
+      },
+    }])
   })
 
   it('resolves a dangling media id to null, never the raw id', async () => {

--- a/src/__tests__/loops/dataRowsFetch.test.ts
+++ b/src/__tests__/loops/dataRowsFetch.test.ts
@@ -401,6 +401,116 @@ describe('fetchPublishedDataRowItems — data-kind ordering', () => {
 })
 
 // ---------------------------------------------------------------------------
+// Custom media fields — id → public URL resolution in loops
+//
+// Built-in `featuredMedia` is resolved above; these lock in that a
+// user-defined `media` field (single) and a multi-value one both resolve to
+// public URLs, and that an unresolved id becomes null rather than leaking the
+// raw media id into an `img src`. Covers both projections: a custom post-type
+// table (rowToLoopItem) and a data-kind table (dataKindRowToLoopItem).
+// ---------------------------------------------------------------------------
+
+describe('fetchPublishedDataRowItems — custom media field resolution', () => {
+  beforeAll(async () => {
+    for (const [id, path] of [
+      ['m-logo', '/uploads/logo.png'],
+      ['m-g1', '/uploads/g1.png'],
+      ['m-g2', '/uploads/g2.png'],
+    ] as const) {
+      await db`
+        insert into media_assets
+          (id, filename, mime_type, size_bytes, storage_path, public_path,
+           storage_adapter_id, externally_hosted)
+        values (${id}, ${id + '.png'}, 'image/png', 100, ${id + '.png'}, ${path}, '', 0)
+      `
+    }
+
+    // Data-kind table with a single media field (`logo`) and a multi one
+    // (`gallery`, allowMultiple).
+    await db`
+      insert into data_tables
+        (id, name, slug, kind, route_base, singular_label, plural_label, fields_json)
+      values ('clients', 'Clients', 'clients', 'data', '/clients', 'Client', 'Clients', ${JSON.stringify([
+        { id: 'title', label: 'Title', type: 'text' },
+        { id: 'logo', label: 'Logo', type: 'media' },
+        { id: 'gallery', label: 'Gallery', type: 'media', allowMultiple: true },
+      ])})
+    `
+    await seedDataRow(db, 'clients', {
+      rowId: 'client-a', slug: 'a',
+      cells: { title: 'Acme', logo: 'm-logo', gallery: ['m-g1', 'm-g2'] },
+      createdAt: '2026-03-01T00:00:00.000Z', updatedAt: '2026-03-01T00:00:00.000Z',
+    })
+    await seedDataRow(db, 'clients', {
+      rowId: 'client-b', slug: 'b',
+      cells: { title: 'Beta', logo: null, gallery: [] },
+      createdAt: '2026-03-02T00:00:00.000Z', updatedAt: '2026-03-02T00:00:00.000Z',
+    })
+    await seedDataRow(db, 'clients', {
+      rowId: 'client-c', slug: 'c',
+      cells: { title: 'Gamma', logo: 'missing-media' },
+      createdAt: '2026-03-03T00:00:00.000Z', updatedAt: '2026-03-03T00:00:00.000Z',
+    })
+
+    // Post-type table with a custom single media field, to cover rowToLoopItem.
+    await db`
+      insert into data_tables
+        (id, name, slug, kind, route_base, singular_label, plural_label, fields_json)
+      values ('vendors', 'Vendors', 'vendors', 'postType', '/vendors', 'Vendor', 'Vendors', ${JSON.stringify([
+        { id: 'title', label: 'Title', type: 'text' },
+        { id: 'logo', label: 'Logo', type: 'media' },
+      ])})
+    `
+    const vendorCells = JSON.stringify({ title: 'Vendere', logo: 'm-logo' })
+    await db`
+      insert into data_rows (id, table_id, cells_json, slug, status, updated_at)
+      values ('vendor-a', 'vendors', ${vendorCells}, 'vendere', 'published', '2026-03-01T00:00:00.000Z')
+    `
+    await db`
+      insert into data_row_versions
+        (id, row_id, version_number, cells_json, slug, published_at, created_at)
+      values ('vendor-a-v1', 'vendor-a', 1, ${vendorCells}, 'vendere',
+              '2026-03-01T00:00:00.000Z', '2026-03-01T00:00:00.000Z')
+    `
+    await db`update data_rows set active_version_id = 'vendor-a-v1' where id = 'vendor-a'`
+  })
+
+  async function clientFields(rowId: string): Promise<Record<string, unknown>> {
+    const { items } = await fetchPublishedDataRowItems(db, {
+      tableId: 'clients', orderBy: 'slug', direction: 'asc', limit: 50, offset: 0,
+    })
+    return items.find((i) => i.id === rowId)!.fields
+  }
+
+  it('resolves a single custom media cell to its public URL (data-kind)', async () => {
+    expect((await clientFields('client-a'))['logo']).toBe('/uploads/logo.png')
+  })
+
+  it('flattens a multi-value media cell to the first element URL', async () => {
+    expect((await clientFields('client-a'))['gallery']).toBe('/uploads/g1.png')
+  })
+
+  it('resolves empty / null media cells to null', async () => {
+    const b = await clientFields('client-b')
+    expect(b['logo']).toBeNull()
+    expect(b['gallery']).toBeNull()
+  })
+
+  it('resolves a dangling media id to null, never the raw id', async () => {
+    const c = await clientFields('client-c')
+    expect(c['logo']).toBeNull()
+    expect(c['logo']).not.toBe('missing-media')
+  })
+
+  it('resolves a custom media field on the post-type path (rowToLoopItem)', async () => {
+    const { items } = await fetchPublishedDataRowItems(db, {
+      tableId: 'vendors', orderBy: 'slug', direction: 'asc', limit: 50, offset: 0,
+    })
+    expect(items[0]!.fields['logo']).toBe('/uploads/logo.png')
+  })
+})
+
+// ---------------------------------------------------------------------------
 // Degenerate inputs
 // ---------------------------------------------------------------------------
 

--- a/src/__tests__/server/mediaBatchResolution.test.ts
+++ b/src/__tests__/server/mediaBatchResolution.test.ts
@@ -132,6 +132,20 @@ describe('resolveMediaIdsToPaths (Finding 1)', () => {
       await cleanup()
     }
   })
+
+  it('omits soft-deleted assets', async () => {
+    const { db, cleanup } = await createTestDb()
+    try {
+      await insertMediaAsset(db, 'deleted-media', '/uploads/deleted.png')
+      await db`update media_assets set deleted_at = '2026-08-11T00:00:00.000Z' where id = 'deleted-media'`
+
+      const map = await resolveMediaIdsToPaths(db, ['deleted-media'])
+
+      expect(map.has('deleted-media')).toBe(false)
+    } finally {
+      await cleanup()
+    }
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/core/data/cells.ts
+++ b/src/core/data/cells.ts
@@ -48,6 +48,20 @@ export function readStringArrayCell(cells: DataRowCells, fieldId: string): strin
 }
 
 /**
+ * Read every media-asset id from a media cell, tolerating both cardinalities:
+ * a single-value media field stores a bare id string, a multi-value field
+ * (`allowMultiple`) stores a `string[]`. Empty / malformed cells yield `[]`.
+ */
+export function readMediaCellIds(cells: DataRowCells, fieldId: string): string[] {
+  const value = cells[fieldId]
+  if (typeof value === 'string') return value.length > 0 ? [value] : []
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.length > 0)
+  }
+  return []
+}
+
+/**
  * Read an ordered repeater value. Malformed legacy or manually-edited values
  * resolve to an empty collection instead of leaking an untyped shape into
  * record editors and loop projection.

--- a/src/core/loops/sources/dataRows.ts
+++ b/src/core/loops/sources/dataRows.ts
@@ -24,7 +24,7 @@ import { isoDate } from '../../utils/isoDate'
 import { firstImagePathFromMarkdown } from '@core/markdown/renderMarkdown'
 import { normalizeRouteBase } from '@core/templates/templateMatching'
 import { publicDataUserFromParts } from '@core/data/publicDataUser'
-import { readFeaturedMediaCell } from '@core/data/cells'
+import { readFeaturedMediaCell, readMediaCellIds } from '@core/data/cells'
 import type { DataRowCells } from '@core/data/schemas'
 
 // ---------------------------------------------------------------------------
@@ -38,6 +38,7 @@ interface PublishedDataRowSqlRow {
   table_slug: string
   table_kind: string
   table_route_base: string
+  table_fields_json: unknown
   version_number: number
   cells_json: Record<string, unknown>
   slug: string
@@ -83,10 +84,11 @@ function positionalParam(db: LoopSourceDb, index: number): string {
 // ---------------------------------------------------------------------------
 // Media path resolution
 //
-// Featured media lives inside cells_json, not as a SQL column. We extract
-// the media id from each row's cells in TypeScript, deduplicate the set, and
-// resolve all unique ids with a SINGLE batched IN-query. One round trip
-// regardless of how many rows the page slice returned.
+// Media ids live inside cells_json, not as SQL columns — the built-in
+// `featuredMedia` cell plus every user-defined `media` field. We extract the
+// ids from each row's cells in TypeScript, deduplicate the set, and resolve
+// all unique ids with a SINGLE batched IN-query. One round trip regardless of
+// how many rows (or media fields) the page slice returned.
 // ---------------------------------------------------------------------------
 
 /**
@@ -111,13 +113,60 @@ export async function resolveMediaIdsToPaths(
   return pathMap
 }
 
-function extractFeaturedMediaIds(rows: Array<{ cells_json: Record<string, unknown> }>): string[] {
+/**
+ * Field ids of every media-typed field on the table, read from the parsed
+ * `fields_json`. Deliberately tolerant — it reads only `type`/`id` so an
+ * unrelated or newer field shape never throws inside a loop fetch.
+ */
+function mediaFieldIdsFromJson(fieldsJson: unknown): string[] {
+  if (!Array.isArray(fieldsJson)) return []
   const ids: string[] = []
-  for (const row of rows) {
-    const id = readFeaturedMediaCell(row.cells_json as DataRowCells)
-    if (id) ids.push(id)
+  for (const field of fieldsJson) {
+    if (field === null || typeof field !== 'object') continue
+    const record = field as Record<string, unknown>
+    if (record.type === 'media' && typeof record.id === 'string') ids.push(record.id)
   }
   return ids
+}
+
+/**
+ * Collect every media id referenced by a page of rows: the built-in
+ * `featuredMedia` cell plus every user-defined `media` field (`mediaFieldIds`).
+ * Multi-value media cells contribute all their ids so the batch resolve covers
+ * them, even though the projection later flattens to the first.
+ */
+function collectMediaIds(
+  rows: Array<{ cells_json: Record<string, unknown> }>,
+  mediaFieldIds: string[],
+): string[] {
+  const ids: string[] = []
+  for (const row of rows) {
+    const cells = row.cells_json as DataRowCells
+    const featured = readFeaturedMediaCell(cells)
+    if (featured) ids.push(featured)
+    for (const fieldId of mediaFieldIds) ids.push(...readMediaCellIds(cells, fieldId))
+  }
+  return ids
+}
+
+/**
+ * Resolve each user-defined media field to its public path, flattening a
+ * multi-value cell to its first element (a scalar `img src` binding renders
+ * one image; iterating all elements is a nested-loop concern, not this one).
+ * Returns an overlay to spread over the raw cells so `{currentEntry.<field>}`
+ * yields a URL instead of the stored media id.
+ */
+function resolvedMediaOverlay(
+  cells: DataRowCells,
+  mediaFieldIds: string[],
+  mediaPathMap: Map<string, string>,
+): Record<string, string | null> {
+  const overlay: Record<string, string | null> = {}
+  for (const fieldId of mediaFieldIds) {
+    const firstId = readMediaCellIds(cells, fieldId)[0] ?? null
+    overlay[fieldId] = firstId ? (mediaPathMap.get(firstId) ?? null) : null
+  }
+  return overlay
 }
 
 // ---------------------------------------------------------------------------
@@ -127,6 +176,7 @@ function extractFeaturedMediaIds(rows: Array<{ cells_json: Record<string, unknow
 function rowToLoopItem(
   row: PublishedDataRowSqlRow,
   mediaPathMap: Map<string, string>,
+  mediaFieldIds: string[],
 ): LoopItem {
   const cells = row.cells_json as DataRowCells
   const tableRouteBase = normalizeRouteBase(row.table_route_base || `/${row.table_slug}`)
@@ -157,6 +207,9 @@ function rowToLoopItem(
     fields: {
       // Cells — all user-defined fields accessible by fieldId
       ...cells,
+      // Media fields: replace stored ids with resolved public paths so a
+      // `{currentEntry.<field>}` binding renders a URL, not the raw id.
+      ...resolvedMediaOverlay(cells, mediaFieldIds, mediaPathMap),
       // System identity (overlay after cells so these are never shadowed)
       id: row.row_id,
       rowId: row.row_id,
@@ -227,6 +280,7 @@ async function fetchPage(
             data_tables.slug as table_slug,
             data_tables.kind as table_kind,
             data_tables.route_base as table_route_base,
+            data_tables.fields_json as table_fields_json,
             data_row_versions.version_number,
             data_row_versions.cells_json,
             data_row_versions.slug,
@@ -276,6 +330,7 @@ interface DataKindRowSqlRow {
   table_id: string
   table_slug: string
   table_route_base: string
+  table_fields_json: unknown
   cells_json: Record<string, unknown>
   slug: string
   author_user_id: string | null
@@ -290,6 +345,7 @@ interface DataKindRowSqlRow {
 function dataKindRowToLoopItem(
   row: DataKindRowSqlRow,
   mediaPathMap: Map<string, string>,
+  mediaFieldIds: string[],
 ): LoopItem {
   const cells = row.cells_json as DataRowCells
   const tableRouteBase = normalizeRouteBase(row.table_route_base || `/${row.table_slug}`)
@@ -308,6 +364,9 @@ function dataKindRowToLoopItem(
     id: row.row_id,
     fields: {
       ...cells,
+      // Media fields: replace stored ids with resolved public paths (see
+      // `rowToLoopItem`).
+      ...resolvedMediaOverlay(cells, mediaFieldIds, mediaPathMap),
       id: row.row_id,
       rowId: row.row_id,
       tableId: row.table_id,
@@ -369,6 +428,7 @@ async function fetchDataKindPage(
             data_rows.table_id,
             data_tables.slug as table_slug,
             data_tables.route_base as table_route_base,
+            data_tables.fields_json as table_fields_json,
             data_rows.cells_json,
             data_rows.slug,
             data_rows.author_user_id,
@@ -445,9 +505,10 @@ export async function fetchPublishedDataRowItems(
     const sqlRows = await fetchDataKindPage(
       db, opts.tableId, orderBy, direction, opts.limit, opts.offset,
     )
-    const mediaPathMap = await resolveMediaIdsToPaths(db, extractFeaturedMediaIds(sqlRows))
+    const mediaFieldIds = mediaFieldIdsFromJson(sqlRows[0]?.table_fields_json)
+    const mediaPathMap = await resolveMediaIdsToPaths(db, collectMediaIds(sqlRows, mediaFieldIds))
     return {
-      items: sqlRows.map((row) => dataKindRowToLoopItem(row, mediaPathMap)),
+      items: sqlRows.map((row) => dataKindRowToLoopItem(row, mediaPathMap, mediaFieldIds)),
       totalItems,
     }
   }
@@ -465,10 +526,11 @@ export async function fetchPublishedDataRowItems(
   if (totalItems === 0) return { items: [], totalItems: 0 }
 
   const sqlRows = await fetchPage(db, opts.tableId, orderBy, direction, opts.limit, opts.offset)
-  const mediaPathMap = await resolveMediaIdsToPaths(db, extractFeaturedMediaIds(sqlRows))
+  const mediaFieldIds = mediaFieldIdsFromJson(sqlRows[0]?.table_fields_json)
+  const mediaPathMap = await resolveMediaIdsToPaths(db, collectMediaIds(sqlRows, mediaFieldIds))
 
   return {
-    items: sqlRows.map((row) => rowToLoopItem(row, mediaPathMap)),
+    items: sqlRows.map((row) => rowToLoopItem(row, mediaPathMap, mediaFieldIds)),
     totalItems,
   }
 }

--- a/src/core/loops/sources/dataRows.ts
+++ b/src/core/loops/sources/dataRows.ts
@@ -24,8 +24,9 @@ import { isoDate } from '../../utils/isoDate'
 import { firstImagePathFromMarkdown } from '@core/markdown/renderMarkdown'
 import { normalizeRouteBase } from '@core/templates/templateMatching'
 import { publicDataUserFromParts } from '@core/data/publicDataUser'
-import { readFeaturedMediaCell, readMediaCellIds } from '@core/data/cells'
-import type { DataRowCells } from '@core/data/schemas'
+import { normalizeDataTableFields } from '@core/data/fields'
+import { readFeaturedMediaCell, readMediaCellIds, readRepeaterCell } from '@core/data/cells'
+import type { DataField, DataRowCells, RepeaterItemField } from '@core/data/schemas'
 
 // ---------------------------------------------------------------------------
 // Internal SQL row shape
@@ -38,7 +39,6 @@ interface PublishedDataRowSqlRow {
   table_slug: string
   table_kind: string
   table_route_base: string
-  table_fields_json: unknown
   version_number: number
   cells_json: Record<string, unknown>
   slug: string
@@ -58,6 +58,11 @@ interface PublishedDataRowSqlRow {
 interface MediaAssetRow {
   id: string
   public_path: string
+}
+
+interface DataTableProjectionRow {
+  kind: string
+  fields_json: unknown
 }
 
 type OrderColumn = 'publishedAt' | 'createdAt' | 'updatedAt' | 'slug'
@@ -106,65 +111,88 @@ export async function resolveMediaIdsToPaths(
   if (idList.length === 0) return pathMap
   const placeholders = idList.map((_, i) => positionalParam(db, i + 1)).join(', ')
   const { rows } = await db.unsafe<MediaAssetRow>(
-    `select id, public_path from media_assets where id in (${placeholders})`,
+    `select id, public_path
+     from media_assets
+     where id in (${placeholders}) and deleted_at is null`,
     idList,
   )
   for (const row of rows) pathMap.set(row.id, row.public_path)
   return pathMap
 }
 
-/**
- * Field ids of every media-typed field on the table, read from the parsed
- * `fields_json`. Deliberately tolerant — it reads only `type`/`id` so an
- * unrelated or newer field shape never throws inside a loop fetch.
- */
-function mediaFieldIdsFromJson(fieldsJson: unknown): string[] {
-  if (!Array.isArray(fieldsJson)) return []
-  const ids: string[] = []
-  for (const field of fieldsJson) {
-    if (field === null || typeof field !== 'object') continue
-    const record = field as Record<string, unknown>
-    if (record.type === 'media' && typeof record.id === 'string') ids.push(record.id)
+type MediaProjectionField = DataField | RepeaterItemField
+
+function collectFieldMediaIds(
+  cells: DataRowCells,
+  fields: readonly MediaProjectionField[],
+  ids: string[],
+): void {
+  for (const field of fields) {
+    if (field.type === 'media') {
+      ids.push(...readMediaCellIds(cells, field.id))
+      continue
+    }
+    if (field.type !== 'repeater') continue
+    for (const item of readRepeaterCell(cells, field.id)) {
+      collectFieldMediaIds(item.cells, field.fields, ids)
+    }
   }
-  return ids
 }
 
 /**
  * Collect every media id referenced by a page of rows: the built-in
- * `featuredMedia` cell plus every user-defined `media` field (`mediaFieldIds`).
- * Multi-value media cells contribute all their ids so the batch resolve covers
- * them, even though the projection later flattens to the first.
+ * `featuredMedia` cell plus every schema-declared media field. Repeater media
+ * is traversed recursively, and multi-value cells contribute every id while
+ * still resolving through one batched query.
  */
 function collectMediaIds(
   rows: Array<{ cells_json: Record<string, unknown> }>,
-  mediaFieldIds: string[],
+  fields: readonly DataField[],
 ): string[] {
   const ids: string[] = []
   for (const row of rows) {
     const cells = row.cells_json as DataRowCells
     const featured = readFeaturedMediaCell(cells)
     if (featured) ids.push(featured)
-    for (const fieldId of mediaFieldIds) ids.push(...readMediaCellIds(cells, fieldId))
+    collectFieldMediaIds(cells, fields, ids)
   }
   return ids
 }
 
 /**
- * Resolve each user-defined media field to its public path, flattening a
- * multi-value cell to its first element (a scalar `img src` binding renders
- * one image; iterating all elements is a nested-loop concern, not this one).
- * Returns an overlay to spread over the raw cells so `{currentEntry.<field>}`
- * yields a URL instead of the stored media id.
+ * Resolve schema-declared media ids without changing collection cardinality:
+ * scalar media becomes a public path (or null), multi-media stays an ordered
+ * array of resolvable public paths, and repeater items keep their `{ id, cells }`
+ * shape while media inside `cells` is projected recursively.
  */
 function resolvedMediaOverlay(
   cells: DataRowCells,
-  mediaFieldIds: string[],
+  fields: readonly MediaProjectionField[],
   mediaPathMap: Map<string, string>,
-): Record<string, string | null> {
-  const overlay: Record<string, string | null> = {}
-  for (const fieldId of mediaFieldIds) {
-    const firstId = readMediaCellIds(cells, fieldId)[0] ?? null
-    overlay[fieldId] = firstId ? (mediaPathMap.get(firstId) ?? null) : null
+): DataRowCells {
+  const overlay: DataRowCells = {}
+  for (const field of fields) {
+    if (field.type === 'media') {
+      const ids = readMediaCellIds(cells, field.id)
+      if (field.allowMultiple === true) {
+        overlay[field.id] = ids.flatMap((id) => {
+          const path = mediaPathMap.get(id)
+          return path ? [path] : []
+        })
+      } else {
+        const id = ids[0]
+        overlay[field.id] = id ? (mediaPathMap.get(id) ?? null) : null
+      }
+      continue
+    }
+    if (field.type !== 'repeater') continue
+    overlay[field.id] = readRepeaterCell(cells, field.id).map((item) => ({
+      ...item,
+      cells: {
+        ...item.cells,
+        ...resolvedMediaOverlay(item.cells, field.fields, mediaPathMap),
+      },
+    }))
   }
   return overlay
 }
@@ -176,7 +204,7 @@ function resolvedMediaOverlay(
 function rowToLoopItem(
   row: PublishedDataRowSqlRow,
   mediaPathMap: Map<string, string>,
-  mediaFieldIds: string[],
+  fields: readonly DataField[],
 ): LoopItem {
   const cells = row.cells_json as DataRowCells
   const tableRouteBase = normalizeRouteBase(row.table_route_base || `/${row.table_slug}`)
@@ -209,7 +237,7 @@ function rowToLoopItem(
       ...cells,
       // Media fields: replace stored ids with resolved public paths so a
       // `{currentEntry.<field>}` binding renders a URL, not the raw id.
-      ...resolvedMediaOverlay(cells, mediaFieldIds, mediaPathMap),
+      ...resolvedMediaOverlay(cells, fields, mediaPathMap),
       // System identity (overlay after cells so these are never shadowed)
       id: row.row_id,
       rowId: row.row_id,
@@ -280,7 +308,6 @@ async function fetchPage(
             data_tables.slug as table_slug,
             data_tables.kind as table_kind,
             data_tables.route_base as table_route_base,
-            data_tables.fields_json as table_fields_json,
             data_row_versions.version_number,
             data_row_versions.cells_json,
             data_row_versions.slug,
@@ -330,7 +357,6 @@ interface DataKindRowSqlRow {
   table_id: string
   table_slug: string
   table_route_base: string
-  table_fields_json: unknown
   cells_json: Record<string, unknown>
   slug: string
   author_user_id: string | null
@@ -345,7 +371,7 @@ interface DataKindRowSqlRow {
 function dataKindRowToLoopItem(
   row: DataKindRowSqlRow,
   mediaPathMap: Map<string, string>,
-  mediaFieldIds: string[],
+  fields: readonly DataField[],
 ): LoopItem {
   const cells = row.cells_json as DataRowCells
   const tableRouteBase = normalizeRouteBase(row.table_route_base || `/${row.table_slug}`)
@@ -366,7 +392,7 @@ function dataKindRowToLoopItem(
       ...cells,
       // Media fields: replace stored ids with resolved public paths (see
       // `rowToLoopItem`).
-      ...resolvedMediaOverlay(cells, mediaFieldIds, mediaPathMap),
+      ...resolvedMediaOverlay(cells, fields, mediaPathMap),
       id: row.row_id,
       rowId: row.row_id,
       tableId: row.table_id,
@@ -428,7 +454,6 @@ async function fetchDataKindPage(
             data_rows.table_id,
             data_tables.slug as table_slug,
             data_tables.route_base as table_route_base,
-            data_tables.fields_json as table_fields_json,
             data_rows.cells_json,
             data_rows.slug,
             data_rows.author_user_id,
@@ -477,22 +502,23 @@ export async function fetchPublishedDataRowItems(
 ): Promise<LoopFetchResult> {
   if (!opts.tableId) return { items: [], totalItems: 0 }
 
-  const { rows: kindRows } = await db<{ kind: string }>`
-    select kind
+  const { rows: tableRows } = await db<DataTableProjectionRow>`
+    select kind, fields_json
     from data_tables
     where id = ${opts.tableId}
       and deleted_at is null
     limit 1
   `
-  const tableKind = kindRows[0]?.kind
-  if (!tableKind) return { items: [], totalItems: 0 }
+  const table = tableRows[0]
+  if (!table) return { items: [], totalItems: 0 }
+  const fields = normalizeDataTableFields(table.fields_json)
 
   const orderBy: OrderColumn = ALLOWED_ORDER_BY.has(opts.orderBy as OrderColumn)
     ? (opts.orderBy as OrderColumn)
     : 'publishedAt'
   const direction: 'asc' | 'desc' = opts.direction === 'asc' ? 'asc' : 'desc'
 
-  if (tableKind === 'data') {
+  if (table.kind === 'data') {
     const { rows: countRows } = await db<{ total: number }>`
       select count(*) as total
       from data_rows
@@ -505,10 +531,9 @@ export async function fetchPublishedDataRowItems(
     const sqlRows = await fetchDataKindPage(
       db, opts.tableId, orderBy, direction, opts.limit, opts.offset,
     )
-    const mediaFieldIds = mediaFieldIdsFromJson(sqlRows[0]?.table_fields_json)
-    const mediaPathMap = await resolveMediaIdsToPaths(db, collectMediaIds(sqlRows, mediaFieldIds))
+    const mediaPathMap = await resolveMediaIdsToPaths(db, collectMediaIds(sqlRows, fields))
     return {
-      items: sqlRows.map((row) => dataKindRowToLoopItem(row, mediaPathMap, mediaFieldIds)),
+      items: sqlRows.map((row) => dataKindRowToLoopItem(row, mediaPathMap, fields)),
       totalItems,
     }
   }
@@ -526,11 +551,10 @@ export async function fetchPublishedDataRowItems(
   if (totalItems === 0) return { items: [], totalItems: 0 }
 
   const sqlRows = await fetchPage(db, opts.tableId, orderBy, direction, opts.limit, opts.offset)
-  const mediaFieldIds = mediaFieldIdsFromJson(sqlRows[0]?.table_fields_json)
-  const mediaPathMap = await resolveMediaIdsToPaths(db, collectMediaIds(sqlRows, mediaFieldIds))
+  const mediaPathMap = await resolveMediaIdsToPaths(db, collectMediaIds(sqlRows, fields))
 
   return {
-    items: sqlRows.map((row) => rowToLoopItem(row, mediaPathMap, mediaFieldIds)),
+    items: sqlRows.map((row) => rowToLoopItem(row, mediaPathMap, fields)),
     totalItems,
   }
 }


### PR DESCRIPTION
## Summary

A `data.rows` loop resolved the built-in `featuredMedia` aliases, but custom `media` fields were projected as stored asset IDs. Binding `{currentEntry.<field>}` to an image source therefore produced a broken relative URL on both the editor canvas and published pages.

This PR resolves schema-declared media values before loop bindings run:

- Loads and validates the table's `fields_json` once for both data-kind and post-type projections.
- Collects top-level and repeater media IDs into the existing single batched lookup.
- Resolves scalar media to a public path (or `null` when missing).
- Preserves multi-media as ordered URL arrays so `entry.field` loops can iterate them.
- Preserves repeater `{ id, cells }` shapes while resolving scalar and multi-media inside item cells.
- Excludes soft-deleted media assets from resolution.
- Keeps the original custom-media fix and adds follow-up coverage for the collection/repeater behavior introduced by #299 and #303.

Relates to #224.

## Verification

- [x] `bun run build`
- [x] `bun run lint`
- [x] `bun test src/__tests__/loops/dataRowsFetch.test.ts src/__tests__/server/mediaBatchResolution.test.ts` (35 pass)
- [x] Full `bun test`: 6,579 pass in the sandbox; the 11 real-socket tests blocked from binding an ephemeral port were rerun outside the sandbox and pass 11/11.
- [x] Tests cover both data-kind and post-type projections, scalar and multi-media, repeater media, dangling IDs, and soft-deleted assets.

## Checklist

- [x] Tests cover behavior changes.
- [x] No compatibility shim was added.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
