### PR TITLE
fix(publish): stop author bindings publishing the account's email address

### DIFF
--- a/server/db/migrations-pg.ts
+++ b/server/db/migrations-pg.ts
@@ -1147,4 +1147,13 @@ export const pgMigrations: Migration[] = [
       alter table collab_documents add column generation text not null default '';
     `,
   },
+  {
+    // See migrations-sqlite.ts:024 — clears display names that are just the
+    // account's email address, because author bindings render them publicly.
+    id: '024_clear_email_display_names',
+    sql: `
+      update users set display_name = ''
+       where trim(lower(display_name)) = trim(lower(email));
+    `,
+  },
 ]

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -1211,4 +1211,17 @@ export const sqliteMigrations: Migration[] = [
       alter table collab_documents add column generation text not null default '';
     `,
   },
+  {
+    // `display_name` is rendered on PUBLIC pages through author bindings, and
+    // setup used to default it to the account's email address — so every
+    // install created before this has an address sitting in a public field.
+    // Clear it only where it is exactly the address; a name somebody actually
+    // chose is left alone. Admin surfaces already fall back to the email for
+    // their own display, so an empty value costs nothing there.
+    id: '024_clear_email_display_names',
+    sql: `
+      update users set display_name = ''
+       where trim(lower(display_name)) = trim(lower(email));
+    `,
+  },
 ]

--- a/server/handlers/cms/setup.ts
+++ b/server/handlers/cms/setup.ts
@@ -54,12 +54,16 @@ export async function handleSetupRoutes(req: Request, db: DbClient): Promise<Res
       siteName: Type.String(),
       email: Type.String(),
       password: Type.String(),
+      // Optional: the owner's public name. Left empty, author bindings render
+      // nothing rather than the email address.
+      displayName: Type.Optional(Type.String()),
     })
     const body = await readValidatedBody(req, SetupBodySchema)
     if (!body) return badRequest('Invalid request body')
     const siteName = body.siteName.trim()
     const email = body.email.trim().toLowerCase()
     const password = body.password.trim()
+    const displayName = body.displayName?.trim() ?? ''
 
     if (!siteName) return badRequest('Missing siteName')
     if (!email.includes('@')) return badRequest('Invalid email')
