### PR TITLE
fix(data): stop the field dialog crashing outside a secure context

### DIFF
--- a/src/__tests__/data/newFieldDialogModel.test.ts
+++ b/src/__tests__/data/newFieldDialogModel.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for makeOption() in the New Field dialog model.
+ *
+ * Regression cover for the crash reported in #319: `crypto.randomUUID()` is
+ * only defined in a secure context, so any admin reached over plain HTTP on a
+ * LAN address or bare hostname (the common Docker Compose setup) has no such
+ * function and the dialog throws on open. Option ids must be generated with a
+ * primitive that does not depend on secure-context availability.
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { Value } from '@sinclair/typebox/value'
+import { DataFieldSchema } from '@core/data/schemas'
+import { makeOption, slugifyOptionValue } from '@admin/pages/data/components/NewFieldDialog/newFieldDialogModel'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Run `fn` with `crypto.randomUUID` absent, mirroring an insecure browsing
+ * context. Restores the original descriptor afterwards.
+ */
+function withoutRandomUUID<T>(fn: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(globalThis.crypto, 'randomUUID')
+  Object.defineProperty(globalThis.crypto, 'randomUUID', {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  })
+  try {
+    return fn()
+  } finally {
+    if (original) Object.defineProperty(globalThis.crypto, 'randomUUID', original)
+    else delete (globalThis.crypto as { randomUUID?: unknown }).randomUUID
+  }
+}
+
+afterEach(() => {
+  expect(typeof globalThis.crypto.randomUUID).toBe('function')
+})
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('makeOption', () => {
+  it('produces an option in a secure context', () => {
+    const option = makeOption('In stock')
+    expect(option.label).toBe('In stock')
+    expect(option.value).toBe('in_stock')
+    expect(option.id).toBeTruthy()
+  })
+
+  it('produces an option in an insecure context, where crypto.randomUUID is undefined', () => {
+    const option = withoutRandomUUID(() => makeOption('In stock'))
+    expect(option.label).toBe('In stock')
+    expect(option.value).toBe('in_stock')
+    expect(option.id).toBeTruthy()
+  })
+
+  it('generates distinct ids in an insecure context', () => {
+    const ids = withoutRandomUUID(() =>
+      Array.from({ length: 100 }, () => makeOption('Option').id),
+    )
+    expect(new Set(ids).size).toBe(100)
+  })
+
+  it('keeps select options schema-valid when generated in an insecure context', () => {
+    const options = withoutRandomUUID(() =>
+      ['Draft', 'Published'].map((label) => {
+        const option = makeOption(label)
+        return { id: option.id, label, value: option.value || slugifyOptionValue(label) }
+      }),
+    )
+    const field = { type: 'select', id: 'status', label: 'Status', options }
+    expect(Value.Check(DataFieldSchema, field)).toBe(true)
+  })
+})

--- a/src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts
+++ b/src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid'
 import type { DataFieldType } from '@core/data/schemas'
 
 export interface DraftOption {
@@ -59,7 +60,7 @@ export function fieldIdFromLabel(label: string): string {
 }
 
 export function makeOption(label: string): DraftOption {
-  return { id: crypto.randomUUID(), label, value: slugifyOptionValue(label) }
+  return { id: nanoid(), label, value: slugifyOptionValue(label) }
 }
 
 export function fieldIdError(id: string, existingIds: string[]): string | null {

--- a/src/admin/pages/site/panels/FrameworkScalePanel/ClassGeneratorList.tsx
+++ b/src/admin/pages/site/panels/FrameworkScalePanel/ClassGeneratorList.tsx
@@ -1,3 +1,4 @@
+import { nanoid } from 'nanoid'
 import { Button } from '@ui/components/Button'
 import { ClassGeneratorRow } from './ClassGeneratorRow'
 import type { GeneratorShape, GroupShape, ScaleAdapter } from './adapter'
@@ -29,7 +30,7 @@ export function ClassGeneratorList<C extends GeneratorShape>({
 
   function handleAdd() {
     const fresh = {
-      id: crypto.randomUUID(),
+      id: nanoid(),
       name: `${groupNamingConvention}-*`,
       property: [adapter.classGeneratorProperties[0]?.value ?? ''],
       tabId: groupId,


### PR DESCRIPTION
Fixes #319.

## Root cause

`crypto.randomUUID()` is only defined when `window.isSecureContext` is true. An admin reached over plain HTTP on a LAN address or a bare hostname is not a secure context, so the function is simply absent and `makeOption()` throws `TypeError: crypto.randomUUID is not a function`, crashing the page.

`localhost` and `127.0.0.1` are treated as secure contexts regardless of scheme, which is why this never shows up in local development and only surfaced on a Docker Compose install reached over the network.

Probed one dev server across three origins:

| origin | `isSecureContext` | `typeof crypto.randomUUID` |
| --- | --- | --- |
| `http://localhost:3001` | true | `function` |
| `http://127.0.0.1:3001` | true | `function` |
| `http://192.168.7.112:3001` | false | `undefined` |

## Change

Two browser call sites reached `crypto.randomUUID()` directly:

- `makeOption()` in `src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts`, the crash in #319, on the admin/data → add table → add field path
- `handleAdd()` in `src/admin/pages/site/panels/FrameworkScalePanel/ClassGeneratorList.tsx`, the same bug, not yet reported

Both move to `nanoid`. That is not a new dependency or a new convention: `nanoid` is already the id primitive in 37 modules, including `src/admin/pages/data/utils/fieldDefaults.ts` and `src/core/framework/scaleGroups.ts`, which sit in these same two feature areas. The two `crypto.randomUUID()` calls were the anomaly.

I fixed the second site in the same change because it is one root cause rather than two problems. Happy to split it out if you would rather keep the PR to the reported path.

## Persistence

`DraftOption.id` does reach storage, via `DataSelectOption` on select and multiSelect fields, so the id format matters. `SelectOptionSchema.id` is `Type.String()` with no format constraint, so nanoid ids validate, ids already persisted in UUID shape stay valid, and no migration is required.

## Tests

New: `src/__tests__/data/newFieldDialogModel.test.ts`, four cases exercising `makeOption()` with `crypto.randomUUID` removed to mirror an insecure context. Covers option creation, id uniqueness across 100 generations, and TypeBox validity of the resulting select options.

Verified failing on `main` with the exact error from the issue, passing on this branch.

- `bun run lint` clean
- `bun run build` clean
- `bun test` 6534 pass, 1 fail

## Unrelated pre-existing failure

That one failure is `Bundle size budgets > ContentPage-*.js`, at 90043 B against a 90000 B budget, 43 bytes over. It is not from this change. I stashed the fix, rebuilt clean `main`, and got the byte-identical 90043. It only appears after `bun run build`, since the budget test reads `dist/`, so a test run on a fresh clone will not show it. Flagging it rather than folding it in, since it is a separate problem.
