### PR TITLE
docs(loops): document the server-rendered loop page query parameter

### DIFF
--- a/docs/features/loops.md
+++ b/docs/features/loops.md
@@ -459,7 +459,35 @@ To enable infinite loading:
 3. The publisher auto-injects `<script type="module" src="/_instatic/assets/loop-runtime.js">` when at least one infinite loop exists on the page (see `server/publish/loopRuntime.ts`). The runtime is < 2 KB and ships only when needed.
 
 For static multi-page navigation (no JS required):
+- Set `pagination: 'infinite'` and link the pages with the query parameter below — the server renders each page. See "Deep-link to a loop page".
 - Use separate `base.loop` nodes with an `offset` filter — one per "page" — and static links between pages.
+
+### Deep-link to a loop page
+
+An infinite-mode loop also renders any page of its own results server-side, driven by a query parameter. `loopPageQueryKey` (`server/publish/loopPrefetch.ts:177`) builds the name as `loop_<loopNodeId>_page`, so every loop on a page paginates independently:
+
+```text
+/blog?loop_Oz1G1FKV5FyxdlFDNKeZP_page=2
+```
+
+`readPageNumber` (`server/publish/loopPrefetch.ts:204`) reads it 1-based. A missing, empty, non-numeric, or sub-1 value falls back to page 1 — there is no error and no 400. The slice is `props.offset + (pageNumber - 1) * props.pageSize` (`loopPrefetch.ts:229-236`).
+
+`publicRouter.ts:224-240` routes any request whose canonical query is non-empty past the Layer A disk artefact and into a live Layer B render, so the response is fully server-rendered and the result set differs with JavaScript disabled. `canonicalRenderQuery` (`loopPrefetch.ts:194`) keeps only `loop_<nodeId>_page` params, sorted, and discards the rest — `?utm_source=x` still collapses to `''` and hits the baked artefact.
+
+Four constraints bound what this can express:
+
+| Constraint | Behaviour |
+|---|---|
+| `pagination` must be `'infinite'` | `loopPrefetch.ts:229` consults the URL only in that mode. Under `'none'` the parameter is ignored silently and the loop always renders page 1. |
+| Contextual sources are excluded | `entry.field` never resolves a page number (`loopPrefetch.ts:292-299`, `src/core/publisher/renderLoop.ts:155-159`). |
+| Out-of-range pages render nothing | Zero items makes `renderLoop` return the empty string (`src/core/publisher/renderLoop.ts:78-80`) — no wrapper element, no attributes, no fallback text at the loop's position. |
+| No total is exposed | The wrapper carries `data-instatic-loop-page` and `data-instatic-loop-has-more` (`renderLoop.ts:111-116`), and `/_instatic/loop/<loopId>` returns `{ html, hasMore, pageNumber }` (`server/handlers/cms/loop.ts:131`, `:169`). Neither carries an item or page count, so "Page 3 of 12" is not derivable. |
+
+Link the pages with ordinary anchors, and bound the upper page number from the authored data rather than probing for it:
+
+```html
+<a href="?loop_Oz1G1FKV5FyxdlFDNKeZP_page=2">Next</a>
+```
 
 ---
 
@@ -474,6 +502,7 @@ For static multi-page navigation (no JS required):
 | Rendering a loop without prefetched data                             | `RenderConfig.loopData` must be populated — otherwise the loop renders a marker comment. |
 | Cycling variants by index `% items.length` instead of `% variants.length` | Round-robin is by variants. Read `node.children.length`. |
 | Source ids without a namespace (just `products`)                     | Namespace by plugin (`acme.products`) — collisions otherwise |
+| `?loop_<nodeId>_page=N` on a `pagination: 'none'` loop               | Silently ignored — the loop always renders page 1. Set `pagination: 'infinite'`. |
 
 ---
 
@@ -493,7 +522,10 @@ For static multi-page navigation (no JS required):
   - `src/core/publisher/renderLoop.ts` — render walker
   - `server/publish/loopPrefetch.ts` — pre-fetch
   - `server/publish/loopRuntime.ts`, `server/handlers/cms/loop.ts` — runtime asset + live-fetch endpoint
