### PR TITLE
fix(templates): strip backslash from escaped \{ in token interpolation

### DIFF
--- a/src/__tests__/templates/bindingSourcesAndTokens.test.ts
+++ b/src/__tests__/templates/bindingSourcesAndTokens.test.ts
@@ -164,10 +164,10 @@ describe('containsTokens', () => {
     expect(containsTokens('Hello {site.name}')).toBe(true)
   })
 
-  it('returns true even for escaped { (the parser will resolve it correctly)', () => {
-    // Cheap check is conservative — false positives are fine because the
-    // parser short-circuits on no real tokens.
-    expect(containsTokens('Literal \\{not-a-token}')).toBe(false)
+  it('returns true even for escaped { (the parser resolves it to a literal)', () => {
+    // Cheap check is conservative — an escaped `\{` still needs a parse so
+    // the backslash is stripped; a false positive only costs one parse.
+    expect(containsTokens('Literal \\{not-a-token}')).toBe(true)
   })
 })
 
@@ -302,6 +302,14 @@ describe('interpolateTokens', () => {
   it('emits empty when the value is missing and there is no fallback', () => {
     const c = ctx({ entryStack: [] })
     expect(interpolateTokens('Welcome, {currentEntry.title}!', c)).toBe('Welcome, !')
+  })
+
+  it('strips the backslash of an escaped `\\{` and emits a literal `{`', () => {
+    expect(interpolateTokens('Literal \\{not-a-token}', ctx())).toBe('Literal {not-a-token}')
+  })
+
+  it('strips the escape even when the string carries no real token', () => {
+    expect(interpolateTokens('\\{just-braces}', ctx())).toBe('{just-braces}')
   })
 })
 

--- a/src/core/templates/tokenInterpolation.ts
+++ b/src/core/templates/tokenInterpolation.ts
@@ -65,15 +65,12 @@ export function bindingToToken(source: DynamicPropBinding['source'], fieldPath: 
  * string-typed props in a published page contain no token syntax at all
  * (button labels, html tags, etc.). Detecting that case in O(n) without
  * allocations short-circuits a full parse + concat per render.
+ *
+ * Any `{` warrants a parse — including an escaped `\{`, which the parser
+ * still processes to strip the backslash and emit a literal `{`.
  */
 export function containsTokens(value: string): boolean {
-  // Need at least `{x.y}` — 5 chars minimum. Looking for an unescaped `{`.
-  if (value.length < 5) return false
-  for (let i = 0; i < value.length; i++) {
-    const c = value[i]
-    if (c === '{' && (i === 0 || value[i - 1] !== '\\')) return true
-  }
-  return false
+  return value.includes('{')
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

An escaped `\{` in a string-typed prop value leaks its backslash into published output. The module documents the escape as *"emits a literal `{not-a-token}` with no replacement"* (`tokenInterpolation.ts:22-23`) and `parseTokenString` implements it correctly — but `interpolateTokens` never reaches the parser for this input.

The culprit is the `containsTokens` fast-path heuristic, which deliberately excluded escaped braces:

```ts
export function containsTokens(value: string): boolean {
  if (value.length < 5) return false
  for (let i = 0; i < value.length; i++) {
    const c = value[i]
    if (c === '{' && (i === 0 || value[i - 1] !== '\\')) return true  // skips \{
  }
  return false
}
```

`interpolateTokens` then short-circuits on the false result:

```ts
if (!containsTokens(input)) return input   // returns input verbatim, backslash intact
```

So `"Literal \{not-a-token}"` is returned unchanged instead of being parsed to `"Literal {not-a-token}"`. `parseTokenString` on the same input already yields the stripped literal, so the heuristic and the parser disagree.

The existing test crystallized the bug — its title states the correct behavior while the assertion encoded the wrong one:

```ts
it('returns true even for escaped { (the parser will resolve it correctly)', () => {
  expect(containsTokens('Literal \\{not-a-token}')).toBe(false)   // contradicts the title
})
```

### Reproduction

```
interpolateTokens('Literal \{not-a-token}', ctx)
  before: 'Literal \{not-a-token}'   ← backslash leaks
  after : 'Literal {not-a-token}'    ← literal, as documented
```

## Fix

Any `{` — escaped or not — needs a parse (the parser is what strips the backslash), so `containsTokens` now returns true whenever a brace is present.

Safe at every call site:
- `publisher/dynamicDetection.ts` — an escape-only string parses to text-only segments (no `kind: 'token'`), so the node correctly stays **static**; no page is newly promoted to a dynamic hole.
- `templates/dynamicBindings.ts` (both sites) — now strip the backslash as documented instead of leaking it.

The `< 5` length floor is dropped with it: a real token's source (`page`/`site`/`route`/`currentEntry`/`parentEntry`) already makes it far longer than 5 chars, but a short escape like `\{x}` is only 4 and was wrongly skipped.

## Verification

- [x] `bun run build`
- [x] `bun test` (6333 pass, 0 fail; the flipped assertion + two new `interpolateTokens` escape tests fail on `main` and pass with the fix)
- [x] `bun run lint`

## Checklist

- [x] Tests cover behavior changes — corrected the self-contradictory `containsTokens` assertion and added `interpolateTokens` escape cases (with and without a real token alongside).
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed — n/a (internal engine; the escape was already documented).
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.