### PR TITLE
fix(templates): expose custom data tokens globally

### DIFF
--- a/docs/features/modules.md
+++ b/docs/features/modules.md
@@ -444,7 +444,7 @@ Modules don't need to know — they just receive resolved props.
 
 ### Bind a prop to dynamic data
 
-`PageNode.dynamicBindings` lets a prop be filled from `currentEntry` / `parentEntry` / `page` / `site` / `route` at render time:
+`PageNode.dynamicBindings` lets a prop be filled from `currentEntry` / `parentEntry` / `page` / `site` / `route` / `data` at render time. The `data` source addresses a custom-data value as `<rowId>.<fieldId>` and is available outside loops and templates:
 
 ```jsonc
 {
@@ -452,6 +452,16 @@ Modules don't need to know — they just receive resolved props.
   "props": { "text": "Default heading", "level": 2 },
   "dynamicBindings": {
     "text": { "source": "currentEntry", "field": "title" }
+  }
+}
+```
+
+```jsonc
+{
+  "moduleId": "base.text",
+  "props": { "text": "Star us on GitHub" },
+  "dynamicBindings": {
+    "text": { "source": "data", "field": "<rowId>.<fieldId>" }
   }
 }
 ```

--- a/docs/features/templates.md
+++ b/docs/features/templates.md
@@ -200,6 +200,7 @@ interface TemplateRenderDataContext {
   page?:        PageFrame       // page id, slug, title, templateTableSlug
   site?:        SiteFrame       // site name, settings, breakpoints
   route?:       RouteFrame      // URL path, slug, segments, and query params
+  data?:        DataFrame       // custom-data rows keyed by row id, then field id
   entryStack:   LoopItem[]      // pushed by loops + entry route render
 }
 ```
@@ -217,6 +218,7 @@ See the "Dynamic bindings" section below for the full source table.
 | `site`         | `ctx.site`                | Anywhere — site name, primary color                     |
 | `route`        | `ctx.route`               | URL-driven (`route.segments`, `route.slug`, `route.query.*`) |
 | `page`         | `ctx.page`                | Current page metadata                                   |
+| `data`         | `ctx.data[rowId]`         | Custom data values available on every page              |
 
 ---
 
@@ -226,6 +228,7 @@ Text props mix literal text + tokens:
 
 ```text
 "Hello {currentEntry.title} — read more at {site.name}"
