### PR TITLE
fix(templates): interpolate tokens inside htmlAttributes

### DIFF
--- a/docs/features/templates.md
+++ b/docs/features/templates.md
@@ -232,6 +232,17 @@ Text props mix literal text + tokens:
 
 Source: `src/core/templates/tokenInterpolation.ts`.
 
+### Where tokens are substituted
+
+`resolveDynamicProps` walks a node's props and interpolates:
+
+- **every string-typed prop** — `text`, `href`, `src`, `alt`, and any module's own string prop. Richtext prop keys (`html`, `richtext`, `*html`, `*richtext`) additionally render the interpolated value as markdown.
+- **every value inside `htmlAttributes`** — the one prop holding strings a level down. An author writing `src="{currentEntry.video-link}"` on a custom tag gets the same substitution a first-class `href` prop gets. Attribute values are never markdown-rendered: an attribute is a value, not a body.
+
+Nothing else is descended into. `filters` on a loop, for example, is a free-form bag whose values are configuration rather than authored output.
+
+All three render surfaces — the publisher (`renderNode.ts`), the editor canvas (`NodeRenderer.tsx`), and `ReadOnlyNodeTree` — resolve through this one function, so a token behaves identically in all of them.
+
 ---
 
 ## Editor canvas preview

--- a/src/__tests__/templates/bindingSourcesAndTokens.test.ts
+++ b/src/__tests__/templates/bindingSourcesAndTokens.test.ts
@@ -383,3 +383,77 @@ describe('frame builders', () => {
     expect(route.path).toBe('/')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Tokens inside htmlAttributes
+// ---------------------------------------------------------------------------
+
+describe('resolveDynamicProps — tokens in htmlAttributes', () => {
+  const entry = { id: 'r1', fields: { 'video-link': 'https://cdn.example.com/hover.mp4', title: 'Peak' } }
+
+  it('interpolates a token written on an author-set attribute', () => {
+    // The case this exists for: a custom `<source>` tag whose `src` is bound
+    // per loop item. `href` on a link already worked because it is a
+    // first-class string prop; an attribute is one level down and was skipped,
+    // so the token shipped to the browser as literal text.
+    const props = resolveDynamicProps(
+      { tag: 'custom', customTag: 'source', htmlAttributes: { src: '{currentEntry.video-link}' } },
+      undefined,
+      ctx({ entryStack: [entry] }),
+    )
+    expect(props.htmlAttributes).toEqual({ src: 'https://cdn.example.com/hover.mp4' })
+  })
+
+  it('leaves attributes without tokens untouched, and does not copy needlessly', () => {
+    const staticProps = { htmlAttributes: { 'data-w-id': 'abc-123', loading: 'lazy' } }
+    const props = resolveDynamicProps(staticProps, undefined, ctx({ entryStack: [entry] }))
+    expect(props).toBe(staticProps)
+  })
+
+  it('interpolates only the attributes that carry tokens', () => {
+    const props = resolveDynamicProps(
+      { htmlAttributes: { src: '{currentEntry.video-link}', 'data-w-id': 'abc-123' } },
+      undefined,
+      ctx({ entryStack: [entry] }),
+    )
+    expect(props.htmlAttributes).toEqual({
+      src: 'https://cdn.example.com/hover.mp4',
+      'data-w-id': 'abc-123',
+    })
+  })
+
+  it('does not mutate the caller’s props object', () => {
+    const staticProps = { htmlAttributes: { src: '{currentEntry.video-link}' } }
+    resolveDynamicProps(staticProps, undefined, ctx({ entryStack: [entry] }))
+    expect(staticProps.htmlAttributes.src).toBe('{currentEntry.video-link}')
+  })
+
+  it('an unresolvable token becomes empty rather than shipping the literal', () => {
+    const props = resolveDynamicProps(
+      { htmlAttributes: { src: '{currentEntry.nope}' } },
+      undefined,
+      ctx({ entryStack: [entry] }),
+    )
+    expect(String((props.htmlAttributes as Record<string, string>).src)).not.toContain('{currentEntry')
+  })
+
+  it('never markdown-renders an attribute value', () => {
+    // `isRichtextPropKey` must not reach attribute values — an attribute is a
+    // value, not a body, and wrapping it in <p> would corrupt the URL.
+    const props = resolveDynamicProps(
+      { htmlAttributes: { html: '{currentEntry.title}' } },
+      undefined,
+      ctx({ entryStack: [entry] }),
+    )
+    expect((props.htmlAttributes as Record<string, string>).html).toBe('Peak')
+  })
+
+  it('ignores a malformed htmlAttributes bag instead of throwing', () => {
+    const props = resolveDynamicProps(
+      { htmlAttributes: { nested: { deep: 'x' } } as unknown as Record<string, string> },
+      undefined,
+      ctx({ entryStack: [entry] }),
+    )
+    expect(props.htmlAttributes).toEqual({ nested: { deep: 'x' } })
+  })
+})

--- a/src/core/templates/dynamicBindings.ts
+++ b/src/core/templates/dynamicBindings.ts
@@ -164,14 +164,38 @@ export function resolveDynamicProps(
   // tokens so the loop below does nothing).
   const target = resolved ?? staticProps
   let mutated = resolved !== null
-  for (const key of Object.keys(target)) {
-    const v = target[key]
-    if (typeof v !== 'string') continue
-    if (!containsTokens(v)) continue
+  const ensureCopy = () => {
     if (!mutated) {
       resolved = { ...staticProps }
       mutated = true
     }
+  }
+
+  for (const key of Object.keys(target)) {
+    const v = target[key]
+
+    // `htmlAttributes` is the one prop that holds strings a level down, and
+    // its values are authored the same way every other string prop is — an
+    // `href` written on a link interpolates, so a `src` written on a custom
+    // tag has to as well. Without this the token ships to the browser as
+    // literal text and the attribute silently points nowhere.
+    if (key === HTML_ATTRIBUTES_PROP_KEY) {
+      if (!isStringRecord(v)) continue
+      const withTokens = Object.entries(v).filter(([, av]) => containsTokens(av))
+      if (withTokens.length === 0) continue
+      ensureCopy()
+      const attrs = { ...v }
+      for (const [attrName, attrValue] of withTokens) {
+        // Never markdown-rendered: an attribute value is a value, not a body.
+        attrs[attrName] = interpolateTokens(attrValue, context)
+      }
+      resolved![key] = attrs
+      continue
+    }
+
+    if (typeof v !== 'string') continue
+    if (!containsTokens(v)) continue
+    ensureCopy()
     const interpolated = interpolateTokens(v, context)
     resolved![key] = isRichtextPropKey(key)
       ? renderMarkdownToHtml(interpolated)
@@ -179,4 +203,12 @@ export function resolveDynamicProps(
   }
 
   return resolved ?? staticProps
+}
+
+/** Prop holding author-set HTML attributes — see the loop in `resolveDynamicProps`. */
+const HTML_ATTRIBUTES_PROP_KEY = 'htmlAttributes'
+
+function isStringRecord(value: unknown): value is Record<string, string> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  return Object.values(value).every((entry) => typeof entry === 'string')
 }


### PR DESCRIPTION
## What

`resolveDynamicProps` now interpolates tokens inside `htmlAttributes`, not just in string-typed props.

## Why

The resolver's second pass reads:

```ts
for (const key of Object.keys(target)) {
  const v = target[key]
  if (typeof v !== 'string') continue   // htmlAttributes is an object → skipped
  …
}
```

`htmlAttributes` is a `Record<string, string>` — the one prop that holds authored strings a level down — so every token written on an attribute was skipped and shipped to the browser verbatim.

The asymmetry is invisible until you need it. `href` on a link is a first-class string prop and interpolates fine, so an author reasonably expects `src` written on a custom tag to behave the same way. It doesn't:

```html
<video>
  <source src="{currentEntry.video-link}">   <!-- published exactly like this -->
</video>
```

That is the shape a per-item hover video takes on a site imported from another builder, where the `<source>` is a custom tag inside a loop and its `src` is bound per row. The failure is completely silent: valid HTML, an attribute that resolves to nothing, no warning anywhere. It took reading the published bytes to find it.

## How

The loop now handles `htmlAttributes` as the string map it is, and leaves everything else exactly as before.

Two deliberate limits:

- **Attribute values are never markdown-rendered.** The richtext shim keys off the prop name, and an attribute happening to be called `html` must not be wrapped in `<p>` — an attribute is a value, not a body. There is a test for this.
- **Nothing else is descended into.** `filters` on a loop is also an object of strings, but it holds configuration rather than authored output; interpolating it would be surprising. Only the one prop that authors type into gets this.

The copy-on-write behaviour is preserved: a props bag with no tokens is returned by identity, so token-free pages allocate nothing extra (also covered by a test).

## User impact

Additive. Every token that resolved before resolves to the same value; tokens that previously leaked as literal text now resolve. All three render surfaces — publisher, editor canvas, `ReadOnlyNodeTree` — go through this one function, so they stay identical to each other.

## Verification

```sh
bun test src/__tests__/templates/ src/__tests__/publisher/ src/__tests__/loops/   # 524 pass
bun run build
bun run lint
```

Seven new tests in `src/__tests__/templates/bindingSourcesAndTokens.test.ts`. **Four of them fail on `main` and pass with this change** — I checked by stashing the source edit and re-running:

```
(fail) interpolates a token written on an author-set attribute
(fail) interpolates only the attributes that carry tokens
(fail) an unresolvable token becomes empty rather than shipping the literal
(fail) never markdown-renders an attribute value
```

The other three pin the behaviour that must not change: no needless copy, no mutation of the caller's object, and a malformed bag ignored rather than thrown on.

Also verified end-to-end on a real imported site: the `<source src>` inside a CMS loop now publishes the row's actual URL instead of the literal token.

*Note: the one `EBUSY` failure in `src/__tests__/loops/dataRowsFetch.test.ts` is a pre-existing Windows temp-file teardown issue in `createTestDb`, unrelated to this change.*
