### PR TITLE
fix(plugin-sdk): carry contentAccess from definePlugin config into the manifest

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -204,6 +204,7 @@ Authors normally write `instatic-plugin.config.ts` with `definePlugin(...)`; the
 - `frontend.assets[]` requires `frontend.assets`.
 - Public routes require both `cms.routes` and `cms.routes.public`.
 - Server `fetch()` requires `network.outbound` and a matching `networkAllowedHosts[]` entry.
+- Any `cms.content.*` permission requires a non-empty `contentAccess[]`, and every mode an entry declares requires its permission (`CONTENT_ACCESS_MODE_PERMISSIONS` in `src/core/plugin-sdk/contentSchemas.ts` is the one mode-to-permission table both checks read). `instatic-plugin lint` additionally warns when a `cms.content.*` permission is requested but no entry declares its mode, since the host fails closed per table and mode and every call under it would be rejected.
 
 ---
 

--- a/src/__tests__/plugin-sdk/builders.test.ts
+++ b/src/__tests__/plugin-sdk/builders.test.ts
@@ -17,6 +17,7 @@ import {
   raw,
   safeUrl,
   vc,
+  type ContentAccessEntry,
 } from '@core/plugin-sdk'
 // Layout compilation maps HTML elements to base.* modules via the registry.
 import '@modules/base'
@@ -323,6 +324,44 @@ describe('definePlugin', () => {
     ].sort())
     expect(definition.modules).toHaveLength(1)
     expect(definition.pack?.classes[0].id).toBe('acme.ui-kit/section')