+"Star us on GitHub — {data.<rowId>.<fieldId>}"
 ```
 
 `parseTokenString(input)` returns `TokenSegmentNode[]`; `interpolateTokens(input, ctx)` evaluates and concatenates. Tokens that resolve to `undefined` render as the empty string.
@@ -280,7 +283,9 @@ Neither mode has a Confirm step — a single click is the action.
 
 **Auto-scope:** when the active page is a `postTypes` template, the picker auto-scopes to the first targeted table. Field rows appear directly under a `"<TableName> fields"` group header with a chip labelled `"Current row — <TableName>"`. No source-selection step is shown.
 
-**Unscoped state:** when the node is outside a loop or template context, table fields are not offered. A footer hint reads: *"Wrap in a Loop or open a postType template to bind to row fields."*
+**Global custom data:** every non-system table whose `kind` is `data` contributes one picker group per row. Each group is labelled `"<TableName> — <PrimaryFieldValue>"`; choosing a field inserts `{data.<rowId>.<fieldId>}`. `useTemplatePreviewContext` fetches only the custom rows referenced anywhere in the site document, and the publisher does the same before rendering. Plain data rows are non-versioned, so Site publish snapshots their current `cells_json` values into the generated artefacts.
+
+**Unscoped state:** when the node is outside a loop or template context, custom data rows remain available, but post-type row fields are not offered. A footer hint reads: *"Wrap in a Loop or open a postType template to bind to row fields."*
 
 Loop nodes supply `availableFields` / `sourceLabel` props to show loop-specific synthetic fields in a `"<SourceLabel> fields"` group in the same single-pane layout.
 

--- a/server/handlers/cms/hole.ts
+++ b/server/handlers/cms/hole.ts
@@ -47,6 +47,7 @@ import { getPublishedNodeIndexForVersion } from '../../publish/publishedSnapshot
 import { getPublishVersion } from '../../publish/publishState'
 import { HOLE_RUNTIME_JS } from '../../publish/holeRuntime'
 import { stampFormPageTokens } from '../../forms/formRuntime'
+import { prefetchGlobalDataBindings } from '../../publish/dataBindingPrefetch'
 
 const HOLE_RUNTIME_PATH = '/_instatic/hole-runtime.js'
 const HOLE_PATH_PREFIX = '/_instatic/hole/'
@@ -125,6 +126,7 @@ async function renderHoleFragment(
   request: SourceRequestContext,
 ): Promise<string> {
   const route = buildRouteFrame(pageUrl.toString())
+  const data = await prefetchGlobalDataBindings([page], db)
   const loopData = await prefetchLoopData(page, site, db, pageUrl, {
     request,
     rootNodeId: nodeId,
@@ -140,6 +142,7 @@ async function renderHoleFragment(
       page: buildPageFrame(page),
       site: buildSiteFrame(site),
       route,
+      data,
     },
     // No dynamicNodeIds: inside a hole endpoint we render the full subtree.
   }

--- a/server/handlers/cms/loop.ts
+++ b/server/handlers/cms/loop.ts
@@ -34,6 +34,7 @@ import { readLoopProps } from '../../publish/loopPrefetch'
 import { getPublishedLoopIndexForVersion } from '../../publish/publishedSnapshotCache'
 import { getPublishVersion } from '../../publish/publishState'
 import { LOOP_RUNTIME_JS } from '../../publish/loopRuntime'
+import { prefetchGlobalDataBindings } from '../../publish/dataBindingPrefetch'
 
 const LOOP_RUNTIME_PATH = '/_instatic/assets/loop-runtime.js'
 
@@ -130,12 +131,13 @@ export async function handleLoopRequest(
   if (variants.length === 0) {
     return jsonResponse({ html: '', hasMore, pageNumber })
   }
+  const data = await prefetchGlobalDataBindings([containingPage], ctx.db)
   const baseConfig: RenderConfig = {
     page: containingPage,
     site,
     registry,
     breakpointId: undefined,
-    templateContext: { entryStack: [] },
+    templateContext: { entryStack: [], data },
     loopData: new Map<string, ResolvedLoopRenderData>([
       [loopId, { items: result.items, totalItems: result.totalItems, pageNumber, hasMore }],
     ]),

--- a/server/publish/dataBindingPrefetch.ts
+++ b/server/publish/dataBindingPrefetch.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@core/page-tree'
+import { collectDataBindingRowIds } from '@core/templates'
+import type { DbClient } from '../db/client'
+import { getGlobalDataBindingRows } from '../repositories/data'
+
+export async function prefetchGlobalDataBindings(
+  pages: readonly Page[],
+  db: DbClient,
+): Promise<Record<string, Record<string, unknown>>> {
+  const rowIds = collectDataBindingRowIds(pages)
+  if (rowIds.length === 0) return {}
+  const rows = await getGlobalDataBindingRows(db, rowIds)
+  return Object.fromEntries(rows.map((row) => [row.rowId, row.cells]))
+}

--- a/server/publish/publicRenderer.ts
+++ b/server/publish/publicRenderer.ts
@@ -5,7 +5,11 @@ import { publishPage } from '@core/publisher'
 import { buildRouteFrame } from '@core/templates/contextFrames'
 import { buildPublishedSiteCssBundle } from './siteCssBundle'
 import { buildPublishedSiteModuleJsMap } from './moduleJsBundle'
-import { resolveTemplateChain, resolveNotFoundTemplate, composeTemplateChain } from '@core/templates'
+import {
+  composeTemplateChain,
+  resolveNotFoundTemplate,
+  resolveTemplateChain,
+} from '@core/templates'
 import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { prefetchLoopData, publishedDataRowToLoopItem } from './loopPrefetch'
 import { prefetchMediaAssets } from './mediaPrefetch'
@@ -15,6 +19,7 @@ import type { SiteCssBundle } from '@core/publisher'
 import type { PublishedDataRow } from '@core/data/schemas'
 import type { DbClient } from '../db/client'
 import type { PublishedPageSnapshot } from '../repositories/publish'
+import { prefetchGlobalDataBindings } from './dataBindingPrefetch'
 
 /**
  * URL prefix where the Bun server exposes the per-site CSS bundle. Mirrors
@@ -92,15 +97,22 @@ async function renderMergedTemplate(
   ctx: RenderPublishedSnapshotContext,
 ): Promise<{ html: string; jsModuleIds: string[]; publishVersion: number; cssBundle: SiteCssBundle }> {
   const publishVersion = ctx.publishVersion ?? getPublishVersion()
+  const data = await prefetchGlobalDataBindings([merged], ctx.db)
+  const resolvedTemplateContext = Object.keys(data).length > 0
+    ? {
+        ...(templateContext ?? { entryStack: [] }),
+        data,
+      }
+    : templateContext
   const moduleJsMap = buildPublishedSiteModuleJsMap(snapshot.site, registry)
   const loopData = await prefetchLoopData(merged, snapshot.site, ctx.db, ctx.url)
   const mediaAssets = await prefetchMediaAssets(merged, snapshot.site, registry, ctx.db, {
-    templateContext,
+    templateContext: resolvedTemplateContext,
     loopData,
   })
   const cssBundle = buildPublishedSiteCssBundle(snapshot.site, registry, merged, publishVersion, { mediaAssets })
   const published = publishPage(merged, snapshot.site, registry, {
-    templateContext,
+    templateContext: resolvedTemplateContext,
     runtimeAssets: snapshot.runtimeAssets,
     runtimePackageImportmap: snapshot.runtimePackageImportmap,
     cssEmission: 'external',

--- a/server/repositories/data/index.ts
+++ b/server/repositories/data/index.ts
@@ -62,6 +62,7 @@ export type { ApplyDataRowChangesInput, DataRowWrite } from './rows'
 
 export {
   getPublishedDataRowByRoute,
+  getGlobalDataBindingRows,
   getDataRowRedirectByRoute,
 } from './publish'
 

--- a/server/repositories/data/publish.ts
+++ b/server/repositories/data/publish.ts
@@ -102,6 +102,11 @@ export interface RowTableRouteInfo {
   tableSlug: string
 }
 
+export interface GlobalDataBindingRow {
+  rowId: string
+  cells: Record<string, unknown>
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -329,6 +334,31 @@ export async function listPublishedRowRoutes(db: DbClient): Promise<PublishedRow
     tableSlug: row.table_slug,
     tableRouteBase: normalizeRouteBase(row.table_route_base),
   }))
+}
+
+/**
+ * Read the live cells for exact rows referenced by global page bindings.
+ * Plain custom data tables are deliberately non-versioned; publishing a site
+ * snapshots their current values into the generated page artefacts.
+ */
+export async function getGlobalDataBindingRows(
+  db: DbClient,
+  rowIds: readonly string[],
+): Promise<GlobalDataBindingRow[]> {
+  if (rowIds.length === 0) return []
+  const ids = rowIds.map((_, index) => placeholder(db.dialect, index + 1)).join(', ')
+  const { rows } = await db.unsafe<{ row_id: string; cells_json: Record<string, unknown> }>(
+    `select data_rows.id as row_id, data_rows.cells_json
+     from data_rows
+     join data_tables on data_tables.id = data_rows.table_id
+     where data_rows.id in (${ids})
+       and data_tables.kind = 'data'
+       and data_tables.system = false
+       and data_rows.deleted_at is null
+       and data_tables.deleted_at is null`,
+    [...rowIds],
+  )
+  return rows.map((row) => ({ rowId: row.row_id, cells: row.cells_json }))
 }
 
 /**

--- a/src/__tests__/data/buildDataMeta.test.ts
+++ b/src/__tests__/data/buildDataMeta.test.ts
@@ -91,6 +91,7 @@ describe('buildDataMeta', () => {
       primaryFieldId: 'title',
       routable: true,    // routeBase: '/posts' → non-empty
       versioned: true,   // kind: 'postType'
+      system: false,
     })
   })
 

--- a/src/__tests__/data/contentAdmin.test.tsx
+++ b/src/__tests__/data/contentAdmin.test.tsx
@@ -372,6 +372,7 @@ beforeEach(() => {
             primaryFieldId: 'title',
             routable: true,
             versioned: true,
+            system: true,
             fields: [
               { id: 'title', label: 'Title', type: 'text' },
               { id: 'body', label: 'Body', type: 'richText' },
@@ -727,6 +728,7 @@ describe('ContentPage', () => {
               primaryFieldId: 'title',
               routable: true,
               versioned: true,
+              system: true,
               fields: [
                 { id: 'title', label: 'Title', type: 'text' },
                 {

--- a/src/__tests__/property-controls/dynamicBindingControl.test.tsx
+++ b/src/__tests__/property-controls/dynamicBindingControl.test.tsx
@@ -31,6 +31,7 @@ const postsTable = {
   primaryFieldId: 'title',
   routable: true,
   versioned: true,
+  system: true,
   fields: [
     { id: 'title', label: 'Title', type: 'text' },
     { id: 'authorName', label: 'Author name', type: 'text' },

--- a/src/__tests__/property-controls/dynamicBindingPicker.test.tsx
+++ b/src/__tests__/property-controls/dynamicBindingPicker.test.tsx
@@ -34,6 +34,7 @@ const postsTable = {
   primaryFieldId: 'title',
   routable: true,
   versioned: true,
+  system: true,
   fields: [
     { id: 'title', label: 'Title', type: 'text' },
     { id: 'slug', label: 'Slug', type: 'text' },
@@ -53,6 +54,7 @@ const productsTable = {
   primaryFieldId: 'name',
   routable: false,
   versioned: false,
+  system: false,
   fields: [
     { id: 'name', label: 'Name', type: 'text' },
     { id: 'price', label: 'Price', type: 'number' },
@@ -62,6 +64,28 @@ const productsTable = {
 
 const mockDataMeta = {
   meta: { tables: [postsTable, productsTable] },
+}
+
+const productRow = {
+  id: 'product-row-1',
+  tableId: 'products-id',
+  cells: { name: 'Featured product', price: 42, thumbnail: null },
+  slug: '',
+  status: 'published',
+  seq: 1,
+  authorUserId: null,
+  createdByUserId: null,
+  updatedByUserId: null,
+  publishedByUserId: null,
+  author: null,
+  createdBy: null,
+  updatedBy: null,
+  publishedBy: null,
+  createdAt: '2026-08-14T00:00:00.000Z',
+  updatedAt: '2026-08-14T00:00:00.000Z',
+  publishedAt: '2026-08-14T00:00:00.000Z',
+  scheduledPublishAt: null,
+  deletedAt: null,
 }
 
 // ---------------------------------------------------------------------------
@@ -91,6 +115,9 @@ beforeEach(() => {
   globalThis.fetch = (async (input: RequestInfo | URL) => {
     if (String(input).includes('/data/_meta')) {
       return new Response(JSON.stringify(mockDataMeta), { status: 200 })
+    }
+    if (String(input).includes('/data/tables/products-id/rows')) {
+      return new Response(JSON.stringify({ rows: [productRow] }), { status: 200 })
     }
     return new Response(JSON.stringify({ error: 'not found' }), { status: 404 })
   }) as typeof fetch
@@ -168,24 +195,21 @@ describe('DynamicBindingControl picker', () => {
     })
   })
 
-  it('hides post-type and data-table fields when unscoped and shows a workflow hint', async () => {
-    // Unscoped opening (no template, no loop) — tables in the system exist
-    // (`posts`, `products`) but they're NOT offered as direct bindings.
-    // `currentEntry.*` has no scope outside a loop or template, so any
-    // binding to them would silently resolve to empty. The picker
-    // surfaces a hint pointing the author at the loop / template flow.
+  it('offers custom data rows globally while keeping post-type fields scoped', async () => {
     renderBinding()
     fireEvent.click(screen.getByRole('button', { name: /bind text/i }))
     await waitFor(() => {
       expect(screen.getByRole('menu', { name: /bind text/i })).toBeDefined()
     })
-    // Single-pane layout: no group headers for the unreachable tables.
+    // Post-type fields still need a currentEntry scope.
     expect(screen.queryByText(/Posts fields/i)).toBeNull()
-    expect(screen.queryByText(/Products fields/i)).toBeNull()
-    expect(screen.queryByRole('button', { name: /^Posts$/i })).toBeNull()
-    expect(screen.queryByRole('button', { name: /^Products$/i })).toBeNull()
-    // The subtle footer hint should be visible so authors know how to
-    // make table fields available.
+    // Plain custom data rows are stable global sources on any page.
+    await waitFor(() => {
+      expect(screen.getByText('Products — Featured product')).toBeDefined()
+    })
+    expect(screen.getByText('Name')).toBeDefined()
+    expect(screen.getByText('Price')).toBeDefined()
+    // The footer still explains how to reach the scoped Posts fields.
     await waitFor(() => {
       expect(screen.getByText(/Wrap in a Loop or open a postType template/i)).toBeDefined()
     })

--- a/src/__tests__/server/dataCms.test.ts
+++ b/src/__tests__/server/dataCms.test.ts
@@ -9,6 +9,7 @@ import {
   listDataAuthorOptions,
   updateDataRowAuthor,
   saveDataRowDraft,
+  getGlobalDataBindingRows,
   getPublishedDataRowByRoute,
   getDataRowRedirectByRoute,
 } from '../../../server/repositories/data'
@@ -56,6 +57,27 @@ describe('data CMS migrations', () => {
 })
 
 describe('data CMS repository', () => {
+  it('reads live custom-data cells for global bindings without requiring a published version', async () => {
+    const db = makeDataFakeDb([
+      (sql, params) => {
+        if (!sql.startsWith('select data_rows.id as row_id')) return undefined
+        expect(sql).toContain("data_tables.kind = 'data'")
+        expect(sql).toContain('data_tables.system = false')
+        expect(sql).not.toContain('active_version_id')
+        expect(sql).not.toContain('data_row_versions')
+        expect(params).toEqual(['global-config-row'])
+        return {
+          rows: [{ row_id: 'global-config-row', cells_json: { stars: '7,000' } }],
+          rowCount: 1,
+        }
+      },
+    ])
+
+    await expect(getGlobalDataBindingRows(db, ['global-config-row'])).resolves.toEqual([
+      { rowId: 'global-config-row', cells: { stars: '7,000' } },
+    ])
+  })
+
   it('lists data tables with frontend field names', async () => {
     const db = makeDataFakeDb([
       (sql) => {

--- a/src/__tests__/server/dataMetaRoute.test.ts
+++ b/src/__tests__/server/dataMetaRoute.test.ts
@@ -158,6 +158,7 @@ describe('GET /admin/api/cms/data/_meta', () => {
       pluralLabel: 'Posts',
       routable: true,
       versioned: true,
+      system: false,
     })
   })
 

--- a/src/__tests__/server/publicRendering.test.ts
+++ b/src/__tests__/server/publicRendering.test.ts
@@ -59,6 +59,7 @@ function snapshot(text: string): PublishedPageSnapshot {
 function makeFakeDb(
   activeSnapshot: PublishedPageSnapshot | null,
   runtimeAssets: Record<string, unknown>[] = [],
+  dataBindingRows: Array<{ row_id: string; cells_json: Record<string, unknown> }> = [],
 ): DbClient {
   const handle = async <Row extends Record<string, unknown> = Record<string, unknown>>(
     strings: TemplateStringsArray,
@@ -102,6 +103,14 @@ function makeFakeDb(
   handle.transaction = async <T>(cb: (tx: DbClient) => Promise<T>): Promise<T> =>
     cb(handle as unknown as DbClient)
 
+  Object.assign(handle, {
+    dialect: 'sqlite',
+    unsafe: async <Row extends Record<string, unknown>>(_sql: string, params: unknown[] = []) => {
+      const matches = dataBindingRows.filter((row) => params.includes(row.row_id))
+      return { rows: matches as unknown as Row[], rowCount: matches.length }
+    },
+  })
+
   return handle as DbClient
 }
 
@@ -120,6 +129,18 @@ describe('public rendering', () => {
     expect(html).toContain('<!DOCTYPE html>')
     expect(html).toContain('Visible to public')
     expect(html).toContain('<title>Public Site</title>')
+  })
+
+  it('renders custom data tokens on ordinary pages', async () => {
+    const snap = snapshot('Star us on GitHub — {data.row-stars.value}')
+    const { html } = await renderPublishedSnapshot(snap, {
+      db: makeFakeDb(snap, [], [
+        { row_id: 'row-stars', cells_json: { name: 'stars', value: '7,000' } },
+      ]),
+    })
+
+    expect(html).toContain('Star us on GitHub — 7,000')
+    expect(html).not.toContain('{data.row-stars.value}')
   })
 
   // Guards the page-wrapper's identity reporting after the shared

--- a/src/__tests__/templates/bindingSourcesAndTokens.test.ts
+++ b/src/__tests__/templates/bindingSourcesAndTokens.test.ts
@@ -28,6 +28,7 @@ import {
   buildRouteFrame,
 } from '@core/templates/contextFrames'
 import type { Page, SiteDocument } from '@core/page-tree'
+import { collectDataBindingRowIds } from '@core/templates'
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -81,6 +82,15 @@ describe('resolveDynamicProps — system sources', () => {
       ctx(),
     )
     expect(props.text).toBe('/about')
+  })
+
+  it('resolves a globally-addressed custom data row field', () => {
+    const props = resolveDynamicProps(
+      { text: 'Static' },
+      { text: { source: 'data', field: 'row-stars.value' } },
+      ctx({ data: { 'row-stars': { name: 'stars', value: '7,000' } } }),
+    )
+    expect(props.text).toBe('7,000')
   })
 
   it('resolves route.query tokens against the route frame', () => {
@@ -259,6 +269,14 @@ describe('interpolateTokens', () => {
     expect(out).toBe('Acme — About Us')
   })
 
+  it('interpolates a custom data token on an ordinary page', () => {
+    const out = interpolateTokens(
+      'Star us on GitHub — {data.row-stars.value}',
+      ctx({ data: { 'row-stars': { value: '7,000' } } }),
+    )
+    expect(out).toBe('Star us on GitHub — 7,000')
+  })
+
   it('omits unknown values silently (empty substitution)', () => {
     const out = interpolateTokens('Before [{site.missing}] After', ctx())
     expect(out).toBe('Before [] After')
@@ -302,6 +320,23 @@ describe('interpolateTokens', () => {
   it('emits empty when the value is missing and there is no fallback', () => {
     const c = ctx({ entryStack: [] })
     expect(interpolateTokens('Welcome, {currentEntry.title}!', c)).toBe('Welcome, !')
+  })
+})
+
+describe('collectDataBindingRowIds', () => {
+  it('deduplicates row ids referenced by tokens and structured bindings', () => {
+    const page = {
+      nodes: {
+        text: {
+          props: { text: '{data.row-stars.value} / {data.row-stars.name}' },
+          dynamicBindings: {
+            alt: { source: 'data', field: 'row-logo.image', format: 'media' },
+          },
+        },
+      },
+    } as unknown as Page
+
+    expect(collectDataBindingRowIds([page])).toEqual(['row-logo', 'row-stars'])
   })
 })
 

--- a/src/admin/pages/site/hooks/useTemplatePreviewContext.ts
+++ b/src/admin/pages/site/hooks/useTemplatePreviewContext.ts
@@ -2,9 +2,9 @@ import { useAsyncResource } from '@admin/lib/useAsyncResource'
 import type { Page } from '@core/page-tree'
 import type { TemplateRenderDataContext } from '@core/templates/dynamicBindings'
 import { dataTablePreviewToLoopItem } from '@core/templates/templatePreviewData'
-import { getCmsDataTableBySlug, previewCmsDataLoopItems } from '@core/persistence/cmsData'
+import { getCmsDataRow, getCmsDataTableBySlug, previewCmsDataLoopItems } from '@core/persistence/cmsData'
 import { buildPageFrame, buildRouteFrame, buildSiteFrame } from '@core/templates/contextFrames'
-import { primaryTemplateTableSlug } from '@core/templates'
+import { collectDataBindingRowIds, primaryTemplateTableSlug } from '@core/templates'
 import { useEditorStore } from '@site/store/store'
 
 /**
@@ -71,13 +71,28 @@ export function useTemplatePreviewContext(page: Page | null): TemplatePreviewCon
     [tableSlug],
   )
 
+  const dataRowIds = site ? collectDataBindingRowIds(site.pages) : []
+  const dataRowKey = dataRowIds.join('\u0000')
+  const { data: dataRowsState, loading: dataRowsLoading } = useAsyncResource<{
+    key: string
+    rows: NonNullable<Awaited<ReturnType<typeof getCmsDataRow>>>[]
+  }>(
+    async () => {
+      const rows = await Promise.all(dataRowIds.map((rowId) => getCmsDataRow(rowId)))
+      return { key: dataRowKey, rows: rows.filter((row) => row !== null) }
+    },
+    [dataRowKey],
+  )
+
   // ── Compose the full context ─────────────────────────────────────────
   // The template entry stack is only valid for the currently-loaded
   // tableSlug; outside that, the stack stays empty so bindings against
   // currentEntry stay empty until the loop interceptor pushes a real
   // iteration on top.
   const previewEntryLoading = Boolean(tableSlug) && loading
-  if (!page || !site) return { context: undefined, loading: previewEntryLoading }
+  if (!page || !site) {
+    return { context: undefined, loading: previewEntryLoading || dataRowsLoading }
+  }
   let entryStack: TemplateRenderDataContext['entryStack'] = []
   if (tableSlug && previewState?.tableSlug === tableSlug) {
     // Selected row → first published row → synthetic sample (empty table).
@@ -88,10 +103,14 @@ export function useTemplatePreviewContext(page: Page | null): TemplatePreviewCon
     entryStack = chosen ? [chosen] : []
   }
   const pageFrame = buildPageFrame(page)
+  const data = dataRowsState?.key === dataRowKey
+    ? Object.fromEntries(dataRowsState.rows.map((row) => [row.id, row.cells]))
+    : {}
   return {
-    loading: previewEntryLoading,
+    loading: previewEntryLoading || dataRowsLoading,
     context: {
       entryStack,
+      data,
       page: pageFrame,
       site: buildSiteFrame(site),
       // Route frame mirrors what the published page will see. Editor

--- a/src/admin/shared/DataBindingPicker/DataBindingPicker.tsx
+++ b/src/admin/shared/DataBindingPicker/DataBindingPicker.tsx
@@ -25,7 +25,7 @@ import { useEffect, useState, type RefObject } from 'react'
 import type { PropertyControl } from '@core/module-engine'
 import type { DynamicPropBinding } from '@core/page-tree'
 import type { LoopItem, LoopSourceField } from '@core/loops/types'
-import type { DataMeta, DataMetaField, DataMetaTable } from '@core/data/schemas'
+import type { DataMeta, DataMetaField, DataMetaTable, DataRow } from '@core/data/schemas'
 import { Button } from '@ui/components/Button'
 import { ContextMenu } from '@ui/components/ContextMenu'
 import { EmptyState } from '@ui/components/EmptyState'
@@ -47,6 +47,7 @@ import {
   type FieldEntry,
   type FieldGroup,
 } from './helpers'
+import { useGlobalDataRows } from './useGlobalDataRows'
 import styles from './DataBindingPicker.module.css'
 import { getErrorMessage } from '@core/utils/errorMessage'
 
@@ -186,6 +187,8 @@ export function DataBindingPicker({
     }
   }, [])
 
+  const globalRowsByTable = useGlobalDataRows(meta)
+
   // Table id is the strongest scope signal. Site templates can instead
   // provide a slug; Content supplies its selected collection id.
   const scopedTable: DataMetaTable | null = (() => {
@@ -275,7 +278,9 @@ export function DataBindingPicker({
 
   function entryMatchesControl(entry: FieldEntry): boolean {
     if (fieldSelectionMode === 'token') return true
-    if (entry.kind === 'meta') return isFieldBindable(controlKind, entry.field)
+    if (entry.kind === 'meta' || entry.kind === 'data') {
+      return isFieldBindable(controlKind, entry.field)
+    }
     return loopFieldMatchesControl(entry.field, controlKind)
   }
 
@@ -319,7 +324,25 @@ export function DataBindingPicker({
       })
     }
 
-    // 3. System sources — Page / Site / Route. Always visible (and always
+    // 3. Custom data rows — globally addressable by immutable row id, so
+    // ordinary pages can reuse singleton/config values without a loop.
+    if (!scopedTable && !hasLoopOnlyScope && meta) {
+      for (const table of meta.tables) {
+        if (table.kind !== 'data' || table.system) continue
+        for (const row of globalRowsByTable[table.id] ?? []) {
+          const rowLabel = formatPreviewValue(row.cells[table.primaryFieldId]) || 'Untitled row'
+          const entries: FieldEntry[] = table.fields.map((field) => ({
+            kind: 'data' as const,
+            table,
+            row,
+            field,
+          }))
+          result.push({ label: `${table.name} — ${rowLabel}`, entries })
+        }
+      }
+    }
+
+    // 4. System sources — Page / Site / Route. Always visible (and always
     // reachable) since the publisher seeds these frames on every render.
     for (const source of SYSTEM_SOURCES) {
       const entries: FieldEntry[] = source.fields.map((f) => ({
@@ -358,6 +381,15 @@ export function DataBindingPicker({
     })
   }
 
+  function pickDataField(row: DataRow, field: DataMetaField) {
+    const format = deriveFormat(controlKind, field.type)
+    onPick({
+      source: 'data',
+      field: `${row.id}.${field.id}`,
+      ...(format !== undefined ? { format } : {}),
+    })
+  }
+
   function pickLoopField(field: LoopSourceField) {
     const format = loopFieldFormat(field.format)
     onPick({
@@ -383,6 +415,7 @@ export function DataBindingPicker({
       if (!frame) return undefined
       return (frame as Record<string, unknown>)[entry.field.id]
     }
+    if (entry.kind === 'data') return entry.row.cells[entry.field.id]
     return currentEntryFields?.[entry.field.id]
   }
 
@@ -394,7 +427,7 @@ export function DataBindingPicker({
 
   // ─── Render: single field row ──────────────────────────────────────────
   function renderFieldRow(entry: FieldEntry): React.ReactNode {
-    if (entry.kind === 'meta') {
+    if (entry.kind === 'meta' || entry.kind === 'data') {
       const { field } = entry
       const FieldIcon = getFieldIcon(field.type)
       const bindable =
@@ -407,7 +440,7 @@ export function DataBindingPicker({
 
       return (
         <Button
-          key={field.id}
+          key={entry.kind === 'data' ? `${entry.row.id}.${field.id}` : field.id}
           variant="ghost"
           size="md"
           fullWidth
@@ -415,7 +448,9 @@ export function DataBindingPicker({
           disabled={!bindable}
           tooltip={tooltip}
           onClick={() => {
-            if (bindable) pickMetaField(field)
+            if (!bindable) return
+            if (entry.kind === 'data') pickDataField(entry.row, field)
+            else pickMetaField(field)
           }}
           type="button"
         >

--- a/src/admin/shared/DataBindingPicker/helpers.ts
+++ b/src/admin/shared/DataBindingPicker/helpers.ts
@@ -5,7 +5,7 @@
  * for the sibling `.tsx` component files.
  */
 
-import type { DataMeta, DataMetaField } from '@core/data/schemas'
+import type { DataMeta, DataMetaField, DataMetaTable, DataRow } from '@core/data/schemas'
 import type { DynamicPropBinding } from '@core/page-tree'
 import type { LoopSourceField } from '@core/loops/types'
 import { SYSTEM_SOURCES, type SystemSourceId } from './systemSources'
@@ -17,6 +17,7 @@ import type { PropertyControlKind } from './bindingCompatibility'
 
 export type FieldEntry =
   | { kind: 'meta'; field: DataMetaField }
+  | { kind: 'data'; table: DataMetaTable; row: DataRow; field: DataMetaField }
   | { kind: 'loop'; field: LoopSourceField }
   | { kind: 'system'; source: SystemSourceId; field: LoopSourceField }
 

--- a/src/admin/shared/DataBindingPicker/useGlobalDataRows.ts
+++ b/src/admin/shared/DataBindingPicker/useGlobalDataRows.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+import type { DataMeta, DataRow } from '@core/data/schemas'
+import { listCmsDataRows } from '@core/persistence/cmsData'
+
+export function useGlobalDataRows(
+  meta: DataMeta | null,
+): Readonly<Record<string, readonly DataRow[]>> {
+  const [rowsByTable, setRowsByTable] = useState<
+    Readonly<Record<string, readonly DataRow[]>>
+  >({})
+
+  useEffect(() => {
+    if (!meta) return
+    const tables = meta.tables.filter((table) => table.kind === 'data' && !table.system)
+    let cancelled = false
+    Promise.all(
+      tables.map(async (table) => [table.id, await listCmsDataRows(table.id)] as const),
+    )
+      .then((entries) => {
+        if (!cancelled) setRowsByTable(Object.fromEntries(entries))
+      })
+      .catch((err) => {
+        console.error('[DataBindingPicker] failed to load custom data rows:', err)
+        if (!cancelled) setRowsByTable({})
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [meta])
+
+  return rowsByTable
+}

--- a/src/core/data/fields.ts
+++ b/src/core/data/fields.ts
@@ -171,6 +171,7 @@ export function buildDataMeta(tables: DataTable[]): DataMeta {
       primaryFieldId: table.primaryFieldId,
       routable: (table.routeBase ?? '').length > 0,
       versioned: table.kind === 'postType',
+      system: table.system,
       fields: buildMetaFields(table.fields, tableSlugById),
     })),
   }

--- a/src/core/data/schemas.ts
+++ b/src/core/data/schemas.ts
@@ -657,6 +657,7 @@ const DataMetaTableSchema = Type.Object({
   primaryFieldId: Type.String(),
   routable: Type.Boolean(),
   versioned: Type.Boolean(),
+  system: Type.Boolean(),
   fields: Type.Array(DataMetaFieldSchema),
 })
 

--- a/src/core/page-tree/dynamicBinding.ts
+++ b/src/core/page-tree/dynamicBinding.ts
@@ -12,6 +12,8 @@
  *   Always present on every render — no loop or template needed.
  * - `site` — site-level fields (name, baseUrl, settings.*). Always present.
  * - `route` — URL frame (path, slug, segments). Always present.
+ * - `data` — a specific custom-data row, addressed by immutable
+ *   row id and field id (`<rowId>.<fieldId>`). Available on every page.
  *
  * Format tag controls how the resolved value is rendered (plain text, raw
  * HTML, URL, media path). Fallback strategy controls behaviour when the
@@ -36,6 +38,7 @@ const DynamicBindingSourceSchema = Type.Union([
   Type.Literal('page'),
   Type.Literal('site'),
   Type.Literal('route'),
+  Type.Literal('data'),
 ])
 type DynamicBindingSource = Static<typeof DynamicBindingSourceSchema>
 
@@ -72,6 +75,7 @@ function parseDynamicPropBinding(raw: unknown): DynamicPropBinding | null {
     'page',
     'site',
     'route',
+    'data',
   ]
   if (!VALID_SOURCES.includes(r.source as DynamicBindingSource)) return null
   if (typeof r.field !== 'string' || r.field.length === 0) return null

--- a/src/core/publisher/render.ts
+++ b/src/core/publisher/render.ts
@@ -249,6 +249,7 @@ function composeTemplateContext(
     page: pageFrame,
     site: provided.site ?? buildSiteFrame(site),
     route: provided.route ?? buildRouteFrame(pageFrame.permalink),
+    data: provided.data,
   }
 }
 

--- a/src/core/templates/dataBindings.ts
+++ b/src/core/templates/dataBindings.ts
@@ -1,0 +1,50 @@
+/**
+ * Discover custom-data rows referenced by a page tree.
+ *
+ * Data bindings persist immutable row ids in paths shaped
+ * `<rowId>.<fieldId>`. Keeping discovery in the template engine gives the
+ * editor and publisher one definition of which rows must be prefetched.
+ */
+
+import type { Page } from '@core/page-tree'
+import { parseTokenString } from './tokenInterpolation'
+
+export function dataBindingRowId(fieldPath: string): string | null {
+  const separator = fieldPath.indexOf('.')
+  if (separator <= 0 || separator === fieldPath.length - 1) return null
+  return fieldPath.slice(0, separator)
+}
+
+function collectTokenRows(value: unknown, rowIds: Set<string>): void {
+  if (typeof value === 'string') {
+    for (const segment of parseTokenString(value)) {
+      if (segment.kind !== 'token' || segment.source !== 'data') continue
+      const rowId = dataBindingRowId(segment.field)
+      if (rowId) rowIds.add(rowId)
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const entry of value) collectTokenRows(entry, rowIds)
+    return
+  }
+  if (!value || typeof value !== 'object') return
+  for (const entry of Object.values(value as Record<string, unknown>)) {
+    collectTokenRows(entry, rowIds)
+  }
+}
+
+export function collectDataBindingRowIds(pages: readonly Page[]): string[] {
+  const rowIds = new Set<string>()
+  for (const page of pages) {
+    for (const node of Object.values(page.nodes)) {
+      for (const binding of Object.values(node.dynamicBindings ?? {})) {
+        if (binding.source !== 'data') continue
+        const rowId = dataBindingRowId(binding.field)
+        if (rowId) rowIds.add(rowId)
+      }
+      collectTokenRows(node.props, rowIds)
+    }
+  }
+  return [...rowIds].sort()
+}

--- a/src/core/templates/dynamicBindings.ts
+++ b/src/core/templates/dynamicBindings.ts
@@ -44,7 +44,7 @@ import {
  * Dispatch by source:
  *   - `currentEntry` / `parentEntry` — read from the entry stack
  *     (top / second-from-top).
- *   - `page` / `site` / `route` — read from the corresponding
+ *   - `page` / `site` / `route` / `data` — read from the corresponding
  *     named frame on the context.
  *
  * Returns `undefined` for fields that don't exist on the resolved frame

--- a/src/core/templates/index.ts
+++ b/src/core/templates/index.ts
@@ -19,3 +19,4 @@ export {
 } from './templateMatching'
 export { composeTemplateChain } from './templateCompose'
 export { firstOutletId, treeHasOutlet, subtreeHasOutlet } from './outlet'
+export { collectDataBindingRowIds, dataBindingRowId } from './dataBindings'

--- a/src/core/templates/renderDataContext.ts
+++ b/src/core/templates/renderDataContext.ts
@@ -22,4 +22,6 @@ export interface TemplateRenderDataContext {
   readonly page?: PageFrame
   readonly site?: SiteFrame
   readonly route?: RouteFrame
+  /** Published custom-data rows keyed by immutable row id. */
+  readonly data?: Readonly<Record<string, Readonly<Record<string, unknown>>>>
 }

--- a/src/core/templates/tokenInterpolation.ts
+++ b/src/core/templates/tokenInterpolation.ts
@@ -40,6 +40,7 @@ const VALID_SOURCES: ReadonlySet<DynamicPropBinding['source']> = new Set([
   'page',
   'site',
   'route',
+  'data',
 ])
 
 function isValidSource(s: string): s is DynamicPropBinding['source'] {
@@ -210,6 +211,8 @@ export function readFrame(
       return (context.site as unknown as Record<string, unknown>) ?? null
     case 'route':
       return (context.route as unknown as Record<string, unknown>) ?? null
+    case 'data':
+      return (context.data as unknown as Record<string, unknown>) ?? null
     default:
       return null
   }


### PR DESCRIPTION
## What changed

- expose rows from non-system custom data tables in the binding picker on ordinary pages
- persist bindings as `{data.<rowId>.<fieldId>}` and resolve them in canvas previews, static publishes, holes, and infinite-loop fragments
- prefetch only referenced custom rows and snapshot their current live cells during Site publish
- document the binding source and add picker, token-engine, repository, and public-rendering regressions

## Why

Custom data tables are the natural home for shared values such as a GitHub star count, but their rows were not available outside loop or post-type template scopes. Plain custom-data rows are also deliberately non-versioned, so the publisher must read their live cells rather than look for an active published row version.

## User impact

Authors can insert a custom-data value into any compatible property and reuse it across ordinary pages. The canvas and published site resolve the same value; a later data change is included by the next Site publish.

## Verification

- `bun test` (6,621 pass)
- `bun run build`
- `bun run lint`
- `bunx tsc -b --pretty false`
- disposable local browser E2E: create table/row, insert token on homepage, verify all canvas frames, publish, verify anonymous homepage
