### PR TITLE
fix(admin): expose AI settings navigation

### DIFF
--- a/src/__tests__/admin/capabilityAwareAdmin.test.tsx
+++ b/src/__tests__/admin/capabilityAwareAdmin.test.tsx
@@ -166,7 +166,31 @@ describe('capability-aware admin UI', () => {
     expect(screen.getByText('Content')).toBeDefined()
     expect(screen.queryByRole('link', { name: 'Site' })).toBeNull()
     expect(screen.queryByRole('link', { name: 'Plugins' })).toBeNull()
+    expect(screen.queryByRole('link', { name: 'AI' })).toBeNull()
     expect(screen.queryByRole('link', { name: 'Users' })).toBeNull()
+  })
+
+  it('shows AI settings navigation only to users who can access that workspace', () => {
+    const firstRender = render(
+      <MemoryRouter initialEntries={['/admin/content']}>
+        <AdminSessionProvider user={currentUser(['ai.providers.manage'])}>
+          <AdminSectionNavigation section="content" />
+        </AdminSessionProvider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('link', { name: 'AI' }).getAttribute('href')).toBe('/admin/ai')
+
+    firstRender.unmount()
+    render(
+      <MemoryRouter initialEntries={['/admin/content']}>
+        <AdminSessionProvider user={currentUser(['ai.chat'])}>
+          <AdminSectionNavigation section="content" />
+        </AdminSessionProvider>
+      </MemoryRouter>,
+    )
+
+    expect(screen.queryByRole('link', { name: 'AI' })).toBeNull()
   })
 
   it('removes collection management and author reassignment for own-content editors', async () => {

--- a/src/admin/shared/AdminSectionNavigation/AdminSectionNavigation.tsx
+++ b/src/admin/shared/AdminSectionNavigation/AdminSectionNavigation.tsx
@@ -10,6 +10,7 @@
  */
 import { useEffect, useState, useSyncExternalStore, type MouseEvent, type ReactNode } from 'react'
 import { ArticleSolidIcon } from 'pixel-art-icons/icons/article-solid'
+import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
 import { DashboardSolidIcon } from 'pixel-art-icons/icons/dashboard-solid'
 import { DatabaseSolidIcon } from 'pixel-art-icons/icons/database-solid'
 import { ImagesSolidIcon } from 'pixel-art-icons/icons/images-solid'
@@ -173,6 +174,15 @@ export function AdminSectionNavigation({
       {canAccess('plugins') && (
         <PluginsNavLink
           active={section === 'plugins'}
+          onNavigateStart={onWorkspaceNavigateStart}
+        />
+      )}
+      {canAccess('ai') && (
+        <NavItem
+          to="/admin/ai"
+          icon={<AiBoxSolidIcon size={NAV_ICON_SIZE} aria-hidden="true" />}
+          label="AI"
+          active={section === 'ai'}
           onNavigateStart={onWorkspaceNavigateStart}
         />
       )}

--- a/src/admin/spotlight/commands/navigation.ts
+++ b/src/admin/spotlight/commands/navigation.ts
@@ -44,6 +44,12 @@ const PLUGINS_ACCESS_CAPABILITIES = [
   'plugins.lifecycle',
 ] as const
 
+/** Mirrors `canAccessAiWorkspace` in access.ts. */
+const AI_ACCESS_CAPABILITIES = [
+  'ai.providers.manage',
+  'ai.audit.read',
+] as const
+
 export function getNavigationCommands(): Command[] {
   return [
     {
@@ -113,6 +119,20 @@ export function getNavigationCommands(): Command[] {
       capability: PLUGINS_ACCESS_CAPABILITIES,
       run: (ctx) => {
         ctx.navigate('/admin/plugins')
+        ctx.closeSpotlight()
+      },
+    },
+    {
+      id: 'navigation.goToAi',
+      title: 'Go to AI settings',
+      subtitle: 'Manage providers, defaults, connections, and usage',
+      group: 'navigation',
+      iconName: 'ai-box-solid',
+      keywords: ['ai', 'models', 'providers', 'openai', 'anthropic', 'ollama', 'mcp'],
+      workspaces: ['any'],
+      capability: AI_ACCESS_CAPABILITIES,
+      run: (ctx) => {
+        ctx.navigate('/admin/ai')
         ctx.closeSpotlight()
       },
     },


### PR DESCRIPTION
## What changed
- add the capability-gated AI workspace to the shared admin navigation
- add an AI settings command to Spotlight
- cover visible and hidden navigation states

## Why
The `/admin/ai` workspace existed, but authenticated users had no primary navigation entry to reach it.

## User impact
Users with `ai.providers.manage` or `ai.audit.read` can reach AI settings from the toolbar and command palette. Chat-only users do not receive settings access.

## Verification
- `bun test src/__tests__/admin/capabilityAwareAdmin.test.tsx`
- `bun run lint`
- `bun run build`
- relevant architecture tests