### PR TITLE
Fix collaborative persistence and deterministic publishing

### DIFF
--- a/docs/features/content-storage.md
+++ b/docs/features/content-storage.md
@@ -32,7 +32,7 @@ The schema for a collection. One row per collection.
 | `kind`            | text      | `'postType' \| 'data' \| 'page' \| 'component' \| 'layout'`      |
 | `singular_label`  | text      | "Post"                                                           |
 | `plural_label`    | text      | "Posts"                                                          |
-| `route_base`      | text      | Empty = not publicly routable. Post-types default to `/<slug>`. |
+| `route_base`      | text      | Empty = not publicly routable. An omitted create value defaults to `/<slug>`; an explicitly empty value stays empty through create, update, and import. |
 | `primary_field_id`| text      | Field id used as the row's display name in grids / pickers      |
 | `fields_json`     | jsonb     | `DataField[]` — the schema                                       |
 | `system`          | boolean   | `true` for seeded tables (`posts`, `pages`, `components`, `layouts`) |

--- a/docs/features/templates.md
+++ b/docs/features/templates.md
@@ -87,7 +87,7 @@ type RouteResolutionContext =
 | `page`     | matched if exists      | never matched          |
 | `entry`    | matched if exists      | matched if `tableSlugs.includes(tableSlug)` |
 
-Within a level, the template with the highest `priority` wins; document order breaks ties.
+Within a level, the template with the highest `priority` wins; document order breaks ties. When the server assembles a persisted draft for publishing, that order is the rows' immutable creation order (then id), not the authoring list's mutable recently-updated order.
 
 **Adding a new breadth level** (e.g. path-prefix sections) means inserting a new entry into the `LEVELS` constant in `templateMatching.ts` — the resolver loop is level-agnostic.
 

--- a/server/collab/relay.ts
+++ b/server/collab/relay.ts
@@ -34,33 +34,11 @@ import { nanoid } from 'nanoid'
 import {
   encodeCollabDocId,
   parseCollabDocId,
-  projectComponentDoc,
-  projectLayoutDoc,
-  projectPageDoc,
   projectSiteDoc,
-  seedComponentDoc,
-  seedLayoutDoc,
-  seedPageDoc,
-  seedSiteDocFromParts,
   SITE_DOC_ID,
   type CollabDocKind,
 } from '@core/collab'
-import '@modules/base' // registry population — inline-text props seed as Y.Text
-import type { SiteShell } from '@core/page-tree'
-import { pageFromRow, pageToCells } from '@core/data/pageFromRow'
-import { visualComponentFromRow, visualComponentToCells } from '@core/data/componentFromRow'
-import { savedLayoutFromRow, savedLayoutToCells } from '@core/data/layoutFromRow'
-import { vcSlugFromName } from '@core/visualComponents'
-import { layoutSlugFromName } from '@core/layouts'
-import { validateSite } from '@core/persistence/validate'
 import type { DbClient } from '../db/client'
