### PR TITLE
fix(server): let platform auto-detection survive an invalid PUBLIC_ORIGIN

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -59,17 +59,24 @@ function normalizeOrigins(raw: readonly string[]): string[] {
  *
  * Precedence:
  *   1. `PUBLIC_ORIGIN` — comma-separated list (platform domain + custom domain
- *      can coexist). Invalid entries are dropped.
+ *      can coexist). Invalid entries are dropped; a list that survives
+ *      normalization with at least one entry wins outright.
  *   2. Platform auto-detection — `RENDER_EXTERNAL_URL` (full URL) and/or
  *      `https://${RAILWAY_PUBLIC_DOMAIN}` (host only). Both are included when
  *      both env vars are present, keeping one-click deploys config-free.
+ *      Reached when `PUBLIC_ORIGIN` is unset *or* every entry in it is
+ *      unparseable, so a malformed value degrades to auto-detection rather
+ *      than suppressing it.
  *   3. `[]` — no public origin configured; the CSRF check falls back to the
  *      inbound `Host` header.
  */
 export function resolvePublicOrigins(env: Record<string, string | undefined>): string[] {
-  const explicit = readCsvList(env.PUBLIC_ORIGIN)
+  // Normalize before the precedence test, not after: gating on the raw CSV
+  // length lets an all-invalid PUBLIC_ORIGIN return [] while still claiming
+  // precedence, which suppresses platform auto-detection entirely.
+  const explicit = normalizeOrigins(readCsvList(env.PUBLIC_ORIGIN))
   if (explicit.length > 0) {
-    return normalizeOrigins(explicit)
+    return explicit
   }
 
   const derived: string[] = []

--- a/src/__tests__/server/serverConfig.test.ts
+++ b/src/__tests__/server/serverConfig.test.ts
@@ -85,6 +85,33 @@ describe('resolvePublicOrigins', () => {
     ).toEqual(['https://www.example.com'])
   })
 
+  it('falls back to platform vars when every PUBLIC_ORIGIN entry is invalid', () => {
+    // A one-click template that renders `https://${RAILWAY_PUBLIC_DOMAIN}`
+    // before the domain exists yields the bare scheme. Gating precedence on
+    // the raw CSV instead of the normalized result made that value suppress
+    // auto-detection, leaving the CSRF check with no configured origin — i.e.
+    // setting PUBLIC_ORIGIN badly was worse than not setting it at all.
+    expect(
+      resolvePublicOrigins({
+        PUBLIC_ORIGIN: 'https://',
+        RAILWAY_PUBLIC_DOMAIN: 'app.up.railway.app',
+      }),
+    ).toEqual(['https://app.up.railway.app'])
+  })
+
+  it('falls back to platform vars when PUBLIC_ORIGIN is only separators', () => {
+    expect(
+      resolvePublicOrigins({
+        PUBLIC_ORIGIN: 'not-a-url, also-bad',
+        RENDER_EXTERNAL_URL: 'https://app.onrender.com',
+      }),
+    ).toEqual(['https://app.onrender.com'])
+  })
+
+  it('returns [] when PUBLIC_ORIGIN is invalid and no platform var is set', () => {
+    expect(resolvePublicOrigins({ PUBLIC_ORIGIN: 'https://' })).toEqual([])
+  })
+
   it('returns [] when nothing is configured', () => {
     expect(resolvePublicOrigins({})).toEqual([])
   })


### PR DESCRIPTION
## The defect

`resolvePublicOrigins` tests the precedence gate against the **raw** CSV list but returns the **normalized** one. A `PUBLIC_ORIGIN` whose entries all fail to parse therefore claims precedence and then resolves to `[]`, silently suppressing platform auto-detection:

```
resolvePublicOrigins({ PUBLIC_ORIGIN: 'https://', RAILWAY_PUBLIC_DOMAIN: 'app.up.railway.app' })
  -> []

resolvePublicOrigins({ RAILWAY_PUBLIC_DOMAIN: 'app.up.railway.app' })
  -> ['https://app.up.railway.app']
```

Setting the variable badly is strictly worse than leaving it unset. `normalizeOrigin` returns null for `'https://'` because `new URL('https://')` throws, so the list empties out after the gate has already been passed.

Downstream, an empty `publicOrigins` puts the CSRF check on its inbound-`Host` fallback, which derives the scheme from `req.url`. Behind a TLS-terminating edge that yields `http://…` against a browser `Origin` of `https://…`, and the request is rejected.

## Change

Normalize before the gate rather than after. One function, four lines.

A list with at least one parseable entry still wins outright, and invalid entries inside a partly valid list are still dropped rather than promoting auto-detection. Both existing tests that pin those behaviors pass unchanged, which is the signal that the diff is narrow.

## A design call that is yours, not mine

Given a `PUBLIC_ORIGIN` where every entry is unparseable, there are three defensible behaviors:

1. Fall through to platform auto-detection (what this PR does)
2. Throw at boot, so a malformed env var fails loudly instead of degrading quietly
3. Warn and fall through

I picked 1 because it makes the function match its own documented precedence, and because it is the smallest change. But this is your CSRF code from #14 and you wrote the existing test that deliberately drops invalid entries, so you may well prefer 2 — a container that refuses to start is arguably better operator feedback than one that quietly resolves to something else. Say the word and I will rewrite it as a boot-time throw, or add a warning alongside the fallthrough.

## On #185

I am referencing that issue as motivation, not claiming it as a fix. The code defect above is proven independently. Whether it explains that particular Railway report is a hypothesis: it fits (a template rendering `https://${{RAILWAY_PUBLIC_DOMAIN}}` before the domain is provisioned collapses to exactly `https://`), but I cannot verify Railway's variable-resolution timing, and if `RAILWAY_PUBLIC_DOMAIN` was also empty on that boot the fallthrough would have returned `[]` anyway. Treat this as a standalone correctness fix.

## Tests

Three cases added to the existing `describe('resolvePublicOrigins')` block. Two of them fail on current `main` and pass here; the third (invalid `PUBLIC_ORIGIN` with no platform var still yields `[]`) passes either way and is there to pin the non-over-correction.

- `bunx tsc -b` exit 0
- `bun run lint` clean
- 190/190 across serverConfig, security, apiSecurityBoundary, security-headers and publicForms
- `bun test` 6533 pass, 1 fail

That single failure is `Bundle size budgets > ContentPage-*.js`, 90043 B against a 90000 B budget. Pre-existing and unrelated: it reproduces byte-identically on untouched `main` and only surfaces once `dist/` exists.

I deliberately did not touch `expectedOrigin`'s scheme handling. `server/auth/security.ts` documents that forwarded headers are not consulted for CSRF, and that is the point of the design.