+  })
+
+  it('copies contentAccess into the manifest as an independent deep copy', () => {
+    const contentAccess: ContentAccessEntry[] = [
+      { table: 'pages', modes: ['read', 'write'] },
+    ]
+    const definition = definePlugin({
+      id: 'acme.workflow',
+      name: 'Workflow',
+      version: '1.0.0',
+      permissions: [permissions.cmsContentRead, permissions.cmsContentWrite],
+      contentAccess,
+    })
+
+    expect(definition.manifest.contentAccess).toEqual([
+      { table: 'pages', modes: ['read', 'write'] },
+    ])
+
+    // Mutating the config input after the fact must not leak into the
+    // manifest — the builder snapshots entries and their modes arrays.
+    contentAccess[0].modes.push('delete')
+    contentAccess.push({ table: 'posts', modes: ['read'] })
+    expect(definition.manifest.contentAccess).toEqual([
+      { table: 'pages', modes: ['read', 'write'] },
+    ])
+  })
+
+  it('omits contentAccess from the manifest when not configured', () => {
+    const definition = definePlugin({
+      id: 'acme.ui-kit',
+      name: 'UI Kit',
+      version: '1.0.0',
+      permissions: [permissions.modulesRegister],
+    })
+    // The key must be absent — not `undefined` — so the in-memory manifest
+    // round-trips through `parsePluginManifest` exactly like the zipped
+    // `plugin.json` (see the omission rationale in definePlugin).
+    expect('contentAccess' in definition.manifest).toBe(false)
   })
 
   it('rejects plugin ids without a vendor namespace', () => {

--- a/src/__tests__/plugin-sdk/lintCli.test.ts
+++ b/src/__tests__/plugin-sdk/lintCli.test.ts
@@ -6,14 +6,20 @@
  *  • Missing or malformed `instatic-plugin.config.ts` is surfaced cleanly
  *  • `network.outbound` permission without `networkAllowedHosts` is an error
  *  • `networkAllowedHosts` without `network.outbound` is a warning
+ *  • `cms.content.*` permissions without a matching `contentAccess` mode
+ *    entry are a warning; the missing-allowlist case stays a single error
  *  • Source files with `'node:*'` / `'bun:*'` / `require(` are errors
  *  • Bundled `dist/` outputs that smuggle forbidden literals are errors
  *  • A clean plugin reports zero findings
+ *  • The CLI's own content-editor scaffold builds a manifest that carries
+ *    `contentAccess` through `definePlugin` and lints clean
  */
 import { describe, expect, it } from 'bun:test'
 import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { lintPlugin } from '../../core/plugin-sdk/cli/lint'
+import { runPluginInit } from '../../core/plugin-sdk/cli/init'
+import { readPluginDefinition } from '../../core/plugin-sdk/cli/build'
 
 const PROJECT_ROOT = join(import.meta.dir, '../../..')
 
@@ -83,6 +89,41 @@ describe('instatic-plugin lint', () => {
     expect(findings).toHaveLength(1)
     expect(findings[0].scope).toBe('manifest')
     expect(findings[0].message).toContain('network.outbound')
+  })
+
+  it('warns when a cms.content.* permission has no contentAccess entry declaring its mode', async () => {
+    const result = await withTempPlugin(async (dir) => {
+      await writeConfig(dir, {
+        permissions: ['cms.content.read', 'cms.content.delete'],
+        contentAccess: [{ table: 'posts', modes: ['read'] }],
+      })
+    })
+    expect(result.findings.filter((f) => f.severity === 'error')).toEqual([])
+    const warnings = result.findings.filter((f) => f.severity === 'warning')
+    expect(warnings).toHaveLength(1)
+    expect(warnings[0].scope).toBe('manifest')
+    expect(warnings[0].message).toContain('cms.content.delete')
+    expect(warnings[0].message).toContain('"delete"')
+  })
+
+  it('does not warn when every cms.content.* permission is covered by a contentAccess mode', async () => {
+    const result = await withTempPlugin(async (dir) => {
+      await writeConfig(dir, {
+        permissions: ['cms.content.read', 'cms.content.write'],
+        contentAccess: [{ table: 'pages', modes: ['read', 'write'] }],
+      })
+    })
+    expect(result.findings).toEqual([])
+  })
+
+  it('keeps the missing-contentAccess case a single manifest error (no duplicate warnings)', async () => {
+    const result = await withTempPlugin(async (dir) => {
+      await writeConfig(dir, { permissions: ['cms.content.read'] })
+    })
+    expect(result.findings).toHaveLength(1)
+    expect(result.findings[0].severity).toBe('error')
+    expect(result.findings[0].scope).toBe('manifest')
+    expect(result.findings[0].message).toContain('contentAccess')
   })
 
   it('errors on forbidden literals in server source files', async () => {
@@ -157,5 +198,33 @@ describe('instatic-plugin lint', () => {
     expect(result.findings[0].severity).toBe('error')
     expect(result.findings[0].scope).toBe('config')
     expect(result.pluginId).toBe('<unknown>')
+  })
+
+  it('content-editor scaffold carries contentAccess into the manifest and lints clean', async () => {
+    // Regression: `definePlugin` used to drop `contentAccess` from the
+    // manifest it returned, so the CLI's own content-editor scaffold failed
+    // this very lint with "contentAccess is required when any cms.content.*
+    // permission is granted" — and installed plugins failed closed on every
+    // cms.content.* call despite the operator's grant.
+    const parentDir = join(PROJECT_ROOT, '.tmp-lint')
+    await mkdir(parentDir, { recursive: true })
+    const dir = await mkdtemp(join(parentDir, 'scaffold-'))
+    try {
+      const pluginDir = await runPluginInit('acme.content-lint', {
+        kind: 'content-editor',
+        parentDir: dir,
+      })
+
+      const definition = await readPluginDefinition(pluginDir)
+      expect(definition.manifest.contentAccess).toEqual([
+        { table: 'pages', modes: ['read', 'write'] },
+      ])
+
+      const result = await lintPlugin(pluginDir)
+      expect(result.findings).toEqual([])
+      expect(result.pluginId).toBe('acme.content-lint')
+    } finally {
+      await rm(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/core/plugin-sdk/builders/definePlugin.ts
+++ b/src/core/plugin-sdk/builders/definePlugin.ts
@@ -13,16 +13,14 @@
  *     permissions: [permissions.modulesRegister, permissions.visualComponentsRegister],
  *     modules: [callout],
  *     pack,
- *     // Optional entry-point hooks — pure objects, not file paths.
- *     // The build script wires them into the runtime zip layout.
- *     editor:   () => import(`./editor`),
- *     server:   () => import(`./server`),
- *     frontend: () => import(`./frontend/tracker`),
  *   })
  *
  * The return value is the host's runtime `PluginManifest` plus the bundled
- * builder objects. The build script (PR 1.1, see scripts/build-plugin.ts)
- * uses those builder objects to emit the final zip.
+ * builder objects. The build CLI (`cli/build.ts`) uses those builder
+ * objects to emit the final zip. Entrypoints are NOT declared here —
+ * `instatic-plugin build` auto-wires them into the emitted `plugin.json`
+ * from the source layout (`server/index.ts`, `editor/index.ts`, top-level
+ * `frontend/*.ts`, admin app entries).
  */
 
 import { PLUGIN_API_VERSION } from '../types'
@@ -33,6 +31,7 @@ import type {
   PluginPermission,
   PluginResource,
 } from '../types'
+import type { ContentAccessEntry } from '../contentSchemas'
 import type { PluginModuleDefinition } from '../modules'
 import type { PluginPackContents } from './definePack'
 import {
@@ -82,6 +81,13 @@ export interface DefinePluginConfig {
    * persists records under each resource's id.
    */
   resources?: PluginResource[]
+
+  /**
+   * Per-table allowlist for the `cms.content.*` surface. Required by the
+   * manifest parser whenever any `cms.content.*` permission is declared;
+   * the host fails closed at runtime for tables/modes not listed here.
+   */
+  contentAccess?: ContentAccessEntry[]
 
   /**
    * Admin pages registered by the plugin (markdown / map / resource / app).
@@ -177,6 +183,9 @@ export function definePlugin(config: DefinePluginConfig): PluginDefinition {
     ...(config.description !== undefined ? { description: config.description } : {}),
     ...(config.networkAllowedHosts
       ? { networkAllowedHosts: [...config.networkAllowedHosts] }
+      : {}),
+    ...(config.contentAccess
+      ? { contentAccess: config.contentAccess.map((entry) => ({ ...entry, modes: [...entry.modes] })) }
       : {}),
     ...(config.settings !== undefined ? { settings: config.settings } : {}),
     ...(config.author !== undefined ? { author: config.author } : {}),

--- a/src/core/plugin-sdk/cli/init.ts
+++ b/src/core/plugin-sdk/cli/init.ts
@@ -135,7 +135,8 @@ export default definePlugin({
     { table: 'pages', modes: ['read', 'write'] },
   ],
 
-  entrypoints: { server: 'server/index.js' },
+  // No entrypoints here — \`instatic-plugin build\` auto-wires
+  // \`entrypoints.server\` because \`server/index.ts\` exists.
 })
 `
 }

--- a/src/core/plugin-sdk/cli/lint.ts
+++ b/src/core/plugin-sdk/cli/lint.ts
@@ -16,6 +16,9 @@
  *   • Bundled outputs in `dist/server/index.js` and `dist/modules/index.js`
  *     pass the same scan (catches authors that bypass `instatic-plugin build`)
  *   • If `network.outbound` is requested, `networkAllowedHosts` is non-empty
+ *   • Every requested `cms.content.*` permission is consumed by a
+ *     `contentAccess` entry declaring the matching mode (the missing-
+ *     allowlist case is already a manifest error from `parsePluginManifest`)
  *
  * The intent: catch every common authoring mistake BEFORE the developer
  * uploads a zip, so they get a precise error in their terminal instead of
@@ -28,6 +31,8 @@ import { findSandboxLiterals } from '@core/plugins/sandboxScan'
 import { parsePluginManifest } from '@core/plugins/manifest'
 import { readPluginDefinition } from './build'
 import type { PluginDefinition } from '../builders/definePlugin'
+import type { PluginPermission } from '../types'
+import type { ContentAccessMode } from '../contentSchemas'
 
 export type LintSeverity = 'error' | 'warning'
 
@@ -47,6 +52,14 @@ export interface LintResult {
 }
 
 const SANDBOXED_ENTRYPOINTS: ReadonlyArray<'server' | 'modules'> = ['server', 'modules']
+
+/** Which `contentAccess` mode consumes each `cms.content.*` permission. */
+const CONTENT_PERMISSION_MODES: ReadonlyArray<{ permission: PluginPermission; mode: ContentAccessMode }> = [
+  { permission: 'cms.content.read', mode: 'read' },
+  { permission: 'cms.content.write', mode: 'write' },
+  { permission: 'cms.content.publish', mode: 'publish' },
+  { permission: 'cms.content.delete', mode: 'delete' },
+]
 
 /**
  * Run all lint checks for a plugin source directory. Throws on a corrupt
@@ -125,6 +138,32 @@ export async function lintPlugin(sourceDir: string): Promise<LintResult> {
           '`networkAllowedHosts` is set but neither `network.outbound` (server) ' +
           'nor `frontend.assets` (browser CSP) is requested. ' +
           'The allowlist will be ignored at install time.',
+      })
+    }
+  }
+
+  // ---- cms.content.* + contentAccess coherence ---------------------------
+  //
+  // `parsePluginManifest` above already fails hard when any `cms.content.*`
+  // permission is declared with no `contentAccess` at all, and when an
+  // entry mode lacks its matching permission. The remaining gap: a
+  // permission whose mode appears in no entry. The host enforces access
+  // per table+mode and fails closed, so every call under that permission
+  // is rejected at runtime — and the install consent screen advertises
+  // capability the plugin can never use. (Skipped when `contentAccess` is
+  // empty so the parser's error isn't double-reported as warnings.)
+  const contentAccess = manifest.contentAccess ?? []
+  if (contentAccess.length > 0) {
+    for (const { permission, mode } of CONTENT_PERMISSION_MODES) {
+      if (!manifest.permissions.includes(permission)) continue
+      if (contentAccess.some((entry) => entry.modes.includes(mode))) continue
+      findings.push({
+        severity: 'warning',
+        scope: 'manifest',
+        message:
+          `\`${permission}\` permission is requested but no \`contentAccess\` entry declares mode "${mode}". ` +
+          `The host fails closed per table+mode, so every ${mode} call will be rejected at runtime — ` +
+          `add the mode to a table entry or drop the permission.`,
       })
     }
   }
@@ -258,7 +297,8 @@ export async function lintPlugin(sourceDir: string): Promise<LintResult> {
           severity: 'error',
           scope: `source:${kind}`,
           message: `references forbidden sandbox literal \`${offender.literal}\` — plugin code can't reach Node/Bun runtime APIs. Use the SDK instead.`,
-          file: file.slice(absoluteSource.length + 1),
+          // Findings report POSIX-style relative paths on every platform.
+          file: file.slice(absoluteSource.length + 1).replaceAll('\\', '/'),
         })
       }
     }

--- a/src/core/plugin-sdk/cli/lint.ts
+++ b/src/core/plugin-sdk/cli/lint.ts
@@ -31,8 +31,7 @@ import { findSandboxLiterals } from '@core/plugins/sandboxScan'
 import { parsePluginManifest } from '@core/plugins/manifest'
 import { readPluginDefinition } from './build'
 import type { PluginDefinition } from '../builders/definePlugin'
-import type { PluginPermission } from '../types'
-import type { ContentAccessMode } from '../contentSchemas'
+import { CONTENT_ACCESS_MODE_PERMISSIONS, type ContentAccessMode } from '../contentSchemas'
 
 export type LintSeverity = 'error' | 'warning'
 
@@ -52,14 +51,6 @@ export interface LintResult {
 }
 
 const SANDBOXED_ENTRYPOINTS: ReadonlyArray<'server' | 'modules'> = ['server', 'modules']
-
-/** Which `contentAccess` mode consumes each `cms.content.*` permission. */
-const CONTENT_PERMISSION_MODES: ReadonlyArray<{ permission: PluginPermission; mode: ContentAccessMode }> = [
-  { permission: 'cms.content.read', mode: 'read' },
-  { permission: 'cms.content.write', mode: 'write' },
-  { permission: 'cms.content.publish', mode: 'publish' },
-  { permission: 'cms.content.delete', mode: 'delete' },
-]
 
 /**
  * Run all lint checks for a plugin source directory. Throws on a corrupt
@@ -154,7 +145,8 @@ export async function lintPlugin(sourceDir: string): Promise<LintResult> {
   // empty so the parser's error isn't double-reported as warnings.)
   const contentAccess = manifest.contentAccess ?? []
   if (contentAccess.length > 0) {
-    for (const { permission, mode } of CONTENT_PERMISSION_MODES) {
+    for (const mode of Object.keys(CONTENT_ACCESS_MODE_PERMISSIONS) as ContentAccessMode[]) {
+      const permission = CONTENT_ACCESS_MODE_PERMISSIONS[mode]
       if (!manifest.permissions.includes(permission)) continue
       if (contentAccess.some((entry) => entry.modes.includes(mode))) continue
       findings.push({

--- a/src/core/plugin-sdk/contentSchemas.ts
+++ b/src/core/plugin-sdk/contentSchemas.ts
@@ -35,6 +35,7 @@ import {
 } from '@core/page-tree'
 import { StorageFilterValueSchema } from './storageSchemas'
 import { PluginContentFieldSchema } from './types/content'
+import type { PluginPermission } from './types/permissions'
 
 // ---------------------------------------------------------------------------
 // Tables
@@ -177,6 +178,19 @@ export const ContentAccessModeSchema = Type.Union([
   Type.Literal('delete'),
 ])
 export type ContentAccessMode = Static<typeof ContentAccessModeSchema>
+
+/**
+ * The permission each `contentAccess` mode consumes. `parsePluginManifest`
+ * requires the permission for every declared mode and `instatic-plugin lint`
+ * warns about a permission no entry's mode consumes — both read this one
+ * table, so the two checks cannot drift apart.
+ */
+export const CONTENT_ACCESS_MODE_PERMISSIONS: Readonly<Record<ContentAccessMode, PluginPermission>> = {
+  read: 'cms.content.read',
+  write: 'cms.content.write',
+  publish: 'cms.content.publish',
+  delete: 'cms.content.delete',
+}
 
 export const ContentAccessEntrySchema = Type.Object({
   table: Type.String(),

--- a/src/core/plugins/manifest.ts
+++ b/src/core/plugins/manifest.ts
@@ -8,6 +8,7 @@ import type {
   PluginResource,
 } from '@core/plugin-sdk'
 import {
+  CONTENT_ACCESS_MODE_PERMISSIONS,
   isCompatiblePluginApiVersion,
   MIN_SUPPORTED_PLUGIN_API_VERSION,
   PLUGIN_API_VERSION,
@@ -557,12 +558,8 @@ export function parsePluginManifest(input: unknown): PluginManifest {
   // Fail-closed defense: a plugin that requests `cms.content.write` but
   // omits the allowlist would otherwise silently fail every write at the
   // host bridge with a cryptic per-call error.
-  const contentPerms = data.permissions.filter((p) =>
-    p === 'cms.content.read' ||
-    p === 'cms.content.write' ||
-    p === 'cms.content.publish' ||
-    p === 'cms.content.delete',
-  )
+  const contentPermissions = new Set<PluginPermission>(Object.values(CONTENT_ACCESS_MODE_PERMISSIONS))
+  const contentPerms = data.permissions.filter((p) => contentPermissions.has(p))
   const contentAccess = data.contentAccess ?? []
   if (contentPerms.length > 0 && contentAccess.length === 0) {
     throw new Error(
@@ -585,11 +582,7 @@ export function parsePluginManifest(input: unknown): PluginManifest {
         }
         seenModes.add(mode)
 
-        const requiredPermission: PluginPermission =
-          mode === 'read' ? 'cms.content.read' :
-          mode === 'write' ? 'cms.content.write' :
-          mode === 'publish' ? 'cms.content.publish' :
-          'cms.content.delete'
+        const requiredPermission = CONTENT_ACCESS_MODE_PERMISSIONS[mode]
 
         if (!data.permissions.includes(requiredPermission)) {
           throw new Error(


### PR DESCRIPTION
Fixes #385

## What changed

`definePlugin()` silently dropped `contentAccess`: `DefinePluginConfig` had no such field and the builder never copied it into the manifest it returns — even though `PluginManifest` supports `contentAccess?: ContentAccessEntry[]` and the CLI's own content-editor scaffold emits a config that passes it. Any plugin built with the CLI lost its per-table allowlist, so every `cms.content.*` call failed closed at runtime despite the operator granting the permissions.

- **`definePlugin`** ([definePlugin.ts](src/core/plugin-sdk/builders/definePlugin.ts)): `contentAccess?: ContentAccessEntry[]` added to `DefinePluginConfig`, snapshotted into the manifest (entries + modes arrays copied), key omitted when undefined — same pattern as the other optional fields. Also fixed the stale docblock that showed `editor:`/`server:`/`frontend:` config fields that don't exist and referenced a dead `scripts/build-plugin.ts` path.
- **Lint coherence** ([lint.ts](src/core/plugin-sdk/cli/lint.ts)): new warning when a declared `cms.content.*` permission has no `contentAccess` entry carrying the matching mode — a permission with no consumer; the host fails closed per table+mode. The missing-allowlist case (permissions with zero entries) stays a single hard **error** via `parsePluginManifest`, which lint already runs — before this fix that error fired misleadingly even for authors who *did* declare entries. Also: source-scan finding paths are now reported POSIX-style on Windows.
- **Scaffold** ([init.ts](src/core/plugin-sdk/cli/init.ts)): removed the dead `entrypoints: { server: 'server/index.js' }` line from the content-editor template — same class of bug (config field `DefinePluginConfig` doesn't accept: an IDE type error for authors, silently ignored at runtime) and redundant, since `instatic-plugin build` auto-wires `entrypoints.server` from `server/index.ts`.

## Why

Operator grants the `cms.content.*` permissions on install, plugin still gets 403s on every content call — the manifest never carried the allowlist the author wrote. Fails closed, no error at build time, nothing pointing at the cause.

## Impact

CLI-built content plugins work as authored. `instatic-plugin lint` now catches the "permission declared but unusable" case pre-upload. Scaffolded configs typecheck clean in the author's IDE.

## Tests

- `definePlugin` copies `contentAccess` as an independent deep copy (input mutation doesn't leak) and omits the key entirely when unset (the `Value.Convert` round-trip footgun).
- Lint: warning fires for an uncovered mode, stays quiet when coherent, and the missing-allowlist case reports exactly one manifest error (no duplicate warnings).
- End-to-end regression: scaffold the CLI's own content-editor template, assert the manifest carries `contentAccess`, and assert it lints with zero findings — this exact path failed before the fix.

## Verification

```
bun run build   # tsc -b && vite build — clean
bun test        # plugin-sdk suites 50/50 green
bun run lint    # clean
```

Full `bun test` shows 299 pre-existing failures (symlink swap semantics, site-document save, etc.) — verified byte-identical with and without this diff on the same machine (Windows-environmental, e.g. symlink privileges), not related to this change.

