### PR TITLE
test(harness): reset every app store before each test

### DIFF
--- a/src/__tests__/canvas/canvasFormControls.test.tsx
+++ b/src/__tests__/canvas/canvasFormControls.test.tsx
@@ -11,28 +11,28 @@ function renderCanvas() {
   return render(<DndContext><CanvasRoot /></DndContext>)
 }
 
+// No hand-written store partial here: the preload resets every app store
+// before each test. This file used to seed one, and the field it forgot to
+// mention (`canvasView`) is exactly what broke it. See
+// `src/__tests__/fixtures/storeIsolation.ts`.
 beforeEach(() => {
   cleanup()
-  useEditorStore.setState({
-    site: null,
-    _historyPast: [],
-    _historyFuture: [],
-    canUndo: false,
-    canRedo: false,
-    selectedNodeId: null,
-    selectedNodeIds: [],
-    hoveredNodeId: null,
-    activeDocument: null,
-    activePageId: null,
-    activeBreakpointId: 'desktop',
-    propertiesPanel: { collapsed: false, x: 0, y: 0, width: 360 },
-    propertiesPanelMode: 'docked',
-    hasUnsavedChanges: false,
-  })
 })
 
 describe('canvas form controls', () => {
+  // Reproduces the leak that made the next test fail on CI and pass locally.
+  // `it` bodies run in declaration order, so this guarantees the real test
+  // always runs against a store a previous test has already dirtied. In live
+  // view `CanvasRoot` renders one preview frame with form-control suppression
+  // deliberately off, which is what the real test used to assert against.
+  it('is isolated from a leaked live canvas view', () => {
+    useEditorStore.setState({ canvasView: 'live' })
+    expect(useEditorStore.getState().canvasView).toBe('live')
+  })
+
   it('prevents native form-control activation while preserving canvas node selection', async () => {
+    expect(useEditorStore.getState().canvasView).toBe('design')
+
     const site = useEditorStore.getState().createSite('Form Controls')
     const page = site.pages[0]!
     const formId = useEditorStore.getState().insertNode('base.form', {

--- a/src/__tests__/fixtures/storeIsolation.ts
+++ b/src/__tests__/fixtures/storeIsolation.ts
@@ -1,0 +1,54 @@
+/**
+ * Store isolation for the test suite.
+ *
+ * Every app store is a module-level Zustand singleton, so one instance is shared
+ * by every test file in the run. `setState(partial)` MERGES, which means a file
+ * that seeds a store with a hand-written partial silently inherits every field
+ * it did not mention from whichever file happened to run before it. `bun test`
+ * walks test files in filesystem order, and that order differs between APFS and
+ * ext4, so the inherited value differs between a local run and CI.
+ *
+ * That is not hypothetical. A leaked `canvasView: 'live'` made
+ * `canvasFormControls.test.tsx` fail on nearly every CI run for weeks while
+ * passing on every local run: in live view `CanvasRoot` renders a single preview
+ * frame where native form-control suppression is deliberately off, so the test
+ * asserted design-mode behaviour against a preview frame.
+ *
+ * `resetAppStores()` runs from a global `beforeEach` in the test preload
+ * (`src/__tests__/setup.ts`), so every test starts from the state the app boots
+ * with and a test file only has to name what it actually wants. Add any new
+ * global store to `RESETTERS` below.
+ */
+
+import { useEditorStore } from '@site/store/store'
+import { useAdminUi } from '@admin/state/adminUi'
+import { useWorkspaceLayout } from '@admin/state/workspaceLayout'
+
+interface ResettableStore<T> {
+  getState: () => T
+  setState: (partial: Partial<T>) => void
+}
+
+/**
+ * Capture a store's pristine state and return a function that restores it.
+ *
+ * The snapshot is taken when THIS module is first imported, which the preload
+ * does before any test file runs. A lazy first import from inside a test would
+ * capture whatever the previous file left behind, which is the very bug this
+ * module exists to prevent.
+ */
+function pristineResetter<T extends object>(store: ResettableStore<T>): () => void {
+  const pristine = { ...store.getState() }
+  return () => store.setState(pristine)
+}
+
+const RESETTERS = [
+  pristineResetter(useEditorStore),
+  pristineResetter(useAdminUi),
+  pristineResetter(useWorkspaceLayout),
+]
+
+/** Restore every app store to the state it had before the suite started. */
+export function resetAppStores(): void {
+  for (const reset of RESETTERS) reset()
+}

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -309,3 +309,25 @@ if (typeof (globalThis as { EventSource?: unknown }).EventSource === 'undefined'
     document.getElementById('toast-root')?.remove()
   })
 }
+
+// ---------------------------------------------------------------------------
+// Reset every app store before each test.
+//
+// Same class of cross-file flake as the RTL cleanup above, one layer down. The
+// app stores are module-level Zustand singletons shared by the whole run, and
+// `setState(partial)` merges, so a test file that seeds a store with a
+// hand-written partial inherits every field it didn't mention from whichever
+// file ran before it. See `./fixtures/storeIsolation` for the flake this
+// actually caused.
+//
+// Registering the reset here (from the preload) means it runs before each
+// file's own `beforeEach`, so a test seeds on top of pristine state instead of
+// on top of the previous file's leftovers. Importing the module here is also
+// what fixes the snapshot at a point where nothing has run yet.
+{
+  const { beforeEach } = await import('bun:test')
+  const { resetAppStores } = await import('./fixtures/storeIsolation')
+  beforeEach(() => {
+    resetAppStores()
+  })
+}


### PR DESCRIPTION
## The bug

`canvas form controls > prevents native form-control activation` failed on nearly every CI run for weeks, including pushes to `main`, and never once locally.

The app stores are module-level Zustand singletons shared by the whole run, and `setState(partial)` merges. A file that seeds a store with a hand-written partial inherits every field it did not mention from whichever file ran before it, and `bun test` walks files in filesystem order, which differs between APFS and ext4.

This file never mentioned `canvasView`. Left on `'live'`, `CanvasRoot` renders one preview frame instead of three breakpoint frames, and native form-control suppression is deliberately off there, so the test asserted design-mode behaviour against a preview frame. The `input` assertion above it kept passing because `NodeRenderer`'s synthetic `onMouseDownCapture` fires for an input in either view.

## The fix

Fixing the one file leaves the same hole in 120 others, so the reset is global. `resetAppStores()` restores `useEditorStore`, `useAdminUi` and `useWorkspaceLayout` to the state the app boots with, registered as a `beforeEach` in the test preload so it runs ahead of each file's own seeding. Snapshots are taken at preload import time, before any test file has run.

`canvasFormControls.test.tsx` drops its partial and gains a first test that leaves the store in live view on purpose, so the real test always runs against a store a previous test has already dirtied. Reverting the reset makes it fail again.

## Verification

```
bun test       # 6599 pass, 0 fail, 1 skip (720 files), 4 consecutive clean runs
bun run lint   # clean
bun run build  # clean
```
