### PR TITLE
docs(server): record the rule that publish diagnostics established

### DIFF
--- a/docs/server.md
+++ b/docs/server.md
@@ -624,6 +624,7 @@ Three static handlers, in order:
 - **Domain errors** are typed `Error` subclasses with a `path` (or similar) field — e.g. `SiteValidationError`, `VisualComponentNameError`. Add a typed class when callers need to distinguish causes.
 - **Generic `throw new Error(...)`** is fine for "this should never happen" invariants.
 - **Never echo raw error messages to the client.** The top-level catch in `server/index.ts` returns a generic 500. Handlers return `{ error: <safe message> }`.
+- **When a failure is the author's to fix, catch it before the generic 500.** That catch is deliberately silent, so a failure a person could act on has to be intercepted first. `RuntimeScriptBuildError` (`server/publish/runtime/buildError.ts`) is the worked example: a script importing an undeclared package used to surface as a bare "Internal server error" while the package name and file sat in the server log. It carries the structured `SiteRuntimeDiagnostic[]`, formats them with `path:line:column`, and the publish handler answers `422` with that message. Everything else still falls through to the 500.
 - **`catch (err)` → client error string:** use `getErrorMessage(err, 'fallback message')` from `src/core/utils/errorMessage.ts`. The hand-rolled `err instanceof Error ? err.message : 'fallback'` pattern is forbidden because it surfaces a blank string for `new Error('')` — `getErrorMessage` falls back when the message is empty or whitespace-only.
 
 See [docs/reference/typebox-patterns.md](reference/typebox-patterns.md) for boundary validation patterns.


### PR DESCRIPTION
`RuntimeScriptBuildError` and its 422 landed in e9e99dff, but `docs/server.md`'s error-handling section still describes only the two shapes that predate it: typed domain errors with a `path`, and the generic `Error` for invariants that fall through to a 500.

Someone following that section today would reach for a plain `throw` and watch their message disappear into the catch-all — which is the bug that fix repaired. This adds the third rule, with the diagnostics work as its worked example, so the next person finds it where they'd look.

Docs only. No code changes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>