### PR TITLE
fix(publish): prefetch the asset behind a bound image

### DIFF
--- a/server/publish/mediaPrefetch.ts
+++ b/server/publish/mediaPrefetch.ts
@@ -86,10 +86,10 @@ export async function prefetchMediaAssets(
 ): Promise<MediaAssetMap> {
   const map = new Map<string, MediaAsset>()
   const paths = collectMediaPaths(page, site, registry)
-  const entryReferences = collectEntryArrayReferences(options)
+  const entryReferences = collectEntryMediaReferences(options)
   if (paths.size === 0 && entryReferences.size === 0) return map
 
-  // `collectMediaPaths` and `collectEntryArrayReferences` both return Sets,
+  // `collectMediaPaths` and `collectEntryMediaReferences` both return Sets,
   // so the lookup values are unique. Entry references are queried against
   // both `id` and `public_path`: multi-media cells store ids, while plugin or
   // imported entry arrays may already carry public paths.
@@ -147,11 +147,37 @@ export async function prefetchMediaAssets(
   return materializeAssetMapForClient(map)
 }
 
-function collectEntryArrayReferences(options: MediaPrefetchOptions): Set<string> {
+/**
+ * Media references carried by the ENTRY data rather than by a node prop.
+ *
+ * A bound image (`<img src="{currentEntry.featuredMedia}">`) stores the
+ * binding token in its prop, so `collectMediaPaths` — which only recognises a
+ * literal `/uploads/...` — never sees it. The path lives in the entry's
+ * fields, and it has to be collected from there or the asset is never
+ * fetched.
+ *
+ * Two shapes qualify, and nothing else:
+ *
+ *   - any string inside an ARRAY — a multi-media cell, every element of which
+ *     is a reference (an id, or already a public path);
+ *   - a SCALAR string that is an upload path — `featuredMedia` and
+ *     `featuredMediaPath` carry the resolved `/uploads/...` URL.
+ *
+ * The scalar case is deliberately narrow. Collecting every scalar string
+ * would drag an entry's whole prose surface into the IN-list; requiring the
+ * `/uploads/` prefix picks out exactly the resolved media cells.
+ *
+ * Missing this case is not cosmetic. Without the asset the image module has
+ * no library record to read, and since alt text comes exclusively from the
+ * library, every bound image published with an EMPTY alt — plus no srcset and
+ * no intrinsic width/height. That is the ordinary CMS pattern: one image per
+ * entry, on every entry route and in every loop row.
+ */
+function collectEntryMediaReferences(options: MediaPrefetchOptions): Set<string> {
   const references = new Set<string>()
   const visit = (value: unknown, insideArray: boolean): void => {
     if (typeof value === 'string') {
-      if (insideArray && value) references.add(value)
+      if (value && (insideArray || value.startsWith('/uploads/'))) references.add(value)
       return
     }
     if (Array.isArray(value)) {

--- a/src/__tests__/server/mediaBatchResolution.test.ts
+++ b/src/__tests__/server/mediaBatchResolution.test.ts
@@ -299,4 +299,102 @@ describe('prefetchMediaAssets (Finding 2)', () => {
       await cleanup()
     }
   })
+
+  it('resolves a SCALAR entry media path — the bound `featuredMedia` case', async () => {
+    const { db, cleanup } = await createTestDb()
+    try {
+      await insertMediaAsset(db, 'aid-1', '/uploads/aid-1.png')
+      // The node prop holds the BINDING TOKEN, not a path, so collectMediaPaths
+      // cannot see it. The resolved path lives on the entry.
+      const page = makePageWithImageProp('n1', 'src', '{currentEntry.featuredMedia}')
+      const registry = makeImageRegistry('src')
+
+      const map = await prefetchMediaAssets(
+        page as never,
+        { visualComponents: [] } as never,
+        registry,
+        db,
+        {
+          templateContext: {
+            entryStack: [{
+              id: 'aid-row-1',
+              fields: {
+                featuredMedia: '/uploads/aid-1.png',
+                featuredMediaPath: '/uploads/aid-1.png',
+                // Prose must NOT be dragged into the lookup.
+                honest: 'We would tell you to buy the cheaper one.',
+                model: 'Basic behind-the-ear',
+              },
+            }],
+          },
+        },
+      )
+
+      // Without the asset the image module has no library record, so the
+      // published <img> gets alt="" and no srcset — on every entry route.
+      expect(map.get('/uploads/aid-1.png')?.id).toBe('aid-1')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('resolves a scalar media path carried by a LOOP row', async () => {
+    const { db, cleanup } = await createTestDb()
+    try {
+      await insertMediaAsset(db, 'aid-2', '/uploads/aid-2.png')
+      const page = makePageWithImageProp('n1', 'src', '{currentEntry.featuredMedia}')
+      const registry = makeImageRegistry('src')
+
+      const map = await prefetchMediaAssets(
+        page as never,
+        { visualComponents: [] } as never,
+        registry,
+        db,
+        {
+          loopData: new Map([
+            ['loop-1', {
+              items: [{ id: 'row-1', fields: { featuredMedia: '/uploads/aid-2.png' } }],
+              totalItems: 1,
+              pageNumber: 1,
+              hasMore: false,
+            }],
+          ]) as never,
+        },
+      )
+
+      expect(map.get('/uploads/aid-2.png')?.id).toBe('aid-2')
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('does not treat ordinary scalar text fields as media references', async () => {
+    const { db, cleanup } = await createTestDb()
+    try {
+      await insertMediaAsset(db, 'aid-3', '/uploads/aid-3.png')
+      const page = makePageWithImageProp('n1', 'content', 'no static media path')
+      const registry = { get: () => ({ id: 'base.text', schema: {} }) } as unknown as IModuleRegistry
+
+      const map = await prefetchMediaAssets(
+        page as never,
+        { visualComponents: [] } as never,
+        registry,
+        db,
+        {
+          templateContext: {
+            entryStack: [{
+              id: 'aid-row-3',
+              fields: { model: 'aid-3', honest: 'A model name is not an asset id.' },
+            }],
+          },
+        },
+      )
+
+      // 'aid-3' matches a real asset ID, and must still not be resolved:
+      // scalars qualify by being an upload PATH, never by looking like an id.
+      expect(map.size).toBe(0)
+    } finally {
+      await cleanup()
+    }
+  })
 })


### PR DESCRIPTION
## What breaks

`<img src="{currentEntry.featuredMedia}">` — one image per entry, on every entry route and in every loop row, the ordinary CMS pattern — publishes as:

```html
<img src="/uploads/xxx-aid-bte.webp" alt="" loading="lazy" decoding="async">
```

No alt. No `srcset`. No `width`/`height`. A statically-authored image on the same page gets all three.

## Why

The node prop holds the **binding token**, not a path, so `collectMediaPaths` skips it — it only recognises a literal `/uploads/...`. The resolved path lives on the entry instead, and `collectEntryArrayReferences` only collected a string when it sat **inside an array**:

```ts
if (typeof value === 'string') {
  if (insideArray && value) references.add(value)   // scalar → dropped
  return
}
```

A multi-media cell (`gallery: ['id-1', 'id-2']`) resolved. A scalar `featuredMedia: '/uploads/aid.webp'` did not.

With no asset in the map, `props._resolvedMediaByKey.src` is `undefined`, and the image module reads alt **exclusively** from the library asset — deliberately, per its own comment:

> Alt text comes exclusively from the library asset — the library is the single source of truth for accessibility metadata. Edited in the Media viewer (asset row), never as a per-instance module prop.

That is a reasonable rule, but combined with the missing prefetch it means **there is no way to give a bound image alt text at all**. Setting alt text on the asset does nothing (never fetched); authoring `alt="..."` in the HTML does nothing (ignored by design). Every bound image is unlabelled, and the same lookup supplies `srcset`, `sizes`, `width` and `height` — so phones get the full-size original and each image shifts layout on load.

Found while building a template pack: six entry pages, each with its own photograph, all published unlabelled with the alt text sitting correctly in the media library.

## The fix

Collect scalar strings too, but only when they are an upload path:

```ts
if (value && (insideArray || value.startsWith('/uploads/'))) references.add(value)
```

That picks out `featuredMedia` / `featuredMediaPath` exactly — the loop source stores the resolved public URL there, not an id — while keeping an entry's prose fields out of the batched `IN` list. Collecting every scalar would drag the whole text surface of every row into the query.

Renamed to `collectEntryMediaReferences`, since it is no longer about arrays.

## Tests

Three added to `mediaBatchResolution.test.ts`. **Two fail without the fix:**

- a scalar entry media path resolves (the bound `featuredMedia` case)
- a scalar media path carried by a loop row resolves
- an ordinary scalar text field is *not* treated as a reference — the guard test: its value is deliberately set to a string that matches a real asset **id**, and must still not resolve, because scalars qualify by being a `/uploads/` path and never by looking like an id

Full suite `6515 pass / 0 fail`, `bun run lint` and `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)