### PR TITLE
fix(ai): save all modified model defaults together

### DIFF
--- a/src/admin/pages/ai/AiPage.module.css
+++ b/src/admin/pages/ai/AiPage.module.css
@@ -243,6 +243,17 @@
     background: var(--warning);
 }
 
+.pendingDot {
+    display: inline-block;
+    flex: none;
+    width: 6px;
+    height: 6px;
+    margin-left: var(--space-xs);
+    border-radius: 50%;
+    background: var(--accent-1);
+    vertical-align: middle;
+}
+
 .settingsDetailCanvas {
     min-width: 0;
 }
@@ -715,13 +726,6 @@
     line-height: 1.4;
 }
 
-.defaultSaveStatus {
-    flex-basis: 100%;
-    color: var(--success-text);
-    font-size: var(--text-xs);
-    text-align: right;
-}
-
 @media (max-width: 1180px) {
     .workspace {
         grid-template-columns: 168px minmax(0, 1fr);
@@ -844,10 +848,6 @@
 
     .settingsDetailActions {
         justify-content: flex-start;
-    }
-
-    .defaultSaveStatus {
-        text-align: left;
     }
 
     .modelsTableHeader,

--- a/src/admin/pages/ai/tabs/DefaultsTab.test.tsx
+++ b/src/admin/pages/ai/tabs/DefaultsTab.test.tsx
@@ -1,0 +1,369 @@
+import { afterEach, beforeEach, describe, expect, it, mock, type Mock } from 'bun:test'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+
+// ---------------------------------------------------------------------------
+// Mocks — API
+// ---------------------------------------------------------------------------
+
+let mockListCredentials: Mock<() => Promise<unknown>>
+let mockListDefaults: Mock<() => Promise<unknown>>
+let mockSetDefault: Mock<(scope: string, body: { credentialId: string; modelId: string }) => Promise<void>>
+let mockClearDefault: Mock<(scope: string) => Promise<void>>
+
+const CRED_ANTHROPIC = {
+  id: 'cred-a',
+  providerId: 'anthropic',
+  authMode: 'apiKey',
+  displayLabel: 'Anthropic key',
+  baseUrl: null,
+  keyFingerprintCurrent: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  lastUsedAt: null,
+}
+
+function resetApiMocks(defaults: Record<string, { credentialId: string; modelId: string }> = {}) {
+  mockListCredentials = mock(async () => [CRED_ANTHROPIC])
+  mockListDefaults = mock(async () => defaults)
+  mockSetDefault = mock(async () => {})
+  mockClearDefault = mock(async () => {})
+}
+
+// Initialize mocks before mock.module so the delegate wrappers have targets.
+resetApiMocks()
+
+mock.module('../../../ai/api', () => ({
+  listCredentials: (...args: unknown[]) => mockListCredentials(...(args as [])),
+  listDefaults: (...args: unknown[]) => mockListDefaults(...(args as [])),
+  setDefault: (...a: unknown[]) => mockSetDefault(...(a as [string, { credentialId: string; modelId: string }])),
+  clearDefault: (...a: unknown[]) => mockClearDefault(...(a as [string])),
+}))
+
+// ---------------------------------------------------------------------------
+// Mocks — ModelPicker
+//
+// The actual ModelPicker opens a ContextMenu with lazy-loaded model lists,
+// which is heavy to drive in unit tests and already tested in isolation.
+// This stub renders a <select> that fires onChange with the chosen pair.
+// ---------------------------------------------------------------------------
+
+mock.module('@admin/ai/ModelPicker', () => ({
+  ModelPicker: ({ value, onChange, ariaLabel, disabled }: {
+    value: { credentialId: string; modelId: string } | null
+    onChange: (choice: { credentialId: string; modelId: string }) => void
+    ariaLabel?: string
+    disabled?: boolean
+  }) => (
+    <select
+      aria-label={ariaLabel}
+      disabled={disabled}
+      value={value ? `${value.credentialId}::${value.modelId}` : ''}
+      onChange={(e) => {
+        const [credentialId, modelId] = e.target.value.split('::')
+        onChange({ credentialId: credentialId!, modelId: modelId! })
+      }}
+    >
+      <option value="">Choose credential and model</option>
+      <option value="cred-a::claude-opus">claude-opus</option>
+      <option value="cred-a::claude-sonnet">claude-sonnet</option>
+      <option value="cred-a::claude-haiku">claude-haiku</option>
+    </select>
+  ),
+}))
+
+// ---------------------------------------------------------------------------
+// Mocks — Toast
+// ---------------------------------------------------------------------------
+
+mock.module('@ui/components/Toast', () => ({
+  pushToast: (input: { kind: string; title: string; body?: string }) => {
+    const toast = document.createElement('div')
+    toast.dataset.testToast = 'true'
+    toast.setAttribute('role', 'alert')
+    toast.textContent = [input.title, input.body].filter(Boolean).join(' ')
+    document.body.append(toast)
+    return 'toast-id'
+  },
+}))
+
+// ---------------------------------------------------------------------------
+// Dynamic import (after all mocks are registered)
+// ---------------------------------------------------------------------------
+
+const { DefaultsTab } = await import('./DefaultsTab')
+
+afterEach(() => {
+  cleanup()
+  document.querySelectorAll('[data-test-toast]').forEach((toast) => toast.remove())
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderTab() {
+  return render(<DefaultsTab onNavigateToProviders={() => {}} />)
+}
+
+/** Select a model from the stub ModelPicker for the given scope label. */
+function pickModel(scopeLabel: string, model: string) {
+  const picker = screen.getByLabelText(`Model for ${scopeLabel}`)
+  fireEvent.change(picker, { target: { value: `cred-a::${model}` } })
+}
+
+/** Click a scope button in the sidebar to switch tabs. */
+function selectScope(label: string) {
+  fireEvent.click(screen.getByRole('button', { name: new RegExp(label) }))
+}
+
+/** Find the Save button (starts with "Save" to avoid matching "unsaved" in sidebar). */
+function saveButton(): HTMLButtonElement {
+  return screen.getByRole('button', { name: /^sav/i }) as HTMLButtonElement
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DefaultsTab – batch save', () => {
+  beforeEach(() => resetApiMocks())
+
+  it('saves defaults for multiple scopes in a single click', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    // Pick model for Site
+    pickModel('Site editor', 'claude-opus')
+
+    // Switch to Content, pick model
+    selectScope('Content')
+    await waitFor(() => expect(screen.getByLabelText('Model for Content')).toBeTruthy())
+    pickModel('Content', 'claude-sonnet')
+
+    selectScope('Data')
+    await waitFor(() => expect(screen.getByLabelText('Model for Data')).toBeTruthy())
+    pickModel('Data', 'claude-haiku')
+
+    selectScope('Plugins')
+    await waitFor(() => expect(screen.getByLabelText('Model for Plugins')).toBeTruthy())
+    pickModel('Plugins', 'claude-opus')
+
+    expect(saveButton().textContent).toContain('Save 4 defaults')
+
+    // Click Save once
+    await act(async () => { fireEvent.click(saveButton()) })
+
+    // All four scopes were submitted
+    expect(mockSetDefault).toHaveBeenCalledTimes(4)
+    const calls = mockSetDefault.mock.calls.map(([scope, body]) => ({ scope, ...body }))
+    expect(calls).toContainEqual({ scope: 'site', credentialId: 'cred-a', modelId: 'claude-opus' })
+    expect(calls).toContainEqual({ scope: 'content', credentialId: 'cred-a', modelId: 'claude-sonnet' })
+    expect(calls).toContainEqual({ scope: 'data', credentialId: 'cred-a', modelId: 'claude-haiku' })
+    expect(calls).toContainEqual({ scope: 'plugin', credentialId: 'cred-a', modelId: 'claude-opus' })
+    expect(screen.getByRole('alert').textContent).toContain('Defaults saved')
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('preserves pending selections when switching between scopes', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    // Pick a model for Site
+    pickModel('Site editor', 'claude-opus')
+
+    // Switch away
+    selectScope('Data')
+    await waitFor(() => expect(screen.getByLabelText('Model for Data')).toBeTruthy())
+
+    // Switch back — the picker should still show the pending value
+    selectScope('Site editor')
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    const picker = screen.getByLabelText('Model for Site editor') as HTMLSelectElement
+    expect(picker.value).toBe('cred-a::claude-opus')
+  })
+
+  it('does not submit unchanged scopes', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    // Only change Site
+    pickModel('Site editor', 'claude-opus')
+
+    await act(async () => { fireEvent.click(saveButton()) })
+
+    expect(mockSetDefault).toHaveBeenCalledTimes(1)
+    expect(mockSetDefault.mock.calls[0]![0]).toBe('site')
+  })
+
+  it('saves a single modified scope correctly', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    selectScope('Plugins')
+    await waitFor(() => expect(screen.getByLabelText('Model for Plugins')).toBeTruthy())
+    pickModel('Plugins', 'claude-haiku')
+
+    await act(async () => { fireEvent.click(saveButton()) })
+
+    expect(mockSetDefault).toHaveBeenCalledTimes(1)
+    expect(mockSetDefault.mock.calls[0]).toEqual(['plugin', { credentialId: 'cred-a', modelId: 'claude-haiku' }])
+  })
+
+  it('disables the Save button when nothing has changed', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    expect(saveButton().disabled).toBe(true)
+  })
+
+  it('does not mark a persisted selection as changed', async () => {
+    resetApiMocks({ site: { credentialId: 'cred-a', modelId: 'claude-opus' } })
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    pickModel('Site editor', 'claude-opus')
+
+    expect(saveButton().disabled).toBe(true)
+    expect(screen.queryByLabelText('unsaved changes')).toBeNull()
+  })
+
+  it('prevents duplicate saves while saving is in progress', async () => {
+    let resolveFirst!: () => void
+    mockSetDefault = mock(() => new Promise<void>((r) => { resolveFirst = r }))
+
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    pickModel('Site editor', 'claude-opus')
+
+    // Click save — starts the request
+    act(() => {
+      const button = saveButton()
+      fireEvent.click(button)
+      fireEvent.click(button)
+    })
+
+    expect(saveButton().disabled).toBe(true)
+    expect(saveButton().textContent).toContain('Saving')
+    expect((screen.getByLabelText('Model for Site editor') as HTMLSelectElement).disabled).toBe(true)
+    expect(mockSetDefault).toHaveBeenCalledTimes(1)
+
+    // Complete the save
+    await act(async () => { resolveFirst() })
+
+    // Only one call was made
+    expect(mockSetDefault).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears pending state on complete success', async () => {
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    pickModel('Site editor', 'claude-opus')
+    await act(async () => { fireEvent.click(saveButton()) })
+
+    // After success, save button should be disabled (no pending changes)
+    await waitFor(() => expect(saveButton().disabled).toBe(true))
+    expect(screen.getByRole('alert').textContent).toContain('Defaults saved')
+  })
+
+  it('preserves failed changes and reports the error on partial failure', async () => {
+    let callCount = 0
+    mockSetDefault = mock(async (scope: string) => {
+      callCount++
+      if (scope === 'content') throw new Error('Server error for content')
+    })
+
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    // Change two scopes
+    pickModel('Site editor', 'claude-opus')
+    selectScope('Content')
+    await waitFor(() => expect(screen.getByLabelText('Model for Content')).toBeTruthy())
+    pickModel('Content', 'claude-sonnet')
+
+    await act(async () => { fireEvent.click(saveButton()) })
+
+    // Both were attempted
+    expect(callCount).toBe(2)
+
+    const partialFailure = screen.getByRole('alert')
+    expect(partialFailure.textContent).toContain('Some defaults could not be saved')
+    expect(partialFailure.textContent).toContain('Content')
+    expect(partialFailure.textContent).not.toContain('Defaults saved')
+
+    // The Save button should still be enabled because the failed scope remains dirty
+    await waitFor(() => expect(saveButton().disabled).toBe(false))
+
+    // Switch to Content — the failed override should still be present
+    selectScope('Content')
+    await waitFor(() => expect(screen.getByLabelText('Model for Content')).toBeTruthy())
+    const picker = screen.getByLabelText('Model for Content') as HTMLSelectElement
+    expect(picker.value).toBe('cred-a::claude-sonnet')
+
+    expect(screen.getAllByLabelText('unsaved changes')).toHaveLength(1)
+    const siteButton = screen.getByRole('button', { name: /Site editor/ })
+    expect(siteButton.textContent).toContain('claude-opus')
+
+    mockSetDefault = mock(async () => {})
+    await act(async () => { fireEvent.click(saveButton()) })
+    expect(mockSetDefault).toHaveBeenCalledTimes(1)
+    expect(mockSetDefault.mock.calls[0]![0]).toBe('content')
+    expect(screen.getAllByRole('alert').at(-1)?.textContent).toContain('Defaults saved')
+  })
+
+  it('keeps the clear-default behaviour working', async () => {
+    resetApiMocks({ site: { credentialId: 'cred-a', modelId: 'claude-opus' } })
+
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    const clearButton = screen.getByRole('button', { name: /clear/i })
+    await act(async () => { fireEvent.click(clearButton) })
+
+    expect(mockClearDefault).toHaveBeenCalledTimes(1)
+    expect(mockClearDefault.mock.calls[0]![0]).toBe('site')
+  })
+
+  it('does not discard pending changes for other scopes when clearing one scope', async () => {
+    resetApiMocks({ site: { credentialId: 'cred-a', modelId: 'claude-opus' } })
+
+    renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+
+    // Pending change on Data
+    selectScope('Data')
+    await waitFor(() => expect(screen.getByLabelText('Model for Data')).toBeTruthy())
+    pickModel('Data', 'claude-haiku')
+
+    // Switch back to Site and clear its default
+    selectScope('Site editor')
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+    const clearButton = screen.getByRole('button', { name: /clear/i })
+    await act(async () => { fireEvent.click(clearButton) })
+
+    // Data's pending selection should survive
+    selectScope('Data')
+    await waitFor(() => expect(screen.getByLabelText('Model for Data')).toBeTruthy())
+    const picker = screen.getByLabelText('Model for Data') as HTMLSelectElement
+    expect(picker.value).toBe('cred-a::claude-haiku')
+
+    // Save should still work for the remaining pending change
+    expect(saveButton().disabled).toBe(false)
+  })
+
+  it('does not show completion feedback after unmount', async () => {
+    let resolveSave!: () => void
+    mockSetDefault = mock(() => new Promise<void>((resolve) => { resolveSave = resolve }))
+    const view = renderTab()
+    await waitFor(() => expect(screen.getByLabelText('Model for Site editor')).toBeTruthy())
+    pickModel('Site editor', 'claude-opus')
+    act(() => { fireEvent.click(saveButton()) })
+
+    view.unmount()
+    await act(async () => { resolveSave() })
+
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+})

--- a/src/admin/pages/ai/tabs/DefaultsTab.tsx
+++ b/src/admin/pages/ai/tabs/DefaultsTab.tsx
@@ -1,5 +1,5 @@
 /** Per-surface model defaults in the shared AI master-detail workspace. */
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import { Button } from '@ui/components/Button'
 import { pushToast } from '@ui/components/Toast'
@@ -59,44 +59,134 @@ export function DefaultsTab({
 }: {
   onNavigateToProviders: () => void
 }) {
-  const { data, loading, error, refresh } = useAsyncResource(
+  const { data, loading, error } = useAsyncResource(
     () => Promise.all([listCredentials(), listDefaults()]).then(([creds, defs]) => ({ creds, defs })),
     [],
     { fallbackError: 'Failed to load defaults.' },
   )
   const credentials: CredentialView[] = data?.creds ?? []
-  const defaults: AiDefaults = data?.defs ?? {}
+  const [defaults, setDefaults] = useState<AiDefaults>({})
+  const [seededDefaults, setSeededDefaults] = useState<AiDefaults | null>(null)
+  if (data && data.defs !== seededDefaults) {
+    setSeededDefaults(data.defs)
+    setDefaults(data.defs)
+  }
   const [selectedScope, setSelectedScope] = useState<ToolScope>('site')
-  const [savingScope, setSavingScope] = useState<ToolScope | null>(null)
-  const [statusByScope, setStatusByScope] = useState<Record<string, string>>({})
+  const [saving, setSaving] = useState(false)
+  const [clearingScope, setClearingScope] = useState<ToolScope | null>(null)
+  const [overrides, setOverrides] = useState<Partial<Record<ToolScope, ModelChoice>>>({})
+  const operationInFlight = useRef(false)
+  const mounted = useRef(true)
 
-  async function handleSave(scope: ToolScope, credentialId: string, modelId: string) {
-    setSavingScope(scope)
-    setStatusByScope((previous) => ({ ...previous, [scope]: '' }))
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+
+  /** Scopes whose override differs from the persisted value. */
+  function getDirtyScopes(): ToolScope[] {
+    return SCOPES.filter((scope) => {
+      const override = overrides[scope]
+      if (!override) return false
+      const current = defaults[scope]
+      return override.credentialId !== current?.credentialId || override.modelId !== current?.modelId
+    })
+  }
+
+  const dirtyScopes = getDirtyScopes()
+  const busy = saving || clearingScope != null
+  const canSave = !busy && dirtyScopes.length > 0
+
+  async function handleSaveAll() {
+    if (operationInFlight.current) return
+    const toSave = getDirtyScopes()
+    if (toSave.length === 0) return
+    const submitted = toSave.map((scope) => ({ scope, choice: overrides[scope]! }))
+    operationInFlight.current = true
+    setSaving(true)
     try {
-      await setDefault(scope, { credentialId, modelId })
-      setStatusByScope((previous) => ({ ...previous, [scope]: 'Saved' }))
-      refresh()
-    } catch (err) {
-      pushToast({
-        kind: 'error',
-        title: `Could not save ${SCOPE_META[scope].label} default`,
-        body: getErrorMessage(err, 'Unknown AI default error'),
+      const results = await Promise.allSettled(
+        submitted.map(({ scope, choice }) => {
+          return setDefault(scope, { credentialId: choice.credentialId, modelId: choice.modelId })
+        }),
+      )
+      if (!mounted.current) return
+
+      const succeeded: Array<{ scope: ToolScope; choice: ModelChoice }> = []
+      const failed: Array<{ scope: ToolScope; error: unknown }> = []
+      results.forEach((result, index) => {
+        const entry = submitted[index]!
+        if (result.status === 'fulfilled') {
+          succeeded.push(entry)
+        } else {
+          failed.push({ scope: entry.scope, error: result.reason })
+        }
       })
+
+      setDefaults((previous) => {
+        const next = { ...previous }
+        for (const { scope, choice } of succeeded) next[scope] = choice
+        return next
+      })
+      setOverrides((previous) => {
+        const next = { ...previous }
+        for (const { scope, choice } of succeeded) {
+          const latest = next[scope]
+          if (latest?.credentialId === choice.credentialId && latest.modelId === choice.modelId) {
+            delete next[scope]
+          }
+        }
+        return next
+      })
+
+      if (failed.length === 0) {
+        pushToast({ kind: 'success', title: 'Defaults saved' })
+      } else if (succeeded.length === 0) {
+        const label = toSave.length === 1
+          ? SCOPE_META[toSave[0]!].label
+          : `${toSave.length} defaults`
+        pushToast({
+          kind: 'error',
+          title: `Could not save ${label}`,
+          body: getErrorMessage(failed[0]!.error, 'Unknown AI default error'),
+        })
+      } else {
+        const failedLabels = failed.map((f) => SCOPE_META[f.scope].label).join(', ')
+        pushToast({
+          kind: 'error',
+          title: 'Some defaults could not be saved',
+          body: `Failed: ${failedLabels}. ${getErrorMessage(failed[0]!.error, 'Unknown AI default error')}`,
+        })
+      }
     } finally {
-      setSavingScope(null)
+      operationInFlight.current = false
+      if (mounted.current) setSaving(false)
     }
   }
 
   async function handleClear(scope: ToolScope): Promise<boolean> {
-    setSavingScope(scope)
-    setStatusByScope((previous) => ({ ...previous, [scope]: '' }))
+    if (operationInFlight.current) return false
+    operationInFlight.current = true
+    setClearingScope(scope)
     try {
       await clearDefault(scope)
-      setStatusByScope((previous) => ({ ...previous, [scope]: 'Cleared' }))
-      refresh()
+      if (!mounted.current) return false
+      setDefaults((previous) => {
+        const next = { ...previous }
+        delete next[scope]
+        return next
+      })
+      setOverrides((prev) => {
+        const next = { ...prev }
+        delete next[scope]
+        return next
+      })
+      pushToast({ kind: 'success', title: `${SCOPE_META[scope].label} default cleared` })
       return true
     } catch (err) {
+      if (!mounted.current) return false
       pushToast({
         kind: 'error',
         title: `Could not clear ${SCOPE_META[scope].label} default`,
@@ -104,8 +194,13 @@ export function DefaultsTab({
       })
       return false
     } finally {
-      setSavingScope(null)
+      operationInFlight.current = false
+      if (mounted.current) setClearingScope(null)
     }
+  }
+
+  function handleOverrideChange(scope: ToolScope, choice: ModelChoice) {
+    setOverrides((prev) => ({ ...prev, [scope]: choice }))
   }
 
   return (
@@ -121,6 +216,9 @@ export function DefaultsTab({
               const meta = SCOPE_META[scope]
               const Icon = meta.icon
               const active = selectedScope === scope
+              const hasPending = overrides[scope] != null
+                && (overrides[scope]!.credentialId !== defaults[scope]?.credentialId
+                  || overrides[scope]!.modelId !== defaults[scope]?.modelId)
               return (
                 <Button
                   key={scope}
@@ -138,7 +236,10 @@ export function DefaultsTab({
                     <Icon size={16} />
                   </span>
                   <span className={styles.settingsListIdentity}>
-                    <span className={styles.settingsListLabel}>{meta.label}</span>
+                    <span className={styles.settingsListLabel}>
+                      {meta.label}
+                      {hasPending && <span className={styles.pendingDot} aria-label="unsaved changes" />}
+                    </span>
                     <span className={styles.settingsListMeta}>
                       {defaults[scope]?.modelId ?? 'Not configured'}
                     </span>
@@ -158,14 +259,17 @@ export function DefaultsTab({
           <p role="alert" className={styles.errorAlert}>{error}</p>
         ) : (
           <ScopeDetail
-            key={selectedScope}
             scope={selectedScope}
             credentials={credentials}
             current={defaults[selectedScope]}
-            busy={savingScope === selectedScope}
-            status={statusByScope[selectedScope]}
+            override={overrides[selectedScope] ?? null}
+            onOverrideChange={(choice) => handleOverrideChange(selectedScope, choice)}
+            busy={busy}
+            saving={saving}
+            canSave={canSave}
+            dirtyCount={dirtyScopes.length}
             onNavigateToProviders={onNavigateToProviders}
-            onSave={(credentialId, modelId) => handleSave(selectedScope, credentialId, modelId)}
+            onSave={handleSaveAll}
             onClear={() => handleClear(selectedScope)}
           />
         )}
@@ -178,8 +282,12 @@ function ScopeDetail({
   scope,
   credentials,
   current,
+  override,
+  onOverrideChange,
   busy,
-  status,
+  saving,
+  canSave,
+  dirtyCount,
   onNavigateToProviders,
   onSave,
   onClear,
@@ -187,13 +295,16 @@ function ScopeDetail({
   scope: ToolScope
   credentials: CredentialView[]
   current: { credentialId: string; modelId: string } | undefined
+  override: ModelChoice | null
+  onOverrideChange: (choice: ModelChoice) => void
   busy: boolean
-  status: string | undefined
+  saving: boolean
+  canSave: boolean
+  dirtyCount: number
   onNavigateToProviders: () => void
-  onSave: (credentialId: string, modelId: string) => Promise<void>
+  onSave: () => Promise<void>
   onClear: () => Promise<boolean>
 }) {
-  const [override, setOverride] = useState<ModelChoice | null>(null)
   const meta = SCOPE_META[scope]
   const Icon = meta.icon
   const savedCredential = current
@@ -205,9 +316,6 @@ function ScopeDetail({
       ? { credentialId: current.credentialId, modelId: current.modelId }
       : null)
   const stale = Boolean(current?.credentialId) && !savedResolves
-  const dirty = override != null
-    && (override.credentialId !== current?.credentialId || override.modelId !== current?.modelId)
-  const canSave = !busy && value != null && dirty
   const canClear = !busy && current != null
 
   return (
@@ -252,8 +360,9 @@ function ScopeDetail({
                   placeholder="Choose credential and model"
                   credentials={credentials}
                   credentialsLoaded
+                  disabled={busy}
                   value={value}
-                  onChange={setOverride}
+                  onChange={onOverrideChange}
                 />
                 {savedCredential && current && (
                   <span className={styles.defaultCurrentChoice}>
@@ -276,11 +385,7 @@ function ScopeDetail({
                   variant="ghost"
                   size="sm"
                   disabled={!canClear}
-                  onClick={() => {
-                    void onClear().then((cleared) => {
-                      if (cleared) setOverride(null)
-                    })
-                  }}
+                  onClick={() => { void onClear() }}
                 >
                   <CloseIcon size={12} aria-hidden="true" />
                   <span>Clear</span>
@@ -291,12 +396,11 @@ function ScopeDetail({
                 variant="primary"
                 size="sm"
                 disabled={!canSave}
-                onClick={() => value && void onSave(value.credentialId, value.modelId)}
+                onClick={() => { void onSave() }}
               >
                 <SaveSolidIcon size={13} aria-hidden="true" />
-                <span>Save default</span>
+                <span>{saving ? 'Saving…' : dirtyCount > 1 ? `Save ${dirtyCount} defaults` : 'Save default'}</span>
               </Button>
-              {status && <span role="status" className={styles.defaultSaveStatus}>{status}</span>}
             </div>
           </>
         )}


### PR DESCRIPTION
## Summary

- preserve pending model selections while switching between AI default scopes
- save all modified defaults with one action
- reconcile complete and partial save results correctly
- prevent duplicate operations and state updates after unmount
- add regression coverage for multi-scope saving

## Root cause

Each scope stored its pending selection inside `ScopeDetail`, which was remounted whenever the selected scope changed. This discarded unsaved selections.

The save handler also accepted and persisted only the currently selected scope, so there was no way to submit changes across Site, Content, Data, and Plugins together.

## Changes

- lift pending selections to `DefaultsTab`
- calculate dirty scopes against confirmed server values
- submit only modified scopes using one Save action
- keep failed selections pending when a partial save fails
- mark successful scopes clean immediately
- ensure retries submit only the scopes that previously failed
- disable editing, clearing, and saving while an operation is active
- guard asynchronous state updates after unmount
- keep clearing isolated to the selected scope
- show pending state and the number of defaults being saved

## Testing

- `bun test src/admin/pages/ai/tabs/DefaultsTab.test.tsx`
  - 12 passed
  - 0 failed
- `bun run lint`
  - passed
- `bun run build`
  - passed
- `git diff --check`
  - passed

The full test suite has 207 failures on this branch. A clean `upstream/main` baseline produced the same 207 failures:

- branch-only failures: 0
- upstream-only failures: 0

No new full-suite failures were introduced by this change.

## Checklist

- [x] Only modified scopes are submitted
- [x] Tests cover the changed behaviour
- [x] Multiple scopes can be edited before saving
- [x] Partial failures retain retryable changes
- [x] Existing clear behaviour remains supported
- [x] Lint and production build pass
- [x] No database or backend changes
- [x] No new dependencies
- [x] No unrelated files included

Closes #290