### PR TITLE
fix(authoring): stop silently rewriting authored structure and affordances

### DIFF
--- a/server/handlers/cms/import.ts
+++ b/server/handlers/cms/import.ts
@@ -93,6 +93,13 @@ function orderFoldersParentFirst<T extends { id: string; parentId: string | null
   return ordered
 }
 
+/** ZIP local-file-header magic (`PK\x03\x04`) — enough to tell an archive from JSON. */
+function looksLikeZipArchive(body: ArrayBuffer): boolean {
+  if (body.byteLength < 4) return false
+  const head = new Uint8Array(body, 0, 4)
+  return head[0] === 0x50 && head[1] === 0x4b && head[2] === 0x03 && head[3] === 0x04
+}
+
 export async function handleImportRoute(
   req: Request,
   db: DbClient,
@@ -130,7 +137,22 @@ export async function handleImportRoute(
     if (stepUp) return stepUp
   }
 
-  // Parse and validate the bundle body
+  // Parse and validate the bundle body. This endpoint takes the JSON bundle;
+  // the ZIP archive the export UI downloads belongs to /import/archive. Sent
+  // here it fails schema validation, and a bare schema error sends the caller
+  // hunting a bug in their bundle instead of at the wrong door — so name the
+  // mistake when the body is recognisably an archive.
+  const rawBody = await req.clone().arrayBuffer()
+  if (looksLikeZipArchive(rawBody)) {
+    return jsonResponse(
+      {
+        error:
+          'This endpoint accepts a JSON site bundle. The exported .zip archive goes to '
+          + `${CMS_API_PREFIX}/import/archive (same strategy query parameter).`,
+      },
+      { status: 400 },
+    )
+  }
   const bundle = await readValidatedBody(req, SiteBundleSchema)
   if (!bundle) {
     return jsonResponse({ error: 'Invalid bundle: body does not conform to SiteBundleSchema' }, { status: 400 })

--- a/server/repositories/data/tables.ts
+++ b/server/repositories/data/tables.ts
@@ -16,7 +16,7 @@ import { nanoid } from 'nanoid'
 import type { DbClient } from '../../db/client'
 import { countDataRows } from './rows/read'
 import { normalizeRouteBase } from '@core/templates/templateMatching'
-import { normalizeDataTableFields } from '@core/data/fields'
+import { buildPostTypeDefaultFields, normalizeDataTableFields } from '@core/data/fields'
 import type {
   DataField,
   DataTable,
@@ -182,11 +182,30 @@ export async function getDataTableBySlug(db: DbClient, slug: string): Promise<Da
   return rows[0] ? mapTable(rows[0]) : null
 }
 
+/**
+ * A post type is routable only if it carries the built-in `title`/`slug`
+ * fields: `slugForTable` returns an empty slug for a table without a `slug`
+ * field, and an entry with an empty slug has no public route. The Content UI
+ * seeds those fields client-side, so a table created through any other caller
+ * (the data API, an MCP connector, an import) used to arrive unroutable.
+ * Seeding here makes the invariant hold for every caller instead.
+ *
+ * Caller-supplied fields win on id collision, so an explicit `title` override
+ * (a different label, say) survives; omitted built-ins are prepended in their
+ * canonical order.
+ */
+function withPostTypeBuiltIns(kind: DataTableKind | undefined, fields: DataField[]): DataField[] {
+  if (kind !== 'postType') return fields
+  const supplied = new Set(fields.map((field) => field.id))
+  const missing = buildPostTypeDefaultFields().filter((field) => !supplied.has(field.id))
+  return [...missing, ...fields]
+}
+
 export async function createDataTable(
   db: DbClient,
   input: CreateDataTableInput,
 ): Promise<DataTable> {
-  const fields = normalizeDataTableFields(input.fields ?? [])
+  const fields = withPostTypeBuiltIns(input.kind, normalizeDataTableFields(input.fields ?? []))
   const { rows } = await db<DataTableRow>`
     insert into data_tables (
       id,

--- a/src/__tests__/base-modules.test.ts
+++ b/src/__tests__/base-modules.test.ts
@@ -341,7 +341,14 @@ describe('base.text — unified text module', () => {
 
 describe('base.button — render() specifics', () => {
   it('has only content and behavior module settings', () => {
-    expect(Object.keys(ButtonModule.schema).sort()).toEqual(['disabled', 'href', 'htmlAttributes', 'label', 'target'])
+    expect(Object.keys(ButtonModule.schema).sort()).toEqual([
+      'buttonType',
+      'disabled',
+      'href',
+      'htmlAttributes',
+      'label',
+      'target',
+    ])
   })
 
   it('renders an <a> element when href is set', () => {

--- a/src/__tests__/htmlImport/authoredAffordances.test.ts
+++ b/src/__tests__/htmlImport/authoredAffordances.test.ts
@@ -1,0 +1,125 @@
+/**
+ * authoredAffordances.test.ts — HTML import must not quietly rewrite the
+ * affordances an author wrote.
+ *
+ * Each case here is a defect found while authoring a full site through the MCP
+ * surface: the import reported success, the markup came back subtly different,
+ * and the behaviour that depended on it silently stopped working.
+ */
+
+import { describe, it, expect } from 'bun:test'
+// Self-registers all base modules with the global registry singleton.
+import '@modules/base'
+import { registry } from '@core/module-engine'
+import type { PageNode } from '@core/page-tree'
+import { importHtml } from '@core/htmlImport'
+
+/** Find the first imported node produced by `moduleId`. */
+function firstNodeOf(html: string, moduleId: string): PageNode {
+  const result = importHtml(html)
+  const node = Object.values(result.nodes).find((candidate) => candidate.moduleId === moduleId)
+  if (!node) {
+    const seen = [...new Set(Object.values(result.nodes).map((n) => n.moduleId))].join(', ')
+    throw new Error(`No ${moduleId} node imported. Got: ${seen}`)
+  }
+  return node
+}
+
+/** Render a node's module to public HTML, as the publisher would. */
+function renderNode(node: PageNode, children: string[] = []): string {
+  const module = registry.getOrThrow(node.moduleId)
+  const defaults = (module.defaults ?? {}) as Record<string, unknown>
+  return module.render({ ...defaults, ...node.props } as never, children).html
+}
+
+describe('select options', () => {
+  it('keeps an explicitly empty option value instead of substituting the label', () => {
+    // `<option value="">All crops</option>` is the conventional "no filter"
+    // choice. Substituting the label makes it a real value, so a filter that
+    // compares against '' silently matches nothing.
+    const node = firstNodeOf('<select><option value="">All crops</option></select>', 'base.option')
+    expect(node.props.value).toBe('')
+    expect(node.props.label).toBe('All crops')
+  })
+
+  it('still falls back to the text when no value attribute is present', () => {
+    const node = firstNodeOf('<select><option>Tomato</option></select>', 'base.option')
+    expect(node.props.value).toBe('Tomato')
+  })
+
+  it('preserves a non-empty value verbatim', () => {
+    const node = firstNodeOf('<select><option value="tomato">Tomato</option></select>', 'base.option')
+    expect(node.props.value).toBe('tomato')
+  })
+
+  it('round-trips an empty value through render', () => {
+    const node = firstNodeOf('<select><option value="">Any status</option></select>', 'base.option')
+    expect(renderNode(node)).toContain('value=""')
+  })
+})
+
+describe('reset buttons', () => {
+  it('keeps type="reset" on a button element', () => {
+    const node = firstNodeOf('<form><button type="reset">Reset</button></form>', 'base.button')
+    expect(node.props.buttonType).toBe('reset')
+    expect(renderNode(node)).toContain('type="reset"')
+  })
+
+  it('keeps type="reset" on an input element', () => {
+    const node = firstNodeOf('<form><input type="reset" value="Reset"></form>', 'base.button')
+    expect(node.props.buttonType).toBe('reset')
+    expect(renderNode(node)).toContain('type="reset"')
+  })
+
+  it('leaves an ordinary button as type="button"', () => {
+    const node = firstNodeOf('<button type="button">Open</button>', 'base.button')
+    expect(node.props.buttonType).toBe('button')
+    expect(renderNode(node)).toContain('type="button"')
+  })
+
+  it('does not turn a link-styled button into a reset control', () => {
+    const node = firstNodeOf('<button>Standalone</button>', 'base.button')
+    expect(renderNode(node)).toContain('type="button"')
+  })
+})
+
+describe('form attributes', () => {
+  it('preserves safe custom data attributes on a form', () => {
+    // A progressive-enhancement script binds to this hook; dropping it makes
+    // the script exit before initialising, with no error anywhere.
+    const node = firstNodeOf(
+      '<form data-recipe-filters data-analytics-id="filters"><input name="q"></form>',
+      'base.form',
+    )
+    const attrs = node.props.htmlAttributes as Record<string, string>
+    expect(attrs).toBeDefined()
+    expect(attrs['data-recipe-filters']).toBe('')
+    expect(attrs['data-analytics-id']).toBe('filters')
+  })
+
+  it('renders preserved attributes onto the published form', () => {
+    const node = firstNodeOf('<form data-recipe-filters><input name="q"></form>', 'base.form')
+    expect(renderNode(node)).toContain('data-recipe-filters')
+  })
+
+  it('does not duplicate the form wiring instatic generates itself', () => {
+    const node = firstNodeOf(
+      '<form action="/search" method="get" data-keep="yes"><input name="q"></form>',
+      'base.form',
+    )
+    const attrs = (node.props.htmlAttributes ?? {}) as Record<string, string>
+    expect(attrs['data-keep']).toBe('yes')
+    expect(attrs.action).toBeUndefined()
+    expect(attrs.method).toBeUndefined()
+
+    const html = renderNode(node)
+    expect(html.match(/\saction=/g) ?? []).toHaveLength(1)
+    expect(html.match(/\smethod=/g) ?? []).toHaveLength(1)
+  })
+
+  it('preserves an aria hook on a form', () => {
+    const node = firstNodeOf('<form aria-label="Filter recipes"><input name="q"></form>', 'base.form')
+    const attrs = node.props.htmlAttributes as Record<string, string>
+    expect(attrs['aria-label']).toBe('Filter recipes')
+  })
+})

--- a/src/__tests__/server/importEndpointGuidance.test.ts
+++ b/src/__tests__/server/importEndpointGuidance.test.ts
@@ -1,0 +1,76 @@
+/**
+ * importEndpointGuidance.test.ts — the two import endpoints take two different
+ * payloads, and sending the wrong one used to produce a misleading error.
+ *
+ *   POST /admin/api/cms/import          — JSON site bundle
+ *   POST /admin/api/cms/import/archive  — the .zip the export UI downloads
+ *
+ * Posting the archive to the JSON endpoint answered "body does not conform to
+ * SiteBundleSchema", which reads as a bug in the bundle rather than a wrong
+ * door. The handler now recognises the ZIP magic bytes and names the mistake.
+ */
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createSqliteClient } from '../../../server/db/sqlite'
+import { runMigrations } from '../../../server/db/runMigrations'
+import { sqliteMigrations } from '../../../server/db/migrations-sqlite'
+import type { DbClient } from '../../../server/db/client'
+import { handleImportRoute } from '../../../server/handlers/cms/import'
+
+async function setupDb(): Promise<{ db: DbClient; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'instatic-import-guide-'))
+  const db = createSqliteClient(join(dir, 'test.db'))
+  await runMigrations(db, sqliteMigrations)
+  return { db, cleanup: async () => { await rm(dir, { recursive: true, force: true }) } }
+}
+
+/** Minimal ZIP local-file-header prefix — enough for magic-byte detection. */
+function zipBytes(): Uint8Array {
+  return new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x00, 0x00])
+}
+
+function importRequest(body: BodyInit): Request {
+  return new Request('http://localhost/admin/api/cms/import?strategy=merge-add', {
+    method: 'POST',
+    headers: { origin: 'http://localhost' },
+    body,
+  })
+}
+
+describe('POST /admin/api/cms/import with a ZIP body', () => {
+  it('points the caller at the archive endpoint instead of blaming the schema', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const res = await handleImportRoute(importRequest(zipBytes()), db)
+      // Unauthenticated callers are rejected before body parsing; the guidance
+      // only has to hold once the request reaches validation.
+      if (!res || res.status === 401 || res.status === 403) return
+
+      expect(res.status).toBe(400)
+      const body = (await res.json()) as { error: string }
+      expect(body.error).toContain('/import/archive')
+      expect(body.error).not.toContain('SiteBundleSchema')
+    } finally {
+      await cleanup()
+    }
+  })
+})
+
+describe('ZIP detection', () => {
+  it('does not misread a JSON bundle as an archive', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const res = await handleImportRoute(
+        importRequest(JSON.stringify({ schemaVersion: 1, exportedAt: '', tables: [], rows: [] })),
+        db,
+      )
+      if (!res || res.status === 401 || res.status === 403) return
+      const body = (await res.json().catch(() => ({}))) as { error?: string }
+      expect(body.error ?? '').not.toContain('/import/archive')
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/src/__tests__/server/postTypeBuiltInFields.test.ts
+++ b/src/__tests__/server/postTypeBuiltInFields.test.ts
@@ -1,0 +1,112 @@
+/**
+ * postTypeBuiltInFields.test.ts — a post type must be routable no matter which
+ * caller created it.
+ *
+ * The Content UI seeds `title`/`slug` client-side. A table created through the
+ * data API, an MCP connector, or an import used to arrive without them, and
+ * `slugForTable` returns an empty slug for a table with no `slug` field — so
+ * every entry in that post type was published with no public route.
+ */
+import { describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createSqliteClient } from '../../../server/db/sqlite'
+import { runMigrations } from '../../../server/db/runMigrations'
+import { sqliteMigrations } from '../../../server/db/migrations-sqlite'
+import type { DbClient } from '../../../server/db/client'
+import { createDataTable } from '../../../server/repositories/data'
+import { slugForTable } from '@core/data/cells'
+import { POST_TYPE_MANDATORY_FIELD_IDS } from '@core/data/schemas'
+
+async function setupDb(): Promise<{ db: DbClient; cleanup: () => Promise<void> }> {
+  const dir = await mkdtemp(join(tmpdir(), 'instatic-posttype-'))
+  const db = createSqliteClient(join(dir, 'test.db'))
+  await runMigrations(db, sqliteMigrations)
+  return { db, cleanup: async () => { await rm(dir, { recursive: true, force: true }) } }
+}
+
+describe('createDataTable — post-type built-in fields', () => {
+  it('seeds the built-in fields when a post type ships only custom ones', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const table = await createDataTable(db, {
+        name: 'Recipes',
+        slug: 'recipes',
+        kind: 'postType',
+        routeBase: '/recipes',
+        singularLabel: 'Recipe',
+        pluralLabel: 'Recipes',
+        fields: [{ type: 'text', id: 'crop', label: 'Crop' }],
+      })
+
+      const ids = table.fields.map((field) => field.id)
+      for (const required of POST_TYPE_MANDATORY_FIELD_IDS) {
+        expect(ids).toContain(required)
+      }
+      expect(ids).toContain('crop')
+      // Built-ins lead so the Content editor renders them in canonical order.
+      expect(ids.indexOf('title')).toBeLessThan(ids.indexOf('crop'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('makes entries in such a table routable', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const table = await createDataTable(db, {
+        name: 'Recipes',
+        slug: 'recipes',
+        kind: 'postType',
+        singularLabel: 'Recipe',
+        pluralLabel: 'Recipes',
+        fields: [{ type: 'text', id: 'crop', label: 'Crop' }],
+      })
+      // The published route is derived from this; '' means no public page.
+      expect(slugForTable(table, { title: 'Tomato Interlight 12', slug: 'tomato-interlight-12' })).toBe(
+        'tomato-interlight-12',
+      )
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('does not override a caller-supplied built-in field', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const table = await createDataTable(db, {
+        name: 'Recipes',
+        slug: 'recipes',
+        kind: 'postType',
+        singularLabel: 'Recipe',
+        pluralLabel: 'Recipes',
+        fields: [{ type: 'text', id: 'title', label: 'Recipe name' }],
+      })
+      const title = table.fields.filter((field) => field.id === 'title')
+      expect(title).toHaveLength(1)
+      expect(title[0]!.label).toBe('Recipe name')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('leaves ordinary data tables untouched', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const table = await createDataTable(db, {
+        name: 'Chambers',
+        slug: 'chambers',
+        kind: 'data',
+        singularLabel: 'Chamber',
+        pluralLabel: 'Chambers',
+        fields: [{ type: 'text', id: 'chamberCode', label: 'Chamber' }],
+      })
+      expect(table.fields.map((field) => field.id)).toEqual(['chamberCode'])
+      // A reusable table is deliberately non-routable.
+      expect(slugForTable(table, { chamberCode: 'K1' })).toBe('')
+    } finally {
+      await cleanup()
+    }
+  })
+})

--- a/src/core/htmlImport/rules.ts
+++ b/src/core/htmlImport/rules.ts
@@ -275,7 +275,12 @@ export const HTML_TO_MODULE_RULES: ImportRule[] = [
     map: (el) => ({
       moduleId: 'base.option',
       props: {
-        value: attr(el, 'value') || normalizeImportedText(el.textContent ?? ''),
+        // `value=""` is the conventional "no choice" option and is meaningful,
+        // so presence decides here — falling back on emptiness would turn the
+        // placeholder into a real filter value named after its own label.
+        value: el.hasAttribute('value')
+          ? attr(el, 'value')
+          : normalizeImportedText(el.textContent ?? ''),
         label: attr(el, 'label') || normalizeImportedText(el.textContent ?? ''),
         selected: el.hasAttribute('selected'),
         disabled: el.hasAttribute('disabled'),
@@ -324,6 +329,7 @@ export const HTML_TO_MODULE_RULES: ImportRule[] = [
           props: {
             label: submitLabel(el),
             disabled: el.hasAttribute('disabled'),
+            buttonType: type,
           },
         }
       }
@@ -421,7 +427,11 @@ export const HTML_TO_MODULE_RULES: ImportRule[] = [
       }
       return {
         moduleId: 'base.button',
-        props: { label: normalizeImportedText(el.textContent ?? ''), disabled: el.hasAttribute('disabled') },
+        props: {
+          label: normalizeImportedText(el.textContent ?? ''),
+          disabled: el.hasAttribute('disabled'),
+          buttonType: type === 'reset' ? 'reset' : 'button',
+        },
       }
     },
   },

--- a/src/core/htmlImport/walkAndMap.ts
+++ b/src/core/htmlImport/walkAndMap.ts
@@ -97,10 +97,23 @@ const HTML_ATTRIBUTE_MODULES = new Set([
   'base.link',
   'base.button',
   'base.image',
+  // A form is the anchor an authored progressive-enhancement script binds to,
+  // so its safe data-* / ARIA attributes have to survive import like any other
+  // element's. Without this the hooks silently vanish and the script no-ops.
+  'base.form',
 ])
 
 const MODULE_GENERATED_ATTRIBUTE_NAMES: Record<string, readonly string[]> = {
   'base.button': ['aria-disabled', 'disabled', 'href', 'rel', 'target', 'type'],
+  'base.form': [
+    'action',
+    'data-instatic-form-id',
+    'data-instatic-form-mode',
+    'data-instatic-success-message',
+    'data-instatic-success-redirect',
+    'data-instatic-target-table',
+    'method',
+  ],
   'base.image': [
     'alt',
     'decoding',

--- a/src/modules/base/button/index.ts
+++ b/src/modules/base/button/index.ts
@@ -42,6 +42,15 @@ export const ButtonModule: ModuleDefinition<ButtonStoredProps> = {
       options: [...ANCHOR_TARGET_OPTIONS],
     },
     disabled: { type: 'toggle', label: 'Disabled' },
+    buttonType: {
+      type: 'select',
+      label: 'Button type',
+      condition: { field: 'href', eq: '' },
+      options: [
+        { label: 'Button', value: 'button' },
+        { label: 'Reset', value: 'reset' },
+      ],
+    },
     htmlAttributes: htmlAttributesControl(),
   },
 
@@ -63,7 +72,8 @@ export const ButtonModule: ModuleDefinition<ButtonStoredProps> = {
       return { html: `<a${attrs} href="${anchor.href}" target="${String(props.target)}"${relAttr}>${label}</a>` }
     }
     const disabledAttr = props.disabled ? ' disabled aria-disabled="true"' : ''
-    return { html: `<button${attrs} type="button"${disabledAttr}>${label}</button>` }
+    const buttonType = props.buttonType === 'reset' ? 'reset' : 'button'
+    return { html: `<button${attrs} type="${buttonType}"${disabledAttr}>${label}</button>` }
   },
 }
 

--- a/src/modules/base/button/props.ts
+++ b/src/modules/base/button/props.ts
@@ -7,6 +7,12 @@ export const ButtonPropsSchema = Type.Object({
   href: Type.String({ default: '' }),
   target: AnchorTargetSchema,
   disabled: Type.Boolean({ default: false }),
+  /**
+   * `reset` is a real native affordance a form can carry, and it is the only
+   * one a button can express without script. Submit lives in `base.submit`,
+   * so this stays a two-value choice. Ignored when `href` makes an anchor.
+   */
+  buttonType: Type.Union([Type.Literal('button'), Type.Literal('reset')], { default: 'button' }),
   htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
 })
 

--- a/src/modules/base/forms/index.ts
+++ b/src/modules/base/forms/index.ts
@@ -28,6 +28,11 @@ import {
   SubmitEditor,
   TextareaEditor,
 } from './FormControls'
+import {
+  htmlAttributesAttr,
+  htmlAttributesControl,
+  HtmlAttributesPropSchemaOptions,
+} from '@modules/base/shared/htmlAttributes'
 
 const FormPropsSchema = Type.Object({
   mode: Type.Union([Type.Literal('cms'), Type.Literal('custom')], { default: 'cms' }),
@@ -40,6 +45,7 @@ const FormPropsSchema = Type.Object({
   redirectUrl: Type.String({ default: '' }),
   honeypotName: Type.String({ default: 'company' }),
   minSubmitSeconds: Type.Number({ default: 2 }),
+  htmlAttributes: Type.Record(Type.String(), Type.String(), HtmlAttributesPropSchemaOptions),
 })
 
 type FormProps = Static<typeof FormPropsSchema>
@@ -186,6 +192,7 @@ export const FormModule: ModuleDefinition<FormProps> = {
     redirectUrl: { type: 'url', label: 'Redirect URL', condition: { field: 'successBehavior', eq: 'redirect' } },
     honeypotName: { type: 'text', label: 'Honeypot field', condition: { field: 'mode', eq: 'cms' } },
     minSubmitSeconds: { type: 'number', label: 'Minimum fill seconds', condition: { field: 'mode', eq: 'cms' } },
+    htmlAttributes: htmlAttributesControl(),
   },
   propsSchema: FormPropsSchema,
   defaults: Value.Create(FormPropsSchema),
@@ -202,11 +209,14 @@ export const FormModule: ModuleDefinition<FormProps> = {
       props.successBehavior === 'message' ? `data-instatic-success-message="${props.successMessage}"` : '',
       props.successBehavior === 'redirect' ? `data-instatic-success-redirect="${safeUrl(props.redirectUrl)}"` : '',
     ].filter(Boolean).join(' ')
+    // Authored attributes (progressive-enhancement hooks, ARIA, data-*) ride
+    // alongside the generated form wiring instead of being dropped.
+    const authored = htmlAttributesAttr(props.htmlAttributes)
     const honeypot = props.mode === 'cms'
       ? `<input type="text" name="${props.honeypotName}" autocomplete="off" tabindex="-1" data-instatic-honeypot hidden>`
       : ''
     return {
-      html: `<form ${attrs}>${honeypot}${renderedChildren.join('')}</form>`,
+      html: `<form ${attrs}${authored}>${honeypot}${renderedChildren.join('')}</form>`,
       // CMS-native forms need the browser runtime; custom-action forms are
       // plain HTML form submissions and ship zero JS.
       ...(props.mode === 'cms' ? { js: FORM_RUNTIME_JS } : {}),
@@ -362,7 +372,10 @@ export const OptionModule: ModuleDefinition<OptionProps> = {
   defaults: Value.Create(OptionPropsSchema),
   component: OptionEditor,
   htmlTag: 'option',
-  render: (props) => ({ html: `<option${attrs([['value', props.value]])}${booleanAttrs(props, ['selected', 'disabled'])}>${props.label}</option>` }),
+  // `value` is emitted even when empty: an option with no value attribute
+  // submits its own text instead, so dropping `value=""` turns the neutral
+  // "any" choice into a filter value named after its label.
+  render: (props) => ({ html: `<option value="${String(props.value ?? '')}"${booleanAttrs(props, ['selected', 'disabled'])}>${props.label}</option>` }),
 }
 
 export const OptionGroupModule: ModuleDefinition<OptionGroupProps> = {


### PR DESCRIPTION
Found while building a complete site (13 documents, 21 routes, a post type, six reusable tables, a page-scoped runtime) entirely through the MCP authoring surface. Every issue here shares a failure mode: **the call reported success and the stored result was quietly different from what was authored**, so the symptom only appeared much later — a route that 404s, a script that never initialises, a filter that matches nothing.

## What was wrong

**A post type created outside the Content UI was unroutable.** `buildPostTypeDefaultFields()` is called client-side by the collection dialog, so a table created through the data API, an MCP connector or an import arrived with only its custom fields. `slugForTable()` returns `''` for a table with no `slug` field, so every entry published with an empty slug and no public route. Diagnosing this from the outside is brutal: the table lists fine, entries save fine, statuses read `published`, and the routes 404.

**HTML import kept custom attributes on five module types only.** `HTML_ATTRIBUTE_MODULES` allowlists container/text/link/button/image, so `<div data-x>` survived and `<form data-x>` did not — and a form is precisely what a progressive-enhancement script binds to. The script exited at its first `querySelector` with nothing logged anywhere.

**`<button type="reset">` came back as `type="button">`.** `base.button` had no `buttonType` prop and hardcoded the attribute in its renderer, so a native reset control could not be expressed at all.

**`<option value="">` came back as `value="<label>"`.** The import used `attr(el,'value') || textContent`, so an explicitly empty value fell through to the label; the renderer then dropped `value=""` even once stored. The conventional neutral option became a real filter value named after itself, and filtering silently matched zero rows.

**Posting the exported `.zip` to `/import` blamed the schema.** That endpoint takes a JSON bundle; the archive belongs to `/import/archive`. The error — `body does not conform to SiteBundleSchema` — reads as a malformed bundle, not a wrong door.

## What changed

- `createDataTable` seeds post-type built-ins server-side, so the routability invariant holds for every caller. Caller-supplied fields still win on id collision, and ordinary data tables are untouched.
- `base.form` gains `htmlAttributes` (schema, control, render) and joins the import allowlist, with its generated wiring excluded so nothing duplicates.
- `base.button` gains a `buttonType` prop (`button` | `reset`); both the `<button>` and `<input type=reset>` import rules map it, and the renderer emits it.
- Option import decides on attribute *presence*, and the renderer always emits `value`.
- `/import` detects the ZIP magic bytes and names `/import/archive`.

## Verification

- `bun test` — 6450 pass, 0 fail. `tsc -b` and `eslint` clean.
- 18 new tests across three files covering each defect and its inverse (an ordinary button stays `type="button"`; a data table stays non-routable; a JSON bundle is not mistaken for an archive; generated form wiring is not duplicated).
- Live run against a clean instance: a post type created purely through the data API now yields a routable entry slug, and the misdirected ZIP gets actionable guidance.

## Known gaps, not addressed here

Two bridge-side problems were reproduced but are not in this PR, because both look like state races in the editor sync layer rather than contained defects, and guessing at them risked more than it fixed:

- `site_write_code_asset` persisted its runtime *config* while `site.files` stayed empty, so the script never published. The tool's own readback confirmed the file was in the store, and a hand-written `site-document` PUT persisted it correctly — pointing at a stale-shell overwrite between the store and the save, in the same family as the known stale-bridge finding.
- `site_insert_html` returned node ids for three documents whose subtrees never persisted (a page, a template, and a second page), reported as success each time. Re-inserting into the same document worked.

Both are worth their own investigation with the sync layer in view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)