### PR TITLE
fix(server): answer HEAD like GET instead of 404 on published pages

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -55,6 +55,14 @@ export async function handleServerRequest(req: Request, runtime: ServerRuntime):
 
 It walks an ordered `routes` array of `RouteHandler` functions. Each handler returns `Response` (it owns the request) or `null` (try the next handler). The first non-null wins. Unknown paths fall through to a `404`.
 
+**`HEAD` is normalised to `GET` before dispatch.** RFC 9110 §9.3.2 defines `HEAD` as identical to `GET` except that the server must not send content, so `handleServerRequest` rewrites the method once and hands the same request to the table. That means:
+
+- Route handlers gate on `GET` only — never write `req.method !== 'GET' && req.method !== 'HEAD'`. The dispatcher already guarantees a `HEAD` arrives as a `GET`.
+- Dropping the body is `Bun.serve`'s job. A `HEAD` response ships the headers a `GET` would have produced, `content-length` included, with no content — handlers stay body-agnostic.
+- A method a route genuinely doesn't support still gets its `405`; only `HEAD` is folded into `GET`.
+
+Before this normalisation existed, `HEAD` matched no `GET`-gated route and fell through to the terminal JSON `404`, so uptime monitors and link checkers — which probe with `HEAD` by convention — reported healthy published pages as missing ([#306](https://github.com/CoreBunch/Instatic/issues/306)).
+
 ### The route table
 
 ```ts
@@ -170,6 +178,8 @@ export async function handlePagesRoutes(req: Request, db: DbClient): Promise<Res
 
 - Path matches some route, but no route has the right method → **405 Method Not Allowed**
 - No route's pattern matches the path → **`null`**, so the CMS entry point tries the next group and ultimately 404s.
+
+A `HEAD` never reaches this rule as `HEAD` — `handleServerRequest` has already normalised it to `GET` — so a `GET` route answers it and only genuinely unsupported methods get the `405`. Route tables therefore declare `GET` and never a parallel `HEAD` entry.
 
 Parameterised routes use a `RegExp` with **named capture groups** (`(?<id>[^/]+)`). The dispatcher decodes each captured value once via `decodeURIComponent`, so handlers receive already-decoded params and never call `decodeURIComponent` themselves.
 

--- a/server/publish/runtime/packageServer.ts
+++ b/server/publish/runtime/packageServer.ts
@@ -83,7 +83,7 @@ function resolveCacheFilePath(pathname: string): { hash: string; absPath: string
 }
 
 export async function tryServeRuntimePackage(req: Request, pathname: string): Promise<Response | null> {
-  if (req.method !== 'GET' && req.method !== 'HEAD') return null
+  if (req.method !== 'GET') return null
   if (!isRuntimePackagePath(pathname)) return null
 
   const resolved = resolveCacheFilePath(pathname)

--- a/server/router.ts
+++ b/server/router.ts
@@ -102,13 +102,38 @@ export async function handleServerRequest(
 ): Promise<Response> {
   const url = new URL(req.url)
   const { pathname } = url
+  const request = asGetForHead(req)
 
   for (const route of routes) {
-    const response = await route(req, runtime, url, pathname)
+    const response = await route(request, runtime, url, pathname)
     if (response) return response
   }
 
   return jsonResponse({ error: 'Not found' }, { status: 404 })
+}
+
+/**
+ * RFC 9110 §9.3.2: HEAD is identical to GET except that the server must not
+ * send content. Normalising it once here — rather than asking every
+ * method-gated handler in the tree to remember — is what makes that guarantee
+ * hold for every route, including ones added later.
+ *
+ * Without it, a HEAD matched no GET-gated route and fell all the way to the
+ * dispatcher's terminal 404, so uptime monitors and link checkers (which probe
+ * with HEAD by convention) reported a healthy published site as permanently
+ * missing. See issue #306.
+ *
+ * Dropping the body is `Bun.serve`'s job and it already does it: a HEAD
+ * response goes out with the headers a GET would have produced, `content-length`
+ * included, and no content. Handlers stay body-agnostic.
+ *
+ * Cloning is safe here — the copy keeps the URL, the cookies, and the synthetic
+ * `x-bun-socket-ip` header that `stampSocketIp` writes at the `Bun.serve`
+ * boundary, so `clientIp()` attribution is unaffected. HEAD carries no body,
+ * so there is nothing to re-stream.
+ */
+function asGetForHead(req: Request): Request {
+  return req.method === 'HEAD' ? new Request(req, { method: 'GET' }) : req
 }
 
 // ---------------------------------------------------------------------------
@@ -323,7 +348,7 @@ async function tryServeMediaRedirect(
   pathname: string,
 ): Promise<Response | null> {
   if (!pathname.startsWith('/_instatic/media/')) return null
-  if (req.method !== 'GET' && req.method !== 'HEAD') {
+  if (req.method !== 'GET') {
     return new Response('Method not allowed', { status: 405 })
   }
   const match = pathname.match(/^\/_instatic\/media\/([^/]+)\/(.+)$/)

--- a/src/__tests__/server/router.test.ts
+++ b/src/__tests__/server/router.test.ts
@@ -154,3 +154,67 @@ describe('server router — Layer A disk artefact fast-path', () => {
     expect(res.status).toBe(404)
   })
 })
+
+/**
+ * RFC 9110 §9.3.2 — HEAD is identical to GET except that the server must not
+ * send content. Every route below the dispatcher gates on `GET`, so an
+ * un-normalised HEAD used to fall past all of them to the terminal JSON 404:
+ * uptime monitors and link checkers probe with HEAD and concluded a healthy
+ * published site was gone. See issue #306.
+ */
+describe('server router — HEAD is GET minus the body', () => {
+  let uploadsDir: string
+
+  beforeEach(async () => {
+    uploadsDir = await mkdtemp(join(tmpdir(), 'router-head-test-'))
+  })
+
+  afterEach(async () => {
+    await rm(uploadsDir, { recursive: true, force: true })
+  })
+
+  it('answers HEAD on a published page with the same status and content-type as GET', async () => {
+    const { slot, slotDir } = await prepareInactiveSlot(uploadsDir)
+    await writeArtefact(slotDir, '/kontakt', '<html><body>Kontakt</body></html>')
+    await swapSlot(uploadsDir, slot)
+
+    const runtime = { db: makeFakeDb({ site: 1, owners: 1 }), uploadsDir }
+    const get = await handleServerRequest(new Request('http://localhost/kontakt'), runtime)
+    const head = await handleServerRequest(
+      new Request('http://localhost/kontakt', { method: 'HEAD' }),
+      runtime,
+    )
+
+    expect(get.status).toBe(200)
+    expect(head.status).toBe(200)
+    expect(head.headers.get('content-type')).toBe(get.headers.get('content-type'))
+  })
+
+  it('answers HEAD with the setup redirect on a fresh install, like GET', async () => {
+    const res = await handleServerRequest(
+      new Request('http://localhost/', { method: 'HEAD' }),
+      { db: makeFakeDb({ site: 0, owners: 0 }) },
+    )
+
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toBe('/admin')
+  })
+
+  it('answers HEAD on a JSON API route like GET instead of 405', async () => {
+    const res = await handleServerRequest(
+      new Request('http://localhost/admin/api/cms/setup/status', { method: 'HEAD' }),
+      { db: makeFakeDb() },
+    )
+
+    expect(res.status).toBe(200)
+  })
+
+  it('still rejects a method that GET-only routes genuinely do not support', async () => {
+    const res = await handleServerRequest(
+      new Request('http://localhost/admin/api/cms/setup/status', { method: 'DELETE' }),
+      { db: makeFakeDb() },
+    )
+
+    expect(res.status).not.toBe(200)
+  })
+})


### PR DESCRIPTION
Fixes #306.

## What changed

`handleServerRequest` now normalises `HEAD` to `GET` once, before walking the route table.

Every route handler gated on `req.method !== 'GET'`, so a `HEAD` matched none of them and fell through to the dispatcher's terminal `jsonResponse({ error: 'Not found' }, { status: 404 })`. Published pages answered `GET` with `200` and `HEAD` with `404`. `/health` and `/admin` were unaffected only because those two handlers never check the method, which is what made the symptom look selective.

RFC 9110 §9.3.2 defines `HEAD` as identical to `GET` except that the server must not send content, so the invariant belongs in the dispatcher rather than in each handler — that way it holds for routes added later too.

Two behaviours this relies on, both verified before writing the fix:

- `Bun.serve` already drops the body from a `HEAD` response while preserving the headers a `GET` would have produced, `content-length` included. Handlers stay body-agnostic.
- `new Request(req, { method: 'GET' })` preserves the URL, cookies, and the synthetic `x-bun-socket-ip` header that `stampSocketIp` stamps at the `Bun.serve` boundary, so `clientIp()` attribution is unaffected.

It also settles the third behaviour the issue noted: `/admin/api/cms/setup/status` answered `HEAD` with `405` and now answers `200` like `GET`. Methods a route genuinely doesn't support still get their `405`.

With the invariant centralised, the two handlers that carried their own `&& req.method !== 'HEAD'` clause (`tryServeMediaRedirect`, `tryServeRuntimePackage`) no longer need it. Removed, so there is one rule: handlers gate on `GET`, the dispatcher guarantees a `HEAD` arrives as a `GET`.

## Impact

- **Users/operators:** uptime monitors and link checkers that probe with `HEAD` now see published pages as reachable. No configuration change, no migration.
- **Developers:** new route handlers should gate on `GET` only. Documented in `docs/server.md`.

## Verification

Tests were written first and observed failing with `404`, `404`, `405` — reproducing the issue — before the fix.

```sh
bun test          # 6318 pass, 1 skip, 0 fail (683 files)
bun run build     # tsc -b && vite build — clean
bun run lint      # clean
```

Wire-level check through a real `Bun.serve` using the actual dispatcher, mirroring the reproduction in the issue:

| path | GET | HEAD | HEAD body bytes |
|---|---|---|---|
| `/health` | 200 | 200 | 0 |
| `/admin/api/cms/setup/status` | 200 | 200 (was 405) | 0 |
| `/` | 200 | 200 (was 404) | 0 |
| `/kontakt` | 200 | 200 (was 404) | 0 |
| `/does-not-exist` | 404 | 404 | 0 |