### PR TITLE
fix(site-import): resolve assets below exporter archive roots

### DIFF
--- a/docs/features/site-import.md
+++ b/docs/features/site-import.md
@@ -121,7 +121,9 @@ User drops files / folder / static .zip / CMS bundle .zip
             ▼
     buildAssetPlan(pagePlans, cssFileResults, fileMap, rawStylesheetSources)
             │  normalizes url() in node props, HTML attributes, CSS values, raw @keyframes
-            │  CSS, and kept-stylesheet text to FileMap keys
+            │  CSS, and kept-stylesheet text to FileMap keys; after exact and
+            │  punctuation-insensitive misses, a unique path suffix can match
+            │  files stored below an exporter-specific archive directory
             │  resolves @font-face → ImportFontFamily[]
             │  flattens kept stylesheets (mode 'file') → ImportStylesheet[]
             │  collects deduplicated asset list

--- a/src/__tests__/siteImport/assetPlan.test.ts
+++ b/src/__tests__/siteImport/assetPlan.test.ts
@@ -45,6 +45,91 @@ describe('buildAssetPlan — img src normalisation', () => {
     expect(assets.some((a) => a.sourcePath === 'images/hero.png')).toBe(true)
   })
 
+  it('matches a root-relative img src to a unique FileMap suffix', () => {
+    const sourcePath = 'passthrough/wp-content/uploads/x.png'
+    const fileMap = makeFileMap({
+      'index.html': { bytes: txt('<html><body><img src="/wp-content/uploads/x.png"></body></html>') },
+      [sourcePath]: { bytes: MINIMAL_PNG, mimeType: 'image/png' },
+    })
+    const { pagePlan } = makeHtmlPagePlan(
+      'index.html',
+      new TextDecoder().decode(fileMap.files['index.html']!.bytes),
+      fileMap,
+    )
+    const { normalizedPagePlans, assets } = buildAssetPlan([pagePlan], [], fileMap)
+
+    const imageNode = Object.values(normalizedPagePlans[0].nodeFragment.nodes).find(
+      (node) => node.moduleId === 'base.image',
+    )
+    expect(imageNode?.props['src']).toBe(sourcePath)
+    expect(assets.some((asset) => asset.sourcePath === sourcePath)).toBe(true)
+  })
+
+  it('prefers an exact FileMap key over a suffix match', () => {
+    const exactPath = 'wp-content/uploads/x.png'
+    const prefixedPath = `export-root/${exactPath}`
+    const exactBytes = txt('exact')
+    const fileMap = makeFileMap({
+      'index.html': { bytes: txt('<html><body><img src="/wp-content/uploads/x.png"></body></html>') },
+      [exactPath]: { bytes: exactBytes, mimeType: 'image/png' },
+      [prefixedPath]: { bytes: txt('prefixed'), mimeType: 'image/png' },
+    })
+    const { pagePlan } = makeHtmlPagePlan(
+      'index.html',
+      new TextDecoder().decode(fileMap.files['index.html']!.bytes),
+      fileMap,
+    )
+    const { normalizedPagePlans, assets } = buildAssetPlan([pagePlan], [], fileMap)
+
+    const imageNode = Object.values(normalizedPagePlans[0].nodeFragment.nodes).find(
+      (node) => node.moduleId === 'base.image',
+    )
+    expect(imageNode?.props['src']).toBe(exactPath)
+    expect(assets.find((asset) => asset.sourcePath === exactPath)?.bytes).toBe(exactBytes)
+  })
+
+  it('leaves an ambiguous suffix unresolved and warns', () => {
+    const rawSrc = '/wp-content/uploads/x.png'
+    const fileMap = makeFileMap({
+      'index.html': { bytes: txt(`<html><body><img src="${rawSrc}"></body></html>`) },
+      'first/wp-content/uploads/x.png': { bytes: MINIMAL_PNG, mimeType: 'image/png' },
+      'second/wp-content/uploads/x.png': { bytes: MINIMAL_PNG, mimeType: 'image/png' },
+    })
+    const { pagePlan } = makeHtmlPagePlan(
+      'index.html',
+      new TextDecoder().decode(fileMap.files['index.html']!.bytes),
+      fileMap,
+    )
+    const { normalizedPagePlans, warnings } = buildAssetPlan([pagePlan], [], fileMap)
+
+    const imageNode = Object.values(normalizedPagePlans[0].nodeFragment.nodes).find(
+      (node) => node.moduleId === 'base.image',
+    )
+    expect(imageNode?.props['src']).toBe(rawSrc)
+    expect(warnings.map((warning) => warning.kind)).toEqual(['unresolved-asset'])
+    expect(warnings[0]?.path).toBe('wp-content/uploads/x.png')
+  })
+
+  it('requires a suffix match to start at a path-segment boundary', () => {
+    const rawSrc = '/content/uploads/x.png'
+    const fileMap = makeFileMap({
+      'index.html': { bytes: txt(`<html><body><img src="${rawSrc}"></body></html>`) },
+      'wp-content/uploads/x.png': { bytes: MINIMAL_PNG, mimeType: 'image/png' },
+    })
+    const { pagePlan } = makeHtmlPagePlan(
+      'index.html',
+      new TextDecoder().decode(fileMap.files['index.html']!.bytes),
+      fileMap,
+    )
+    const { normalizedPagePlans, warnings } = buildAssetPlan([pagePlan], [], fileMap)
+
+    const imageNode = Object.values(normalizedPagePlans[0].nodeFragment.nodes).find(
+      (node) => node.moduleId === 'base.image',
+    )
+    expect(imageNode?.props['src']).toBe(rawSrc)
+    expect(warnings.map((warning) => warning.kind)).toEqual(['unresolved-asset'])
+  })
+
   it('leaves external URLs unchanged', () => {
     const fileMap = makeFileMap({
       'index.html': { bytes: txt('<html><body><img src="https://cdn.example.com/img.png"></body></html>') },

--- a/src/core/siteImport/assetPlan.ts
+++ b/src/core/siteImport/assetPlan.ts
@@ -102,8 +102,8 @@ interface AssetPlanResult {
  * The four normalisers below (node props, CSS bags, raw CSS text, `@font-face`)
  * all funnel into `resolveAndRecord`, and all of them need the same four
  * things — so they take the resolver rather than passing the pieces around
- * individually. The two caches live here for the same reason: they are per
- * import, not per call.
+ * individually. The lookup indexes live here for the same reason: they are
+ * per import, not per call.
  */
 interface AssetResolver {
   fileMap: FileMap
@@ -112,6 +112,8 @@ interface AssetResolver {
   warnings: ImportWarning[]
   /** Lazily built by `normalizedIndex` — see the note there. */
   byNormalizedPath?: ReadonlyMap<string, string | null>
+  /** Lazily built by `suffixIndex` — see the note there. */
+  bySuffixPath?: ReadonlyMap<string, string | null>
   /** One `unresolved-asset` warning per path, however many pages reference it. */
   reportedMissing: Set<string>
 }
@@ -588,23 +590,22 @@ function resolveAndRecord(rawUrl: string, basePath: string, resolver: AssetResol
  * Turn a resolved archive path into the FileMap key that actually holds the
  * bytes, and report the ones that hold nothing.
  *
- * An exact hit is the normal case. The fallback exists because exporters do
- * not always agree with themselves about filenames: a file stored as
- * `101-&Berlin-Office-Us+ Coworking.webp` gets referenced from the HTML as
- * `101-Berlin-Office-Us-Coworking.webp`, and the page imports with a broken
- * image through no fault of the archive's owner. Comparing punctuation-
- * insensitively reunites the two.
+ * Exporters do not always agree with themselves about filenames or archive
+ * roots. Punctuation-insensitive matching rejoins filename variants, while a
+ * unique path suffix finds files stored below an extra archive directory.
  *
- * The match must be UNIQUE. Two files that differ only in punctuation are two
- * different files, and picking one would silently put the wrong image on the
- * page — a worse outcome than the broken reference we started with. Ambiguity
- * and genuine absence both fall through to the same warning.
+ * A fallback match must be UNIQUE. Picking between equivalent candidates would
+ * silently put the wrong image on the page. Ambiguity and genuine absence both
+ * fall through to the same warning.
  */
 function resolveFileMapKey(resolvedPath: string, resolver: AssetResolver): string | null {
   if (resolver.fileMap.files[resolvedPath]) return resolvedPath
 
   const match = normalizedIndex(resolver).get(normalizeAssetPath(resolvedPath))
   if (match) return match
+
+  const suffixMatch = suffixIndex(resolver).get(resolvedPath)
+  if (suffixMatch) return suffixMatch
 
   // Only media references are worth reporting. Anchors point at pages and
   // extensionless routes that legitimately live outside the archive, and a
@@ -636,6 +637,26 @@ function normalizedIndex(resolver: AssetResolver): ReadonlyMap<string, string | 
     index.set(key, index.has(key) ? null : filePath)
   }
   resolver.byNormalizedPath = index
+  return index
+}
+
+/**
+ * Index FileMap keys by path-segment suffix. Shared suffixes map to `null`, and
+ * lazy construction avoids a full FileMap scan for every lookup.
+ */
+function suffixIndex(resolver: AssetResolver): ReadonlyMap<string, string | null> {
+  if (resolver.bySuffixPath) return resolver.bySuffixPath
+
+  const index = new Map<string, string | null>()
+  for (const filePath of Object.keys(resolver.fileMap.files)) {
+    let separatorIndex = filePath.indexOf('/')
+    while (separatorIndex !== -1) {
+      const suffix = filePath.slice(separatorIndex + 1)
+      index.set(suffix, index.has(suffix) ? null : filePath)
+      separatorIndex = filePath.indexOf('/', separatorIndex + 1)
+    }
+  }
+  resolver.bySuffixPath = index
   return index
 }
 
@@ -674,4 +695,3 @@ function replaceRawUrlInValue(value: string, rawUrl: string, fileMapKey: string)
   const re = new RegExp(`url\\(\\s*(['"]?)${escaped}\\1\\s*\\)`, 'g')
   return value.replace(re, `url('${fileMapKey}')`)
 }
-


### PR DESCRIPTION
## Summary

A WordPress export can store media below an extra archive directory while its HTML references the same files from the archive root. The import uploaded those unreferenced files during its media sweep, but resolveFileMapKey could not connect the HTML references to their bytes, so the published page kept broken image URLs.

resolveFileMapKey now tries a unique path-segment suffix after exact and punctuation-insensitive lookup. The suffix index is built lazily once per import. Exact keys still win, and suffix collisions remain unresolved and emit the existing unresolved-asset warning instead of choosing a file.

Coverage keeps the reported passthrough/wp-content case and adds exact-key precedence, ambiguous suffixes, and path-segment boundary behavior. The site-import pipeline documentation now describes exporter-specific archive directories rather than treating passthrough/ as an Instatic convention.

## Verification

- [x] bun run build (clean)
- [x] bun test (6,831 pass, 0 fail)
- [x] bun run lint (clean)
- [ ] Docker/deployment check, if relevant (not relevant: importer-only resolver change)

The reported root-relative asset test fails on current main before the resolver change and passes on this branch.

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.