### PR TITLE
chore(release): prepare 0.0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## Unreleased
 
+## 0.0.15 - 2026-08-11
+
+### Collaboration, AI, and integrations
+
+- Added real-time collaborative editing with continuous CRDT persistence, per-document undo, reconnect recovery, generation-aware resets, transport health checks, and clear user feedback when an edit cannot reach the relay.
+- Adopted the stateless MCP protocol and hardened authoring so connector writes wait for a writable editor, preserve authored structure, and cannot report changes that were never persisted.
+- Made AI colour-palette installation atomic so complete token batches land together or fail visibly.
+
+### Editor and data
+
+- Added hover previews to Site explorer rows and a **Used** filter to the Selectors panel.
+- Let every floating editor panel clear docked sidebars, polished context menus and data-binding controls, and rebuilt shared tabs with consistent keyboard and ARIA behavior.
+- Protected mandatory post-type title and slug fields from destructive table updates and repaired those fields when an earlier update removed them.
+
+### Publishing and runtime
+
+- Surfaced runtime-script build diagnostics in the Code editor and publish flow so authored script failures identify the affected file and source location.
+- Made collaborative persistence and publishing deterministic across resets, imports, route rosters, selector styles, and site-document ordering.
+- Scoped entry-route runtime assets to the template that renders them and stopped author bindings from exposing internal user objects or account email addresses.
+- Prefetched resolved media metadata for bound images so published output includes accessibility text, responsive variants, and intrinsic dimensions.
+- Made published routes answer `HEAD` like `GET`, allowing uptime monitors and link checkers to recognize healthy pages.
+
+### Import reliability
+
+- Scaled large CSS catalogue imports and reported invalid, unresolved, empty, or unsortable loop definitions instead of silently publishing missing or incorrectly ordered content.
+
 ## 0.0.14 - 2026-07-25
 
 ### Security

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.13 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.15 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.13
+docker pull ghcr.io/corebunch/instatic:0.0.15
 ```
 
-The v0.0.13 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.15 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.13
+ghcr.io/corebunch/instatic:0.0.15
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.13` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.15` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.13
+Image=ghcr.io/corebunch/instatic:0.0.15
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.13
+ghcr.io/corebunch/instatic:0.0.15
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.13` |
+| Image | `ghcr.io/corebunch/instatic:0.0.15` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.13` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.15` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.14",
+  "version": "0.0.15",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },

--- a/src/__tests__/architecture/bundle-size-budgets.test.ts
+++ b/src/__tests__/architecture/bundle-size-budgets.test.ts
@@ -157,10 +157,10 @@ const BUDGETS: ChunkBudget[] = [
 
   {
     prefix: 'ContentPage-',
-    maxBytes: 90_000,
+    maxBytes: 100_000,
     rationale:
-      'content workspace route after Tiptap/LiveCanvas lazy split. Current ' +
-      '~81 KB raw / ~27 KB gzipped.',
+      'content workspace route after Tiptap/LiveCanvas lazy split and shared ' +
+      'data-binding picker adoption. Current ~91 KB raw / ~31 KB gzipped.',
   },
 
   {


### PR DESCRIPTION
## What changed

- bump the package version to 0.0.15
- add release notes for the 20 commits shipped since v0.0.14
- update the checked-in GHCR and Railway examples to the 0.0.15 image
- refresh the Content workspace bundle budget after the intentional shared data-binding picker growth

## Why

The current main branch contains the collaboration, MCP, editor, publishing, data-integrity, and import work intended for the next tagged release. The release workflow requires version, changelog, and pinned deployment surfaces to be aligned before creating the tag.

## Impact

After this PR merges, tagging the merge commit as v0.0.15 will trigger the release workflow to verify the source, publish the linux/amd64 GHCR image tags, create the GitHub Release, and upload the install bundle.

## Verification

- `bun run build`
- `bun test` — 6,583 passed, 0 failed
- `bun run lint`
- `bun test src/__tests__/architecture/bundle-size-budgets.test.ts`
- `bun run release:bundle -- 0.0.15`
- `git diff --check`