+  - `server/publish/publicRouter.ts` — routes `loop_<nodeId>_page` requests past the static artefact
 - Gate tests:
   - `src/__tests__/architecture/loop-source-id-format.test.ts`
   - `src/__tests__/architecture/loop-source-sql-safety.test.ts`
   - `src/__tests__/loops/sitePagesLoopItemParity.test.ts` — canvas preview ↔ publisher parity for `site.pages`
+  - `src/__tests__/publisher/canonicalRenderQuery.test.ts` — which query params survive canonicalisation
+  - `src/__tests__/architecture/static-artefact-served-before-render.test.ts` — Layer A fast-path eligibility


### PR DESCRIPTION
## Summary

An infinite-mode loop already server-renders any page of its own results from `?loop_<loopNodeId>_page=N`. `loopPageQueryKey` builds the name (`server/publish/loopPrefetch.ts:177`), `readPageNumber` reads it (`:204`), and `publicRouter.ts:224-240` deliberately routes any request carrying it past the Layer A disk artefact into a live Layer B render.

The parameter is not undocumented — but it is documented only as a *cache-invalidation input*, in `docs/architecture.md:240`, `docs/server.md:487`, `docs/features/publisher.md:19,384,474` and `docs/reference/architecture-tests.md:202`. All six describe how it affects the fast path, none mention that it renders a different page.

`docs/features/loops.md` — the doc a page author actually reads, and the one that describes the pagination modes — never mentions it. Its "Pagination" section instead recommends a manual workaround for precisely the case the parameter already covers:

> For static multi-page navigation (no JS required):
> - Use separate `base.loop` nodes with an `offset` filter — one per "page" — and static links between pages.

This adds a `### Deep-link to a loop page` subsection next to that one, and points the existing bullet at it.

## What it documents

The mechanism, plus the four constraints that bound it — deliberately, so the section cannot be read as promising a numbered paginator:

| Constraint | Source |
|---|---|
| honoured only when `pagination: 'infinite'`, silently ignored otherwise | `loopPrefetch.ts:229` |
| never applies to contextual sources (`entry.field`) | `loopPrefetch.ts:292-299`, `renderLoop.ts:155-159` |
| a page past the end renders the empty string — no wrapper, no attributes | `renderLoop.ts:78-80` |
| no item or page total is exposed anywhere, so "Page 3 of 12" is not derivable | `renderLoop.ts:111-116`, `server/handlers/cms/loop.ts:131,169` |

`src/modules/base/loop/index.ts:17-23` says numeric pagination will live in a future `base.pagination` module, so per `docs/CONVENTIONS.md` rule 8 nothing here describes that as existing.

Also in the same change, since they belong to the same section:

- a "Forbidden patterns" row for the silent-ignore case (rule 6);
- `canonicalRenderQuery.test.ts` and `static-artefact-served-before-render.test.ts` added to the "Gate tests" list, and `publicRouter.ts` to the source-of-truth list (rule 4).

## Verification

Docs-only — no code changed, so no new test. Claims were checked against the source at `6b055cf7` and against the existing suites:

```
$ bun test src/__tests__/publisher/canonicalRenderQuery.test.ts \
           src/__tests__/publisher/loopRender.test.ts \
           src/__tests__/architecture/static-artefact-served-before-render.test.ts
 20 pass
 0 fail
Ran 20 tests across 3 files. [187.00ms]
```

and the canonicalisation claim directly:

```
"?utm_source=x&gclid=y"          -> ""
"?loop_ABC_page=2"               -> "?loop_ABC_page=2"
"?utm_source=x&loop_ABC_page=2"  -> "?loop_ABC_page=2"
"?loop_B_page=3&loop_A_page=2"   -> "?loop_A_page=2&loop_B_page=3"
```

File is 531 lines, within the ~600 cap. No nav registration needed — `docs/README.md` indexes files, not subsections.

## Note

#350 also touches `docs/features/loops.md`, but adds a subsection around line 265; this one lands in the Cookbook at 460+. They should not conflict.

Happy to cut the "Forbidden patterns" row or the gate-test lines if you would rather keep this to the new subsection alone.
