### PR TITLE
fix(page-tree): map NULL to U+FFFD in escapeCssIdentifier

### DIFF
--- a/src/core/page-tree/__tests__/cssIdentifier.test.ts
+++ b/src/core/page-tree/__tests__/cssIdentifier.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { escapeCssIdentifier } from '../cssIdentifier'
+
+const ch = (code: number) => String.fromCharCode(code)
+const NULL = ch(0x0000)
+const REPLACEMENT = ch(0xfffd)
+
+// Vendored implementation of the CSS.escape algorithm
+// (https://drafts.csswg.org/cssom/#serialize-an-identifier). These assertions
+// match what the browser's native CSS.escape returns for the same inputs.
+describe('escapeCssIdentifier', () => {
+  it('replaces NULL (U+0000) with the replacement character U+FFFD', () => {
+    expect(escapeCssIdentifier(NULL)).toBe(REPLACEMENT)
+    expect(escapeCssIdentifier('a' + NULL + 'b')).toBe('a' + REPLACEMENT + 'b')
+  })
+
+  it('escapes control characters and DEL as a hex code point', () => {
+    expect(escapeCssIdentifier(ch(0x0001))).toBe('\\1 ')
+    expect(escapeCssIdentifier(ch(0x001f))).toBe('\\1f ')
+    expect(escapeCssIdentifier(ch(0x007f))).toBe('\\7f ')
+  })
+
+  it('escapes a leading digit, and a digit after a leading dash, as a hex code point', () => {
+    expect(escapeCssIdentifier('9lives')).toBe('\\39 lives')
+    expect(escapeCssIdentifier('-9')).toBe('-\\39 ')
+  })
+
+  it('escapes a lone leading dash', () => {
+    expect(escapeCssIdentifier('-')).toBe('\\-')
+  })
+
+  it('backslash-escapes other non-identifier characters', () => {
+    expect(escapeCssIdentifier('a b')).toBe('a\\ b')
+    expect(escapeCssIdentifier('a.b')).toBe('a\\.b')
+  })
+
+  it('passes identifier-safe characters (incl. non-ASCII) through unchanged', () => {
+    expect(escapeCssIdentifier('ok-name_1')).toBe('ok-name_1')
+    expect(escapeCssIdentifier('café')).toBe('café')
+  })
+})

--- a/src/core/page-tree/cssIdentifier.ts
+++ b/src/core/page-tree/cssIdentifier.ts
@@ -16,6 +16,12 @@ export function escapeCssIdentifier(value: string): string {
     const codeUnit = value.charCodeAt(index)
     const char = value.charAt(index)
 
+    // NULL (U+0000) serializes to the replacement character U+FFFD.
+    if (codeUnit === 0x0000) {
+      escaped += '\uFFFD'
+      continue
+    }
+
     if (
       (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
       codeUnit === 0x007f ||


### PR DESCRIPTION
## Summary

`escapeCssIdentifier` is a vendored implementation of the CSS.escape algorithm ([CSSOM §serialize-an-identifier](https://drafts.csswg.org/cssom/#serialize-an-identifier)), used to build class-kind selectors (`styleRule.ts`) and class-attribute tokens. It implements every step of the spec except **step 1**: *"If the character is NULL (U+0000), then append U+FFFD REPLACEMENT CHARACTER to result."*

The control-character branch deliberately starts at `U+0001`:

```ts
if (
  (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||   // NULL (0x0000) excluded
  codeUnit === 0x007f ||
  ...
```

so a `U+0000` matches no branch and falls through to the generic `escaped += '\\' + char`, emitting a backslash followed by a literal NULL byte. The browser's native `CSS.escape` maps `U+0000` to `U+FFFD` instead.

### Reproduction

| Input (as code points) | Before | Native `CSS.escape` / spec |
|---|---|---|
| `U+0000` | `\` + literal `U+0000` | `U+FFFD` |
| `a`, `U+0000`, `b` | `a\` + `U+0000` + `b` | `a` + `U+FFFD` + `b` |

Every other step (control chars, DEL, leading digit, `-`+digit, lone `-`, allowed set, escape-as-char) already matches the spec — this is a single missing branch.

## Fix

Add the `U+0000` → `U+FFFD` branch as the first step of the per-code-unit loop, exactly where the spec places it.

The function had no direct test coverage, so this adds one alongside the fix — NULL, control characters, leading digit, digit-after-dash, lone dash, and passthrough — all matching native `CSS.escape`. The test is co-located under `src/core/page-tree/__tests__/` and imports the helper relatively, so it neither expands the module barrel nor trips the deep-import gate.

## Verification

- [x] `bun run build`
- [x] `bun test` (6337 pass, 0 fail; the NULL case fails on `main` and passes with the fix)
- [x] `bun run lint`

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed — n/a (the docstring already claims CSS.escape parity; this makes the code match it).
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
