### PR TITLE
fix(data): let the New field dialog accept camelCase ids

### DIFF
--- a/src/__tests__/data/newFieldDialogModel.test.ts
+++ b/src/__tests__/data/newFieldDialogModel.test.ts
@@ -10,7 +10,12 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { Value } from '@sinclair/typebox/value'
 import { DataFieldSchema } from '@core/data/schemas'
-import { makeOption, slugifyOptionValue } from '@admin/pages/data/components/NewFieldDialog/newFieldDialogModel'
+import { fieldIdError, makeOption, slugifyOptionValue } from '@admin/pages/data/components/NewFieldDialog/newFieldDialogModel'
+import {
+  POST_TYPE_FIELD_FEATURED_MEDIA,
+  POST_TYPE_FIELD_SEO_DESCRIPTION,
+  POST_TYPE_FIELD_SEO_TITLE,
+} from '@core/data/schemas'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -74,5 +79,52 @@ describe('makeOption', () => {
     )
     const field = { type: 'select', id: 'status', label: 'Status', options }
     expect(Value.Check(DataFieldSchema, field)).toBe(true)
+  })
+})
+
+describe('fieldIdError', () => {
+  it('accepts camelCase, the convention the built-in fields already use', () => {
+    for (const id of ['firmaUrl', 'interviewUrl', 'aufStartseite', 'seoTitle']) {
+      expect(fieldIdError(id, [])).toBeNull()
+    }
+  })
+
+  it("accepts Instatic's own built-in post-type field ids", () => {
+    // The regression in #434: the dialog rejected ids that the product itself
+    // ships, so one table could end up holding two naming conventions.
+    for (const id of [
+      POST_TYPE_FIELD_FEATURED_MEDIA,
+      POST_TYPE_FIELD_SEO_TITLE,
+      POST_TYPE_FIELD_SEO_DESCRIPTION,
+    ]) {
+      expect(id).toMatch(/[A-Z]/)
+      expect(fieldIdError(id, [])).toBeNull()
+    }
+  })
+
+  it('still accepts snake_case, so nothing that validated before stops', () => {
+    for (const id of ['firma_url', 'title', 'field_1', 'a']) {
+      expect(fieldIdError(id, [])).toBeNull()
+    }
+  })
+
+  it('still requires a lowercase first character', () => {
+    for (const id of ['FirmaUrl', '_leading', '1st', 'Ärger']) {
+      expect(fieldIdError(id, [])).not.toBeNull()
+    }
+  })
+
+  it('still rejects characters that are unsafe as a token key', () => {
+    for (const id of ['firma-url', 'firma url', 'firma.url', 'firma$url']) {
+      expect(fieldIdError(id, [])).not.toBeNull()
+    }
+  })
+
+  it('reports an empty id as no error, leaving the submit gate to handle it', () => {
+    expect(fieldIdError('', [])).toBeNull()
+  })
+
+  it('still flags a duplicate id ahead of the pattern message', () => {
+    expect(fieldIdError('firmaUrl', ['firmaUrl'])).toBe('This ID is already in use.')
   })
 })

--- a/src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts
+++ b/src/admin/pages/data/components/NewFieldDialog/newFieldDialogModel.ts
@@ -41,7 +41,18 @@ export const MEDIA_KIND_OPTIONS = [
   { value: 'video', label: 'Video' },
 ]
 
-const FIELD_ID_PATTERN = /^[a-z][a-z0-9_]*$/
+/**
+ * Field ids must start with a lowercase letter so they stay safe as token
+ * and binding keys, but the body accepts any letter case.
+ *
+ * camelCase is deliberately allowed: the storage schema puts no pattern on
+ * `id` at all (`FieldCommonProps.id` is a bare `Type.String()`), the API
+ * accepts camelCase today, and three of the built-in post-type fields —
+ * `featuredMedia`, `seoTitle`, `seoDescription` — are themselves camelCase.
+ * Rejecting it here was the only thing forcing a second convention into
+ * tables that already carry the first.
+ */
+const FIELD_ID_PATTERN = /^[a-z][a-zA-Z0-9_]*$/
 
 export function slugifyOptionValue(label: string): string {
   return label
@@ -65,7 +76,7 @@ export function makeOption(label: string): DraftOption {
 
 export function fieldIdError(id: string, existingIds: string[]): string | null {
   if (!id) return null
-  if (!FIELD_ID_PATTERN.test(id)) return 'Must start with a lowercase letter; use letters, numbers, underscores only.'
+  if (!FIELD_ID_PATTERN.test(id)) return 'Must start with a lowercase letter, then letters, numbers or underscores.'
   if (existingIds.includes(id)) return 'This ID is already in use.'
   return null
 }


### PR DESCRIPTION
Fixes #434.

## The dialog is the only place that holds this rule

`FIELD_ID_PATTERN` was `/^[a-z][a-z0-9_]*$/`, and `fieldIdError` gates `canCreate`, so `firmaUrl` blocked creation outright. I checked what else agrees with that rule, and nothing does:

| Layer | Accepts camelCase? |
| --- | --- |
| `FieldCommonProps.id` in `src/core/data/schemas.ts` | yes — bare `Type.String()`, no pattern |
| `PATCH /admin/api/cms/data/tables/{id}` | yes — stores it, and it resolves in loops and `{currentEntry.*}` |
| Built-in post-type fields | **already are** — `featuredMedia`, `seoTitle`, `seoDescription` |
| `RESOURCE_FIELD_ID_PATTERN` in `src/core/plugins/manifest.ts` | yes — `/^[a-zA-Z_][a-zA-Z0-9_-]*$/` |

That last row is worth calling out: the codebase already has a field-id pattern, in the plugin manifest, and it permits camelCase. The Data dialog was the outlier against its own storage layer, its own API, its own built-ins, and its own sibling validator.

The practical cost is the part of the report I found most convincing. An author ends up with `aufstartseite` next to `seoDescription` in one table, every binding has to be written against whichever convention that particular field happened to land in, and a mistyped token renders as an empty node with no warning.

## Change

The body of the pattern accepts any letter case. The **first character still has to be a lowercase letter**, which keeps ids safe as token and binding keys and matches every built-in, so this loosens exactly one thing.

The error message also described a rule the pattern did not implement — it said "use letters, numbers, underscores only" while rejecting uppercase letters. It now matches the behaviour.

## Deliberately not in scope

`fieldIdFromLabel` still derives snake_case from a label. Auto-derivation produced a valid id before and still does, and changing the *suggested* convention is a different decision from accepting what an author types. Say the word if you want the suggestion switched to camelCase too — that is a one-line follow-up, but it changes what every future field is named by default, which felt like yours to call rather than something to slip into a bug fix.

I also did not take the issue's second option (enforce snake_case at the schema and API layer, rename or grandfather the built-ins). That would be a breaking change to stored data for the sake of the stricter convention, and the built-ins picking camelCase reads as the intended house style.

## Tests

Seven cases added to `src/__tests__/data/newFieldDialogModel.test.ts`, covering camelCase acceptance, the actual built-in constants imported from `@core/data/schemas` (so a rename upstream keeps this honest), snake_case still passing, the lowercase-first rule still holding, unsafe characters still rejected, and duplicate detection still taking precedence.

Verified they fail on `main`: 3 of the new tests fail before the change, all 11 pass after.

- `bun run lint` clean
- `bunx tsc -b` exit 0
- `bun run build` clean
- `bun test` **6676 pass, 0 fail**
