### PR TITLE
ci(docker): publish multi-architecture images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,21 @@ jobs:
       - name: Lint
         run: bun run lint
 
-  image:
-    name: Publish GHCR Image
-    runs-on: ubuntu-latest
+  image-build:
+    name: Build GHCR Image (${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: verify
-    outputs:
-      version: ${{ steps.version.outputs.version }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            artifact: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -74,17 +82,92 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push image
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/corebunch/instatic,push-by-digest=true,name-canonical=true,push=true
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             INSTATIC_VERSION=${{ steps.version.outputs.version }}
             INSTATIC_REVISION=${{ github.sha }}
             INSTATIC_CREATED=${{ steps.version.outputs.created }}
+
+      - name: Export image digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+
+      - name: Upload image digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.artifact }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  image:
+    name: Publish GHCR Image
+    runs-on: ubuntu-latest
+    needs: image-build
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - name: Resolve release version
+        id: version
+        shell: bash
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Download image digests
+        uses: actions/download-artifact@v5
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/corebunch/instatic
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Create multi-architecture manifest
+        working-directory: /tmp/digests
+        env:
+          DOCKER_METADATA_OUTPUT_JSON: ${{ steps.meta.outputs.json }}
+        shell: bash
+        run: |
+          mapfile -t TAGS < <(jq -r '.tags[]' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          ARGS=()
+          for TAG in "${TAGS[@]}"; do
+            ARGS+=(--tag "$TAG")
+          done
+          for DIGEST in *; do
+            ARGS+=("ghcr.io/corebunch/instatic@sha256:$DIGEST")
+          done
+          docker buildx imagetools create "${ARGS[@]}"
+
+      - name: Inspect published image
+        run: docker buildx imagetools inspect "ghcr.io/corebunch/instatic:${{ steps.version.outputs.version }}"
 
   bundle:
     name: Publish Release Bundle

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project is pre-1.0. Breaking changes may appear in minor or patch releases 
 
 ## 0.0.17
 
+### Deployment
+
+- Added native `linux/arm64` GHCR images alongside `linux/amd64` releases, so Apple Silicon, AWS Graviton, Oracle Ampere, and other ARM64 hosts can pull the published image directly. Tags through `0.0.16` remain AMD64-only.
+
 ### AI and integrations
 
 - Fixed adding the Instatic MCP connector on Postgres installations. The dynamic client registration response returned `client_id_issued_at` as a quoted string, because Postgres declares the column `bigint` and returns it as a string to protect precision, so clients that validate the response against RFC 7591 rejected the connector with `expected number, received string`. SQLite installations were unaffected.

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -39,7 +39,7 @@ docker pull ghcr.io/corebunch/instatic:latest
 docker pull ghcr.io/corebunch/instatic:0.0.16
 ```
 
-The v0.0.16 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The release workflow publishes new images for `linux/amd64` and `linux/arm64`. Docker selects the correct image for compatible hosts. Tags created before multi-architecture publishing was enabled, including `0.0.16`, remain `linux/amd64` only.
 
 ## Run With SQLite
 

--- a/docs/deployment/release-workflow.md
+++ b/docs/deployment/release-workflow.md
@@ -117,13 +117,13 @@ The release workflow should:
 
 - run tests and build checks
 - log in to GitHub Container Registry with `GITHUB_TOKEN`
-- build `Dockerfile` for `linux/amd64`
+- build `Dockerfile` for `linux/amd64` and `linux/arm64` on separate native GitHub-hosted runners
 - push a semver tag for `v*` tags
 - push `latest` for tagged releases
 - create a release bundle with the Compose files and deployment docs
 - include the Render Blueprint templates in the release bundle
 
-The first release targets `linux/amd64` because QEMU-based arm64 publishing made the tagged workflow too slow to use as a release gate. Add arm64 as a separate native-runner build before advertising multi-arch images.
+The release workflow builds each architecture on a native GitHub-hosted runner, pushes each image by digest, and merges the digests into the published manifest. This avoids the QEMU latency that made the original arm64 release gate too slow.
 
 ## Image Registry
 

--- a/src/__tests__/server/dockerConfig.test.ts
+++ b/src/__tests__/server/dockerConfig.test.ts
@@ -31,6 +31,18 @@ describe('self-host docker config', () => {
     expect(dockerfile).not.toContain('vite build && bun run server/index.ts')
   })
 
+  it('publishes amd64 and arm64 images on native release runners', () => {
+    const workflow = readFileSync('.github/workflows/release.yml', 'utf8')
+
+    expect(workflow).toContain('runner: ubuntu-latest')
+    expect(workflow).toContain('runner: ubuntu-24.04-arm')
+    expect(workflow).toContain('platform: linux/amd64')
+    expect(workflow).toContain('platform: linux/arm64')
+    expect(workflow).toContain('push-by-digest=true')
+    expect(workflow).toContain('docker buildx imagetools create')
+    expect(workflow).not.toContain('docker/setup-qemu-action')
+  })
+
   it('keeps TypeScript path aliases available in the runtime image', () => {
     const dockerfile = readFileSync('Dockerfile', 'utf8')
 


### PR DESCRIPTION
## Summary

- build release images in parallel on native AMD64 and ARM64 GitHub-hosted runners
- push each platform image by digest, then merge the digests into the existing semver, minor, and `latest` tags
- preserve the existing `image` job output consumed by the release-bundle job
- document the multi-architecture release boundary without retroactively describing old tags as ARM64-compatible
- announce native ARM64 image support in the in-progress `0.0.17` changelog
- add a focused regression test for the native-runner and manifest-merge contract

## Why

Instatic originally configured QEMU-based AMD64 + ARM64 publishing, then intentionally limited releases to AMD64 in `b8dda9ac` because emulated ARM64 publishing made the tagged workflow too slow.

This follows the repository's documented intended fix: each architecture builds on a separate native GitHub-hosted runner (`ubuntu-latest` and `ubuntu-24.04-arm`). The final job merges the platform digests into one OCI image index, so the release gate does not run the application build under QEMU.

## Verification

- fork CI — Build & Typecheck, Lint, and Test passed on the submitted head
- `actionlint .github/workflows/release.yml` — passed
- focused Docker/release tests — 11 passed, 0 failed
- `bun run lint` — passed
- `bun run build` — passed
- AMD64 runtime: SQLite, Sharp PNG encoding, esbuild transform, non-root user, and `/health` passed
- ARM64 runtime under QEMU: SQLite, Sharp PNG encoding, esbuild transform, non-root user, and `/health` passed
- local-registry digest merge produced one OCI index containing `linux/amd64` and `linux/arm64`
- `docker buildx build --check --platform linux/amd64,linux/arm64 .` — passed with no warnings
- `git diff --check` — passed

The tag-triggered GHCR publication cannot be exercised end to end from the fork because the workflow intentionally publishes to the upstream `corebunch` package namespace. The platform images, native runtime dependencies, and manifest-merge operation were verified separately as listed above.