@@ -70,7 +74,7 @@ export async function handleSetupRoutes(req: Request, db: DbClient): Promise<Res
       const owner = await createUser(tx, {
         id: nanoid(),
         email,
-        displayName: email,
+        displayName,
         passwordHash: await hashPassword(password),
         roleId: 'owner',
         allowOwnerRole: true,

--- a/server/publish/loopPrefetch.ts
+++ b/server/publish/loopPrefetch.ts
@@ -79,12 +79,15 @@ export function publishedDataRowToLoopItem(row: PublishedDataRow): LoopItem {
       versionNumber: row.versionNumber,
       tableId: row.tableId,
       tableSlug: row.tableSlug,
-      // People
-      author,
+      // People. `author` and `publishedBy` are the DISPLAY NAME, not the
+      // reference object — a binding lands in public HTML, and a non-scalar
+      // there used to be JSON-stringified, publishing display name, role slug
+      // and role name together. Every people key here is now a leaf.
+      author: author?.displayName ?? null,
       authorName: author?.displayName ?? null,
       authorRoleSlug: author?.roleSlug ?? null,
       authorRoleName: author?.roleName ?? null,
-      publishedBy,
+      publishedBy: publishedBy?.displayName ?? null,
       publishedByName: publishedBy?.displayName ?? null,
       publishedByRoleSlug: publishedBy?.roleSlug ?? null,
       publishedByRoleName: publishedBy?.roleName ?? null,

--- a/server/repositories/users.ts
+++ b/server/repositories/users.ts
@@ -285,7 +285,13 @@ export async function createUser(
   const email = input.email.trim()
   const emailNormalized = normalizeEmail(email)
   if (!emailNormalized.includes('@')) throw new UserMutationError('Invalid email')
-  const displayName = input.displayName.trim() || email
+  // Empty means empty. `display_name` is rendered on PUBLIC pages through
+  // author bindings, so defaulting it to the email address publishes the
+  // address the moment anyone binds an author field. Admin surfaces already
+  // fall back to the email for their own display (UserAvatar,
+  // AccountMenuButton, ContentSettingsPanel, ActivityWidget) — that fallback
+  // is authenticated-only and stays.
+  const displayName = input.displayName.trim()
   const id = input.id ?? nanoid()
   const status = input.status ?? 'active'
   if (input.roleId === 'owner' && input.allowOwnerRole !== true) {
@@ -318,9 +324,10 @@ export async function updateUser(
   const email = input.email === undefined ? current.email : input.email.trim()
   const emailNormalized = normalizeEmail(email)
   if (!emailNormalized.includes('@')) throw new UserMutationError('Invalid email')
+  // Clearing the field is allowed and means "no public name" — see createUser.
   const displayName = input.displayName === undefined
     ? current.displayName
-    : input.displayName.trim() || email
+    : input.displayName.trim()
   const status = input.status ?? current.status
   const roleId = input.roleId ?? current.role.id
   const passwordHash = input.passwordHash ?? current.passwordHash

--- a/src/__tests__/loops/dataRowsSource.test.ts
+++ b/src/__tests__/loops/dataRowsSource.test.ts
@@ -3,9 +3,15 @@ import { DataRowsSource } from '@core/loops/sources/dataRows'
 
 describe('data.rows loop source', () => {
   it('offers author display fields without exposing user ids as binding fields', () => {
+    // `author` is declared, because it is the name an author reaches for and
+    // an undeclared key is exactly how a binding to a non-field goes unnoticed.
+    expect(DataRowsSource.fields).toContainEqual({
+      id: 'author',
+      label: 'Author name',
+    })
     expect(DataRowsSource.fields).toContainEqual({
       id: 'authorName',
-      label: 'Author name',
+      label: 'Author name (alias)',
     })
     expect(DataRowsSource.fields).toContainEqual({
       id: 'authorRoleName',

--- a/src/__tests__/publisher/authorBindingLeak.test.ts
+++ b/src/__tests__/publisher/authorBindingLeak.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A binding must never publish internal shape.
+ *
+ * `{currentEntry.author}` used to resolve to the `PublicDataUserReference`
+ * object, and the token interpolator JSON-stringified any non-scalar "so
+ * mistakes stay visible" — an author-facing debug affordance running in the
+ * public publish path. A single template binding therefore published
+ * `{"displayName":"owner@example.com","roleSlug":"owner","roleName":"Owner"}`
+ * into live HTML, and into every screenshot taken of it.
+ *
+ * Two independent guards keep that shut, and both are asserted here: the
+ * people keys are leaf strings, and a non-scalar value renders as nothing
+ * rather than as JSON.
+ */
+import { describe, expect, it } from 'bun:test'
+import { interpolateTokens } from '@core/templates/tokenInterpolation'
+import type { TemplateContext } from '@core/templates/contextFrames'
+
+function contextWithEntry(fields: Record<string, unknown>): TemplateContext {
+  return { entryStack: [{ id: 'row_1', fields }] } as unknown as TemplateContext
+}
+
+describe('author bindings never publish internal shape', () => {
+  it('renders the display name for {currentEntry.author}', () => {
+    const ctx = contextWithEntry({ author: 'Rosa Ferrandis' })
+    expect(interpolateTokens('By {currentEntry.author}', ctx)).toBe('By Rosa Ferrandis')
+  })
+
+  it('renders nothing for a binding that resolves to an object', () => {
+    const ctx = contextWithEntry({
+      author: { displayName: 'owner@example.com', roleSlug: 'owner', roleName: 'Owner' },
+    })
+    const out = interpolateTokens('By {currentEntry.author}', ctx)
+
+    expect(out).toBe('By ')
+    expect(out).not.toContain('@')
+    expect(out).not.toContain('roleSlug')
+    expect(out).not.toContain('displayName')
+  })
+
+  it('renders nothing for a binding that resolves to an array', () => {
+    const ctx = contextWithEntry({ tags: ['a', 'b'] })
+    expect(interpolateTokens('{currentEntry.tags}', ctx)).toBe('')
+  })
+
+  it('still honours an author-supplied fallback when the value is non-scalar', () => {
+    const ctx = contextWithEntry({ author: { displayName: 'owner@example.com' } })
+    expect(interpolateTokens('{currentEntry.author|Anonymous}', ctx)).toBe('Anonymous')
+  })
+
+  it('leaves scalar bindings untouched', () => {
+    const ctx = contextWithEntry({ title: 'El inventario', year: 2025, pardoned: false })
+    expect(interpolateTokens('{currentEntry.title} ({currentEntry.year})', ctx))
+      .toBe('El inventario (2025)')
+    expect(interpolateTokens('{currentEntry.pardoned}', ctx)).toBe('false')
+  })
+})

--- a/src/__tests__/server/loopPrefetch.test.ts
+++ b/src/__tests__/server/loopPrefetch.test.ts
@@ -49,24 +49,22 @@ describe('loopPrefetch', () => {
       createdAt: '2026-05-01T10:02:00.000Z',
     })
 
+    // Every people key is a LEAF. `author` used to be the reference object,
+    // so a template binding it published `{"displayName":…,"roleSlug":…}`
+    // straight into the page.
     expect(item.fields).toMatchObject({
-      author: {
-        displayName: 'Author Name',
-        roleSlug: 'editor',
-        roleName: 'Editor',
-      },
+      author: 'Author Name',
       authorName: 'Author Name',
       authorRoleName: 'Editor',
       authorRoleSlug: 'editor',
-      publishedBy: {
-        displayName: 'Publisher Name',
-        roleSlug: 'admin',
-        roleName: 'Admin',
-      },
+      publishedBy: 'Publisher Name',
       publishedByName: 'Publisher Name',
       publishedByRoleName: 'Admin',
       publishedByRoleSlug: 'admin',
     })
+    for (const key of ['author', 'publishedBy']) {
+      expect(typeof item.fields[key]).not.toBe('object')
+    }
     expect('authorUserId' in item.fields).toBe(false)
     expect('authorId' in item.fields).toBe(false)
     expect('publishedByUserId' in item.fields).toBe(false)

--- a/src/__tests__/server/setupDisplayName.test.ts
+++ b/src/__tests__/server/setupDisplayName.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A display name is never silently the account's email address.
+ *
+ * `display_name` is rendered on PUBLIC pages through author bindings, and both
+ * setup and `createUser` used to default it to the email. So a fresh install
+ * had the owner's address sitting in a publicly-bindable field before anyone
+ * had written a line of content, and the only way to change it was the account
+ * page after the fact.
+ *
+ * Setup now takes an optional `displayName`, and an unset name stays empty.
+ */
+import { describe, expect, it } from 'bun:test'
+import type { DbClient } from '../../../server/db'
+import { handleCmsRequest } from '../../../server/handlers/cms'
+import { createUser, findUserByEmail } from '../../../server/repositories/users'
+import { createTestDb } from '../helpers/createTestDb'
+
+const EMAIL = 'owner@example.com'
+const PASSWORD = 'long-enough-password'
+
+async function runSetup(db: DbClient, body: Record<string, unknown>): Promise<Response> {
+  return await handleCmsRequest(
+    new Request('http://localhost/admin/api/cms/setup', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ siteName: 'Test', email: EMAIL, password: PASSWORD, ...body }),
+    }),
+    db,
+  )
+}
+
+describe('setup display name', () => {
+  it('leaves the display name empty when none is given', async () => {
+    const { db } = await createTestDb()
+    expect((await runSetup(db, {})).status).toBe(201)
+
+    const owner = await findUserByEmail(db, EMAIL)
+    expect(owner?.displayName).toBe('')
+    expect(owner?.displayName).not.toContain('@')
+  })
+
+  it('stores the display name given at setup', async () => {
+    const { db } = await createTestDb()
+    expect((await runSetup(db, { displayName: 'Rosa Ferrandis' })).status).toBe(201)
+
+    expect((await findUserByEmail(db, EMAIL))?.displayName).toBe('Rosa Ferrandis')
+  })
+
+  it('trims a whitespace-only display name to empty rather than the email', async () => {
+    const { db } = await createTestDb()
+    expect((await runSetup(db, { displayName: '   ' })).status).toBe(201)
+
+    expect((await findUserByEmail(db, EMAIL))?.displayName).toBe('')
+  })
+})
+
+describe('createUser display name', () => {
+  it('does not fall back to the email address', async () => {
+    const { db } = await createTestDb()
+    await runSetup(db, {})
+
+    const created = await createUser(db, {
+      email: 'editor@example.com',
+      displayName: '',
+      passwordHash: 'x',
+      roleId: 'admin',
+    })
+
+    expect(created.displayName).toBe('')
+    expect(created.displayName).not.toContain('@')
+  })
+})

--- a/src/admin/preauth/AdminPreAuthForm.module.css
+++ b/src/admin/preauth/AdminPreAuthForm.module.css
@@ -43,6 +43,12 @@
   font-weight: 600;
 }
 
+/* Secondary note inside a field label — lighter than the label it follows. */
+.hint {
+  color: var(--text-subtle);
+  font-weight: 400;
+}
+
 @keyframes instaticAdminSpin {
   to {
     transform: rotate(360deg);

--- a/src/admin/preauth/AdminPreAuthForm.tsx
+++ b/src/admin/preauth/AdminPreAuthForm.tsx
@@ -68,6 +68,7 @@ export function AdminPreAuthForm({
   onAuthenticated,
 }: AdminPreAuthFormProps) {
   const [siteName, setSiteName] = useState('My Site')
+  const [displayName, setDisplayName] = useState('')
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [mfaCode, setMfaCode] = useState('')
@@ -75,6 +76,7 @@ export function AdminPreAuthForm({
   const [error, setError] = useState<string | null>(initialError)
 
   const siteNameId = useId()
+  const displayNameId = useId()
   const emailId = useId()
   const passwordId = useId()
   const mfaCodeId = useId()
@@ -86,7 +88,7 @@ export function AdminPreAuthForm({
       return
     }
     await runAuthAction(async () => {
-      await setupCms({ siteName, email, password })
+      await setupCms({ siteName, email, password, displayName })
       await loginCms({ email, password })
       onAuthenticated(await getCurrentCmsUser())
     }, 'Setup failed', setSubmitting, setError)
@@ -167,16 +169,32 @@ export function AdminPreAuthForm({
               />
             </label>
           ) : phase === 'setup' && (
-            <label className={styles.field} htmlFor={siteNameId}>
-              <span>Site name</span>
-              <Input
-                id={siteNameId}
-                value={siteName}
-                onChange={(event) => setSiteName(event.target.value)}
-                required
-                autoComplete="organization"
-              />
-            </label>
+            <>
+              <label className={styles.field} htmlFor={siteNameId}>
+                <span>Site name</span>
+                <Input
+                  id={siteNameId}
+                  value={siteName}
+                  onChange={(event) => setSiteName(event.target.value)}
+                  required
+                  autoComplete="organization"
+                />
+              </label>
+
+              {/* Optional, and public: this is what author bindings render on
+                  published pages. Left blank they render nothing — which is
+                  why it is offered here rather than only on the account page. */}
+              <label className={styles.field} htmlFor={displayNameId}>
+                <span>Your name <span className={styles.hint}>optional, shown on published pages</span></span>
+                <Input
+                  id={displayNameId}
+                  value={displayName}
+                  onChange={(event) => setDisplayName(event.target.value)}
+                  autoComplete="name"
+                  data-testid="admin-setup-display-name"
+                />
+              </label>
+            </>
           )}
 
           {phase !== 'mfa' && (

--- a/src/core/data/publicDataUser.ts
+++ b/src/core/data/publicDataUser.ts
@@ -1,8 +1,15 @@
 /**
  * Public-facing user reference attached to published data rows.
  *
- * Strips internal-only ids and email addresses, retaining only the bits the
- * publisher and frontend templates need to render bylines safely.
+ * Drops internal-only ids and the `email` field, retaining only the bits the
+ * publisher and frontend templates need to render bylines.
+ *
+ * It does NOT guarantee the result is free of email addresses: `displayName`
+ * carries whatever the account has set, and setup used to default that to the
+ * address. Two things keep it out of public HTML now — a display name is empty
+ * until someone sets one (`createUser`), and the binding frames expose the
+ * display name as a leaf string rather than this object, because a non-scalar
+ * binding used to be serialised wholesale into the page.
  */
 
 interface PublicDataUserReference {

--- a/src/core/loops/sources/dataRows.ts
+++ b/src/core/loops/sources/dataRows.ts
@@ -164,12 +164,12 @@ function rowToLoopItem(
       versionNumber: Number(row.version_number),
       tableId: row.table_id,
       tableSlug: row.table_slug,
-      // People
-      author,
+      // People — display names, never the reference object. See loopPrefetch.
+      author: author?.displayName ?? null,
       authorName: author?.displayName ?? null,
       authorRoleSlug: author?.roleSlug ?? null,
       authorRoleName: author?.roleName ?? null,
-      publishedBy,
+      publishedBy: publishedBy?.displayName ?? null,
       publishedByName: publishedBy?.displayName ?? null,
       publishedByRoleSlug: publishedBy?.roleSlug ?? null,
       publishedByRoleName: publishedBy?.roleName ?? null,
@@ -503,7 +503,8 @@ export const DataRowsSource: LoopEntitySource = {
   fields: [
     { id: 'slug', label: 'Slug' },
     { id: 'title', label: 'Title (post-type)' },
-    { id: 'authorName', label: 'Author name' },
+    { id: 'author', label: 'Author name' },
+    { id: 'authorName', label: 'Author name (alias)' },
     { id: 'authorRoleName', label: 'Author role' },
     { id: 'body', label: 'Body (post-type, markdown)', format: 'html' },
     { id: 'featuredMedia', label: 'Featured media (post-type)', format: 'media' },

--- a/src/core/persistence/cmsAuth.ts
+++ b/src/core/persistence/cmsAuth.ts
@@ -11,6 +11,8 @@ interface CmsSetupInput {
   siteName: string
   email: string
   password: string
+  /** The owner's public name. Omitted or empty means author bindings render nothing. */
+  displayName?: string
 }
 
 interface CmsLoginInput {

--- a/src/core/templates/tokenInterpolation.ts
+++ b/src/core/templates/tokenInterpolation.ts
@@ -276,14 +276,18 @@ export function interpolateTokens(input: string, context: TemplateRenderDataCont
     } else if (typeof rawValue === 'number' || typeof rawValue === 'boolean') {
       out += String(rawValue)
     } else {
-      // Objects / arrays — fall back to JSON for visibility. Real-world
-      // bindings should target leaf fields; surfacing the JSON keeps
-      // mistakes visible instead of silent.
-      try {
-        out += JSON.stringify(rawValue)
-      } catch {
-        // ignore
-      }
+      // Objects / arrays resolve to NOTHING, deliberately.
+      //
+      // This branch used to JSON.stringify the value "so mistakes stay
+      // visible". That is an author-facing debug affordance running in the
+      // public publish path: `{currentEntry.author}` against a reference
+      // object published the account's display name, role slug and role name
+      // into live HTML. A binding that misses is a blank, never a dump of
+      // whatever internal shape happened to sit behind the key — the frame
+      // cannot know which of its values are safe to print.
+      //
+      // Treated as missing, so an author-supplied fallback still applies.
+      if (seg.fallback !== undefined) out += seg.fallback
     }
   }
   return out


### PR DESCRIPTION
## The leak

A template containing `{currentEntry.author}` published this into live HTML:

```html
<p class="caption">Written by {"displayName":"owner@example.com","roleSlug":"owner","roleName":"Owner"}</p>
```

Found while reviewing a generated site — the address was in the page and in every screenshot taken of it. Three independent causes stack.

**The interpolator serialised internals.** `tokenInterpolation.ts:283` JSON-stringified any non-scalar value, commented as keeping "mistakes visible". That is an author-facing debug affordance running unconditionally in the **public** publish path.

**The frame put an object where an author would reach.** `loopPrefetch.ts:83` and `dataRows.ts:168,315` overlaid the internal `PublicDataUserReference` into the same flat namespace as user cells, under the key `author`. A safe-field list already existed at `dataRows.ts:500-516` — deliberately excluding `author`, including `authorName` — but `walkFieldPath` never consulted it, so the list was advertising for `site_list_loop_sources` and nothing more.

**Display names were emails.** `setup.ts:73` and `users.ts:288` both defaulted `display_name` to the account's email. That field is rendered publicly through author bindings, so the *legitimate* `{currentEntry.authorName}` leaked the address too. `publicDataUser.ts` documented itself as stripping email addresses; it strips the `email` field while `displayName` carries the value.

## The fix

`author` and `publishedBy` are now the display name itself — what a binding to them was always meant to produce — and both are declared in the loop source's field list so they are discoverable instead of accidental.

A non-scalar binding renders as missing, honouring any author-supplied fallback, rather than dumping whatever internal shape sat behind the key. The frame cannot know which of its values are safe to print, so it prints none of them.

Display names are empty until somebody sets one. Setup accepts an optional `displayName` and the first onboarding screen now offers it — previously the account page was the only place to set it, after the fact. Migration `024` clears display names that are exactly the account's email, since otherwise no existing install benefits.

Admin surfaces are unchanged: `UserAvatar.tsx:39`, `AccountMenuButton.tsx:57`, `ContentSettingsPanel.tsx:91`, `ActivityWidget.tsx:190` and `ContentPage.tsx:144` already fall back to the email for their own display. That fallback is authenticated-only and stays.

## Verification

Unit — `authorBindingLeak.test.ts`: `{currentEntry.author}` renders the display name; object and array bindings render empty and still honour a fallback; scalars untouched. `setupDisplayName.test.ts`: setup with, without, and with a whitespace-only name; `createUser` no longer falls back to the email.

Live — a fresh install now stores `display_name = ''` rather than the address. An existing instance carrying `owner@masterclass.invalid` in that field had it cleared by migration 024 on next boot, verified before and after against two real databases.

Suite: 6470 pass / 0 fail. Lint and `tsc --noEmit` clean.

React Doctor flags `prefer-useReducer` on `AdminPreAuthForm` — the new field takes it from 6 `useState` calls to 7. Those are independent form scalars plus two status flags; a reducer would not simplify them, and refactoring an auth form does not belong in a security fix.

## Follow-ups (not in this PR)

Two further defects found in the same investigation, planned as separate PRs: entry routes serve the oldest published page's runtime manifest rather than their own (`getLatestPublishedSiteSnapshot` is `order by created_at asc limit 1`, and its `runtime_assets_json` rides along by accident); and `content_set_document_status` silently reassigns the editor's active document, which also discards a human's unsaved draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)