### PR TITLE
fix(sanitize): allow trusted-host iframe embeds in post/page body content

### DIFF
--- a/src/__tests__/core/sanitize.test.ts
+++ b/src/__tests__/core/sanitize.test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, expect } from 'bun:test'
-import { sanitizeRichtext, isRichtextPropKey, PLAIN_TEXT_CONFIG } from '@core/sanitize'
+import { sanitizeRichtext, sanitizePostBody, isRichtextPropKey, PLAIN_TEXT_CONFIG } from '@core/sanitize'
 
 // ---------------------------------------------------------------------------
 // XSS prevention — the core contract
@@ -227,6 +227,96 @@ describe('sanitizeRichtext() in server runtime', () => {
       const stderr = new TextDecoder().decode(result.stderr)
       throw new Error(stderr)
     }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sanitizePostBody() — 2026-08-13 blog round-2 fix. Post/page body content
+// (base.outlet's markdown-rendered html) needs a wider allowlist than
+// sanitizeRichtext(), including iframe embeds scoped to a trusted-host
+// allowlist. See @core/sanitize POST_BODY_CONFIG.
+// ---------------------------------------------------------------------------
+
+describe('sanitizePostBody() — trusted-host iframe embeds', () => {
+  it('keeps an iframe embed from youtube.com', () => {
+    const result = sanitizePostBody(
+      '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315" allowfullscreen></iframe>',
+    )
+    expect(result).toContain('<iframe')
+    expect(result).toContain('youtube.com/embed/dQw4w9WgXcQ')
+  })
+
+  it('keeps an iframe embed from youtube-nocookie.com', () => {
+    const result = sanitizePostBody(
+      '<iframe src="https://www.youtube-nocookie.com/embed/dQw4w9WgXcQ"></iframe>',
+    )
+    expect(result).toContain('<iframe')
+    expect(result).toContain('youtube-nocookie.com/embed/dQw4w9WgXcQ')
+  })
+
+  it('keeps a bare (non-www) youtube.com host', () => {
+    const result = sanitizePostBody('<iframe src="https://youtube.com/embed/dQw4w9WgXcQ"></iframe>')
+    expect(result).toContain('<iframe')
+  })
+
+  it('strips an iframe embed from an untrusted host entirely (not just the src)', () => {
+    const result = sanitizePostBody('<iframe src="https://evil.com/phish"></iframe>')
+    expect(result).not.toContain('<iframe')
+    expect(result).not.toContain('evil.com')
+  })
+
+  it('strips an iframe with no src at all', () => {
+    const result = sanitizePostBody('<iframe></iframe>')
+    expect(result).not.toContain('<iframe')
+  })
+
+  it('strips a lookalike host that merely contains "youtube.com" (not a real subdomain)', () => {
+    // e.g. "youtube.com.evil.com" or "evilyoutube.com" must NOT pass a naive
+    // substring check — isTrustedIframeHost requires exact match or a
+    // genuine `.` + trusted-host suffix.
+    const lookalikes = [
+      'https://youtube.com.evil.com/embed/x',
+      'https://evilyoutube.com/embed/x',
+      'https://notyoutube.com/embed/x',
+    ]
+    for (const src of lookalikes) {
+      const result = sanitizePostBody(`<iframe src="${src}"></iframe>`)
+      expect(result).not.toContain('<iframe')
+    }
+  })
+
+  it('strips javascript: and data: iframe src', () => {
+    expect(sanitizePostBody('<iframe src="javascript:alert(1)"></iframe>')).not.toContain('<iframe')
+    expect(sanitizePostBody('<iframe src="data:text/html,<script>alert(1)</script>"></iframe>')).not.toContain('<iframe')
+  })
+
+  it('still strips <script> tags and event-handler attributes (iframe allowlisting is not a blanket HTML-open)', () => {
+    const result = sanitizePostBody('<p onclick="alert(1)">hi</p><script>alert(2)</script>')
+    expect(result).not.toContain('onclick')
+    expect(result).not.toContain('<script')
+    expect(result).not.toContain('alert')
+    expect(result).toContain('hi')
+  })
+
+  it('preserves images, tables, and video — the elements a real post body needs that plain richtext strips', () => {
+    const result = sanitizePostBody(
+      '<img src="https://example.com/a.png" alt="a"><table><tbody><tr><td>x</td></tr></tbody></table><video controls src="https://example.com/v.mp4"></video>',
+    )
+    expect(result).toContain('<img')
+    expect(result).toContain('<table')
+    expect(result).toContain('<video')
+  })
+
+  it('preserves the same safe formatting tags sanitizeRichtext does', () => {
+    const result = sanitizePostBody('<p><strong>Bold</strong> <em>italic</em> <a href="https://example.com">link</a></p>')
+    expect(result).toContain('<strong>Bold</strong>')
+    expect(result).toContain('<em>italic</em>')
+    expect(result).toContain('rel="noopener noreferrer"')
+  })
+
+  it('plain sanitizeRichtext() (used by every OTHER richtext field) still strips iframe — confirms the wider allowlist is scoped to post-body only', () => {
+    const result = sanitizeRichtext('<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ"></iframe>')
+    expect(result).not.toContain('<iframe')
   })
 })
 

--- a/src/__tests__/core/sanitize.test.ts
+++ b/src/__tests__/core/sanitize.test.ts
@@ -307,6 +307,41 @@ describe('sanitizePostBody() — trusted-host iframe embeds', () => {
     expect(result).toContain('<video')
   })
 
+  it('preserves a <video poster> with a <source> child — the form real editors/importers emit', () => {
+    // A bare `<video src=…>` is the exception, not the rule: most editors
+    // (Webflow among them) emit `<video controls poster=…><source src=…
+    // type=…></video>` and rely on <source> to carry the actual playable
+    // file. Before `source`/`poster`/`type` were allowlisted this published
+    // as an empty, unplayable `<video controls>`.
+    const result = sanitizePostBody(
+      '<video controls poster="https://example.com/thumb.avif"><source src="https://example.com/clip.mp4" type="video/mp4"></video>',
+    )
+    expect(result).toContain('<video')
+    expect(result).toContain('poster="https://example.com/thumb.avif"')
+    expect(result).toContain('<source')
+    expect(result).toContain('src="https://example.com/clip.mp4"')
+    expect(result).toContain('type="video/mp4"')
+  })
+
+  it('preserves playsinline, loop, muted, and preload on <video>', () => {
+    const result = sanitizePostBody(
+      '<video controls playsinline loop muted preload="auto" src="https://example.com/v.mp4"></video>',
+    )
+    expect(result).toContain('playsinline')
+    expect(result).toContain('loop')
+    expect(result).toContain('muted')
+    expect(result).toContain('preload="auto"')
+  })
+
+  it('preserves figure/figcaption — the wrapper rich-text editors put around images', () => {
+    const result = sanitizePostBody(
+      '<figure><img src="https://example.com/a.png" alt="a"><figcaption>A caption</figcaption></figure>',
+    )
+    expect(result).toContain('<figure')
+    expect(result).toContain('<figcaption')
+    expect(result).toContain('A caption')
+  })
+
   it('preserves the same safe formatting tags sanitizeRichtext does', () => {
     const result = sanitizePostBody('<p><strong>Bold</strong> <em>italic</em> <a href="https://example.com">link</a></p>')
     expect(result).toContain('<strong>Bold</strong>')

--- a/src/__tests__/publisher/outletEntryBody.test.ts
+++ b/src/__tests__/publisher/outletEntryBody.test.ts
@@ -17,11 +17,11 @@ const bodyModule = makeModule('base.body', {
   render: (_props, children) => ({ html: `<main>${children.join('')}</main>` }),
 })
 
-// Mirrors the real base.outlet render: a hidden richtext `html` prop (so
-// `escapeProps` sanitises rather than HTML-escapes it) emitted inside the
-// content-region marker.
+// Mirrors the real base.outlet render: a hidden richtextBody `html` prop (so
+// `escapeProps` sanitises via the wider POST_BODY_CONFIG rather than
+// HTML-escaping it) emitted inside the content-region marker.
 const outletModule = makeModule('base.outlet', {
-  schema: { html: { type: 'richtext', label: 'Content', hidden: true } },
+  schema: { html: { type: 'richtextBody', label: 'Content', hidden: true } },
   render: (props) => ({
     html: `<section data-instatic-content-region>${String((props as { html?: string }).html ?? '')}</section>`,
   }),
@@ -65,5 +65,52 @@ describe('entry outlet body binding', () => {
 
     expect(html).toContain('data-instatic-content-region')
     expect(html).not.toContain('Hello world')
+  })
+
+  // 2026-08-13 blog round-2 regression: a raw <iframe> YouTube embed pasted
+  // into a post's markdown body (the CMS has no @[video]-style syntax for
+  // iframe embeds — authors paste the platform's real embed HTML) was being
+  // silently stripped by the outlet's sanitizer end-to-end. This is the same
+  // path the real blog posts hit: markdown body -> renderMarkdownToHtml
+  // (passes raw HTML blocks through untouched) -> escapeProps ->
+  // sanitizePostBody (trusted-host allowlist, not a blanket strip).
+  it('renders a YouTube iframe embed pasted into the entry body, end-to-end', () => {
+    const page = makePage({
+      root: { moduleId: 'base.body', children: ['outlet'] },
+      outlet: { moduleId: 'base.outlet' },
+    })
+
+    const body = [
+      '## How to Run MCP Servers',
+      '',
+      '<iframe src="https://www.youtube.com/embed/dQw4w9WgXcQ" width="560" height="315" allowfullscreen></iframe>',
+      '',
+      'More text after the embed.',
+    ].join('\n')
+
+    const { html } = publishPage(page, makeSite(), registry, {
+      templateContext: { entryStack: [entry(body)] },
+    })
+
+    expect(html).toContain('<iframe')
+    expect(html).toContain('youtube.com/embed/dQw4w9WgXcQ')
+    expect(html).toContain('More text after the embed.')
+  })
+
+  it('strips an iframe embed from an untrusted host in the entry body, end-to-end', () => {
+    const page = makePage({
+      root: { moduleId: 'base.body', children: ['outlet'] },
+      outlet: { moduleId: 'base.outlet' },
+    })
+
+    const body = '<iframe src="https://evil.com/phish"></iframe>\n\nSafe text.'
+
+    const { html } = publishPage(page, makeSite(), registry, {
+      templateContext: { entryStack: [entry(body)] },
+    })
+
+    expect(html).not.toContain('<iframe')
+    expect(html).not.toContain('evil.com')
+    expect(html).toContain('Safe text.')
   })
 })

--- a/src/admin/shared/DataBindingPicker/bindingCompatibility.ts
+++ b/src/admin/shared/DataBindingPicker/bindingCompatibility.ts
@@ -44,6 +44,11 @@ export const BINDING_COMPATIBILITY: Record<PropertyControlKind, readonly DataFie
   text:     ['text', 'longText', 'richText', 'url', 'email', 'select', 'multiSelect', 'relation', 'number', 'boolean', 'date', 'dateTime'],
   textarea: ['text', 'longText', 'richText'],
   richtext: ['richText', 'longText', 'text'],
+  // richtextBody is the implicit body-content binding target on base.outlet —
+  // the publisher wires it programmatically (dynamicBindings.ts's
+  // OUTLET_BODY_BINDING), never through this picker, and the control is
+  // `hidden: true` so it never reaches the UI this map serves.
+  richtextBody: [],
   // svg holds raw inline-SVG markup — edited in the code editor, never wired
   // to a data field.
   svg:      [],

--- a/src/core/module-engine/propertySchema.ts
+++ b/src/core/module-engine/propertySchema.ts
@@ -163,6 +163,17 @@ export const PropertyControlSchema = Type.Recursive((Self) => Type.Union([
     { additionalProperties: false },
   ),
   Type.Object(
+    // Distinct from `richtext`: full post/page body content rendered from
+    // markdown (base.outlet's `html` binding target), which needs a wider
+    // safe-tag allowlist than short-form richtext fields — images, tables,
+    // and iframe embeds scoped to a trusted-host allowlist (see
+    // `POST_BODY_CONFIG` in `@core/sanitize`). Kept separate from `richtext`
+    // rather than widening that config globally, so every other richtext
+    // field in the CMS (CTA copy, etc.) stays on the narrower default.
+    { ...PropertyControlBaseSchema, type: Type.Literal('richtextBody') },
+    { additionalProperties: false },
+  ),
+  Type.Object(
     { ...PropertyControlBaseSchema, type: Type.Literal('svg') },
     { additionalProperties: false },
   ),
@@ -208,6 +219,7 @@ const CONTENT_CONTROL_TYPES: ReadonlySet<PropertyControl['type']> = new Set([
   'text',
   'textarea',
   'richtext',
+  'richtextBody',
   'svg',
   'url',
   'image',

--- a/src/core/publisher/escapeProps.ts
+++ b/src/core/publisher/escapeProps.ts
@@ -37,7 +37,7 @@
 
 import type { PropertyControl, PropertySchema } from '@core/module-engine'
 import { escapeHtml, isSafeUrl } from './utils'
-import { sanitizeRichtext, sanitizeSvg } from '@core/sanitize'
+import { sanitizeRichtext, sanitizeSvg, sanitizePostBody } from '@core/sanitize'
 
 /**
  * Resolve the control declared for `key`. Top-level keys are a direct lookup;
@@ -95,6 +95,14 @@ export function escapeProps(
       // sanitizeRichtext falls back to conservative tag stripping only in
       // runtimes that have not installed DOMPurify (for example one-off scripts).
       escaped[key] = sanitizeRichtext(value)
+    } else if (type === 'richtextBody') {
+      // Post/page body content (base.outlet's markdown-rendered `html`):
+      // wider allowlist than plain `richtext` (images, tables, iframe embeds
+      // scoped to a trusted-host allowlist) — see POST_BODY_CONFIG in
+      // @core/sanitize. Kept as its own control type rather than widening
+      // RICHTEXT_CONFIG globally, so short-form richtext fields elsewhere in
+      // the CMS stay on the narrower default.
+      escaped[key] = sanitizePostBody(value)
     } else if (type === 'url' || type === 'image' || type === 'media') {
       // URLs: block javascript: and vbscript: schemes; pass safe URLs through raw
       // so that module render() functions can HTML-escape them via safeUrl() from

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -31,12 +31,22 @@ import DOMPurify, { type Config } from 'dompurify'
 
 type DOMPurifyHookNode = {
   tagName?: string
+  getAttribute?: (name: string) => string | null
   setAttribute?: (name: string, value: string) => void
+  remove?: () => void
 }
+
+type DOMPurifySanitizeElementData = { tagName: string; allowedTags: Record<string, boolean> }
 
 export type DOMPurifyRuntime = {
   sanitize?: (value: string, config?: Config) => unknown
-  addHook?: (hookName: 'afterSanitizeAttributes', callback: (node: DOMPurifyHookNode) => void) => void
+  addHook?: {
+    (hookName: 'afterSanitizeAttributes', callback: (node: DOMPurifyHookNode) => void): void
+    (
+      hookName: 'uponSanitizeElement',
+      callback: (node: DOMPurifyHookNode, data: DOMPurifySanitizeElementData) => void,
+    ): void
+  }
 }
 
 type DOMPurifyFactory = DOMPurifyRuntime & ((window: Window) => DOMPurifyRuntime)
@@ -141,6 +151,100 @@ const RICHTEXT_CONFIG: Config = {
   // Return a string, not a DOM node
   RETURN_DOM: false,
   RETURN_DOM_FRAGMENT: false,
+}
+
+/**
+ * Hosts a `<iframe>` in post-body content is allowed to embed. Checked
+ * against the `src` attribute's hostname (case-insensitive, exact match or
+ * subdomain of one of these) by the DOMPurify hook installed below —
+ * everything else has its iframe stripped, script tags and all other
+ * dangerous elements are already excluded by ALLOWED_TAGS regardless of
+ * this list.
+ */
+const TRUSTED_IFRAME_HOSTS = [
+  'youtube.com',
+  'youtube-nocookie.com',
+] as const
+
+function isTrustedIframeHost(hostname: string): boolean {
+  const host = hostname.toLowerCase()
+  return TRUSTED_IFRAME_HOSTS.some((trusted) => host === trusted || host.endsWith(`.${trusted}`))
+}
+
+/**
+ * Post-body config — used for full post/page body content rendered from
+ * markdown (base.outlet's `html` binding, `richtextBody` control type).
+ * Wider than `RICHTEXT_CONFIG`: adds the block-level elements a markdown
+ * body actually produces (images, GFM tables, headings' remaining levels,
+ * horizontal rules, the CMS `@[video](url)` embed) PLUS `iframe`, scoped to
+ * `TRUSTED_IFRAME_HOSTS` via the `uponSanitizeElement` hook below — an
+ * iframe whose `src` host isn't on the allowlist (or is missing/unparsable)
+ * is removed entirely, not just stripped of the offending attribute, since
+ * a same-tag-different-src replacement is exactly what an attacker would
+ * try first.
+ */
+const POST_BODY_CONFIG: Config = {
+  ALLOWED_TAGS: [
+    'p', 'br', 'hr',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+    'strong', 'b', 'em', 'i', 'u', 's', 'del', 'ins',
+    'a', 'ul', 'ol', 'li',
+    'blockquote', 'code', 'pre',
+    'span', 'div',
+    'img', 'video',
+    'table', 'thead', 'tbody', 'tr', 'th', 'td',
+    'iframe',
+  ],
+  ALLOWED_ATTR: [
+    'href', 'target', 'rel', 'class', 'id',
+    'src', 'alt', 'title', 'loading', 'controls',
+    'width', 'height', 'frameborder', 'allow', 'allowfullscreen', 'referrerpolicy',
+  ],
+  ADD_ATTR: ['target'],
+  ALLOW_DATA_ATTR: false,
+  NAMESPACE: 'http://www.w3.org/1999/xhtml',
+  RETURN_DOM: false,
+  RETURN_DOM_FRAGMENT: false,
+}
+
+const postBodyPurifiersWithIframeHook = new WeakSet<object>()
+
+function installIframeHostHook(purifier: DOMPurifyRuntime): DOMPurifyRuntime {
+  if (postBodyPurifiersWithIframeHook.has(purifier) || typeof purifier.addHook !== 'function') {
+    return purifier
+  }
+  purifier.addHook('uponSanitizeElement', (node, data) => {
+    if (data.tagName !== 'iframe') return
+    const src = node.getAttribute?.('src') ?? ''
+    let hostname: string
+    try {
+      hostname = new URL(src, 'http://invalid.example').hostname
+    } catch {
+      hostname = ''
+    }
+    if (!src || !isTrustedIframeHost(hostname)) {
+      node.remove?.()
+    }
+  })
+  postBodyPurifiersWithIframeHook.add(purifier)
+  return purifier
+}
+
+/**
+ * Sanitize full post/page body HTML (already markdown-rendered) — the
+ * `richtextBody` control type's escapeProps() path. See `POST_BODY_CONFIG`.
+ */
+export function sanitizePostBody(value: unknown): string {
+  const str = String(value ?? '')
+  if (!str.trim()) return ''
+
+  const purifier = getDOMPurify()
+  if (!purifier || typeof purifier.sanitize !== 'function') {
+    return stripHtmlFallback(str)
+  }
+
+  installIframeHostHook(purifier)
+  return String(purifier.sanitize(str, POST_BODY_CONFIG))
 }
 
 /**

--- a/src/core/sanitize.ts
+++ b/src/core/sanitize.ts
@@ -182,6 +182,15 @@ function isTrustedIframeHost(hostname: string): boolean {
  * is removed entirely, not just stripped of the offending attribute, since
  * a same-tag-different-src replacement is exactly what an attacker would
  * try first.
+ *
+ * `source`, `figure`, and `figcaption` are included because that's the
+ * markup real rich-text editors and importers (Webflow, etc.) actually
+ * emit — a `<video>` wraps its playable file in `<source src=… type=…>`
+ * rather than using `<video src=…>` directly, and images get wrapped in
+ * `<figure>`/`<figcaption>` for captions. Without `source` the tag was
+ * previously dropped, so a `<video controls poster="…"><source src="…"
+ * type="video/mp4"></video>` published as a bare, unplayable `<video
+ * controls>`.
  */
 const POST_BODY_CONFIG: Config = {
   ALLOWED_TAGS: [
@@ -191,7 +200,7 @@ const POST_BODY_CONFIG: Config = {
     'a', 'ul', 'ol', 'li',
     'blockquote', 'code', 'pre',
     'span', 'div',
-    'img', 'video',
+    'img', 'video', 'source', 'figure', 'figcaption',
     'table', 'thead', 'tbody', 'tr', 'th', 'td',
     'iframe',
   ],
@@ -199,6 +208,7 @@ const POST_BODY_CONFIG: Config = {
     'href', 'target', 'rel', 'class', 'id',
     'src', 'alt', 'title', 'loading', 'controls',
     'width', 'height', 'frameborder', 'allow', 'allowfullscreen', 'referrerpolicy',
+    'poster', 'type', 'playsinline', 'loop', 'muted', 'preload',
   ],
   ADD_ATTR: ['target'],
   ALLOW_DATA_ATTR: false,

--- a/src/modules/base/outlet/index.ts
+++ b/src/modules/base/outlet/index.ts
@@ -42,12 +42,14 @@ export const OutletModule: ModuleDefinition<OutletStoredProps> = {
     /**
      * Binding target only — the publisher fills this with the current entry's
      * richtext body (`{currentEntry.body}`) or a bound VC param. Declared as a
-     * hidden richtext control so the publisher's `escapeProps` sanitises it via
-     * DOMPurify (rather than HTML-escaping it, which would entity-encode the
-     * rendered body). `hidden: true` keeps it out of the Properties panel — it
+     * hidden `richtextBody` control (not the narrower `richtext`) so the
+     * publisher's `escapeProps` sanitises it via the wider POST_BODY_CONFIG —
+     * images, tables, and iframe embeds scoped to a trusted-host allowlist,
+     * all of which a real markdown post body needs and plain `richtext`
+     * fields don't. `hidden: true` keeps it out of the Properties panel — it
      * is never hand-edited.
      */
-    html: { type: 'richtext', label: 'Content', hidden: true },
+    html: { type: 'richtextBody', label: 'Content', hidden: true },
   },
 
   propsSchema: OutletPropsSchema,


### PR DESCRIPTION
## Summary

`base.outlet`'s `html` prop (the markdown-rendered post/page body) is typed `richtext`, so `escapeProps()` sanitizes it through `RICHTEXT_CONFIG` — an allowlist built for short marketing copy with no `img`/`video`/`table`/`iframe`. `marked` passes raw HTML blocks through untouched during markdown parsing, so a pasted YouTube `<iframe>` (or any other embed) survives parsing and then gets silently stripped at the later sanitize step — with no error or warning surfaced to the author.

Confirmed there's no existing zero-code path around this: the Tiptap post-body editor has no video/embed insertion feature ("Add Media" opens the media-library file picker, not a URL-embed), and `base.video` (the module that could otherwise host a YouTube embed) is page-builder-canvas-only — it has no bridge into markdown post-body fields.

## Change

- New `richtextBody` control type, distinct from `richtext`, used only by `base.outlet`.
- New `POST_BODY_CONFIG` DOMPurify config: allows `img`/`video`/`source`/`figure`/`figcaption`/`table`/`iframe`, with `iframe` scoped to a trusted-host allowlist (`youtube.com`, `youtube-nocookie.com`, subdomain-aware) via an `uponSanitizeElement` hook.
- Lookalike-host tests included (`youtube.com.evil.com`, `evilyoutube.com` both correctly rejected) to guard the allowlist logic itself.
- Every other `richtext`-typed field (short-copy fields elsewhere in the module system) is unaffected — this only changes the config used by `base.outlet`'s body prop.

**Update (per [review](https://github.com/CoreBunch/Instatic/pull/369#issuecomment-5337871827)):** the initial allowlist let `video` through but not `source`, so the common editor/importer output — `<video controls poster="…"><source src="…" type="video/mp4"></video>` — published as a bare, unplayable `<video controls>`. Added `source` to `ALLOWED_TAGS` and `poster`/`type`/`playsinline`/`loop`/`muted`/`preload` to `ALLOWED_ATTR`, plus `figure`/`figcaption` since that's what rich-text editors wrap images in.

That review also flagged a pre-existing DOMPurify/happy-dom quirk worth documenting here for anyone bisecting old behavior: under the narrower `RICHTEXT_CONFIG` (no `img` in `ALLOWED_TAGS`), DOMPurify's element traversal on happy-dom skips the node immediately after each removal — so exactly *one* `<img>` per document was silently dropped and the rest survived. That's why the old symptom read as an isolated rendering glitch (one missing picture per post) rather than "images are stripped from bodies entirely." This PR's wider `POST_BODY_CONFIG` allowlists `img` outright, so the traversal quirk no longer has anything to trigger it on `base.outlet` bodies — no separate fix needed, just calling it out so the history makes sense.

## Test plan

- [x] Full suite green (6613+ tests passing at the time of the latest push, no regressions — one flaky, unrelated `ExportDialog` fetch-mock test observed and reproduced as flaky on rerun)
- [x] `tsc` clean
- [x] `eslint` clean
- [x] Manually verified against a real broken post in a live deployment: iframe embed survives the write path (confirmed via API), was stripped at render time before this fix, renders correctly after.
- [x] New unit tests cover `<video poster>` + `<source type>`, `playsinline`/`loop`/`muted`/`preload`, and `<figure>`/`<figcaption>` preservation.

Happy to adjust the trusted-host list or expose it as a config option if that's preferred upstream — went with a hardcoded YouTube-only allowlist since that's the immediate need, but a configurable allowlist would be a small follow-up if there's appetite for embeds from other providers.
