### PR TITLE
docs(data): describe the built-in value lock that actually exists

### DIFF
--- a/docs/features/data-workspace.md
+++ b/docs/features/data-workspace.md
@@ -118,7 +118,7 @@ isLabelLocked(field, table)         // true for built-in postType fields and sys
 deleteTooltip(field, table)         // disabled-button tooltip text, or undefined
 ```
 
-Built-in field **values** (row cells) are additionally read-only on the *structural* system tables (pages/components/layouts) via `isBuiltInValueLocked` (`@core/data/systemTableGuard`); `posts` built-in values stay editable. The same predicate backs the server's row-write rejection (`lockedBuiltInCellKey`).
+Built-in field **values** (row cells) stay editable on existing records everywhere, including the *structural* system tables (pages/components/layouts). The one remaining value lock is at **create** time: `protectedBuiltInCreateCellKey` (`@core/data/systemTableGuard`) rejects a create that supplies built-in cells for a structural system table, so those rows are born through their own authoring surfaces rather than the generic row endpoint. `posts` is exempt (`kind === 'postType'`), and the server enforces this in `server/handlers/cms/data/tables.ts`.
 
 `FIELD_TYPE_LABELS` maps every `DataFieldType` to a human-readable string and
 is shared by `FieldRow` and `FieldSchemaComposer`.

--- a/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.test.tsx
+++ b/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.test.tsx
@@ -35,10 +35,10 @@ function button(): HTMLButtonElement {
 }
 
 describe('PageTreeCell', () => {
-  // A `pageTree` cell on a system table is ALWAYS readOnly — every built-in
-  // field of `pages` / `components` / `layouts` is value-locked. The button
-  // navigates to the visual editor rather than editing the cell, so gating it
-  // on readOnly disabled it on exactly the rows it exists for.
+  // A `pageTree` cell is never editable inline — the tree is authored in the
+  // visual editor, not typed into a cell. The button navigates to that editor
+  // rather than editing the cell, so gating it on readOnly disabled it on
+  // exactly the rows it exists for.
   it('stays enabled on a read-only cell when a handler is wired', async () => {
     let opened = 0
     renderCell({ readOnly: true, onOpenEditor: () => { opened += 1 } })

--- a/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.tsx
+++ b/src/admin/pages/data/components/DataGrid/cells/PageTreeCell.tsx
@@ -10,11 +10,11 @@
  * pattern that `RelationCell` uses for `onOpenPicker`.
  *
  * `readOnly` deliberately does NOT gate the button. It means "this value is
- * not editable in the grid", which is always true for a `pageTree` cell on a
- * system table (`isBuiltInValueLocked` holds for every built-in field of
- * `pages` / `components` / `layouts`). The button edits nothing — it navigates
- * to the visual editor, which enforces its own permissions. Gating it on
- * `readOnly` disabled it on exactly the rows it exists for.
+ * not editable inline in the grid", which a `pageTree` cell never is — the
+ * tree is authored in the visual editor, not typed into a cell. The button
+ * edits nothing, it navigates to that editor, which enforces its own
+ * permissions. Gating it on `readOnly` disabled it on exactly the rows it
+ * exists for.
  */
 import type { ReactElement } from 'react'
 import { Button } from '@ui/components/Button'


### PR DESCRIPTION
## What is stale

#303 removed `isBuiltInValueLocked` and `lockedBuiltInCellKey`. Both now have **zero** references anywhere in `src/`, `server/` or `docs/` apart from the three sites this PR fixes.

The problem is not only the dead names. `docs/features/data-workspace.md` currently states the opposite of what the code does:

> Built-in field **values** (row cells) are additionally read-only on the *structural* system tables (pages/components/layouts)

They are editable on existing records, which is what `systemTableGuard.ts`'s own header says:

> Built-in field values remain editable on existing records through both the Data workspace and their purpose-built authoring surfaces.

What actually survives is narrower and create-time only: `protectedBuiltInCreateCellKey` rejects a create that supplies built-in cells for a structural system table, so those rows are born through their own authoring surfaces rather than the generic row endpoint. `posts` is exempt via `kind === 'postType'`, and the server enforces it at `server/handlers/cms/data/tables.ts:313`. The docs paragraph now describes that.

## Two comments, same dead reference

`PageTreeCell.tsx` and `PageTreeCell.test.tsx` both justified the always-enabled "Open editor" button by claiming `isBuiltInValueLocked` holds for every built-in field of `pages` / `components` / `layouts`.

The behavior is correct and unchanged. Only the reasoning was wrong, and it was wrong in a way that mattered: `readOnly` on that cell does not come from a built-in value lock at all. It is a grid-level prop, and a `pageTree` cell is never editable inline because the tree is authored in the visual editor rather than typed into a cell. Both comments now say that instead.

## Scope

Docs plus two comments. No behavior change, so no new test. `bun run lint` is clean and the 11 tests across `PageTreeCell.test.tsx` and `systemTableGuard.test.ts` pass.

Happy to drop the comment edits and keep this to the doc line if you would rather review them separately.