-import {
-  getDataRow,
-  listDataRowIdSlugs,
-  softDeleteDataRow,
-  upsertDataRowDraft,
-} from '../repositories/data'
-import { getDraftSite, saveDraftSite } from '../repositories/site'
 import {
   deleteCollabDocuments,
   getCollabDocumentState,
@@ -70,14 +48,9 @@ import {
   registerRowWriteListener,
   registerShellWriteListener,
 } from '../repositories/rowWriteEvents'
-import { bumpPublishVersionSerialized } from '../publish/publishState'
 import { registerPublishFlush } from '../publish/publishFlush'
+import { createRelayPersistence } from './relayPersistence'
 
-const KIND_TABLE: Record<Exclude<CollabDocKind, 'site'>, string> = {
-  page: 'pages',
-  component: 'components',
-  layout: 'layouts',
-}
 const TABLE_KIND: Record<string, Exclude<CollabDocKind, 'site'>> = {
   pages: 'page',
   components: 'component',
@@ -96,8 +69,7 @@ interface RelayEntry {
   detachUpdateHandler: () => void
 }
 
-type DerivedWrite = 'written' | 'incomplete' | 'invalid'
-type PersistOutcome = 'clean' | 'retry' | 'invalid'
+type PersistOutcome = 'clean' | 'deferred' | 'superseded' | 'retry' | 'invalid'
 
 export type RelayUpdateListener = (
   docId: string,
@@ -139,148 +111,74 @@ export function createCollabRelay(
    * blob a reset is still deleting.
    */
   const settling = new Map<string, Promise<void>>()
-  // Last roster set the site-doc persist actually swept, so shell-field-only
-  // persists skip the three full-table scans. Cleared when the site doc resets.
-  let lastSweptRostersKey: string | null = null
+  const resetGates = new Map<string, Promise<void>>()
   const updateListeners = new Set<RelayUpdateListener>()
   const resetListeners = new Set<RelayResetListener>()
+  const invalidationVersions = new Map<string, number>()
+  const activeInvalidations = new Set<string>()
+  let nextInvalidationVersion = 0
+  // A reset evicts live docs before deleting their stored lineages. If that
+  // deletion fails, preserve socket ref counts until a later retry can reseed
+  // the docs; the sockets still list those ids in their bound-doc sets.
+  const heldResetRefs = new Map<string, number>()
+  const persistence = createRelayPersistence(db, {
+    isResident: (docId) => entries.has(docId),
+    schedulePersist: (docId) => schedulePersist(docId),
+    openDoc: async (docId) => { await openDoc(docId) },
+    invalidationVersion: (docId) => invalidationVersions.get(docId) ?? 0,
+  })
 
-  // ── Seeding ───────────────────────────────────────────────────────────────
-
-  async function seedFromJson(docId: string, doc: Y.Doc): Promise<void> {
-    const parsed = parseCollabDocId(docId)
-    if (!parsed) return
-    if (parsed.kind === 'site') {
-      const shell = await getDraftSite(db)
-      if (!shell) return // pre-setup — nothing to seed
-      const [pages, components, layouts] = await Promise.all([
-        listDataRowIdSlugs(db, 'pages'),
-        listDataRowIdSlugs(db, 'components'),
-        listDataRowIdSlugs(db, 'layouts'),
-      ])
-      seedSiteDocFromParts(doc, shell as unknown as Record<string, unknown>, {
-        pages: pages.map((r) => r.id),
-        components: components.map((r) => r.id),
-        layouts: layouts.map((r) => r.id),
-      })
-      return
+  function activateInvalidations(docIds: readonly string[]): Map<string, number> {
+    const versions = new Map<string, number>()
+    const version = ++nextInvalidationVersion
+    for (const docId of docIds) {
+      invalidationVersions.set(docId, version)
+      activeInvalidations.add(docId)
+      versions.set(docId, version)
     }
-    const row = await getDataRow(db, parsed.rowId)
-    if (!row || row.tableId !== KIND_TABLE[parsed.kind]) return // client-created flow
-    if (parsed.kind === 'page') {
-      seedPageDoc(doc, pageFromRow(row))
-    } else if (parsed.kind === 'component') {
-      const vc = visualComponentFromRow(row)
-      if (vc) seedComponentDoc(doc, vc)
-    } else {
-      const layout = savedLayoutFromRow(row)
-      if (layout) seedLayoutDoc(doc, layout)
-    }
+    return versions
   }
 
-  // ── Persistence ───────────────────────────────────────────────────────────
-
-  /**
-   * Outcome of a derived-JSON write. `invalid` is the one that MUST be
-   * retried: the blob was written but the JSON the publisher (and a reseed)
-   * read is now stale, so leaving the doc clean is how an accepted edit
-   * silently disappears. `incomplete` is a doc that is simply not assembled
-   * yet — retrying that would spin forever.
-   */
-  async function persistDerivedJson(docId: string, doc: Y.Doc): Promise<DerivedWrite> {
-    const parsed = parseCollabDocId(docId)
-    if (!parsed) return 'incomplete'
-    if (parsed.kind === 'site') {
-      const projected = projectSiteDoc(doc)
-      if (Object.keys(projected.shell).length === 0) return 'incomplete' // never seeded
-      let shell: SiteShell
-      try {
-        // `id` and `updatedAt` are deliberately NOT collaborative (fixed row /
-        // per-mutation noise) — inject them at the persistence boundary.
-        shell = validateSite({
-          ...projected.shell,
-          id: 'default',
-          updatedAt:
-            typeof projected.shell.updatedAt === 'number' ? projected.shell.updatedAt : Date.now(),
-        })
-      } catch (err) {
-        // The blob stays authoritative; JSON write is skipped until the doc
-        // heals — never persist an invalid shell for the publisher to read.
-        console.error('[collab] projected shell failed validation — JSON write skipped:', err)
-        return 'invalid'
+  function finishInvalidations(versions: ReadonlyMap<string, number>): void {
+    for (const [docId, version] of versions) {
+      // A newer queued invalidation still owns the active marker.
+      if ((invalidationVersions.get(docId) ?? 0) === version) {
+        activeInvalidations.delete(docId)
       }
-      await saveDraftSite(db, shell, null, { collabInternal: true })
-
-      // Roster-driven deletions: live rows missing from the roster are gone.
-      // The three full-table scans below are wasted when only a shell FIELD
-      // changed (settings/styleRules edits, the common case) and the rosters
-      // are identical to the last sweep — a heavy edit session would otherwise
-      // run them on every debounced persist. Skip when the roster is unchanged;
-      // out-of-relay deletions reset the doc, so a stale roster can't linger.
-      const rostersKey =
-        projected.rosters.pages.join(',') + '|' +
-        projected.rosters.components.join(',') + '|' +
-        projected.rosters.layouts.join(',')
-      if (rostersKey === lastSweptRostersKey) return 'written'
-      let deletedPublished = false
-      for (const [table, ids] of [
-        ['pages', projected.rosters.pages],
-        ['components', projected.rosters.components],
-        ['layouts', projected.rosters.layouts],
-      ] as const) {
-        const live = await listDataRowIdSlugs(db, table)
-        const keep = new Set(ids)
-        for (const row of live) {
-          if (keep.has(row.id)) continue
-          const deleted = await softDeleteDataRow(db, row.id, null, { collabInternal: true })
-          if (deleted?.status === 'published') deletedPublished = true
-        }
-      }
-      lastSweptRostersKey = rostersKey
-      if (deletedPublished) await bumpPublishVersionSerialized()
-      return 'written'
     }
-
-    const table = KIND_TABLE[parsed.kind]
-    let cells: Record<string, unknown>
-    let slug: string
-    if (parsed.kind === 'page') {
-      const page = projectPageDoc(doc, parsed.rowId)
-      if (!page.rootNodeId) return 'incomplete' // never seeded / still assembling
-      cells = pageToCells(page)
-      slug = page.slug
-    } else if (parsed.kind === 'component') {
-      const vc = projectComponentDoc(doc, parsed.rowId)
-      if (!vc.tree.rootNodeId || typeof vc.name !== 'string' || vc.name === '') return 'incomplete'
-      cells = visualComponentToCells(vc)
-      slug = vcSlugFromName(vc.name)
-    } else {
-      const layout = projectLayoutDoc(doc, parsed.rowId)
-      if (!layout.rootNodeId || layout.name === '') return 'incomplete'
-      cells = savedLayoutToCells(layout)
-      slug = layoutSlugFromName(layout.name)
-    }
-
-    // upsert = update live / resurrect soft-deleted / create fresh. A row the
-    // roster sweep soft-deleted and a peer then restored (Cmd+Z of a page
-    // delete) still holds its primary key, so a plain insert would conflict
-    // forever — the upsert revives it in place instead.
-    await upsertDataRowDraft(
-      db,
-      { id: parsed.rowId, tableId: table, cells, slug },
-      null,
-      { collabInternal: true },
-    )
-    return 'written'
   }
 
   async function persistNow(docId: string): Promise<PersistOutcome> {
     const entry = entries.get(docId)
     if (!entry || !entry.dirty) return 'clean'
     entry.dirty = false
+    const invalidationVersion = invalidationVersions.get(docId) ?? 0
+    const invalidationCutoff = nextInvalidationVersion
+    const state = Y.encodeStateAsUpdate(entry.doc)
+    const snapshot = new Y.Doc()
+    Y.applyUpdate(snapshot, state, 'persist-snapshot')
     try {
-      await putCollabDocumentState(db, docId, Y.encodeStateAsUpdate(entry.doc), entry.generation)
-      const derived = await persistDerivedJson(docId, entry.doc)
+      // Even an unrostered doc writes its CRDT tombstone so a later roster
+      // undo restores the latest accepted content. Only its relational upsert
+      // is deferred.
+      await putCollabDocumentState(db, docId, state, entry.generation)
+      const derived = await persistence.serializeMutation(async () => {
+        // An out-of-relay write committed while this blob was in flight. Its
+        // queued reset is authoritative; never overwrite it with this older
+        // collaborative snapshot.
+        if (
+          activeInvalidations.has(docId) ||
+          (invalidationVersions.get(docId) ?? 0) !== invalidationVersion
+        ) {
+          return 'superseded' as const
+        }
+        // Re-check INSIDE the shared mutation order. A page blob write may
+        // have been blocked while the site roster removed and swept its row.
+        if (persistence.isUnrosteredEstablishedDoc(docId)) return 'deferred' as const
+        return persistence.persistDerivedJson(docId, snapshot, invalidationCutoff)
+      })
+      if (derived === 'deferred') return 'deferred'
+      if (derived === 'superseded') return 'superseded'
       // A shell that failed validation MUST be retried: the blob is fresh but
       // the derived JSON is stale, and a reset reseeds from that JSON. Leaving
       // the doc clean here is how an accepted page silently disappears.
@@ -293,6 +191,8 @@ export function createCollabRelay(
       entry.dirty = true
       console.error(`[collab] persist failed for ${docId}:`, err)
       return 'retry'
+    } finally {
+      snapshot.destroy()
     }
   }
 
@@ -308,6 +208,10 @@ export function createCollabRelay(
       void persist.then((outcome) => {
         if (outcome === 'retry') {
           schedulePersist(docId)
+        } else if (outcome === 'deferred' && entry.refs <= 0) {
+          void evict(docId, { persist: true }).catch((err) => {
+            console.error(`[collab] retirement after roster removal failed for ${docId}:`, err)
+          })
         } else if (outcome === 'clean' && entry.refs <= 0) {
           // A final persist may have failed after the last editor disconnected.
           // Keep the doc resident until a retry succeeds, then finish eviction.
@@ -321,46 +225,71 @@ export function createCollabRelay(
 
   // ── Registry ──────────────────────────────────────────────────────────────
 
-  async function openDoc(docId: string): Promise<RelayDoc> {
+  async function openDoc(docId: string, ignoreResetGate = false): Promise<RelayDoc> {
+    const parsed = parseCollabDocId(docId)
+    if (!ignoreResetGate) {
+      const resetGate = resetGates.get(docId)
+      if (resetGate) {
+        await resetGate
+        return openDoc(docId)
+      }
+    }
+    const settlement = settling.get(docId)
+    if (settlement) {
+      await settlement
+      return openDoc(docId, ignoreResetGate)
+    }
     const existing = entries.get(docId)
     if (existing) return { doc: existing.doc, generation: existing.generation }
     const inFlight = opening.get(docId)
     if (inFlight) return inFlight
 
     const open = (async () => {
-      // Never step on a doc that is being torn down: an eviction still has a
-      // persist in flight (whose blob write would resurrect state a reset is
-      // deleting), and a reset has not finished deleting the blob we would
-      // otherwise hydrate from — keeping the dead generation alive.
-      await settling.get(docId)
+      // Row-doc persistence needs a current roster snapshot. Register this
+      // page opening before awaiting SITE so resetDocs can see and drain it.
+      if (parsed && parsed.kind !== 'site' && !persistence.hasRosterSnapshot()) {
+        await openDoc(SITE_DOC_ID, ignoreResetGate)
+      }
       const doc = new Y.Doc()
       const stored = await getCollabDocumentState(db, docId)
       let generation: string
       let minted: boolean
+      let seeded = false
       if (stored) {
         Y.applyUpdate(doc, stored.state, 'hydrate')
         // Rows written before migration 023 carry ''.
         minted = stored.generation === ''
         generation = minted ? nanoid() : stored.generation
       } else {
-        await seedFromJson(docId, doc)
+        seeded = await persistence.seedFromJson(docId, doc)
         generation = nanoid()
         minted = true
       }
       const updateHandler = (update: Uint8Array, origin: unknown) => {
         for (const listener of updateListeners) listener(docId, update, origin, generation)
+        if (docId === SITE_DOC_ID) persistence.observeSiteRoster(doc)
         schedulePersist(docId)
       }
       doc.on('update', updateHandler)
+      const heldRefs = heldResetRefs.get(docId) ?? 0
       entries.set(docId, {
         doc,
         generation,
-        refs: 0,
+        refs: heldRefs,
         dirty: false,
         persistTimer: null,
         persistChain: Promise.resolve(),
         detachUpdateHandler: () => doc.off('update', updateHandler),
       })
+      // A frame can reopen a doc after a transient reset failure but before
+      // the retry. Transfer the still-bound sockets into that gap entry so
+      // subsequent retain/release operations update one logical ref count.
+      if (heldRefs > 0) heldResetRefs.delete(docId)
+      if (parsed?.kind === 'site') {
+        persistence.observeSiteRoster(doc)
+      } else if (parsed) {
+        persistence.noteOpenedRow(docId, { stored: stored !== null, seeded })
+      }
       if (minted) {
         // Persist the mint IMMEDIATELY rather than through the debounce. A doc
         // that hydrated cleanly is not dirty, so a mint riding the debounce
@@ -394,8 +323,17 @@ export function createCollabRelay(
         opts2.persist ? persistNow(docId) : Promise.resolve<PersistOutcome>('clean'),
       )
       entry.persistChain = persist.then(() => undefined)
-      const outcome = await persist
-      if (outcome !== 'clean') {
+      let outcome = await persist
+      // Membership may have changed while an earlier persist was in flight;
+      // a concurrent undo cancels retirement and must finish the deferred
+      // write before this entry can be detached.
+      if (outcome === 'deferred' && !persistence.isUnrosteredEstablishedDoc(docId)) {
+        const resumed = entry.persistChain.then(() => persistNow(docId))
+        entry.persistChain = resumed.then(() => undefined)
+        outcome = await resumed
+      }
+      const deferred = outcome === 'deferred' && persistence.isUnrosteredEstablishedDoc(docId)
+      if (outcome !== 'clean' && !deferred) {
         if (outcome === 'retry') schedulePersist(docId)
         throw new Error(
           outcome === 'invalid'
@@ -411,6 +349,8 @@ export function createCollabRelay(
       entry.detachUpdateHandler()
       entry.doc.destroy()
       entries.delete(docId)
+      // A roster-removed row keeps its blob as an undo tombstone. External
+      // authoritative deletes still remove blobs through resetDocs below.
     })()
     settling.set(docId, run.then(() => undefined, () => undefined))
     try {
@@ -420,12 +360,90 @@ export function createCollabRelay(
     }
   }
 
-  async function resetDocs(docIds: readonly string[]): Promise<void> {
-    const affected = docIds.filter((id) => parseCollabDocId(id) !== null)
+  function orderedEntryDocIds(): string[] {
+    const docIds = [...entries.keys()]
+    return entries.has(SITE_DOC_ID)
+      ? [SITE_DOC_ID, ...docIds.filter((docId) => docId !== SITE_DOC_ID)]
+      : docIds
+  }
+
+  async function resetDocs(
+    docIds: readonly string[],
+    ownedInvalidations?: ReadonlyMap<string, number>,
+  ): Promise<void> {
+    const affected = [...new Set(docIds.filter((id) => parseCollabDocId(id) !== null))]
     if (affected.length === 0) return
-    // The site doc reseeds from the DB on next bind — force a full roster
-    // sweep on its first persist afterwards.
-    if (affected.includes(SITE_DOC_ID)) lastSweptRostersKey = null
+    const existingGates = [...new Set(
+      affected.flatMap((docId) => {
+        const gate = resetGates.get(docId)
+        return gate ? [gate] : []
+      }),
+    )]
+    if (existingGates.length > 0) {
+      await Promise.all(existingGates)
+      const refreshedInvalidations = ownedInvalidations
+        ? activateInvalidations(affected)
+        : undefined
+      return resetDocs(affected, refreshedInvalidations)
+    }
+    let releaseResetGate!: () => void
+    const resetGate = new Promise<void>((resolve) => {
+      releaseResetGate = resolve
+    })
+    for (const docId of affected) resetGates.set(docId, resetGate)
+    const invalidations = ownedInvalidations ?? activateInvalidations(affected)
+    let completed = false
+    try {
+    // An open that registered before this gate may already be reading the old
+    // lineage. Drain it, then evict the resulting entry; all later opens wait
+    // on resetGate until delete + authoritative reseed are complete.
+    for (const docId of affected) {
+      try {
+        await opening.get(docId)
+      } catch {
+        // A failed open may still have installed an entry before its mint
+        // write failed. The eviction pass below handles either outcome.
+      }
+    }
+    for (const docId of affected) {
+      const parsed = parseCollabDocId(docId)
+      if (!parsed || parsed.kind === 'site') continue
+      // An authoritative out-of-relay write ends the provisional-create
+      // phase for this id, including when that write is a deletion.
+      persistence.markRowEstablished(docId)
+    }
+    const resetsSite = affected.includes(SITE_DOC_ID)
+    if (resetsSite) {
+      const siteEntry = entries.get(SITE_DOC_ID)
+      if (siteEntry) {
+        // The shell write that triggered this reset must win, so do not persist
+        // the stale collaborative shell. Apply only its authoritative deletion
+        // roster before replacement row docs claim a freed slug. Rows explicitly
+        // affected by the out-of-relay write are protected because they seed the
+        // replacement site roster below.
+        if (siteEntry.persistTimer) {
+          clearTimeout(siteEntry.persistTimer)
+          siteEntry.persistTimer = null
+        }
+        const projected = projectSiteDoc(siteEntry.doc)
+        const sweep = siteEntry.persistChain.then(() =>
+          persistence.serializeMutation(() =>
+            persistence.sweepRosterDeletions(
+              projected.rosters,
+              invalidations.get(SITE_DOC_ID) ?? nextInvalidationVersion,
+              new Set(affected),
+            ),
+          ),
+        )
+        // A failed reset is surfaced to this caller, but must not poison every
+        // later persist chained onto the retained entry.
+        siteEntry.persistChain = sweep.then(() => undefined, () => undefined)
+        await sweep
+      }
+      // The site doc reseeds from the DB on next bind. Its first later persist
+      // must run a full sweep even if the old and replacement keys compare equal.
+      persistence.invalidateRosterSweep()
+    }
 
     // Flush the docs we are NOT resetting first. The site doc reseeds its
     // rosters from `listDataRowIdSlugs`, so a page whose row-doc JSON is still
@@ -433,23 +451,26 @@ export function createCollabRelay(
     // the reseeded roster, and would then be soft-deleted by the next sweep.
     // The reset docs themselves are deliberately NOT flushed: the out-of-relay
     // write that triggered the reset already committed and must win.
-    for (const docId of [...entries.keys()]) {
+    for (const docId of orderedEntryDocIds()) {
       if (affected.includes(docId)) continue
       const entry = entries.get(docId)
       if (!entry?.dirty) continue
       const persist = entry.persistChain.then(() => persistNow(docId))
       entry.persistChain = persist.then(() => undefined)
       const outcome = await persist
-      if (outcome !== 'clean') {
+      if (
+        outcome !== 'clean' &&
+        outcome !== 'deferred' &&
+        outcome !== 'superseded'
+      ) {
         if (outcome === 'retry') schedulePersist(docId)
         throw new Error(`cannot reset ${affected.join(', ')}: failed to flush ${docId}`)
       }
     }
 
-    const heldRefs = new Map<string, number>()
     for (const docId of affected) {
       const refs = entries.get(docId)?.refs ?? 0
-      if (refs > 0) heldRefs.set(docId, refs)
+      if (refs > 0) heldResetRefs.set(docId, refs)
       await evict(docId, { persist: false })
     }
 
@@ -464,40 +485,123 @@ export function createCollabRelay(
       for (const docId of affected) settling.delete(docId)
     }
 
+    if (resetsSite) {
+      // Keep the old authority through eviction/deletion, then replace it in
+      // one step by observing the freshly seeded site doc. There is never a
+      // null-authority window in which a dirty deleted row can pass its guard.
+      await openDoc(SITE_DOC_ID, true)
+    }
+
     // Re-register the ref counts the eviction dropped. Without this the next
     // `openDoc` starts at 0 while N connections still list the doc in
     // `boundDocs`, so the first close drives refs negative and evicts a doc
     // other editors are actively writing.
-    for (const [docId, refs] of heldRefs) {
-      await openDoc(docId)
-      const reopened = entries.get(docId)
-      if (reopened) reopened.refs = refs
+    for (const docId of affected) {
+      if ((heldResetRefs.get(docId) ?? 0) <= 0) continue
+      await openDoc(docId, true)
     }
     for (const docId of affected) {
       for (const listener of resetListeners) listener(docId)
+    }
+      completed = true
+    } finally {
+      // A failed reset leaves the ids actively invalidated. The queued reset
+      // path retains the failed batch and explicit flushes refuse to publish;
+      // a later successful retry owns a newer version and clears the marker.
+      if (completed) finishInvalidations(invalidations)
+      for (const docId of affected) {
+        if (resetGates.get(docId) === resetGate) resetGates.delete(docId)
+      }
+      releaseResetGate()
     }
   }
 
   // ── Out-of-relay write sources → resets ───────────────────────────────────
 
+  const pendingResetDocIds = new Set<string>()
+  const failedResetDocIds = new Set<string>()
+  let resetBatchScheduled = false
+  let resetChain: Promise<void> = Promise.resolve()
+  let failedResetError: unknown = null
+
+  function queueResetDocs(docIds: readonly string[]): void {
+    // Mark synchronously with the post-commit notification. The microtask
+    // batching below must not create a window for an older persist to write.
+    const combined = [...new Set([...failedResetDocIds, ...docIds])]
+    failedResetDocIds.clear()
+    failedResetError = null
+    activateInvalidations(combined)
+    for (const docId of combined) pendingResetDocIds.add(docId)
+    if (resetBatchScheduled) return
+    resetBatchScheduled = true
+    queueMicrotask(() => {
+      resetBatchScheduled = false
+      const batch = [...pendingResetDocIds]
+      pendingResetDocIds.clear()
+      if (batch.length === 0) return
+      const invalidations = new Map(
+        batch.map((docId) => [docId, invalidationVersions.get(docId) ?? 0]),
+      )
+      const reset = resetChain.then(() => resetDocs(batch, invalidations))
+      resetChain = reset.then(
+        () => undefined,
+        (err) => {
+          failedResetError = err
+          for (const docId of batch) failedResetDocIds.add(docId)
+          console.error('[collab] reset after out-of-relay write failed:', err)
+        },
+      )
+    })
+  }
+
   const detachRowListener = registerRowWriteListener((event) => {
     const kind = TABLE_KIND[event.tableId]
     if (!kind) return
     const docIds = event.rowIds.map((rowId) => encodeCollabDocId({ kind, rowId }))
-    // Creations/deletions also change the roster — the site doc must reseed.
-    if (event.kind !== 'update') docIds.push(SITE_DOC_ID)
-    void resetDocs(docIds).catch((err) => {
-      console.error('[collab] reset after out-of-relay row write failed:', err)
-    })
+    // The site-document batch API reports creations in its changed-id group as
+    // `update`. An id absent from the observed roster therefore also means
+    // membership may have changed and site authority must reseed.
+    if (
+      event.kind !== 'update' ||
+      !persistence.hasRosterSnapshot() ||
+      docIds.some((docId) => !persistence.rosterContains(docId))
+    ) docIds.push(SITE_DOC_ID)
+    queueResetDocs(docIds)
   })
   const detachShellListener = registerShellWriteListener(() => {
-    void resetDocs([SITE_DOC_ID]).catch((err) => {
-      console.error('[collab] reset after out-of-relay shell write failed:', err)
-    })
+    queueResetDocs([SITE_DOC_ID])
   })
 
+  async function drainResetQueue(throwOnFailure = true): Promise<void> {
+    let retriedFailure = false
+    for (;;) {
+      // Let a batch queued by the current call stack attach to resetChain.
+      await Promise.resolve()
+      const observed = resetChain
+      await observed
+      if (failedResetError) {
+        if (!throwOnFailure) return
+        if (!retriedFailure) {
+          const retry = [...failedResetDocIds]
+          retriedFailure = true
+          queueResetDocs(retry)
+          continue
+        }
+        throw failedResetError
+      }
+      if (
+        !resetBatchScheduled &&
+        pendingResetDocIds.size === 0 &&
+        resetChain === observed
+      ) return
+    }
+  }
+
   async function flushAll(): Promise<void> {
-    for (const docId of [...entries.keys()]) {
+    await drainResetQueue()
+    await persistence.drainRecoveries(true)
+    // The site sweep must free slugs before replacement row docs write them.
+    for (const docId of orderedEntryDocIds()) {
       const entry = entries.get(docId)
       if (!entry) continue
       if (entry.persistTimer) {
@@ -507,7 +611,11 @@ export function createCollabRelay(
       const persist = entry.persistChain.then(() => persistNow(docId))
       entry.persistChain = persist.then(() => undefined)
       const outcome = await persist
-      if (outcome !== 'clean') {
+      if (
+        outcome !== 'clean' &&
+        outcome !== 'deferred' &&
+        outcome !== 'superseded'
+      ) {
         if (outcome === 'retry') schedulePersist(docId)
         throw new Error(
           outcome === 'invalid'
@@ -516,6 +624,10 @@ export function createCollabRelay(
         )
       }
     }
+    // A repository write may have committed during the loop above. Its reset
+    // must finish before publish/headless reads consume the derived JSON.
+    await drainResetQueue()
+    await persistence.drainRecoveries(true)
   }
 
   // Every publish path flushes the relay first (see publishFlush.ts) so the
@@ -530,18 +642,32 @@ export function createCollabRelay(
       // that was just destroyed. Re-open until the doc we return is the one
       // whose refs we incremented.
       for (;;) {
-        await openDoc(docId)
+        const opened = await openDoc(docId)
+        const barrier = resetGates.get(docId) ?? settling.get(docId)
+        if (barrier) {
+          await barrier
+          continue
+        }
         const entry = entries.get(docId)
-        if (!entry) continue
+        if (!entry || entry.doc !== opened.doc || entry.generation !== opened.generation) continue
         entry.refs += 1
         return { doc: entry.doc, generation: entry.generation }
       }
     },
     release: (docId) => {
+      const heldRefs = heldResetRefs.get(docId)
+      if (heldRefs !== undefined) {
+        // Once reset snapshots ownership, that held count is authoritative
+        // even while evict is still draining the doomed entry's persist chain.
+        // Starting a second eviction here would race its settling barrier.
+        if (heldRefs <= 1) heldResetRefs.delete(docId)
+        else heldResetRefs.set(docId, heldRefs - 1)
+        return
+      }
       const entry = entries.get(docId)
       if (!entry) return
       entry.refs -= 1
-      if (entry.refs <= 0) {
+      if (entry.refs <= 0 && !resetGates.has(docId)) {
         void evict(docId, { persist: true }).catch((err) => {
           console.error(`[collab] final persist for ${docId} failed:`, err)
         })
@@ -561,6 +687,8 @@ export function createCollabRelay(
       detachRowListener()
       detachShellListener()
       detachPublishFlush()
+      await drainResetQueue()
+      await persistence.drainRecoveries(true)
       for (const docId of [...entries.keys()]) {
         await evict(docId, { persist: true })
       }

--- a/server/collab/relayPersistence.ts
+++ b/server/collab/relayPersistence.ts
@@ -1,0 +1,348 @@
+/**
+ * Relational projection and site-roster authority for the collaborative relay.
+ *
+ * The relay owns document lifecycle and socket references; this module owns the
+ * database-facing half of a Y document: deterministic JSON seeding, derived
+ * row/site writes, authoritative roster deletion, and undo recovery.
+ */
+import * as Y from 'yjs'
+import {
+  encodeCollabDocId,
+  parseCollabDocId,
+  projectComponentDoc,
+  projectLayoutDoc,
+  projectPageDoc,
+  projectSiteDoc,
+  seedComponentDoc,
+  seedLayoutDoc,
+  seedPageDoc,
+  seedSiteDocFromParts,
+  type CollabDocKind,
+} from '@core/collab'
+import '@modules/base' // registry population — inline-text props seed as Y.Text
+import type { SiteShell } from '@core/page-tree'
+import { pageFromRow, pageToCells } from '@core/data/pageFromRow'
+import { visualComponentFromRow, visualComponentToCells } from '@core/data/componentFromRow'
+import { savedLayoutFromRow, savedLayoutToCells } from '@core/data/layoutFromRow'
+import { vcSlugFromName } from '@core/visualComponents'
+import { layoutSlugFromName } from '@core/layouts'
+import { validateSite } from '@core/persistence/validate'
+import type { DbClient } from '../db/client'
+import {
+  getDataRow,
+  listDataRowIdSlugs,
+  softDeleteDataRow,
+  upsertDataRowDraft,
+} from '../repositories/data'
+import { getDraftSite, saveDraftSite } from '../repositories/site'
+import { getCollabDocumentState } from '../repositories/collabDocuments'
+import { serializeCollabAwareWrite } from '../repositories/rowWriteEvents'
+import { bumpPublishVersionSerialized } from '../publish/publishState'
+
+const KIND_TABLE: Record<Exclude<CollabDocKind, 'site'>, string> = {
+  page: 'pages',
+  component: 'components',
+  layout: 'layouts',
+}
+
+export type DerivedWrite = 'written' | 'incomplete' | 'invalid'
+type SiteRosters = ReturnType<typeof projectSiteDoc>['rosters']
+
+interface RelayPersistenceHooks {
+  isResident(docId: string): boolean
+  schedulePersist(docId: string): void
+  openDoc(docId: string): Promise<void>
+  invalidationVersion(docId: string): number
+}
+
+export interface RelayPersistence {
+  hasRosterSnapshot(): boolean
+  rosterContains(docId: string): boolean
+  observeSiteRoster(doc: Y.Doc): void
+  noteOpenedRow(docId: string, state: { stored: boolean; seeded: boolean }): void
+  markRowEstablished(docId: string): void
+  isUnrosteredEstablishedDoc(docId: string): boolean
+  seedFromJson(docId: string, doc: Y.Doc): Promise<boolean>
+  serializeMutation<T>(operation: () => Promise<T>): Promise<T>
+  sweepRosterDeletions(
+    rosters: SiteRosters,
+    invalidationCutoff: number,
+    protectedDocIds?: ReadonlySet<string>,
+  ): Promise<void>
+  persistDerivedJson(
+    docId: string,
+    doc: Y.Doc,
+    invalidationCutoff: number,
+  ): Promise<DerivedWrite>
+  invalidateRosterSweep(): void
+  drainRecoveries(throwOnFailure: boolean): Promise<void>
+}
+
+export function createRelayPersistence(
+  db: DbClient,
+  hooks: RelayPersistenceHooks,
+): RelayPersistence {
+  // Last roster set the site-doc persist actually swept, so shell-field-only
+  // persists skip the three full-table scans. Reset when the site doc resets.
+  let lastSweptRostersKey: string | null = null
+  /**
+   * The site roster is authoritative for an established row doc. A freshly
+   * created client doc may arrive before its roster frame, so it remains
+   * provisional until either the roster names it or its first derived row is
+   * written. Once established, removing it from the roster defers all later
+   * row writes instead of letting a dirty editor resurrect the deletion.
+   */
+  let rosterDocIds: Set<string> | null = null
+  const knownRowDocIds = new Set<string>()
+  const provisionalRowDocIds = new Set<string>()
+  const pendingRosterRecoveries = new Map<string, Promise<void>>()
+  const failedRosterRecoveries = new Set<string>()
+
+  function serializeMutation<T>(operation: () => Promise<T>): Promise<T> {
+    return serializeCollabAwareWrite(operation)
+  }
+
+  function projectedRosterDocIds(doc: Y.Doc): Set<string> {
+    const { rosters } = projectSiteDoc(doc)
+    return new Set([
+      ...rosters.pages.map((rowId) => encodeCollabDocId({ kind: 'page', rowId })),
+      ...rosters.components.map((rowId) => encodeCollabDocId({ kind: 'component', rowId })),
+      ...rosters.layouts.map((rowId) => encodeCollabDocId({ kind: 'layout', rowId })),
+    ])
+  }
+
+  function observeSiteRoster(doc: Y.Doc): void {
+    const previous = rosterDocIds
+    const next = projectedRosterDocIds(doc)
+    rosterDocIds = next
+    for (const docId of next) {
+      knownRowDocIds.add(docId)
+      provisionalRowDocIds.delete(docId)
+      // Re-adding the same id is undo-of-delete. Its row was soft-deleted by
+      // the sweep, so recover even when its row doc is no longer resident and
+      // no page-local edit accompanied the roster change.
+      if (previous && !previous.has(docId)) scheduleRosterRecovery(docId)
+    }
+  }
+
+  function scheduleRosterRecovery(docId: string): void {
+    failedRosterRecoveries.delete(docId)
+    if (hooks.isResident(docId)) {
+      hooks.schedulePersist(docId)
+      return
+    }
+    if (pendingRosterRecoveries.has(docId)) return
+    const recovery = (async () => {
+      // Collaborative deletion keeps the row blob as an undo tombstone. Only
+      // a stored lineage can be revived; never mint an empty page here.
+      const stored = await getCollabDocumentState(db, docId)
+      if (!stored || !rosterDocIds?.has(docId)) return
+      await hooks.openDoc(docId)
+      if (rosterDocIds?.has(docId)) hooks.schedulePersist(docId)
+    })()
+    pendingRosterRecoveries.set(docId, recovery)
+    void recovery.catch((err) => {
+      failedRosterRecoveries.add(docId)
+      console.error(`[collab] roster undo recovery failed for ${docId}:`, err)
+    }).finally(() => {
+      if (pendingRosterRecoveries.get(docId) === recovery) {
+        pendingRosterRecoveries.delete(docId)
+      }
+    })
+  }
+
+  function markRowEstablished(docId: string): void {
+    knownRowDocIds.add(docId)
+    provisionalRowDocIds.delete(docId)
+  }
+
+  function noteOpenedRow(
+    docId: string,
+    state: { stored: boolean; seeded: boolean },
+  ): void {
+    if (provisionalRowDocIds.has(docId)) {
+      // A fresh client-created doc can reconnect before its roster frame.
+    } else if (state.stored || state.seeded || knownRowDocIds.has(docId)) {
+      markRowEstablished(docId)
+    } else {
+      provisionalRowDocIds.add(docId)
+    }
+  }
+
+  function isUnrosteredEstablishedDoc(docId: string): boolean {
+    return rosterDocIds !== null && knownRowDocIds.has(docId) && !rosterDocIds.has(docId)
+  }
+
+  async function seedFromJson(docId: string, doc: Y.Doc): Promise<boolean> {
+    const parsed = parseCollabDocId(docId)
+    if (!parsed) return false
+    if (parsed.kind === 'site') {
+      const shell = await getDraftSite(db)
+      if (!shell) return false // pre-setup — nothing to seed
+      const [pages, components, layouts] = await Promise.all([
+        listDataRowIdSlugs(db, 'pages'),
+        listDataRowIdSlugs(db, 'components'),
+        listDataRowIdSlugs(db, 'layouts'),
+      ])
+      seedSiteDocFromParts(doc, shell as unknown as Record<string, unknown>, {
+        pages: pages.map((row) => row.id),
+        components: components.map((row) => row.id),
+        layouts: layouts.map((row) => row.id),
+      })
+      return true
+    }
+    const row = await getDataRow(db, parsed.rowId)
+    if (!row || row.tableId !== KIND_TABLE[parsed.kind]) return false
+    if (parsed.kind === 'page') {
+      seedPageDoc(doc, pageFromRow(row))
+    } else if (parsed.kind === 'component') {
+      const component = visualComponentFromRow(row)
+      if (!component) return false
+      seedComponentDoc(doc, component)
+    } else {
+      const layout = savedLayoutFromRow(row)
+      if (!layout) return false
+      seedLayoutDoc(doc, layout)
+    }
+    return true
+  }
+
+  async function sweepRosterDeletions(
+    rosters: SiteRosters,
+    invalidationCutoff: number,
+    protectedDocIds: ReadonlySet<string> = new Set(),
+  ): Promise<void> {
+    let deletedPublished = false
+    for (const [kind, table, ids] of [
+      ['page', 'pages', rosters.pages],
+      ['component', 'components', rosters.components],
+      ['layout', 'layouts', rosters.layouts],
+    ] as const) {
+      const live = await listDataRowIdSlugs(db, table)
+      const keep = new Set(ids)
+      for (const row of live) {
+        const rowDocId = encodeCollabDocId({ kind, rowId: row.id })
+        // A newer roster frame or authoritative row write may land while this
+        // snapshot's sweep is queued. Only writes ordered AFTER the snapshot
+        // are protected; an older invalidation still resetting must not erase
+        // a later collaborative deletion.
+        if (
+          keep.has(row.id) ||
+          rosterDocIds?.has(rowDocId) ||
+          hooks.invalidationVersion(rowDocId) > invalidationCutoff ||
+          protectedDocIds.has(rowDocId)
+        ) continue
+        const deleted = await softDeleteDataRow(db, row.id, null, { collabInternal: true })
+        if (deleted?.status === 'published') deletedPublished = true
+      }
+    }
+    if (deletedPublished) await bumpPublishVersionSerialized()
+  }
+
+  async function persistDerivedJson(
+    docId: string,
+    doc: Y.Doc,
+    invalidationCutoff: number,
+  ): Promise<DerivedWrite> {
+    const parsed = parseCollabDocId(docId)
+    if (!parsed) return 'incomplete'
+    if (parsed.kind === 'site') {
+      const projected = projectSiteDoc(doc)
+      if (Object.keys(projected.shell).length === 0) return 'incomplete'
+      let shell: SiteShell
+      try {
+        // `id` and `updatedAt` are deliberately NOT collaborative (fixed row /
+        // per-mutation noise) — inject them at the persistence boundary.
+        shell = validateSite({
+          ...projected.shell,
+          id: 'default',
+          updatedAt:
+            typeof projected.shell.updatedAt === 'number' ? projected.shell.updatedAt : Date.now(),
+        })
+      } catch (err) {
+        // The blob stays authoritative; JSON write is skipped until the doc
+        // heals — never persist an invalid shell for the publisher to read.
+        console.error('[collab] projected shell failed validation — JSON write skipped:', err)
+        return 'invalid'
+      }
+      await saveDraftSite(db, shell, null, { collabInternal: true })
+
+      const rostersKey =
+        projected.rosters.pages.join(',') + '|' +
+        projected.rosters.components.join(',') + '|' +
+        projected.rosters.layouts.join(',')
+      if (rostersKey === lastSweptRostersKey) return 'written'
+      await sweepRosterDeletions(projected.rosters, invalidationCutoff)
+      lastSweptRostersKey = rostersKey
+      return 'written'
+    }
+
+    const table = KIND_TABLE[parsed.kind]
+    let cells: Record<string, unknown>
+    let slug: string
+    if (parsed.kind === 'page') {
+      const page = projectPageDoc(doc, parsed.rowId)
+      if (!page.rootNodeId) return 'incomplete'
+      cells = pageToCells(page)
+      slug = page.slug
+    } else if (parsed.kind === 'component') {
+      const component = projectComponentDoc(doc, parsed.rowId)
+      if (
+        !component.tree.rootNodeId ||
+        typeof component.name !== 'string' ||
+        component.name === ''
+      ) return 'incomplete'
+      cells = visualComponentToCells(component)
+      slug = vcSlugFromName(component.name)
+    } else {
+      const layout = projectLayoutDoc(doc, parsed.rowId)
+      if (!layout.rootNodeId || layout.name === '') return 'incomplete'
+      cells = savedLayoutToCells(layout)
+      slug = layoutSlugFromName(layout.name)
+    }
+
+    await upsertDataRowDraft(
+      db,
+      { id: parsed.rowId, tableId: table, cells, slug },
+      null,
+      { collabInternal: true },
+    )
+    markRowEstablished(docId)
+    return 'written'
+  }
+
+  async function drainRecoveries(throwOnFailure: boolean): Promise<void> {
+    for (const docId of [...failedRosterRecoveries]) {
+      if (rosterDocIds?.has(docId)) scheduleRosterRecovery(docId)
+      else failedRosterRecoveries.delete(docId)
+    }
+    while (pendingRosterRecoveries.size > 0) {
+      const results = await Promise.allSettled([...pendingRosterRecoveries.values()])
+      if (throwOnFailure) {
+        const failed = results.find((result) => result.status === 'rejected')
+        if (failed?.status === 'rejected') throw failed.reason
+      }
+      await Promise.resolve()
+    }
+    if (throwOnFailure && failedRosterRecoveries.size > 0) {
+      throw new Error(
+        `cannot recover roster undo for ${[...failedRosterRecoveries].join(', ')}`,
+      )
+    }
+  }
+
+  return {
+    hasRosterSnapshot: () => rosterDocIds !== null,
+    rosterContains: (docId) => rosterDocIds?.has(docId) ?? false,
+    observeSiteRoster,
+    noteOpenedRow,
+    markRowEstablished,
+    isUnrosteredEstablishedDoc,
+    seedFromJson,
+    serializeMutation,
+    sweepRosterDeletions,
+    persistDerivedJson,
+    invalidateRosterSweep: () => { lastSweptRostersKey = null },
+    drainRecoveries,
+  }
+}

--- a/server/handlers/cms/data/tables.ts
+++ b/server/handlers/cms/data/tables.ts
@@ -39,7 +39,6 @@ import {
 import { normalizeDataTableFields } from '@core/data/fields'
 import { slugForTable } from '@core/data/cells'
 import { slugFromTitle } from '@core/utils/slug'
-import { normalizeRouteBase } from '@core/templates/templateMatching'
 import { fetchPublishedDataRowItems } from '@core/loops/sources/dataRows'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../../http'
 import { CMS_API_PREFIX, requestAuditContext } from '../shared'
@@ -86,7 +85,7 @@ function buildTablePatch(
     update.slug = slug
   }
   if (body.routeBase !== undefined) {
-    update.routeBase = normalizeRouteBase(body.routeBase.trim())
+    update.routeBase = body.routeBase
   }
   if (body.singularLabel !== undefined) {
     if (!body.singularLabel.trim()) return { error: 'Singular label is required' }
@@ -210,13 +209,12 @@ async function handleTablesCollection(req: Request, db: DbClient): Promise<Respo
     const singularLabel = body.singularLabel?.trim() || name.replace(/s$/i, '') || name
     const pluralLabel = body.pluralLabel?.trim() || name
     const slug = slugFromTitle(body.slug?.trim() || pluralLabel)
-    const routeBase = normalizeRouteBase(body.routeBase?.trim() || slug)
 
     const table = await createDataTable(db, {
       name,
       slug,
       kind: body.kind === 'postType' ? 'postType' : 'data',
-      routeBase,
+      routeBase: body.routeBase,
       singularLabel,
       pluralLabel,
       primaryFieldId: body.primaryFieldId?.trim() || undefined,

--- a/server/handlers/cms/import.ts
+++ b/server/handlers/cms/import.ts
@@ -64,6 +64,12 @@ import {
   type ImportStrategy,
 } from '@core/data/bundleSchema'
 import { CMS_API_PREFIX, type CmsHandlerOptions } from './shared'
+import {
+  notifyRowWrite,
+  notifyShellWrite,
+  serializeCollabAwareWrite,
+  type RowWriteKind,
+} from '../../repositories/rowWriteEvents'
 
 // The four system table ids that are always seeded and never deleted.
 const SYSTEM_TABLE_IDS = new Set(['posts', 'pages', 'components', 'layouts'])
@@ -187,6 +193,25 @@ export async function handleImportRoute(
   // DB transaction
   // ---------------------------------------------------------------------------
 
+  await serializeCollabAwareWrite(async () => {
+    const affectedCollabRows = new Map(
+      ['pages', 'components', 'layouts'].map((tableId) => [tableId, new Set<string>()]),
+    )
+    const removedCollabRows = new Map(
+      ['pages', 'components', 'layouts'].map((tableId) => [tableId, new Set<string>()]),
+    )
+    const createdCollabRows = new Map(
+      ['pages', 'components', 'layouts'].map((tableId) => [tableId, new Set<string>()]),
+    )
+    let shellWasWritten = false
+    if (strategy === 'replace') {
+      for (const tableId of affectedCollabRows.keys()) {
+        for (const row of await listDataRows(db, tableId)) {
+          affectedCollabRows.get(tableId)?.add(row.id)
+        }
+      }
+    }
+
   if (strategy === 'replace') {
     // Wipe-and-replace: delete all rows + custom tables, then reimport.
     await db.transaction(async (tx) => {
@@ -247,12 +272,14 @@ export async function handleImportRoute(
           updatedAt: row.updatedAt,
         }
         await replaceDataRow(tx, input)
+        affectedCollabRows.get(row.tableId)?.add(row.id)
         rowsInserted++
       }
 
       // 6. Replace the site shell (only when the bundle carries one)
       if (bundle.site) {
-        await saveDraftSite(tx, bundle.site)
+        await saveDraftSite(tx, bundle.site, null, { collabInternal: true })
+        shellWasWritten = true
       }
 
       // 7. Media folder tree. `delete from data_rows` above does NOT touch
@@ -311,6 +338,7 @@ export async function handleImportRoute(
         }
         const inserted = await insertDataRowIfAbsent(tx, input)
         if (inserted) {
+          affectedCollabRows.get(row.tableId)?.add(row.id)
           rowsInserted++
         } else {
           rowsSkipped++
@@ -323,12 +351,13 @@ export async function handleImportRoute(
   } else {
     // merge-overwrite: upsert rows/tables; update existing with bundle values.
     await db.transaction(async (tx) => {
-      // Pre-fetch all existing row ids for tables referenced in the bundle so
-      // we can classify each row as inserted vs replaced without per-row SELECTs.
-      const existingRowIds = new Set<string>()
-      for (const table of bundle.tables) {
+      // Pre-fetch all existing rows. An upsert can move an id from a table the
+      // bundle does not mention, and both its old and new collab docs/rosters
+      // must be invalidated after commit.
+      const existingRowTables = new Map<string, string>()
+      for (const table of await listDataTables(tx)) {
         const existing = await listDataRows(tx, table.id)
-        for (const r of existing) existingRowIds.add(r.id)
+        for (const row of existing) existingRowTables.set(row.id, row.tableId)
       }
 
       // Tables: insert if absent, update if already present
@@ -371,7 +400,16 @@ export async function handleImportRoute(
           updatedAt: row.updatedAt,
         }
         await upsertDataRow(tx, input)
-        if (existingRowIds.has(row.id)) {
+        const previousTableId = existingRowTables.get(row.id)
+        if (previousTableId === undefined) {
+          createdCollabRows.get(row.tableId)?.add(row.id)
+        } else if (previousTableId !== row.tableId) {
+          removedCollabRows.get(previousTableId)?.add(row.id)
+          createdCollabRows.get(row.tableId)?.add(row.id)
+        } else {
+          affectedCollabRows.get(row.tableId)?.add(row.id)
+        }
+        if (previousTableId !== undefined) {
           rowsReplaced++
         } else {
           rowsInserted++
@@ -380,10 +418,30 @@ export async function handleImportRoute(
 
       // Site shell: overwrite if the bundle carries one
       if (bundle.site) {
-        await saveDraftSite(tx, bundle.site)
+        await saveDraftSite(tx, bundle.site, null, { collabInternal: true })
+        shellWasWritten = true
       }
     })
   }
+
+    if (shellWasWritten) notifyShellWrite()
+    if (strategy === 'merge-overwrite') {
+      for (const [tableId, ids] of affectedCollabRows) {
+        if (ids.size > 0) notifyRowWrite({ tableId, rowIds: [...ids], kind: 'update' })
+      }
+      for (const [tableId, ids] of removedCollabRows) {
+        if (ids.size > 0) notifyRowWrite({ tableId, rowIds: [...ids], kind: 'delete' })
+      }
+      for (const [tableId, ids] of createdCollabRows) {
+        if (ids.size > 0) notifyRowWrite({ tableId, rowIds: [...ids], kind: 'create' })
+      }
+    } else {
+      const eventKind: RowWriteKind = strategy === 'replace' ? 'delete' : 'create'
+      for (const [tableId, ids] of affectedCollabRows) {
+        if (ids.size > 0) notifyRowWrite({ tableId, rowIds: [...ids], kind: eventKind })
+      }
+    }
+  })
 
   // ---------------------------------------------------------------------------
   // Media — outside the DB transaction (filesystem writes)

--- a/server/handlers/cms/setup.ts
+++ b/server/handlers/cms/setup.ts
@@ -29,6 +29,11 @@ import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '.
 import { Type, safeParseValue } from '@core/utils/typeboxHelpers'
 import type { SiteRow } from '../../types'
 import { CMS_API_PREFIX, requestAuditContext } from './shared'
+import {
+  notifyRowWrite,
+  notifyShellWrite,
+  serializeCollabAwareWrite,
+} from '../../repositories/rowWriteEvents'
 
 export async function handleSetupRoutes(req: Request, db: DbClient): Promise<Response | null> {
   const url = new URL(req.url)
@@ -69,39 +74,48 @@ export async function handleSetupRoutes(req: Request, db: DbClient): Promise<Res
     if (!email.includes('@')) return badRequest('Invalid email')
     if (password.length < 12) return badRequest('Password must be at least 12 characters')
 
-    return await db.transaction(async (tx) => {
-      await createSite(tx, siteName, {})
-      const owner = await createUser(tx, {
-        id: nanoid(),
-        email,
-        displayName,
-        passwordHash: await hashPassword(password),
-        roleId: 'owner',
-        allowOwnerRole: true,
+    return serializeCollabAwareWrite(async () => {
+      let homePageId = ''
+      const response = await db.transaction(async (tx) => {
+        await createSite(tx, siteName, {})
+        const owner = await createUser(tx, {
+          id: nanoid(),
+          email,
+          displayName,
+          passwordHash: await hashPassword(password),
+          roleId: 'owner',
+          allowOwnerRole: true,
+        })
+        await createAuditEvent(tx, {
+          actorUserId: null,
+          action: 'user.create',
+          targetType: 'user',
+          targetId: owner.id,
+          metadata: { roleId: 'owner', source: 'setup' },
+          ...requestAuditContext(req),
+        })
+        // Seed a starter homepage as a data_row in the 'pages' system table.
+        const rootNode = createNode('base.body')
+        const homePage: Page = {
+          id: nanoid(),
+          title: 'Home',
+          slug: 'index',
+          nodes: { [rootNode.id]: rootNode },
+          rootNodeId: rootNode.id,
+        }
+        homePageId = homePage.id
+        await createDataRow(
+          tx,
+          { id: homePage.id, tableId: 'pages', cells: pageToCells(homePage), slug: homePage.slug },
+          owner.id,
+          null,
+          { collabInternal: true },
+        )
+        return jsonResponse({ ok: true }, { status: 201 })
       })
-      await createAuditEvent(tx, {
-        actorUserId: null,
-        action: 'user.create',
-        targetType: 'user',
-        targetId: owner.id,
-        metadata: { roleId: 'owner', source: 'setup' },
-        ...requestAuditContext(req),
-      })
-      // Seed a starter homepage as a data_row in the 'pages' system table.
-      const rootNode = createNode('base.body')
-      const homePage: Page = {
-        id: nanoid(),
-        title: 'Home',
-        slug: 'index',
-        nodes: { [rootNode.id]: rootNode },
-        rootNodeId: rootNode.id,
-      }
-      await createDataRow(
-        tx,
-        { id: homePage.id, tableId: 'pages', cells: pageToCells(homePage), slug: homePage.slug },
-        owner.id,
-      )
-      return jsonResponse({ ok: true }, { status: 201 })
+      notifyShellWrite()
+      notifyRowWrite({ tableId: 'pages', rowIds: [homePageId], kind: 'create' })
+      return response
     })
   }
 

--- a/server/handlers/cms/siteDocument.ts
+++ b/server/handlers/cms/siteDocument.ts
@@ -81,6 +81,7 @@ import { shellsEqual } from '@core/persistence/shellsEqual'
 import {
   notifyRowWrite,
   notifyShellWrite,
+  serializeCollabAwareWrite,
   type RowWriteKind,
 } from '../../repositories/rowWriteEvents'
 import { badRequest, jsonResponse, methodNotAllowed, readValidatedBody } from '../../http'
@@ -349,7 +350,8 @@ export async function handleSiteDocumentRoutes(req: Request, db: DbClient): Prom
 
     let seq = 0
     let deletedPublishedPage = false
-    await db.transaction(async (tx) => {
+    await serializeCollabAwareWrite(async () => {
+      await db.transaction(async (tx) => {
       // Allocate FIRST: the counter-row UPDATE takes a row lock, so two
       // concurrent save transactions serialize here (on Postgres as well as
       // SQLite's fully-serialized chain) — which makes the conflict reads
@@ -415,30 +417,30 @@ export async function handleSiteDocumentRoutes(req: Request, db: DbClient): Prom
         })
         deletedPublishedPage = pagesResult.deletedPublished
       }
+      })
+
+      // Collab invalidation — this save wrote rows/shell OUTSIDE the relay, so
+      // affected CRDT documents must reset while this ordered write still owns
+      // the lane (post-commit; see rowWriteEvents).
+      if (shellChanged) notifyShellWrite()
+      const writtenGroups: Array<[string, Iterable<string>, RowWriteKind]> = [
+        ['pages', changedPageIdsRaw, 'update'],
+        ['pages', pageDeleteIds, 'delete'],
+        ['components', changedComponentIds, 'update'],
+        ['components', componentDeleteIds, 'delete'],
+        ['layouts', changedLayoutIds, 'update'],
+        ['layouts', layoutDeleteIds, 'delete'],
+      ]
+      for (const [tableId, ids, kind] of writtenGroups) {
+        const rowIds = [...ids]
+        if (rowIds.length > 0) notifyRowWrite({ tableId, rowIds, kind })
+      }
     })
 
-    // ─── Phase 3: post-commit effects ────────────────────────────────────────
-    // Deleting a published page retracts its public route — invalidate the
-    // render cache AFTER the transaction commits (never inside it: the bump
-    // serializes against the publish lock, which itself waits on the
-    // transaction chain).
+    // Publish-lock work stays outside the collab-aware lane: publish flushes
+    // need that lane, so acquiring the locks in the opposite order could
+    // deadlock. The database transaction and sync invalidations are complete.
     if (deletedPublishedPage) await bumpPublishVersionSerialized()
-
-    // Collab invalidation — this save wrote rows/shell OUTSIDE the relay, so
-    // affected CRDT documents must reset (post-commit; see rowWriteEvents).
-    if (shellChanged) notifyShellWrite()
-    const writtenGroups: Array<[string, Iterable<string>, RowWriteKind]> = [
-      ['pages', changedPageIdsRaw, 'update'],
-      ['pages', pageDeleteIds, 'delete'],
-      ['components', changedComponentIds, 'update'],
-      ['components', componentDeleteIds, 'delete'],
-      ['layouts', changedLayoutIds, 'update'],
-      ['layouts', layoutDeleteIds, 'delete'],
-    ]
-    for (const [tableId, ids, kind] of writtenGroups) {
-      const rowIds = [...ids]
-      if (rowIds.length > 0) notifyRowWrite({ tableId, rowIds, kind })
-    }
 
     return jsonResponse({ ok: true, seq })
   } catch (err) {

--- a/server/repositories/data/__tests__/tables.test.ts
+++ b/server/repositories/data/__tests__/tables.test.ts
@@ -3,7 +3,13 @@ import { createSqliteClient } from '../../../db/sqlite'
 import { sqliteMigrations } from '../../../db/migrations-sqlite'
 import { runMigrations } from '../../../db/runMigrations'
 import type { DbClient } from '../../../db/client'
-import { createDataTable, getDataTable, listDataTables } from '../tables'
+import {
+  createDataTable,
+  getDataTable,
+  insertDataTableIfAbsent,
+  listDataTables,
+  updateDataTable,
+} from '../tables'
 
 async function freshDb(): Promise<DbClient> {
   const db = createSqliteClient(':memory:')
@@ -55,5 +61,84 @@ describe('data_tables.system column', () => {
     const tables = await listDataTables(db)
     const systemSlugs = tables.filter((t) => t.system).map((t) => t.slug).sort()
     expect(systemSlugs).toEqual(['components', 'layouts', 'pages', 'posts'])
+  })
+})
+
+describe('data_tables.route_base persistence', () => {
+  let db: DbClient
+
+  beforeEach(async () => {
+    db = await freshDb()
+  })
+
+  it('preserves an explicitly blank route base on create and read', async () => {
+    const table = await createDataTable(db, {
+      name: 'Fee lines',
+      slug: 'fee-lines',
+      kind: 'data',
+      routeBase: '',
+      singularLabel: 'Fee line',
+      pluralLabel: 'Fee lines',
+    })
+
+    expect(table.routeBase).toBe('')
+    expect((await getDataTable(db, table.id))?.routeBase).toBe('')
+
+    const { rows } = await db<{ route_base: string }>`
+      select route_base from data_tables where id = ${table.id}
+    `
+    expect(rows[0]?.route_base).toBe('')
+  })
+
+  it('uses the slug fallback only when routeBase is omitted', async () => {
+    const fallback = await createDataTable(db, {
+      name: 'Work orders',
+      slug: 'work-orders',
+      kind: 'data',
+      singularLabel: 'Work order',
+      pluralLabel: 'Work orders',
+    })
+    const explicit = await createDataTable(db, {
+      name: 'Bench notes',
+      slug: 'bench-notes',
+      kind: 'data',
+      routeBase: '  /notes/  ',
+      singularLabel: 'Bench note',
+      pluralLabel: 'Bench notes',
+    })
+
+    expect(fallback.routeBase).toBe('/work-orders')
+    expect(explicit.routeBase).toBe('/notes')
+  })
+
+  it('preserves an explicitly blank route base on update', async () => {
+    const table = await createDataTable(db, {
+      name: 'Questions',
+      slug: 'questions',
+      kind: 'data',
+      routeBase: '/questions',
+      singularLabel: 'Question',
+      pluralLabel: 'Questions',
+    })
+
+    const updated = await updateDataTable(db, table.id, { routeBase: '   ' })
+
+    expect(updated?.routeBase).toBe('')
+    expect((await getDataTable(db, table.id))?.routeBase).toBe('')
+  })
+
+  it('preserves an explicitly blank route base on the import insertion path', async () => {
+    const inserted = await insertDataTableIfAbsent(db, {
+      id: 'imported-custody-stages',
+      name: 'Custody stages',
+      slug: 'custody-stages',
+      kind: 'data',
+      routeBase: '',
+      singularLabel: 'Custody stage',
+      pluralLabel: 'Custody stages',
+    })
+
+    expect(inserted).toBe(true)
+    expect((await getDataTable(db, 'imported-custody-stages'))?.routeBase).toBe('')
   })
 })

--- a/server/repositories/data/rows/apply.ts
+++ b/server/repositories/data/rows/apply.ts
@@ -49,6 +49,7 @@ import {
   softDeleteDataRow,
 } from './mutations'
 import { listDataRowIdSlugs, listSoftDeletedDataRowIds } from './read'
+import { notifyRowWrite, serializeCollabAwareWrite } from '../../rowWriteEvents'
 
 export interface DataRowWrite {
   id: string
@@ -162,9 +163,25 @@ export async function applyDataRowChanges(
   db: DbClient,
   input: ApplyDataRowChangesInput,
 ): Promise<ApplyDataRowChangesResult> {
-  let result: ApplyDataRowChangesResult = { deletedPublished: false }
-  await db.transaction(async (tx) => {
-    result = await applyDataRowChangesInTx(tx, input)
+  return serializeCollabAwareWrite(async () => {
+    let result: ApplyDataRowChangesResult = { deletedPublished: false }
+    await db.transaction(async (tx) => {
+      result = await applyDataRowChangesInTx(tx, input)
+    })
+    if (input.writes.length > 0) {
+      notifyRowWrite({
+        tableId: input.tableId,
+        rowIds: input.writes.map((write) => write.id),
+        kind: 'update',
+      })
+    }
+    if (input.deleteIds.size > 0) {
+      notifyRowWrite({
+        tableId: input.tableId,
+        rowIds: [...input.deleteIds],
+        kind: 'delete',
+      })
+    }
+    return result
   })
-  return result
 }

--- a/server/repositories/data/rows/bulk.ts
+++ b/server/repositories/data/rows/bulk.ts
@@ -11,6 +11,7 @@ import type { DbClient } from '../../../db/client'
 import type { DataRow } from '@core/data/schemas'
 import type { InsertDataRowInput, UpdateDataRowDraftInput } from './mapper'
 import { createDataRow, saveDataRowDraft, softDeleteDataRow } from './mutations'
+import { notifyRowWrite, serializeCollabAwareWrite } from '../../rowWriteEvents'
 
 /**
  * Bulk-insert N draft rows in a single transaction. Used by
@@ -24,10 +25,22 @@ export async function createDataRowMany(
   actorUserId: string | null = null,
   pluginActorId: string | null = null,
 ): Promise<DataRow[]> {
-  return db.transaction(async (tx) => {
-    const created: DataRow[] = []
-    for (const input of inputs) {
-      created.push(await createDataRow(tx, input, actorUserId, pluginActorId))
+  return serializeCollabAwareWrite(async () => {
+    const created = await db.transaction(async (tx) => {
+      const rows: DataRow[] = []
+      for (const input of inputs) {
+        rows.push(await createDataRow(
+          tx,
+          input,
+          actorUserId,
+          pluginActorId,
+          { collabInternal: true },
+        ))
+      }
+      return rows
+    })
+    for (const row of created) {
+      notifyRowWrite({ tableId: row.tableId, rowIds: [row.id], kind: 'create' })
     }
     return created
   })
@@ -44,11 +57,24 @@ export async function saveDataRowDraftMany(
   actorUserId: string | null = null,
   pluginActorId: string | null = null,
 ): Promise<DataRow[]> {
-  return db.transaction(async (tx) => {
-    const updated: DataRow[] = []
-    for (const { id, input } of updates) {
-      const result = await saveDataRowDraft(tx, id, input, actorUserId, pluginActorId)
-      if (result) updated.push(result)
+  return serializeCollabAwareWrite(async () => {
+    const updated = await db.transaction(async (tx) => {
+      const rows: DataRow[] = []
+      for (const { id, input } of updates) {
+        const result = await saveDataRowDraft(
+          tx,
+          id,
+          input,
+          actorUserId,
+          pluginActorId,
+          { collabInternal: true },
+        )
+        if (result) rows.push(result)
+      }
+      return rows
+    })
+    for (const row of updated) {
+      notifyRowWrite({ tableId: row.tableId, rowIds: [row.id], kind: 'update' })
     }
     return updated
   })
@@ -67,16 +93,26 @@ export async function softDeleteDataRowMany(
   rowIds: ReadonlyArray<string>,
   actorUserId: string | null = null,
 ): Promise<{ deleted: number; publishedDeleted: number }> {
-  return db.transaction(async (tx) => {
-    let deleted = 0
-    let publishedDeleted = 0
-    for (const id of rowIds) {
-      const result = await softDeleteDataRow(tx, id, actorUserId)
-      if (result) {
-        deleted++
-        if (result.status === 'published') publishedDeleted++
+  return serializeCollabAwareWrite(async () => {
+    const deletedRows = await db.transaction(async (tx) => {
+      const rows: NonNullable<Awaited<ReturnType<typeof softDeleteDataRow>>>[] = []
+      for (const id of rowIds) {
+        const result = await softDeleteDataRow(
+          tx,
+          id,
+          actorUserId,
+          { collabInternal: true },
+        )
+        if (result) rows.push(result)
       }
+      return rows
+    })
+    for (const row of deletedRows) {
+      notifyRowWrite({ tableId: row.tableId, rowIds: [row.id], kind: 'delete' })
     }
-    return { deleted, publishedDeleted }
+    return {
+      deleted: deletedRows.length,
+      publishedDeleted: deletedRows.filter((row) => row.status === 'published').length,
+    }
   })
 }

--- a/server/repositories/data/rows/mutations.ts
+++ b/server/repositories/data/rows/mutations.ts
@@ -23,7 +23,7 @@ import { bumpPublishVersionSerialized } from '../../../publish/publishState'
 import { type InsertDataRowInput, type UpdateDataRowDraftInput } from './mapper'
 import { isoDateOrNull } from '@core/utils/isoDate'
 import { getDataRow } from './read'
-import { notifyRowWrite } from '../../rowWriteEvents'
+import { notifyRowWrite, serializeCollabAwareWrite } from '../../rowWriteEvents'
 
 type UpdateDataRowTableResult =
   | { ok: true; row: DataRow }
@@ -36,6 +36,19 @@ export async function createDataRow(
   pluginActorId: string | null = null,
   opts: { collabInternal?: boolean } = {},
 ): Promise<DataRow> {
+  if (!opts.collabInternal) {
+    return serializeCollabAwareWrite(async () => {
+      const created = await createDataRow(
+        db,
+        input,
+        actorUserId,
+        pluginActorId,
+        { collabInternal: true },
+      )
+      notifyRowWrite({ tableId: created.tableId, rowIds: [created.id], kind: 'create' })
+      return created
+    })
+  }
   const { rows } = await db<{ id: string }>`
     insert into data_rows (
       id,
@@ -63,11 +76,6 @@ export async function createDataRow(
   `
   const created = await getDataRow(db, rows[0].id)
   if (!created) throw new Error('data row was created but could not be re-read')
-  // Out-of-relay creations invalidate collab state (roster + row doc) — see
-  // rowWriteEvents. The relay's own persistence opts out.
-  if (!opts.collabInternal) {
-    notifyRowWrite({ tableId: created.tableId, rowIds: [created.id], kind: 'create' })
-  }
   return created
 }
 
@@ -79,12 +87,22 @@ export async function saveDataRowDraft(
   pluginActorId: string | null = null,
   opts: { collabInternal?: boolean } = {},
 ): Promise<DataRow | null> {
-  const updated = await updateDataRowDraftCells(db, rowId, input, actorUserId, pluginActorId)
-  const row = updated ? await getDataRow(db, rowId) : null
-  if (row && !opts.collabInternal) {
-    notifyRowWrite({ tableId: row.tableId, rowIds: [row.id], kind: 'update' })
+  if (!opts.collabInternal) {
+    return serializeCollabAwareWrite(async () => {
+      const row = await saveDataRowDraft(
+        db,
+        rowId,
+        input,
+        actorUserId,
+        pluginActorId,
+        { collabInternal: true },
+      )
+      if (row) notifyRowWrite({ tableId: row.tableId, rowIds: [row.id], kind: 'update' })
+      return row
+    })
   }
-  return row
+  const updated = await updateDataRowDraftCells(db, rowId, input, actorUserId, pluginActorId)
+  return updated ? getDataRow(db, rowId) : null
 }
 
 /**
@@ -151,14 +169,15 @@ export async function upsertDataRowDraft(
   actorUserId: string | null = null,
   opts: { collabInternal?: boolean } = {},
 ): Promise<void> {
+  if (!opts.collabInternal) {
+    return serializeCollabAwareWrite(async () => {
+      await upsertDataRowDraft(db, input, actorUserId, { collabInternal: true })
+      notifyRowWrite({ tableId: input.tableId, rowIds: [input.id], kind: 'update' })
+    })
+  }
   const draft = { cells: input.cells, slug: input.slug }
   const updated = await updateDataRowDraftCells(db, input.id, draft, actorUserId)
-  if (updated) {
-    if (!opts.collabInternal) {
-      notifyRowWrite({ tableId: input.tableId, rowIds: [input.id], kind: 'update' })
-    }
-    return
-  }
+  if (updated) return
   const { rows } = await db<{ id: string }>`
     select id from data_rows where id = ${input.id} and deleted_at is not null
   `
@@ -166,9 +185,6 @@ export async function upsertDataRowDraft(
     await resurrectDataRow(db, input.id, draft, actorUserId)
   } else {
     await createDataRow(db, input, actorUserId, null, { collabInternal: true })
-  }
-  if (!opts.collabInternal) {
-    notifyRowWrite({ tableId: input.tableId, rowIds: [input.id], kind: 'create' })
   }
 }
 
@@ -206,6 +222,13 @@ export async function softDeleteDataRow(
   actorUserId: string | null = null,
   opts: { collabInternal?: boolean } = {},
 ): Promise<DeletedRowSummary | null> {
+  if (!opts.collabInternal) {
+    return serializeCollabAwareWrite(async () => {
+      const row = await softDeleteDataRow(db, rowId, actorUserId, { collabInternal: true })
+      if (row) notifyRowWrite({ tableId: row.tableId, rowIds: [row.id], kind: 'delete' })
+      return row
+    })
+  }
   const { rows } = await db<{
     id: string
     table_id: string
@@ -223,9 +246,6 @@ export async function softDeleteDataRow(
   `
   const row = rows[0]
   if (!row) return null
-  if (!opts.collabInternal) {
-    notifyRowWrite({ tableId: row.table_id, rowIds: [row.id], kind: 'delete' })
-  }
   return {
     id: row.id,
     tableId: row.table_id,
@@ -246,7 +266,35 @@ export async function updateDataRowTable(
   rowId: string,
   tableId: string,
   actorUserId: string | null = null,
+  opts: { collabInternal?: boolean } = {},
 ): Promise<UpdateDataRowTableResult> {
+  if (!opts.collabInternal) {
+    const moved = await serializeCollabAwareWrite(async () => {
+      const before = await getDataRow(db, rowId)
+      const result = await updateDataRowTable(
+        db,
+        rowId,
+        tableId,
+        actorUserId,
+        { collabInternal: true },
+      )
+      let bumpPublishVersion = false
+      if (before && result.ok && before.tableId !== result.row.tableId) {
+        // A table move changes both collection rosters. Emit the pair while
+        // still holding the collab-aware write lane so a dirty old row doc
+        // cannot land between the move and its synchronous invalidation.
+        notifyRowWrite({ tableId: before.tableId, rowIds: [rowId], kind: 'delete' })
+        notifyRowWrite({ tableId: result.row.tableId, rowIds: [rowId], kind: 'create' })
+        bumpPublishVersion = before.status === 'published'
+      }
+      return { result, bumpPublishVersion }
+    })
+    // The publish lock may itself wait on persistence work. Never hold the
+    // non-reentrant collab-aware lane while awaiting that independent lock.
+    if (moved.bumpPublishVersion) await bumpPublishVersionSerialized()
+    return moved.result
+  }
+
   const row = await getDataRow(db, rowId)
   if (!row) return { ok: false, reason: 'row_not_found' }
   if (row.tableId === tableId) return { ok: true, row }
@@ -284,10 +332,6 @@ export async function updateDataRowTable(
   if (!rows[0]) return { ok: false, reason: 'row_not_found' }
   const updated = await getDataRow(db, rows[0].id)
   if (!updated) return { ok: false, reason: 'row_not_found' }
-  // Moving a published row changes its public route (the route base comes
-  // from the table) — invalidate the render cache so the old URL stops
-  // being served.
-  if (row.status === 'published') await bumpPublishVersionSerialized()
   return { ok: true, row: updated }
 }
 

--- a/server/repositories/data/tables.ts
+++ b/server/repositories/data/tables.ts
@@ -77,13 +77,30 @@ interface DataTableRow {
   updated_at: string | Date
 }
 
+/**
+ * An empty route base is the persisted sentinel for a non-routable table.
+ * Only an omitted value gets the conventional slug-derived route on create;
+ * callers that explicitly send an empty (or whitespace-only) value are opting
+ * out of public routing and that choice must survive every repository path.
+ */
+function normalizeExplicitRouteBase(routeBase: string): string {
+  const trimmed = routeBase.trim()
+  return trimmed === '' ? '' : normalizeRouteBase(trimmed)
+}
+
+function routeBaseForCreate(routeBase: string | undefined, slug: string): string {
+  return routeBase === undefined
+    ? normalizeRouteBase(slug)
+    : normalizeExplicitRouteBase(routeBase)
+}
+
 function mapTable(row: DataTableRow): DataTable {
   return {
     id: row.id,
     name: row.name,
     slug: row.slug,
     kind: row.kind,
-    routeBase: row.route_base ? normalizeRouteBase(row.route_base) : normalizeRouteBase(row.slug),
+    routeBase: normalizeExplicitRouteBase(row.route_base),
     singularLabel: row.singular_label,
     pluralLabel: row.plural_label,
     primaryFieldId: row.primary_field_id,
@@ -271,7 +288,7 @@ export async function createDataTable(
       ${input.name},
       ${input.slug},
       ${input.kind ?? 'data'},
-      ${normalizeRouteBase(input.routeBase ?? input.slug)},
+      ${routeBaseForCreate(input.routeBase, input.slug)},
       ${input.singularLabel},
       ${input.pluralLabel},
       ${input.primaryFieldId ?? 'title'},
@@ -299,7 +316,7 @@ export async function updateDataTable(
     if (!existing) return null
     fields = keepPostTypeBuiltIns(existing, normalizeDataTableFields(input.fields))
   }
-  const routeBase = input.routeBase === undefined ? null : normalizeRouteBase(input.routeBase)
+  const routeBase = input.routeBase === undefined ? null : normalizeExplicitRouteBase(input.routeBase)
   const { rows } = await db<DataTableRow>`
     update data_tables
     set name = coalesce(${input.name ?? null}, name),
@@ -353,7 +370,7 @@ export async function insertDataTableIfAbsent(
       ${input.name},
       ${input.slug},
       ${input.kind ?? 'data'},
-      ${normalizeRouteBase(input.routeBase ?? input.slug)},
+      ${routeBaseForCreate(input.routeBase, input.slug)},
       ${input.singularLabel},
       ${input.pluralLabel},
       ${input.primaryFieldId ?? 'title'},

--- a/server/repositories/publish.ts
+++ b/server/repositories/publish.ts
@@ -22,6 +22,7 @@
  *   getDraftPublishStatus     — compare draft vs published state for the UI
  */
 import { createHash } from 'node:crypto'
+import type { DataRow } from '@core/data/schemas'
 import type { SiteDocument } from '@core/page-tree'
 import type { PublishedPageRuntimeAssets } from '@core/site-runtime'
 import type { PublishedRuntimePackageImportmap } from '@core/publisher'
@@ -123,6 +124,18 @@ function siteContentHash(site: SiteDocument): string {
   return createHash('sha256').update(canonicalJson(site)).digest('hex')
 }
 
+/**
+ * `listDataRows` is intentionally recency-ordered for authoring surfaces, but
+ * that order is not a stable site-document order: a full publish updates every
+ * page's `updated_at`, which can reshuffle an otherwise unchanged collection.
+ * Creation order is immutable, with id as the deterministic tie-breaker.
+ */
+function orderSiteDocumentRows(rows: readonly DataRow[]): DataRow[] {
+  return rows.toSorted((a, b) =>
+    a.createdAt.localeCompare(b.createdAt) || a.id.localeCompare(b.id)
+  )
+}
+
 /** Reassemble the `PublishedPageSnapshot` shape from the getter join. */
 function snapshotFromQueryRow(row: SnapshotQueryRow): PublishedPageSnapshot {
   return {
@@ -156,11 +169,12 @@ export async function getDraftSiteDocument(db: DbClient): Promise<SiteDocument |
     listDataRows(db, 'components'),
   ])
   const visualComponents = validateVisualComponents(
-    vcRows.flatMap((r) => { const vc = visualComponentFromRow(r); return vc ? [vc] : [] })
+    orderSiteDocumentRows(vcRows)
+      .flatMap((r) => { const vc = visualComponentFromRow(r); return vc ? [vc] : [] })
   )
   return {
     ...shell,
-    pages: pageRows.map(pageFromRow),
+    pages: orderSiteDocumentRows(pageRows).map(pageFromRow),
     visualComponents,
     layouts: [],
   }

--- a/server/repositories/rowWriteEvents.ts
+++ b/server/repositories/rowWriteEvents.ts
@@ -22,6 +22,28 @@ type RowWriteListener = (event: RowWriteEvent) => void
 
 const listeners = new Set<RowWriteListener>()
 
+/**
+ * One ordering lane for authoritative repository writes and the collab
+ * relay's derived-JSON writes. Notifications alone are too late to arbitrate
+ * a derived UPDATE that is already waiting on the same database row: it can
+ * otherwise land after the external commit and erase the authoritative body
+ * before reset gets a chance to reseed. Callers hold this through their
+ * commit and synchronous notification; relay writes re-check invalidation
+ * after they enter the same lane.
+ *
+ * This lane is deliberately NON-REENTRANT. A coordinated transaction must
+ * call nested repositories with `collabInternal: true`, may synchronously
+ * notify before returning, and must never await reset/publish-flush work from
+ * inside the callback.
+ */
+let collabAwareWriteChain: Promise<void> = Promise.resolve()
+
+export function serializeCollabAwareWrite<T>(operation: () => Promise<T>): Promise<T> {
+  const run = collabAwareWriteChain.then(operation)
+  collabAwareWriteChain = run.then(() => undefined, () => undefined)
+  return run
+}
+
 export function registerRowWriteListener(listener: RowWriteListener): () => void {
   listeners.add(listener)
   return () => listeners.delete(listener)

--- a/server/repositories/site.ts
+++ b/server/repositories/site.ts
@@ -22,7 +22,7 @@ import { validateSite } from '@core/persistence/validate'
 import { normalizeSitePackageJson } from '@core/site-dependencies/manifest'
 import { normalizeSiteRuntimeConfig } from '@core/site-runtime'
 import type { DbClient } from '../db/client'
-import { notifyShellWrite } from './rowWriteEvents'
+import { notifyShellWrite, serializeCollabAwareWrite } from './rowWriteEvents'
 import type { SiteRow } from '../types'
 
 const CMS_SITE_SCHEMA_VERSION = 1
@@ -88,6 +88,12 @@ export async function saveDraftSite(
   _actorUserId: string | null = null,
   opts: { collabInternal?: boolean } = {},
 ): Promise<void> {
+  if (!opts.collabInternal) {
+    return serializeCollabAwareWrite(async () => {
+      await saveDraftSite(db, shell, _actorUserId, { collabInternal: true })
+      notifyShellWrite()
+    })
+  }
   await db`
     insert into site (id, name, settings_json)
     values ('default', ${shell.name}, ${shellToStorage(shell)})
@@ -96,10 +102,6 @@ export async function saveDraftSite(
           settings_json = excluded.settings_json,
           updated_at = current_timestamp
   `
-  // Out-of-relay shell writes invalidate the site collab doc — see
-  // rowWriteEvents. The relay's own persistence (and the transactional save,
-  // which notifies post-commit) opt out.
-  if (!opts.collabInternal) notifyShellWrite()
 }
 
 /**

--- a/src/__tests__/agent/mcpWorkspaceReadiness.test.tsx
+++ b/src/__tests__/agent/mcpWorkspaceReadiness.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { cleanup, renderHook, waitFor } from '@testing-library/react'
+import { useMcpWorkspaceBridge } from '@admin/ai/useMcpWorkspaceBridge'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('MCP workspace bridge readiness', () => {
+  it('does not register a Site bridge before the editor store is hydrated', async () => {
+    const realFetch = globalThis.fetch
+    let bridgeRequests = 0
+    globalThis.fetch = (async () => {
+      bridgeRequests += 1
+      return new Response(null, { status: 401 })
+    }) as typeof fetch
+
+    const dispatch = async () => ({ ok: true as const })
+    try {
+      const view = renderHook(
+        ({ enabled }) => {
+          useMcpWorkspaceBridge('site', dispatch, undefined, enabled)
+        },
+        { initialProps: { enabled: false } },
+      )
+      await Promise.resolve()
+
+      expect(bridgeRequests).toBe(0)
+
+      view.rerender({ enabled: true })
+      await waitFor(() => {
+        expect(bridgeRequests).toBe(1)
+      })
+    } finally {
+      cleanup()
+      globalThis.fetch = realFetch
+    }
+  })
+
+  it('gates SitePage bridge registration on the hydrated editor store', () => {
+    const source = readFileSync(
+      join(process.cwd(), 'src/admin/pages/site/SitePage.tsx'),
+      'utf8',
+    )
+
+    expect(source).toContain(
+      'const siteHydrated = useEditorStore((state) => state.site !== null)',
+    )
+    expect(source).toContain(
+      "useMcpWorkspaceBridge('site', executeAgentTool, undefined, siteHydrated)",
+    )
+  })
+})

--- a/src/__tests__/server/cmsPublish.test.ts
+++ b/src/__tests__/server/cmsPublish.test.ts
@@ -75,8 +75,19 @@ function createPublishFakeDb() {
     }
     // listDataRows for pages — select from data_rows where table_id = 'pages'
     if (sql.includes('from data_rows') && sql.includes('left join users')) {
-      const rows = state.dataRows
-        .filter((r) => r.deleted_at == null)
+      const matchingRows = state.dataRows.filter((r) => {
+        if (r.deleted_at != null) return false
+        if (sql.includes('data_rows.table_id =')) return r.table_id === params[0]
+        if (sql.includes('data_rows.id =')) return r.id === params[0]
+        return true
+      })
+      const rows = (sql.includes('order by data_rows.updated_at desc')
+        ? matchingRows.sort((a, b) =>
+            String(b.updated_at).localeCompare(String(a.updated_at)) ||
+            String(b.created_at).localeCompare(String(a.created_at))
+          )
+        : matchingRows
+      )
         .map((r) => ({
           ...r,
           author_email: null,
@@ -157,6 +168,8 @@ function createPublishFakeDb() {
         row.status = 'published'
         row.published_by_user_id = publishedBy
         row.published_at = new Date('2026-01-03').toISOString()
+        row.updated_by_user_id = publishedBy
+        row.updated_at = new Date('2026-01-03').toISOString()
       }
       return { rows: [], rowCount: row ? 1 : 0 }
     }
@@ -306,6 +319,51 @@ describe('CMS publishing', () => {
       publishedPages: 1,
     })
     expect(status.lastPublishedAt).toBeTruthy()
+  })
+
+  it('keeps publish status matched when publishing changes the rows recency order', async () => {
+    const { state, db } = createPublishFakeDb()
+    const shell = makeSiteShell()
+    await saveDraftSite(db, shell)
+
+    const home = makeHomePage('Home')
+    const layout = {
+      ...makeHomePage('Layout'),
+      id: 'page_layout',
+      title: 'Main layout',
+      slug: 'main-layout',
+      template: {
+        enabled: true as const,
+        target: { kind: 'everywhere' as const },
+        priority: 0,
+      },
+    }
+    for (const page of [home, layout]) {
+      await createDataRow(db, {
+        id: page.id,
+        tableId: 'pages',
+        cells: pageToCells(page),
+        slug: page.slug,
+      }, 'admin_1')
+    }
+
+    const homeRow = state.dataRows.find((row) => row.id === home.id)
+    const layoutRow = state.dataRows.find((row) => row.id === layout.id)
+    if (!homeRow || !layoutRow) throw new Error('test pages were not seeded')
+    homeRow.created_at = new Date('2026-01-01').toISOString()
+    homeRow.updated_at = new Date('2026-01-02').toISOString()
+    layoutRow.created_at = new Date('2026-01-02').toISOString()
+    layoutRow.updated_at = new Date('2026-01-01').toISOString()
+
+    await publishDraftSite(db, 'admin_1')
+    const status = await getDraftPublishStatus(db)
+
+    expect(status).toMatchObject({
+      hasPublishedVersion: true,
+      draftMatchesPublished: true,
+      draftPages: 2,
+      publishedPages: 2,
+    })
   })
 
   it('reports that the current draft no longer matches after a later draft save', async () => {

--- a/src/__tests__/server/collabRelay.test.ts
+++ b/src/__tests__/server/collabRelay.test.ts
@@ -10,13 +10,25 @@ import {
   LOCAL_ORIGIN,
   projectPageDoc,
   rostersMap,
+  shellMap,
   SITE_DOC_ID,
   treeMap,
 } from '@core/collab'
 import { createCollabRelay, type CollabRelay } from '../../../server/collab/relay'
 import type { DbClient } from '../../../server/db'
 import { getCollabDocumentState } from '../../../server/repositories/collabDocuments'
-import { saveDataRowDraft } from '../../../server/repositories/data'
+import {
+  createDataRow,
+  createDataTable,
+  listDataRows,
+  saveDataRowDraft,
+  updateDataRowTable,
+} from '../../../server/repositories/data'
+import { getDraftSite, saveDraftSite } from '../../../server/repositories/site'
+import {
+  notifyRowWrite,
+  notifyShellWrite,
+} from '../../../server/repositories/rowWriteEvents'
 import {
   createCapabilityTestHarness,
   type CapabilityTestHarness,
@@ -79,6 +91,117 @@ function gateCollabBlobWrites(db: DbClient): {
   return { db: wrapped, arm: () => { armed = true }, blocked, release }
 }
 
+function gateDerivedRowWrites(db: DbClient, targetRowId: string): {
+  db: DbClient
+  arm: () => void
+  blocked: Promise<void>
+  release: () => void
+} {
+  let announceBlocked!: () => void
+  const blocked = new Promise<void>((resolve) => {
+    announceBlocked = resolve
+  })
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  let armed = false
+  let gated = false
+
+  const wrapped = (async <Row,>(strings: TemplateStringsArray, ...values: unknown[]) => {
+    const sql = strings.join('?')
+    if (
+      armed &&
+      !gated &&
+      sql.includes('update data_rows') &&
+      sql.includes('set cells_json') &&
+      values.includes(targetRowId)
+    ) {
+      gated = true
+      announceBlocked()
+      await gate
+    }
+    return db<Row>(strings, ...values)
+  }) as DbClient
+  Object.defineProperty(wrapped, 'dialect', { get: () => db.dialect })
+  wrapped.unsafe = ((sql: string, params?: unknown[]) => db.unsafe(sql, params)) as DbClient['unsafe']
+  wrapped.transaction = ((fn: Parameters<DbClient['transaction']>[0]) =>
+    db.transaction(fn)) as DbClient['transaction']
+  return { db: wrapped, arm: () => { armed = true }, blocked, release }
+}
+
+function gateRosterSweep(db: DbClient): {
+  db: DbClient
+  arm: () => void
+  blocked: Promise<void>
+  release: () => void
+} {
+  let announceBlocked!: () => void
+  const blocked = new Promise<void>((resolve) => {
+    announceBlocked = resolve
+  })
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  let armed = false
+  let gated = false
+
+  const wrapped = (async <Row,>(strings: TemplateStringsArray, ...values: unknown[]) => {
+    const sql = strings.join('?')
+    if (
+      armed &&
+      !gated &&
+      sql.includes('select id, slug from data_rows') &&
+      values.includes('pages')
+    ) {
+      gated = true
+      announceBlocked()
+      await gate
+    }
+    return db<Row>(strings, ...values)
+  }) as DbClient
+  Object.defineProperty(wrapped, 'dialect', { get: () => db.dialect })
+  wrapped.unsafe = ((sql: string, params?: unknown[]) => db.unsafe(sql, params)) as DbClient['unsafe']
+  wrapped.transaction = ((fn: Parameters<DbClient['transaction']>[0]) =>
+    db.transaction(fn)) as DbClient['transaction']
+  return { db: wrapped, arm: () => { armed = true }, blocked, release }
+}
+
+function gateCollabBlobRead(db: DbClient, targetDocId: string): {
+  db: DbClient
+  blocked: Promise<void>
+  release: () => void
+} {
+  let announceBlocked!: () => void
+  const blocked = new Promise<void>((resolve) => {
+    announceBlocked = resolve
+  })
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  let gated = false
+
+  const wrapped = (async <Row,>(strings: TemplateStringsArray, ...values: unknown[]) => {
+    if (
+      !gated &&
+      strings.join('?').includes('select state_blob') &&
+      values.includes(targetDocId)
+    ) {
+      gated = true
+      announceBlocked()
+      await gate
+    }
+    return db<Row>(strings, ...values)
+  }) as DbClient
+  Object.defineProperty(wrapped, 'dialect', { get: () => db.dialect })
+  wrapped.unsafe = ((sql: string, params?: unknown[]) => db.unsafe(sql, params)) as DbClient['unsafe']
+  wrapped.transaction = ((fn: Parameters<DbClient['transaction']>[0]) =>
+    db.transaction(fn)) as DbClient['transaction']
+  return { db: wrapped, blocked, release }
+}
+
 function failNextCollabBlobWrite(db: DbClient): {
   db: DbClient
   arm: () => void
@@ -110,12 +233,127 @@ function failNextCollabBlobWrite(db: DbClient): {
   return { db: wrapped, arm: () => { armed = true }, failed }
 }
 
+function failNextCollabBlobDelete(db: DbClient): {
+  db: DbClient
+  arm: () => void
+  failed: Promise<void>
+} {
+  let announceFailed!: () => void
+  const failed = new Promise<void>((resolve) => {
+    announceFailed = resolve
+  })
+  let armed = false
+  let hasFailed = false
+
+  const wrapped = (async <Row,>(strings: TemplateStringsArray, ...values: unknown[]) =>
+    db<Row>(strings, ...values)) as DbClient
+  Object.defineProperty(wrapped, 'dialect', { get: () => db.dialect })
+  wrapped.unsafe = (async (sql: string, params?: unknown[]) => {
+    if (
+      armed &&
+      !hasFailed &&
+      sql.includes('delete from collab_documents')
+    ) {
+      hasFailed = true
+      announceFailed()
+      throw new Error('simulated transient collab reset failure')
+    }
+    return db.unsafe(sql, params)
+  }) as DbClient['unsafe']
+  wrapped.transaction = ((fn: Parameters<DbClient['transaction']>[0]) =>
+    db.transaction(fn)) as DbClient['transaction']
+  return { db: wrapped, arm: () => { armed = true }, failed }
+}
+
+function gateCollabBlobDelete(db: DbClient, targetDocId: string): {
+  db: DbClient
+  arm: () => void
+  blocked: Promise<void>
+  release: () => void
+} {
+  let announceBlocked!: () => void
+  const blocked = new Promise<void>((resolve) => { announceBlocked = resolve })
+  let release!: () => void
+  const gate = new Promise<void>((resolve) => { release = resolve })
+  let armed = false
+  let gated = false
+
+  const wrapped = (async <Row,>(strings: TemplateStringsArray, ...values: unknown[]) =>
+    db<Row>(strings, ...values)) as DbClient
+  Object.defineProperty(wrapped, 'dialect', { get: () => db.dialect })
+  wrapped.unsafe = (async (sql: string, params?: unknown[]) => {
+    if (
+      armed &&
+      !gated &&
+      sql.includes('delete from collab_documents') &&
+      params?.includes(targetDocId)
+    ) {
+      gated = true
+      announceBlocked()
+      await gate
+    }
+    return db.unsafe(sql, params)
+  }) as DbClient['unsafe']
+  wrapped.transaction = ((fn: Parameters<DbClient['transaction']>[0]) =>
+    db.transaction(fn)) as DbClient['transaction']
+  return { db: wrapped, arm: () => { armed = true }, blocked, release }
+}
+
+function observeRosterSweep(db: DbClient): {
+  db: DbClient
+  arm: () => void
+  completedPass: Promise<void>
+} {
+  let announceCompleted!: () => void
+  const completedPass = new Promise<void>((resolve) => { announceCompleted = resolve })
+  let armed = false
+  let announced = false
+
+  const wrapped = (async <Row,>(strings: TemplateStringsArray, ...values: unknown[]) => {
+    const result = await db<Row>(strings, ...values)
+    if (
+      armed &&
+      !announced &&
+      strings.join('?').includes('select id, slug from data_rows') &&
+      values.includes('layouts')
+    ) {
+      announced = true
+      announceCompleted()
+    }
+    return result
+  }) as DbClient
+  Object.defineProperty(wrapped, 'dialect', { get: () => db.dialect })
+  wrapped.unsafe = ((sql: string, params?: unknown[]) => db.unsafe(sql, params)) as DbClient['unsafe']
+  wrapped.transaction = ((fn: Parameters<DbClient['transaction']>[0]) =>
+    db.transaction(fn)) as DbClient['transaction']
+  return { db: wrapped, arm: () => { armed = true }, completedPass }
+}
+
 function editTitleUpdate(doc: Y.Doc, nodeText: string): void {
   doc.transact(() => {
     const nodes = treeMap(doc).get('nodes') as Y.Map<unknown>
     const rootId = treeMap(doc).get('rootNodeId') as string
     const root = nodes.get(rootId) as Y.Map<unknown>
     root.set('label', nodeText)
+  }, LOCAL_ORIGIN)
+}
+
+function populateFreshPage(doc: Y.Doc, title: string, slug: string): void {
+  doc.transact(() => {
+    const tree = treeMap(doc)
+    tree.set('rootNodeId', 'root')
+    const nodes = new Y.Map<unknown>()
+    tree.set('nodes', nodes)
+    const root = new Y.Map<unknown>()
+    root.set('id', 'root')
+    root.set('moduleId', 'base.body')
+    root.set('props', new Y.Map())
+    root.set('breakpointOverrides', new Y.Map())
+    root.set('children', new Y.Array())
+    nodes.set('root', root)
+    const meta = doc.getMap('meta')
+    meta.set('title', title)
+    meta.set('slug', slug)
   }, LOCAL_ORIGIN)
 }
 
@@ -284,10 +522,576 @@ describe('collab relay', () => {
     expect(rows[0]?.slug).toBe('fresh')
   })
 
+  it('does not resurrect a dirty deleted page ahead of its same-slug replacement', async () => {
+    const { harness, relay, homeId } = await setup()
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    const { doc: oldPage } = await relay.openDoc(`page:${homeId}`)
+    editTitleUpdate(oldPage, 'Dirty page being replaced')
+
+    const replacementId = 'replacement-page'
+    const { doc: replacement } = await relay.openDoc(`page:${replacementId}`)
+    populateFreshPage(replacement, 'Replacement', 'index')
+
+    siteDoc.transact(() => {
+      const pages = rostersMap(siteDoc).get('pages') as Y.Map<unknown>
+      pages.delete(homeId)
+      pages.set(replacementId, true)
+    }, LOCAL_ORIGIN)
+
+    await relay.flushAll()
+
+    const { rows } = await harness.db<{ id: string; deleted_at: string | null }>`
+      select id, deleted_at from data_rows
+      where table_id = ${'pages'} and slug = ${'index'}
+      order by id asc
+    `
+    expect(rows.find((row) => row.id === homeId)?.deleted_at).not.toBeNull()
+    expect(rows.find((row) => row.id === replacementId)?.deleted_at).toBeNull()
+    expect(rows.filter((row) => row.deleted_at === null).map((row) => row.id))
+      .toEqual([replacementId])
+  })
+
+  it('keeps blob and derived JSON on the same immutable persist snapshot', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 60_000 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{ id: string }>`
+      select id from data_rows where table_id = ${'pages'}
+    `
+    const docId = `page:${rows[0].id}`
+    const { doc } = await relay.openDoc(docId)
+    gated.arm()
+    editTitleUpdate(doc, 'Snapshot A')
+    const firstFlush = relay.flushAll()
+    await gated.blocked
+    editTitleUpdate(doc, 'Snapshot B')
+    gated.release()
+    await firstFlush
+
+    const stored = await getCollabDocumentState(harness.db, docId)
+    const storedDoc = new Y.Doc()
+    Y.applyUpdate(storedDoc, stored!.state)
+    const storedPage = projectPageDoc(storedDoc, rows[0].id)
+    const { rows: firstRows } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${rows[0].id}
+    `
+    const firstBody = firstRows[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(storedPage.nodes[storedPage.rootNodeId]?.label).toBe('Snapshot A')
+    expect(firstBody.nodes[firstBody.rootNodeId]?.label).toBe('Snapshot A')
+    storedDoc.destroy()
+
+    await relay.flushAll()
+    const { rows: secondRows } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${rows[0].id}
+    `
+    const secondBody = secondRows[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(secondBody.nodes[secondBody.rootNodeId]?.label).toBe('Snapshot B')
+  })
+
+  it('does not insert a client-created page that was removed from the roster before its first flush', async () => {
+    const { harness, relay } = await setup()
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    const rowId = 'abandoned-page'
+    const { doc: pageDoc } = await relay.openDoc(`page:${rowId}`)
+    populateFreshPage(pageDoc, 'Abandoned', 'abandoned')
+
+    siteDoc.transact(() => {
+      ;(rostersMap(siteDoc).get('pages') as Y.Map<unknown>).set(rowId, true)
+    }, LOCAL_ORIGIN)
+    siteDoc.transact(() => {
+      ;(rostersMap(siteDoc).get('pages') as Y.Map<unknown>).delete(rowId)
+    }, LOCAL_ORIGIN)
+
+    await relay.flushAll()
+
+    const { rows } = await harness.db<{ id: string }>`
+      select id from data_rows where id = ${rowId}
+    `
+    expect(rows).toHaveLength(0)
+  })
+
+  it('restores the latest page after deletion, disconnect, eviction, and roster undo', async () => {
+    const { harness, relay, homeId } = await setup()
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    const retained = await relay.retain(`page:${homeId}`)
+    editTitleUpdate(retained.doc, 'Latest content survives undo')
+
+    siteDoc.transact(() => {
+      ;(rostersMap(siteDoc).get('pages') as Y.Map<unknown>).delete(homeId)
+    }, LOCAL_ORIGIN)
+    await relay.flushAll()
+    expect(await getCollabDocumentState(harness.db, `page:${homeId}`)).not.toBeNull()
+
+    const destroyed = new Promise<void>((resolve) => {
+      retained.doc.on('destroy', () => resolve())
+    })
+    relay.release(`page:${homeId}`)
+    await destroyed
+    expect(await getCollabDocumentState(harness.db, `page:${homeId}`)).not.toBeNull()
+
+    siteDoc.transact(() => {
+      ;(rostersMap(siteDoc).get('pages') as Y.Map<unknown>).set(homeId, true)
+    }, LOCAL_ORIGIN)
+    await relay.flushAll()
+
+    const { rows } = await harness.db<{ cells_json: Record<string, unknown>; deleted_at: string | null }>`
+      select cells_json, deleted_at from data_rows where id = ${homeId}
+    `
+    const body = rows[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(rows[0].deleted_at).toBeNull()
+    expect(body.nodes[body.rootNodeId]?.label).toBe('Latest content survives undo')
+  })
+
+  it('does not resurrect a row persist that was already in flight when its roster entry is removed', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{ id: string }>`
+      select id from data_rows where table_id = ${'pages'}
+    `
+    const homeId = rows[0].id
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    const { doc: pageDoc } = await relay.openDoc(`page:${homeId}`)
+
+    gated.arm()
+    editTitleUpdate(pageDoc, 'Persist blocked before roster removal')
+    await gated.blocked
+    siteDoc.transact(() => {
+      ;(rostersMap(siteDoc).get('pages') as Y.Map<unknown>).delete(homeId)
+    }, LOCAL_ORIGIN)
+
+    let swept = false
+    for (let attempt = 0; attempt < 100; attempt++) {
+      const { rows: state } = await harness.db<{ deleted_at: string | null }>`
+        select deleted_at from data_rows where id = ${homeId}
+      `
+      if (state[0]?.deleted_at !== null) {
+        swept = true
+        break
+      }
+      await Bun.sleep(10)
+    }
+    expect(swept).toBeTrue()
+    gated.release()
+    await relay.flushAll()
+
+    const { rows: state } = await harness.db<{ deleted_at: string | null }>`
+      select deleted_at from data_rows where id = ${homeId}
+    `
+    expect(state[0]?.deleted_at).not.toBeNull()
+  })
+
   // ── Lifecycle races ───────────────────────────────────────────────────────
   // The reset seam is how every out-of-relay write (Settings save, Super
   // Import, plugin install, data-workspace edit) reaches connected editors.
   // Both cases below FAIL without the eviction/flush ordering in relay.ts.
+
+  it('coalesces shell and row invalidations so an external batch creation survives reset', async () => {
+    const { harness, relay, homeId } = await setup()
+    await relay.openDoc(SITE_DOC_ID)
+    const { rows: sourceRows } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${homeId}
+    `
+    const rowId = 'external-batch-page'
+    await createDataRow(
+      harness.db,
+      {
+        id: rowId,
+        tableId: 'pages',
+        cells: sourceRows[0].cells_json,
+        slug: 'external-batch',
+      },
+      null,
+      null,
+      { collabInternal: true },
+    )
+
+    const resetIds = new Set<string>()
+    let finishReset!: () => void
+    const resetDone = new Promise<void>((resolve) => {
+      finishReset = resolve
+    })
+    const unsubscribe = relay.onReset((docId) => {
+      resetIds.add(docId)
+      if (resetIds.has(SITE_DOC_ID) && resetIds.has(`page:${rowId}`)) finishReset()
+    })
+    // siteDocument emits these synchronously after one committed save and
+    // reports newly created rows in the changed/update group.
+    notifyShellWrite()
+    notifyRowWrite({ tableId: 'pages', rowIds: [rowId], kind: 'update' })
+    await resetDone
+    unsubscribe()
+
+    const { rows } = await harness.db<{ deleted_at: string | null }>`
+      select deleted_at from data_rows where id = ${rowId}
+    `
+    expect(rows[0]?.deleted_at).toBeNull()
+    const { doc: reseededSite } = await relay.openDoc(SITE_DOC_ID)
+    const pages = rostersMap(reseededSite).get('pages') as Y.Map<unknown>
+    expect([...pages.keys()]).toContain(rowId)
+  })
+
+  it('an older site reset cannot sweep a creation owned by a later reset batch', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows: sourceRows } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where table_id = ${'pages'}
+    `
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+
+    gated.arm()
+    siteDoc.transact(() => {
+      shellMap(siteDoc).set('name', 'Older collaborative shell')
+    }, LOCAL_ORIGIN)
+    await gated.blocked
+    notifyShellWrite()
+    // Let reset A capture its own SITE-only batch and wait on the blocked
+    // persist before the external creation emits reset B.
+    await Bun.sleep(5)
+
+    const rowId = 'later-reset-page'
+    await createDataRow(harness.db, {
+      id: rowId,
+      tableId: 'pages',
+      cells: sourceRows[0].cells_json,
+      slug: 'later-reset',
+    })
+    gated.release()
+    await relay.flushAll()
+
+    const { rows } = await harness.db<{ deleted_at: string | null }>`
+      select deleted_at from data_rows where id = ${rowId}
+    `
+    expect(rows[0]?.deleted_at).toBeNull()
+    const { doc: reseededSite } = await relay.openDoc(SITE_DOC_ID)
+    const pages = rostersMap(reseededSite).get('pages') as Y.Map<unknown>
+    expect([...pages.keys()]).toContain(rowId)
+  })
+
+  it('a later roster deletion beats an older row invalidation still resetting', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const page = rows[0]
+    const pageDocId = `page:${page.id}`
+    const deleting = gateCollabBlobDelete(harness.db, pageDocId)
+    const sweep = observeRosterSweep(deleting.db)
+    const relay = createCollabRelay(sweep.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    await relay.openDoc(pageDocId)
+
+    const externalCells = structuredClone(page.cells_json)
+    const externalBody = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    externalBody.nodes[externalBody.rootNodeId].label = 'Older external page write'
+    deleting.arm()
+    await saveDataRowDraft(sweep.db, page.id, {
+      cells: externalCells,
+      slug: page.slug,
+    })
+    // The external P-only reset is now active but held before deleting its
+    // lineage. A later collaborative roster removal must still delete P.
+    await deleting.blocked
+    sweep.arm()
+    siteDoc.transact(() => {
+      ;(rostersMap(siteDoc).get('pages') as Y.Map<unknown>).delete(page.id)
+    }, LOCAL_ORIGIN)
+    await sweep.completedPass
+    await Bun.sleep(5)
+
+    deleting.release()
+    await relay.flushAll()
+
+    const { rows: persisted } = await harness.db<{ deleted_at: string | null }>`
+      select deleted_at from data_rows where id = ${page.id}
+    `
+    expect(persisted[0]?.deleted_at).not.toBeNull()
+    const currentPages = rostersMap(siteDoc).get('pages') as Y.Map<unknown>
+    expect([...currentPages.keys()]).not.toContain(page.id)
+  })
+
+  it('a superseded unaffected flush does not abort an older site reset', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateRosterSweep(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 60_000 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const page = rows[0]
+    const pageDocId = `page:${page.id}`
+    await relay.openDoc(SITE_DOC_ID)
+    const { doc: pageDoc } = await relay.openDoc(pageDocId)
+    editTitleUpdate(pageDoc, 'Older dirty collaborative page')
+
+    const resetIds = new Set<string>()
+    let finishResets!: () => void
+    const resetsDone = new Promise<void>((resolve) => { finishResets = resolve })
+    const unsubscribe = relay.onReset((docId) => {
+      resetIds.add(docId)
+      if (resetIds.has(SITE_DOC_ID) && resetIds.has(pageDocId)) finishResets()
+    })
+
+    const externalShell = await getDraftSite(harness.db)
+    expect(externalShell).not.toBeNull()
+    gated.arm()
+    await saveDraftSite(gated.db, {
+      ...externalShell!,
+      name: 'Authoritative external shell',
+    })
+    // Reset A now owns SITE and is blocked in its roster sweep. Queue an
+    // authoritative page save behind that sweep; its reset B supersedes A's
+    // attempt to flush this dirty, non-reset page.
+    await gated.blocked
+    const externalCells = structuredClone(page.cells_json)
+    const body = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    body.nodes[body.rootNodeId].label = 'Authoritative external page'
+    const pageWrite = saveDataRowDraft(gated.db, page.id, {
+      cells: externalCells,
+      slug: page.slug,
+    })
+    gated.release()
+    await pageWrite
+    await resetsDone
+    unsubscribe()
+
+    expect((await getDraftSite(harness.db))?.name).toBe('Authoritative external shell')
+    const { rows: persisted } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${page.id}
+    `
+    const persistedBody = persisted[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(persistedBody.nodes[persistedBody.rootNodeId]?.label)
+      .toBe('Authoritative external page')
+    const { doc: reseededSite } = await relay.openDoc(SITE_DOC_ID)
+    const { doc: reseededPage } = await relay.openDoc(pageDocId)
+    expect(shellMap(reseededSite).get('name')).toBe('Authoritative external shell')
+    expect(projectPageDoc(reseededPage, page.id).nodes[body.rootNodeId]?.label)
+      .toBe('Authoritative external page')
+  })
+
+  it('keeps an external page-to-custom-table move authoritative over a dirty retained page', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const customTable = await createDataTable(harness.db, {
+      id: 'archive-table',
+      name: 'Archive',
+      slug: 'archive',
+      kind: 'data',
+      singularLabel: 'Archive item',
+      pluralLabel: 'Archive items',
+    })
+    const { rows } = await harness.db<{
+      id: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const original = rows[0]
+    const docId = `page:${original.id}`
+    const relay = createCollabRelay(harness.db, { persistDebounceMs: 60_000 })
+    cleanups.push(() => relay.destroy())
+    const retained = await relay.retain(docId)
+    let oldDocDestroyed = false
+    retained.doc.on('destroy', () => { oldDocDestroyed = true })
+    editTitleUpdate(retained.doc, 'Stale page edit must not undo the move')
+
+    const moved = await updateDataRowTable(harness.db, original.id, customTable.id)
+    expect(moved.ok).toBeTrue()
+    await relay.flushAll()
+
+    const { rows: persisted } = await harness.db<{
+      table_id: string
+      cells_json: Record<string, unknown>
+    }>`
+      select table_id, cells_json from data_rows where id = ${original.id}
+    `
+    expect(persisted[0]?.table_id).toBe(customTable.id)
+    expect(persisted[0]?.cells_json).toEqual(original.cells_json)
+    expect(oldDocDestroyed).toBeTrue()
+
+    const resetBlob = await getCollabDocumentState(harness.db, docId)
+    expect(resetBlob?.generation).not.toBe(retained.generation)
+    const rebound = await relay.openDoc(docId)
+    expect(rebound.generation).not.toBe(retained.generation)
+    const { doc: reseededSite } = await relay.openDoc(SITE_DOC_ID)
+    const pages = rostersMap(reseededSite).get('pages') as Y.Map<unknown>
+    expect([...pages.keys()]).not.toContain(original.id)
+    relay.release(docId)
+  })
+
+  it('merge-overwrite invalidates the old collab kind when an imported row moves tables', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    const cookie = await harness.setupOwner()
+    const targetTable = await createDataTable(harness.db, {
+      id: 'import-target',
+      name: 'Import targets',
+      slug: 'import-targets',
+      kind: 'data',
+      singularLabel: 'Import target',
+      pluralLabel: 'Import targets',
+    })
+    const [page] = await listDataRows(harness.db, 'pages')
+    const docId = `page:${page.id}`
+    const relay = createCollabRelay(harness.db, { persistDebounceMs: 60_000 })
+    cleanups.push(() => relay.destroy())
+    const retained = await relay.retain(docId)
+    const oldGeneration = retained.generation
+    let oldDocDestroyed = false
+    retained.doc.on('destroy', () => { oldDocDestroyed = true })
+    editTitleUpdate(retained.doc, 'Stale page-shaped import overwrite')
+
+    const importedCells = { headline: 'Authoritative imported custom row' }
+    const response = await harness.cms('/admin/api/cms/import?strategy=merge-overwrite', {
+      method: 'POST',
+      cookie,
+      json: {
+        schemaVersion: 1,
+        exportedAt: new Date().toISOString(),
+        tables: [targetTable],
+        rows: [{
+          ...page,
+          tableId: targetTable.id,
+          cells: importedCells,
+          slug: 'imported-custom-row',
+        }],
+      },
+    })
+    expect(response.status).toBe(200)
+    await relay.flushAll()
+
+    const { rows } = await harness.db<{
+      table_id: string
+      cells_json: Record<string, unknown>
+    }>`
+      select table_id, cells_json from data_rows where id = ${page.id}
+    `
+    expect(rows[0]?.table_id).toBe(targetTable.id)
+    expect(rows[0]?.cells_json).toEqual(importedCells)
+    expect(oldDocDestroyed).toBeTrue()
+    const rebound = await relay.openDoc(docId)
+    expect(rebound.generation).not.toBe(oldGeneration)
+    const { doc: reseededSite } = await relay.openDoc(SITE_DOC_ID)
+    const pages = rostersMap(reseededSite).get('pages') as Y.Map<unknown>
+    expect([...pages.keys()]).not.toContain(page.id)
+    relay.release(docId)
+  })
+
+  it('a no-op merge-add import does not reset skipped row or shell edits', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    const cookie = await harness.setupOwner()
+    const [existingPage] = await listDataRows(harness.db, 'pages')
+    const storedShell = await getDraftSite(harness.db)
+    expect(storedShell).not.toBeNull()
+
+    const relay = createCollabRelay(harness.db, { persistDebounceMs: 60_000 })
+    cleanups.push(() => relay.destroy())
+    const { doc: pageDoc } = await relay.openDoc(`page:${existingPage.id}`)
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    editTitleUpdate(pageDoc, 'Dirty row survives skipped import')
+    siteDoc.transact(() => {
+      shellMap(siteDoc).set('name', 'Dirty shell survives skipped import')
+    }, LOCAL_ORIGIN)
+
+    const res = await harness.cms('/admin/api/cms/import?strategy=merge-add', {
+      method: 'POST',
+      cookie,
+      json: {
+        schemaVersion: 1,
+        exportedAt: new Date().toISOString(),
+        site: storedShell,
+        tables: [],
+        rows: [existingPage],
+      },
+    })
+    expect(res.status).toBe(200)
+    expect((await res.json() as { rowsSkipped: number }).rowsSkipped).toBe(1)
+
+    await relay.flushAll()
+    const { rows } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${existingPage.id}
+    `
+    const body = rows[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(body.nodes[body.rootNodeId]?.label).toBe('Dirty row survives skipped import')
+    expect((await getDraftSite(harness.db))?.name)
+      .toBe('Dirty shell survives skipped import')
+  })
+
+  it('sweeps roster deletions before a site reset flushes a same-slug replacement', async () => {
+    const { harness, relay, homeId } = await setup()
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    const { doc: oldPage } = await relay.openDoc(`page:${homeId}`)
+    editTitleUpdate(oldPage, 'Dirty page during site reset')
+    const replacementId = 'reset-replacement'
+    const { doc: replacement } = await relay.openDoc(`page:${replacementId}`)
+    populateFreshPage(replacement, 'Reset replacement', 'index')
+    siteDoc.transact(() => {
+      const pages = rostersMap(siteDoc).get('pages') as Y.Map<unknown>
+      pages.delete(homeId)
+      pages.set(replacementId, true)
+    }, LOCAL_ORIGIN)
+
+    // A settings save resets only site:default. Its stale shell must not be
+    // written back, but its current roster still has to release the old slug
+    // before non-reset row docs are flushed.
+    await relay.resetDocs([SITE_DOC_ID])
+
+    const { rows } = await harness.db<{ id: string; deleted_at: string | null }>`
+      select id, deleted_at from data_rows
+      where table_id = ${'pages'} and slug = ${'index'}
+      order by id asc
+    `
+    expect(rows.find((row) => row.id === homeId)?.deleted_at).not.toBeNull()
+    expect(rows.find((row) => row.id === replacementId)?.deleted_at).toBeNull()
+    expect(rows.filter((row) => row.deleted_at === null).map((row) => row.id))
+      .toEqual([replacementId])
+  })
 
   it('a reset is not undone by a persist that was already in flight', async () => {
     const harness = await createCapabilityTestHarness()
@@ -316,6 +1120,421 @@ describe('collab relay', () => {
     // Without the await in `evict`, the released insert lands AFTER
     // deleteCollabDocuments and resurrects the dead generation.
     expect(await getCollabDocumentState(harness.db, docId)).toBeNull()
+  })
+
+  it('a socket release during reset decrements held ownership without leaking a ref', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{ id: string }>`
+      select id from data_rows where table_id = ${'pages'}
+    `
+    const docId = `page:${rows[0].id}`
+    const retained = await relay.retain(docId)
+
+    gated.arm()
+    editTitleUpdate(retained.doc, 'Blocked while socket closes')
+    await gated.blocked
+    const reset = relay.resetDocs([docId])
+    // resetDocs has installed its gate, captured the retained ref, and is now
+    // waiting for this blocked persist inside eviction.
+    await Bun.sleep(5)
+    relay.release(docId)
+    gated.release()
+    await reset
+
+    const { doc: unboundFresh } = await relay.openDoc(docId)
+    let destroyed = false
+    unboundFresh.on('destroy', () => { destroyed = true })
+    editTitleUpdate(unboundFresh, 'No phantom owner remains')
+    await Bun.sleep(30)
+    expect(destroyed).toBeTrue()
+  })
+
+  it('a release before reset captures held refs leaves no phantom page owner', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{ id: string }>`
+      select id from data_rows where table_id = ${'pages'}
+    `
+    const docId = `page:${rows[0].id}`
+    const retained = await relay.retain(docId)
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+    let originalDestroyed = false
+    retained.doc.on('destroy', () => { originalDestroyed = true })
+
+    gated.arm()
+    siteDoc.transact(() => {
+      shellMap(siteDoc).set('name', 'Blocked before held-ref snapshot')
+    }, LOCAL_ORIGIN)
+    await gated.blocked
+
+    // resetDocs installs both reset gates immediately, then waits for the
+    // blocked SITE persist before it snapshots heldResetRefs. Releasing here
+    // must decrement the live entry without starting a competing eviction.
+    const reset = relay.resetDocs([SITE_DOC_ID, docId])
+    relay.release(docId)
+    gated.release()
+    await reset
+    expect(originalDestroyed).toBeTrue()
+
+    const { doc: unboundFresh } = await relay.openDoc(docId)
+    expect(unboundFresh).not.toBe(retained.doc)
+    let freshDestroyed = false
+    unboundFresh.on('destroy', () => { freshDestroyed = true })
+    editTitleUpdate(unboundFresh, 'No pre-snapshot phantom owner remains')
+    await Bun.sleep(30)
+    expect(freshDestroyed).toBeTrue()
+  })
+
+  it('a reset drains an open already reading the old lineage before deleting it', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const row = rows[0]
+    const docId = `page:${row.id}`
+
+    const seedRelay = createCollabRelay(harness.db, { persistDebounceMs: 5 })
+    const { doc: seededDoc } = await seedRelay.openDoc(docId)
+    editTitleUpdate(seededDoc, 'Old collaborative lineage')
+    await seedRelay.flushAll()
+    await seedRelay.destroy()
+
+    const gated = gateCollabBlobRead(harness.db, docId)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const staleOpen = relay.openDoc(docId)
+    await gated.blocked
+
+    const externalCells = structuredClone(row.cells_json)
+    const externalBody = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    externalBody.nodes[externalBody.rootNodeId].label = 'External while open is pending'
+    const resetDone = new Promise<void>((resolve) => {
+      const unsubscribe = relay.onReset((resetId) => {
+        if (resetId !== docId) return
+        unsubscribe()
+        resolve()
+      })
+    })
+    await saveDataRowDraft(harness.db, row.id, {
+      cells: externalCells,
+      slug: row.slug,
+    })
+    // Let the queued reset install its gate and begin waiting for staleOpen.
+    await Bun.sleep(10)
+    gated.release()
+    await staleOpen
+    await resetDone
+
+    const { doc: freshDoc } = await relay.openDoc(docId)
+    const freshPage = projectPageDoc(freshDoc, row.id)
+    expect(freshPage.nodes[freshPage.rootNodeId]?.label)
+      .toBe('External while open is pending')
+  })
+
+  it('retain never returns the doomed entry a reset is awaiting from open', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const { rows } = await harness.db<{ id: string }>`
+      select id from data_rows where table_id = ${'pages'}
+    `
+    const docId = `page:${rows[0].id}`
+
+    const seedRelay = createCollabRelay(harness.db, { persistDebounceMs: 5 })
+    const seeded = await seedRelay.openDoc(docId)
+    const oldGeneration = seeded.generation
+    await seedRelay.destroy()
+
+    const gated = gateCollabBlobRead(harness.db, docId)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    let returnedDestroyCount = 0
+    const retainedPromise = relay.retain(docId).then((retained) => {
+      retained.doc.on('destroy', () => { returnedDestroyCount += 1 })
+      return retained
+    })
+    await gated.blocked
+
+    // The reset installs its gate and waits on the same opening promise.
+    // retain attached first, so its continuation is deliberately poised to
+    // observe the just-opened but already-doomed entry.
+    const reset = relay.resetDocs([docId])
+    gated.release()
+    const [retained] = await Promise.all([retainedPromise, reset])
+
+    expect(returnedDestroyCount).toBe(0)
+    expect(retained.generation).not.toBe(oldGeneration)
+    const current = await relay.openDoc(docId)
+    expect(current.doc).toBe(retained.doc)
+    expect(current.generation).toBe(retained.generation)
+
+    let finishDestroy!: () => void
+    const destroyed = new Promise<void>((resolve) => { finishDestroy = resolve })
+    retained.doc.on('destroy', finishDestroy)
+    relay.release(docId)
+    await destroyed
+    await Bun.sleep(5)
+    expect(returnedDestroyCount).toBe(1)
+  })
+
+  it('an external row save wins over a collaborative persist already in flight', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const row = rows[0]
+    const docId = `page:${row.id}`
+    const { doc } = await relay.openDoc(docId)
+
+    gated.arm()
+    editTitleUpdate(doc, 'Stale collaborative edit')
+    await gated.blocked
+
+    const externalCells = structuredClone(row.cells_json)
+    const externalBody = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    externalBody.nodes[externalBody.rootNodeId].label = 'External save wins'
+    const resetDone = new Promise<void>((resolve) => {
+      const unsubscribe = relay.onReset((resetId) => {
+        if (resetId !== docId) return
+        unsubscribe()
+        resolve()
+      })
+    })
+    await saveDataRowDraft(harness.db, row.id, {
+      cells: externalCells,
+      slug: row.slug,
+    })
+    gated.release()
+    await resetDone
+
+    const { rows: persisted } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${row.id}
+    `
+    const persistedBody = persisted[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(persistedBody.nodes[persistedBody.rootNodeId]?.label).toBe('External save wins')
+    expect(await getCollabDocumentState(harness.db, docId)).toBeNull()
+  })
+
+  it('orders an external save after a collaborative derived write already in flight', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const row = rows[0]
+    const docId = `page:${row.id}`
+    const gated = gateDerivedRowWrites(harness.db, row.id)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { doc } = await relay.openDoc(docId)
+
+    gated.arm()
+    editTitleUpdate(doc, 'Collaborative update already in derived SQL')
+    const collabFlush = relay.flushAll()
+    await gated.blocked
+
+    const externalCells = structuredClone(row.cells_json)
+    const externalBody = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    externalBody.nodes[externalBody.rootNodeId].label = 'External ordered last'
+    let externalFinished = false
+    const resetDone = new Promise<void>((resolve) => {
+      const unsubscribe = relay.onReset((resetId) => {
+        if (resetId !== docId) return
+        unsubscribe()
+        resolve()
+      })
+    })
+    const externalSave = saveDataRowDraft(harness.db, row.id, {
+      cells: externalCells,
+      slug: row.slug,
+    }).then(() => { externalFinished = true })
+
+    await Bun.sleep(10)
+    const externalWaitedForDerivedWrite = !externalFinished
+    gated.release()
+    await Promise.all([collabFlush, externalSave, resetDone])
+
+    const { rows: persisted } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${row.id}
+    `
+    const persistedBody = persisted[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(externalWaitedForDerivedWrite).toBeTrue()
+    expect(persistedBody.nodes[persistedBody.rootNodeId]?.label).toBe('External ordered last')
+  })
+
+  it('an edit that starts after reset invalidation cannot overwrite the external row', async () => {
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const gated = gateCollabBlobWrites(harness.db)
+    const relay = createCollabRelay(gated.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const row = rows[0]
+    const docId = `page:${row.id}`
+    const { doc: pageDoc } = await relay.openDoc(docId)
+    const { doc: siteDoc } = await relay.openDoc(SITE_DOC_ID)
+
+    const externalCells = structuredClone(row.cells_json)
+    const externalBody = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    externalBody.nodes[externalBody.rootNodeId].label = 'External reset is authoritative'
+    await saveDataRowDraft(
+      harness.db,
+      row.id,
+      { cells: externalCells, slug: row.slug },
+      null,
+      null,
+      { collabInternal: true },
+    )
+
+    // Hold an older SITE persist so resetDocs has activated both ids but is
+    // still waiting. The page edit begins only after that invalidation mark.
+    gated.arm()
+    siteDoc.transact(() => {
+      shellMap(siteDoc).set('name', 'Stale collaborative shell')
+    }, LOCAL_ORIGIN)
+    await gated.blocked
+    const reset = relay.resetDocs([SITE_DOC_ID, docId])
+    editTitleUpdate(pageDoc, 'Late stale collaborative edit')
+    await Bun.sleep(30)
+    gated.release()
+    await reset
+
+    const { rows: persisted } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${row.id}
+    `
+    const persistedBody = persisted[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(persistedBody.nodes[persistedBody.rootNodeId]?.label)
+      .toBe('External reset is authoritative')
+    expect(await getCollabDocumentState(harness.db, docId)).toBeNull()
+  })
+
+  it('an explicit flush retries and drains a transient queued reset failure', async () => {
+    const errorLog = spyOn(console, 'error').mockImplementation(() => {})
+    const harness = await createCapabilityTestHarness()
+    cleanups.push(() => harness.cleanup())
+    await harness.setupOwner()
+    const failing = failNextCollabBlobDelete(harness.db)
+    const relay = createCollabRelay(failing.db, { persistDebounceMs: 5 })
+    cleanups.push(() => relay.destroy())
+    const { rows } = await harness.db<{
+      id: string
+      slug: string
+      cells_json: Record<string, unknown>
+    }>`
+      select id, slug, cells_json from data_rows where table_id = ${'pages'}
+    `
+    const row = rows[0]
+    const docId = `page:${row.id}`
+    await relay.retain(docId)
+    await relay.flushAll()
+
+    const externalCells = structuredClone(row.cells_json)
+    const externalBody = externalCells.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    externalBody.nodes[externalBody.rootNodeId].label = 'Survives reset retry'
+    failing.arm()
+    await saveDataRowDraft(harness.db, row.id, {
+      cells: externalCells,
+      slug: row.slug,
+    })
+    await failing.failed
+
+    // An already-bound socket can send another frame before publish triggers
+    // the retry, and a new socket can briefly bind/unbind in the same window.
+    // Both must share one logical ref count with the refs held by the reset.
+    await Bun.sleep(5)
+    const { doc: gapDoc } = await relay.openDoc(docId)
+    const extraBinding = await relay.retain(docId)
+    expect(extraBinding.doc).toBe(gapDoc)
+    relay.release(docId)
+
+    // The queued failure remains authoritative and flushAll retries the whole
+    // batch before it allows publish/headless consumers to proceed.
+    await relay.flushAll()
+
+    const { rows: persisted } = await harness.db<{ cells_json: Record<string, unknown> }>`
+      select cells_json from data_rows where id = ${row.id}
+    `
+    const persistedBody = persisted[0].cells_json.body as {
+      nodes: Record<string, { label?: string }>
+      rootNodeId: string
+    }
+    expect(persistedBody.nodes[persistedBody.rootNodeId]?.label).toBe('Survives reset retry')
+    expect(await getCollabDocumentState(harness.db, docId)).not.toBeNull()
+    expect(errorLog).toHaveBeenCalled()
+
+    // The retry must also restore the ref owned by the still-bound socket.
+    // With refs lost at zero, the next debounce persist immediately evicts
+    // this newly seeded authoritative doc even though the socket is connected.
+    const { doc: rebound } = await relay.openDoc(docId)
+    let reboundDestroyed = false
+    rebound.on('destroy', () => { reboundDestroyed = true })
+    editTitleUpdate(rebound, 'Connected after reset retry')
+    await Bun.sleep(30)
+    expect(reboundDestroyed).toBeFalse()
+    relay.release(docId)
+    await Bun.sleep(10)
+    expect(reboundDestroyed).toBeTrue()
+    errorLog.mockRestore()
   })
 
   it('a relay-only page survives a site-doc reset instead of vanishing from the roster', async () => {

--- a/src/__tests__/server/dataSystemTableAccess.test.ts
+++ b/src/__tests__/server/dataSystemTableAccess.test.ts
@@ -5,6 +5,51 @@ import type { DataTable } from '@core/data/schemas'
 const TABLES = '/admin/api/cms/data/tables'
 
 describe('data system-table visibility + lockdown', () => {
+  it('preserves explicitly blank route bases through API create and PATCH', async () => {
+    const harness = await createCapabilityTestHarness()
+    try {
+      const ownerCookie = await harness.setupOwner()
+      const createdResponse = await harness.cms(TABLES, {
+        method: 'POST',
+        cookie: ownerCookie,
+        json: {
+          name: 'Fee lines',
+          slug: 'fee-lines',
+          kind: 'data',
+          routeBase: '',
+          singularLabel: 'Fee line',
+          pluralLabel: 'Fee lines',
+        },
+      })
+      expect(createdResponse.status).toBe(201)
+      const created = (await readJson<{ table: DataTable }>(createdResponse)).table
+      expect(created.routeBase).toBe('')
+
+      const routedResponse = await harness.cms(`${TABLES}/${created.id}`, {
+        method: 'PATCH',
+        cookie: ownerCookie,
+        json: { routeBase: '  /fees/  ' },
+      })
+      expect(routedResponse.status).toBe(200)
+      expect((await readJson<{ table: DataTable }>(routedResponse)).table.routeBase).toBe('/fees')
+
+      const blankResponse = await harness.cms(`${TABLES}/${created.id}`, {
+        method: 'PATCH',
+        cookie: ownerCookie,
+        json: { routeBase: '   ' },
+      })
+      expect(blankResponse.status).toBe(200)
+      expect((await readJson<{ table: DataTable }>(blankResponse)).table.routeBase).toBe('')
+
+      const { rows } = await harness.db<{ route_base: string }>`
+        select route_base from data_tables where id = ${created.id}
+      `
+      expect(rows[0]?.route_base).toBe('')
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
   it('does not create a template page when creating a post-type table', async () => {
     const harness = await createCapabilityTestHarness()
     try {

--- a/src/__tests__/siteImport/cssToStyleRules.test.ts
+++ b/src/__tests__/siteImport/cssToStyleRules.test.ts
@@ -485,6 +485,21 @@ describe('cssToStyleRules — ambient name defaults to selector', () => {
 // ---------------------------------------------------------------------------
 
 describe('cssToStyleRules — duplicate class names', () => {
+  it('does not leak a later duplicate into sibling selectors split from one list', () => {
+    const { rules } = cssToStyleRules(
+      '.register, .source-rule { color: red } .source-rule { display: grid }',
+    )
+
+    expect(rules).toHaveLength(2)
+    expect(rules.find((rule) => rule.name === 'register')?.styles).toEqual({
+      color: 'red',
+    })
+    expect(rules.find((rule) => rule.name === 'source-rule')?.styles).toEqual({
+      color: 'red',
+      display: 'grid',
+    })
+  })
+
   it('duplicate .foo → 1 rule with later value + 1 duplicate-class warning', () => {
     const { rules, warnings } = cssToStyleRules('.foo { color: red } .foo { color: blue }')
     expect(rules).toHaveLength(1)

--- a/src/admin/ai/useMcpWorkspaceBridge.ts
+++ b/src/admin/ai/useMcpWorkspaceBridge.ts
@@ -110,8 +110,17 @@ export function useMcpWorkspaceBridge(
   scope: McpWorkspaceScope,
   dispatchTool: McpToolDispatcher,
   afterSuccessfulTool?: McpAfterSuccessfulTool,
+  enabled = true,
 ): void {
   useEffect(() => {
+    // A mounted route is not necessarily a usable workspace yet. In
+    // particular, SitePage paints its shell before usePersistence has loaded
+    // the SiteDocument into the editor store. Registering during that window
+    // makes get_context report siteConnected=true even though every browser
+    // runner sees store.site === null. Keep the server-side presence signal
+    // aligned with actual dispatcher readiness.
+    if (!enabled) return undefined
+
     const lifecycleController = new AbortController()
     let stopped = false
     let reconnectTimer: ReturnType<typeof setTimeout> | null = null
@@ -152,5 +161,5 @@ export function useMcpWorkspaceBridge(
       if (reconnectTimer) clearTimeout(reconnectTimer)
       lifecycleController.abort()
     }
-  }, [scope, dispatchTool, afterSuccessfulTool])
+  }, [scope, dispatchTool, afterSuccessfulTool, enabled])
 }

--- a/src/admin/pages/site/SitePage.tsx
+++ b/src/admin/pages/site/SitePage.tsx
@@ -13,12 +13,16 @@ import { executeAgentTool } from './agent'
  * lazy-loaded one level down by AdminCanvasLayout after the shell has painted.
  */
 export function SitePage() {
+  const siteHydrated = useEditorStore((state) => state.site !== null)
+
   // Relay MCP browser-tool calls to this open editor while it's mounted. No
   // post-tool persistence step: store mutations stream to the relay through the
   // collab socket the moment they land, and every headless MCP read flushes the
   // relay server-side first (see server/ai/mcp/server.ts), so a follow-up read
-  // always observes the edit.
-  useMcpWorkspaceBridge('site', executeAgentTool)
+  // always observes the edit. Delay registration until the editor store is
+  // hydrated so get_context's siteConnected flag means browser tools can
+  // actually see an active site.
+  useMcpWorkspaceBridge('site', executeAgentTool, undefined, siteHydrated)
 
   // Consume cross-workspace pending actions queued by the spotlight. Each
   // action waits for the editor store to hydrate (site !== null) — we

--- a/src/core/siteImport/cssToStyleRules.ts
+++ b/src/core/siteImport/cssToStyleRules.ts
@@ -563,9 +563,13 @@ function processBaseSelector(
     kind: classified.kind,
     selector,
     order: idx,
-    styles: declarations.styles,
+    // A selector list is split into independently editable rules. Do not let
+    // those rules share the parser's declaration objects: a later duplicate
+    // of one selector merges in place, and shared bags would leak that update
+    // into every sibling from the original list.
+    styles: { ...declarations.styles },
     ...(sparsePriorities(declarations.priorities)
-      ? { stylePriorities: declarations.priorities }
+      ? { stylePriorities: { ...declarations.priorities } }
       : {}),
     contextStyles: {},
   })


### PR DESCRIPTION
Summary
- serialize collaboration-aware writes and preserve authoritative roster deletion/undo semantics
- isolate split-selector style declaration bags during site import
- preserve explicit blank reusable-table route bases
- assemble published pages and visual components in deterministic creation order so publish status remains accurate

Verification
- collaboration relay regression suite and related build/lint gates passed for the original fix
- site-import focused regression passed
- reusable-table focused tests: 13/13 passed
- publish regression is red without the fix and green with it; focused publish tests: 6/6 passed
- latest full build, lint, and diff check passed

This is a draft because the branch combines four product defects reproduced while building portable Instatic template packs.