### PR TITLE
fix(loops): read the loop endpoint from the tag, not currentScript

### DIFF
--- a/server/publish/loopRuntime.ts
+++ b/server/publish/loopRuntime.ts
@@ -22,7 +22,13 @@
  */
 
 function runInstaticLoopRuntime(): void {
-  const scriptEl = document.currentScript
+  // Located by attribute rather than `document.currentScript`, which the HTML
+  // spec leaves null inside a module script — and the publisher injects this
+  // as `type="module"`. Reading currentScript therefore always fell through to
+  // the default below, so the endpoint attribute was never honoured. The
+  // runtime is deferred by virtue of being a module, so the tag is parsed and
+  // queryable by the time this runs.
+  const scriptEl = document.querySelector('script[data-instatic-loop-endpoint]')
   const endpointBase =
     (scriptEl && scriptEl.getAttribute('data-instatic-loop-endpoint')) || '/_instatic/loop/'
   const pagePath = location.pathname

--- a/src/__tests__/publisher/loopRuntimeEndpoint.test.ts
+++ b/src/__tests__/publisher/loopRuntimeEndpoint.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Loop runtime endpoint resolution (#395).
+ *
+ * The publisher injects the runtime as `<script type="module">`, and the HTML
+ * spec leaves `document.currentScript` null inside a module script. The
+ * runtime read the endpoint off `currentScript`, so the
+ * `data-instatic-loop-endpoint` attribute was never honoured and every fetch
+ * fell through to the hardcoded default.
+ *
+ * No user-visible breakage today, because both producers happen to pass the
+ * same string as the fallback. These tests pin the plumbing so the first
+ * change that sets a different endpoint (subpath mount, CDN prefix) does not
+ * silently keep hitting `/_instatic/loop/`.
+ */
+import { afterEach, describe, expect, it } from 'bun:test'
+import { LOOP_RUNTIME_JS } from '../../../server/publish/loopRuntime'
+
+const ORIGINAL_FETCH = globalThis.fetch
+
+afterEach(() => {
+  globalThis.fetch = ORIGINAL_FETCH
+  document.body.innerHTML = ''
+  document.head.innerHTML = ''
+})
+
+/**
+ * Render a page carrying one infinite loop plus the runtime script tag, run
+ * the runtime, click "Load more", and report the URL it fetched.
+ */
+async function fetchedUrlFor(endpointAttr: string | null): Promise<string> {
+  document.head.innerHTML = endpointAttr === null
+    ? '<script type="module" src="/_instatic/assets/loop-runtime.js"></script>'
+    : `<script type="module" src="/_instatic/assets/loop-runtime.js" data-instatic-loop-endpoint="${endpointAttr}"></script>`
+
+  document.body.innerHTML = `
+    <div data-instatic-loop="loop-1"
+         data-instatic-loop-mode="infinite"
+         data-instatic-loop-page="1"
+         data-instatic-loop-has-more="true"></div>
+  `
+
+  let requested = ''
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    requested = typeof input === 'string' ? input : String(input)
+    // The shape the runtime actually consumes: it parses JSON and reads
+    // `html` / `hasMore`. Returning an empty body made it throw mid-handler.
+    return new Response(JSON.stringify({ html: '', hasMore: false }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  }) as typeof fetch
+
+  // The runtime is shipped as a self-invoking source string.
+  new Function(LOOP_RUNTIME_JS)()
+
+  const button = document.querySelector('[data-instatic-loop-load-more]') as HTMLButtonElement | null
+  expect(button).not.toBeNull()
+  button!.click()
+  // Let the click handler's async work settle.
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  return requested
+}
+
+describe('loop runtime endpoint', () => {
+  it('honours data-instatic-loop-endpoint from the script tag', async () => {
+    const url = await fetchedUrlFor('/cdn-prefix/loop/')
+    expect(url.startsWith('/cdn-prefix/loop/')).toBe(true)
+  })
+
+  it('falls back to the default when the attribute is absent', async () => {
+    const url = await fetchedUrlFor(null)
+    expect(url.startsWith('/_instatic/loop/')).toBe(true)
+  })
+
+  it('does not depend on document.currentScript, which is null in a module', () => {
+    // The regression guard: currentScript is spec-null inside `type="module"`,
+    // so reading it can only ever yield the fallback.
+    expect(LOOP_RUNTIME_JS).not.toContain('currentScript')
+  })
+})

--- a/src/core/publisher/render.ts
+++ b/src/core/publisher/render.ts
@@ -393,7 +393,7 @@ function buildRuntimeAssetsBlock(
   const hasInfiniteLoops = acc.infiniteLoopIds.size > 0
   const loopEndpointBaseUrl = options.loopEndpointBaseUrl ?? '/_instatic/loop/'
   const loopRuntimeScript = hasInfiniteLoops
-    ? `  <script type="module" src="/_instatic/assets/loop-runtime.js" data-instatic-loop-endpoint="${escapeHtml(loopEndpointBaseUrl)}" defer></script>`
+    ? `  <script type="module" src="/_instatic/assets/loop-runtime.js" data-instatic-loop-endpoint="${escapeHtml(loopEndpointBaseUrl)}"></script>`
     : ''
 
   // Hole runtime — injected into <head> (not body-end) so IntersectionObserver


### PR DESCRIPTION
Fixes #395.

## The bug

`loopRuntime.ts` read its endpoint from `document.currentScript`, but `render.ts` injects the runtime as `<script type="module">`, and the HTML spec leaves `currentScript` null inside a module script. `scriptEl` was therefore always null, `data-instatic-loop-endpoint` was never read, and every fetch fell through to the hardcoded `/_instatic/loop/`.

## Why fix rather than remove

The issue offered both. The module's own docstring settles it:

> Endpoint URL is read from `data-instatic-loop-endpoint` on the script tag — defaults to `/_instatic/loop/`.

`render.ts` also accepts a `loopEndpointBaseUrl` option and escapes it into the tag. The configurable seam is deliberate, so this makes it work instead of deleting it. The runtime now locates the tag by attribute, which is safe precisely because a module script is deferred by definition — the tag is parsed and queryable by the time it runs.

## Nothing is user-visible today

Both producers (`publicRenderer.ts` and `data/preview.ts`) pass the same string as the fallback, so infinite pagination works either way. I want to be straight that this fixes a trap, not an outage. The value is that the next change setting a different endpoint — a subpath mount, a CDN prefix — would otherwise have silently kept hitting the default, with the plumbing reading as though it were wired.

## Drive-by

Dropped `defer` from the injected tag. It is a no-op on `type="module"`, which is deferred by default. One character of noise, in the line this PR already touches.

## Tests

New `src/__tests__/publisher/loopRuntimeEndpoint.test.ts`. Rather than only asserting the source text, it executes the shipped runtime: renders a page with an infinite loop plus the script tag into the happy-dom document, runs `LOOP_RUNTIME_JS`, clicks the generated "Load more" button, and captures the URL it fetches.

- honours a custom `data-instatic-loop-endpoint`
- falls back to `/_instatic/loop/` when the attribute is absent (so the fix does not over-correct)
- a source guard that `currentScript` is gone, since reading it can only ever yield the fallback

Verified against `main`: 2 of the 3 fail before the change, all pass after. The fallback case passes either way by design — it is the non-regression half.

- `bun run lint` clean
- `bunx tsc -b` exit 0
- `bun run build` clean
- `bun test` **6672 pass, 0 fail**
