### PR TITLE
chore(changelog): open 0.0.17 instead of an Unreleased bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to Instatic will be documented here.
 
 This project is pre-1.0. Breaking changes may appear in minor or patch releases until a stable release line exists.
 
-## Unreleased
+## 0.0.17
 
 ## 0.0.16 - 2026-08-11
 


### PR DESCRIPTION
## What

Replaces the `## Unreleased` changelog heading with `## 0.0.17`, the next release.

## Why

An `Unreleased` bucket defers the versioning decision to release time, so it gets made by whoever cuts the release rather than the person who understood the change. It also accumulates silently: ten PRs merged above this section while it stayed empty, which turns release prep into archaeology through `git log`.

A bare version number with no date carries the same meaning and forces the decision while the change is fresh. The missing date is what marks it unreleased, so releasing is adding a date rather than renaming a section and migrating entries.

Entries for the ten PRs already merged since 0.0.16 are still written at release time as usual; this only changes where they land.

## Verification

```
docs-only change, no code touched
```
