### PR TITLE
fix(framework): parse space-separated hsl() color values

### DIFF
--- a/src/__tests__/framework/colors.test.ts
+++ b/src/__tests__/framework/colors.test.ts
@@ -100,6 +100,37 @@ describe('framework color generation', () => {
     expect(spaceSets.light.find((variable) => variable.name === '--space')?.value).toBe('hsla(0, 0%, 1.96%, 0.78)')
   })
 
+  it('parses space-separated hsl() base values — CSS Color-4 / imported tokens derive variants', () => {
+    // Modern CSS and importers (e.g. Tailwind) emit space-separated hsl()
+    // like `hsl(0 0% 80%)` and `hsl(0 0% 80% / 50%)`; parsing only the
+    // comma form dropped every derived variant for those tokens.
+    const sets = generateFrameworkColorVariableSets(makeColorSettings({
+      tokens: [{
+        ...makeColorSettings().tokens[0],
+        id: 'rule-token',
+        slug: 'rule',
+        lightValue: 'hsl(0 0% 80%)',
+        darkModeEnabled: false,
+      }],
+    }))
+
+    expect(sets.light.find((variable) => variable.name === '--rule')?.value).toBe('hsla(0, 0%, 80%, 1)')
+    expect(sets.light.find((variable) => variable.name === '--rule-20')?.value).toBe('hsla(0, 0%, 80%, 0.2)')
+    expect(sets.light.some((variable) => variable.name === '--rule-d-1')).toBe(true)
+
+    // Slash-delimited percentage alpha resolves like the rgb() space form.
+    const alphaSets = generateFrameworkColorVariableSets(makeColorSettings({
+      tokens: [{
+        ...makeColorSettings().tokens[0],
+        id: 'veil-token',
+        slug: 'veil',
+        lightValue: 'hsl(0 0% 80% / 50%)',
+        darkModeEnabled: false,
+      }],
+    }))
+    expect(alphaSets.light.find((variable) => variable.name === '--veil')?.value).toBe('hsla(0, 0%, 80%, 0.5)')
+  })
+
   it('emits unparseable base values verbatim instead of silently dropping the variable', () => {
     const sets = generateFrameworkColorVariableSets(makeColorSettings({
       tokens: [{

--- a/src/core/framework/colors.ts
+++ b/src/core/framework/colors.ts
@@ -57,7 +57,8 @@ interface FrameworkColorVariant {
 
 const TRANSPARENT_STEPS = [5, 10, 20, 30, 40, 50, 60, 70, 80, 90] as const
 const UTILITY_ORDER: FrameworkColorUtilityType[] = ['text', 'background', 'border', 'fill']
-const HSLA_RE = /^hsla?\(\s*([-+]?\d*\.?\d+)(?:deg)?\s*,\s*([-+]?\d*\.?\d+)%\s*,\s*([-+]?\d*\.?\d+)%(?:\s*,\s*([-+]?\d*\.?\d+))?\s*\)$/i
+// hsl()/hsla(), both comma and space syntax, alpha as number or percentage.
+const HSLA_RE = /^hsla?\(\s*([-+]?\d*\.?\d+)(?:deg)?\s*[, ]\s*([-+]?\d*\.?\d+)%\s*[, ]\s*([-+]?\d*\.?\d+)%(?:\s*[,/]\s*(\d*\.?\d+%?))?\s*\)$/i
 const HEX_RE = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i
 // rgb()/rgba(), both comma and space syntax, alpha as number or percentage.
 const RGBA_RE = /^rgba?\(\s*(\d*\.?\d+)\s*[, ]\s*(\d*\.?\d+)\s*[, ]\s*(\d*\.?\d+)\s*(?:[,/]\s*(\d*\.?\d+%?))?\s*\)$/i
@@ -389,6 +390,15 @@ function shiftLightness(
   return formatHsla({ ...channels, l: nextLightness })
 }
 
+// The alpha channel accepts either a number (`0.5`) or a percentage (`50%`)
+// in both rgb/rgba and hsl/hsla, comma or space/slash syntax. A missing alpha
+// is fully opaque.
+function parseAlpha(raw: string | undefined): number {
+  if (raw === undefined) return 1
+  if (raw.endsWith('%')) return clamp(Number(raw.slice(0, -1)) / 100, 0, 1)
+  return clamp(Number(raw), 0, 1)
+}
+
 function parseColor(value: string): ColorChannels | null {
   const input = value.trim()
   const hslaMatch = input.match(HSLA_RE)
@@ -397,7 +407,7 @@ function parseColor(value: string): ColorChannels | null {
       h: normalizeHue(Number(hslaMatch[1])),
       s: clamp(Number(hslaMatch[2]), 0, 100),
       l: clamp(Number(hslaMatch[3]), 0, 100),
-      a: hslaMatch[4] === undefined ? 1 : clamp(Number(hslaMatch[4]), 0, 1),
+      a: parseAlpha(hslaMatch[4]),
     }
   }
 
@@ -408,19 +418,13 @@ function parseColor(value: string): ColorChannels | null {
 
   const rgbaMatch = input.match(RGBA_RE)
   if (rgbaMatch) {
-    const alphaRaw = rgbaMatch[4]
-    const alpha = alphaRaw === undefined
-      ? 1
-      : alphaRaw.endsWith('%')
-        ? clamp(Number(alphaRaw.slice(0, -1)) / 100, 0, 1)
-        : clamp(Number(alphaRaw), 0, 1)
     return {
       ...rgbToHsl(
         clamp(Number(rgbaMatch[1]), 0, 255),
         clamp(Number(rgbaMatch[2]), 0, 255),
         clamp(Number(rgbaMatch[3]), 0, 255),
       ),
-      a: alpha,
+      a: parseAlpha(rgbaMatch[4]),
     }
   }
 


### PR DESCRIPTION
## Summary

Color tokens authored with CSS Color-4 **space syntax** — `hsl(0 0% 80%)` and `hsl(0 0% 80% / 50%)` — silently lose every derived variant (transparent steps, shades, tints). Only the bare `--<slug>` base is emitted, verbatim.

`HSLA_RE` in `src/core/framework/colors.ts` only matched the legacy comma form with a number-only alpha:

```ts
const HSLA_RE = /^hsla?\(\s*([-+]?\d*\.?\d+)(?:deg)?\s*,\s*([-+]?\d*\.?\d+)%\s*,\s*([-+]?\d*\.?\d+)%(?:\s*,\s*([-+]?\d*\.?\d+))?\s*\)$/i
```

Space-separated `hsl()` therefore failed `parseColor`, fell through to the verbatim base fallback, and produced no channels to derive from. Its sibling `RGBA_RE` — one line below — already documents and supports "both comma and space syntax, alpha as number or percentage", so the two were asymmetric.

This matters in practice: modern CSS and common import sources (Tailwind) emit space-separated `hsl()`, and `src/core/siteImport/colorTokens.ts` even uses `hsl(0 0% 80%)` as a canonical example of an imported palette entry that becomes a framework color token.

### Before → after

| Input token `lightValue` | Before | After |
|---|---|---|
| `hsl(0 0% 80%)` | 1 var (`--c` verbatim, no variants) | base `hsla(0, 0%, 80%, 1)` + 10 transparent + 2 shades + 2 tints |
| `hsl(0 0% 80% / 50%)` | dropped | base `hsla(0, 0%, 80%, 0.5)` + variants |
| `hsl(0, 0%, 80%)` (comma) | worked | unchanged |

## Fix

- Widen `HSLA_RE` to the same comma-or-space separator and number-or-percentage / slash-delimited alpha shape `RGBA_RE` already uses.
- Extract `parseAlpha` and share it between the hsl and rgb branches instead of duplicating the number/percentage coercion.

No new behavior for values that already parsed; comma-syntax `hsl()`/`hsla()` output is byte-identical.

## Verification

- [x] `bun run build`
- [x] `bun test` (6332 pass, 0 fail; the new test fails on `main` and passes with the fix)
- [x] `bun run lint`

## Checklist

- [x] Tests cover behavior changes — added an `hsl(0 0% 80%)` + `hsl(... / 50%)` case alongside the existing `rgb(5 5 5 / 78%)` space-syntax test.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed — n/a (internal parser; no documented surface changes).
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.