### PR TITLE
chore(release): prepare 0.0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,20 +4,43 @@ All notable changes to Instatic will be documented here.
 
 This project is pre-1.0. Breaking changes may appear in minor or patch releases until a stable release line exists.
 
-## 0.0.17
+## 0.0.17 - 2026-08-30
 
 ### AI and integrations
 
 - Fixed adding the Instatic MCP connector on Postgres installations. The dynamic client registration response returned `client_id_issued_at` as a quoted string, because Postgres declares the column `bigint` and returns it as a string to protect precision, so clients that validate the response against RFC 7591 rejected the connector with `expected number, received string`. SQLite installations were unaffected.
+- Streamed the MCP editor bridge as `text/event-stream` so buffering reverse proxies flush each record instead of holding the connection, keeping connected agents working against an open Site or Content workspace on proxied installations.
+- Added the AI workspace to the shared admin navigation and a Spotlight command, so users holding the AI capabilities can reach AI settings without typing the URL.
 
 ### Editor, import, and publishing
 
+- Added TypeScript tooling to Site Editor scripts: strict semantic diagnostics, DOM-aware completions, and hover information from a worker-isolated language service, collected in a compact Problems panel. Publish-time script build errors now come back as an author-actionable error with `file:line:column` diagnostics instead of a silent server error.
 - Added a condition to data-row loops so a list can show a subset of a table rather than always its newest rows — pick one of the table's own fields and require it to be checked, unchecked, equal to a value, or to have any value at all. A relation field offers its rows by name instead of asking for an id. The condition applies on the canvas, on published pages, and in the "load more" endpoint, and the item count follows it so pagination never advertises rows the page drops.
 - Added the table's own fields to a data-row loop's "Order by" list, so a list can follow a real date, title, or rank stored in the row instead of only the row's built-in columns. Values compare as text, which sorts ISO dates chronologically.
+- Let a data-row loop's wrapper carry custom HTML attributes, the same control containers already have, applied identically on the canvas and in published output.
+- Interpolated `{tokens}` inside a node's custom HTML attributes at publish time, so data-bound values reach `data-*` and ARIA attributes instead of publishing verbatim.
+- Fixed escaped `\{` in token interpolation to emit a literal brace without its backslash, as the escaping syntax always documented.
+- Fixed the loop "load more" runtime to read its endpoint from the script tag's attribute — `document.currentScript` is null inside module scripts, so a configured endpoint was never honored.
+- Let the New field dialog accept camelCase field ids, matching the camelCase built-in fields it sits beside.
+- Stopped the New field dialog crashing on admins served over plain HTTP, where no secure context means `crypto.randomUUID` does not exist.
+- Parsed CSS Color-4 space-separated `hsl()` values in framework color tokens, so tokens authored in the modern syntax generate their transparent, shade, and tint variants again.
+- Restored Escape dismissal in the Settings modal after focus left the dialog, and while tooltips are open.
+- Fixed Command Spotlight so select-type argument options can be chosen with a mouse click, not only with Enter.
+- Named every asset reference a site-import archive cannot satisfy: after a punctuation-insensitive retry against the archive's file list, each remaining media reference emits an `unresolved-asset` warning ranked first in the import log instead of disappearing silently.
+- Kept a newly created entry's title in the Content sidebar when the entries list was still loading — a request race left a nameless row.
 
 ### Content and publishing
 
 - Fixed the SEO title and SEO description fields on a post so they reach the published page. Both were editable in the Content settings panel but never emitted anything: an entry's `<title>` always showed its plain title, and no description tag was written at all. An authored value now drives `<title>` / `<meta name="description">` and outranks the site-wide Meta Title and Meta Description, on the published page and in the Content editor's Live preview alike. The on-page `{page.title}` and `{currentEntry.title}` bindings keep rendering the entry's real title.
+- Interpolated `{currentEntry.*}`, `{page.*}`, and `{site.*}` tokens in the published meta title and description, so per-entry SEO values written as token patterns resolve at publish time instead of appearing verbatim in the `<head>`.
+
+### Platform and maintenance
+
+- Let Railway and Render platform auto-detection survive an invalid `PUBLIC_ORIGIN` value: an unparseable origin list now falls through to auto-detection instead of silently degrading the origin check to an empty allowlist.
+- Gave `DbClient` a `close()` on both database adapters and wired it into file-backed test teardown, clearing the Windows test failures caused by SQLite handles outliving their temp directories.
+- Scaffolded plugin server entries now import the SDK through the same specifier as every other template, so a freshly scaffolded plugin type-checks inside the monorepo.
+- Mapped U+0000 to U+FFFD in `escapeCssIdentifier`, matching the `CSS.escape` specification it vendors.
+- Moved HTML tag and attribute rendering helpers into the engine so `src/core` never imports from `src/modules`, now gated by an architecture test.
 
 ## 0.0.16 - 2026-08-11
 

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -57,7 +57,7 @@ INSTATIC_IMAGE=ghcr.io/corebunch/instatic:latest docker compose -f compose.prod.
 Pin a semver tag for predictable upgrades:
 
 ```sh
-INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.16 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
+INSTATIC_IMAGE=ghcr.io/corebunch/instatic:0.0.17 docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 ```
 
 Source builds remain supported for contributors and release-candidate testing:

--- a/docs/deployment/docker-image.md
+++ b/docs/deployment/docker-image.md
@@ -36,10 +36,10 @@ GHCR is the canonical image registry:
 
 ```sh
 docker pull ghcr.io/corebunch/instatic:latest
-docker pull ghcr.io/corebunch/instatic:0.0.16
+docker pull ghcr.io/corebunch/instatic:0.0.17
 ```
 
-The v0.0.16 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
+The v0.0.17 published image is built for `linux/amd64`. Use it on Railway and x86_64 VPS/container hosts. ARM64 hosts should build from source for now, or wait for the native arm64 release job before pulling GHCR images directly.
 
 ## Run With SQLite
 
@@ -92,7 +92,7 @@ Replace `instatic:local` with `ghcr.io/corebunch/instatic:<tag>` when deploying 
 Create an app service from Docker image source:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.16
+ghcr.io/corebunch/instatic:0.0.17
 ```
 
 Attach a Railway volume at `/app/storage`, set the health check path to `/health`, and set app variables:
@@ -109,7 +109,7 @@ RAILWAY_RUN_UID=0
 
 `RAILWAY_RUN_UID=0` is required because Railway volumes are mounted as `root` and the published image otherwise runs as the non-root `bun` user. `PUBLIC_ORIGIN=https://${{RAILWAY_PUBLIC_DOMAIN}}` gives Instatic the public origin for its CSRF check now that Railway terminates HTTPS at the edge; the server would auto-detect the same value from `RAILWAY_PUBLIC_DOMAIN`, but setting it explicitly survives custom-domain edits.
 
-Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.16` if you want Railway's semver update controls.
+Enable Railway Image Auto Updates when you want Railway to move the service forward automatically during a maintenance window. Use `:latest` for "always follow the newest image", or a semver tag such as `:0.0.17` if you want Railway's semver update controls.
 
 ## Run On Render From The Image
 

--- a/docs/deployment/railway.md
+++ b/docs/deployment/railway.md
@@ -16,7 +16,7 @@ Railway is the simplest managed target for Instatic because it can run the publi
 Both templates use:
 
 ```txt
-Image=ghcr.io/corebunch/instatic:0.0.16
+Image=ghcr.io/corebunch/instatic:0.0.17
 PORT=8080
 UPLOADS_DIR=/app/storage/uploads
 STATIC_DIR=/app/dist
@@ -32,7 +32,7 @@ Configure the app service health check path as `/health`. If Railway asks which 
 Use a Docker image source for production installs:
 
 ```txt
-ghcr.io/corebunch/instatic:0.0.16
+ghcr.io/corebunch/instatic:0.0.17
 ```
 
 The image already runs:
@@ -48,7 +48,7 @@ Recommended service settings:
 | Setting | Value |
 |---|---|
 | Source | Docker image |
-| Image | `ghcr.io/corebunch/instatic:0.0.16` |
+| Image | `ghcr.io/corebunch/instatic:0.0.17` |
 | Public networking | HTTP enabled |
 | Target port | `8080` |
 | Healthcheck path | `/health` |
@@ -135,7 +135,7 @@ Railway volume backups apply to mounted volumes. For Postgres, use Railway's dat
 Enable Railway Image Auto Updates on the app service:
 
 - Use `ghcr.io/corebunch/instatic:latest` when you want the service to redeploy whenever the `latest` tag moves.
-- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.16` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
+- Use a semver tag like `ghcr.io/corebunch/instatic:0.0.17` when you want Railway to stage matching patch or minor updates according to the service's auto-update preference.
 
 Set a maintenance window before enabling automatic updates on sites with attached volumes.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "instatic",
   "private": true,
-  "version": "0.0.16",
+  "version": "0.0.17",
   "engines": {
     "bun": ">=1.3.0 <1.4.0"
   },


### PR DESCRIPTION
Dates the 0.0.17 changelog heading and records every user-facing change since v0.0.16: the merged quick-win batch (#308, #309, #326, #327, #328, #337, #346, #349, #350, #353, #391, #424, #436, #437), the TypeScript script tooling (#367), the MCP bridge and UI fixes (#282, #272, #401, #307), and the core/modules layering hoist (#438). Bumps package.json to 0.0.17 and moves the pinned image tags in docs/deployment to 0.0.17.

Verification: bun test (6701 pass, 0 fail) and bun run lint clean on this branch. The full Playwright E2E suite is running against the same tree and will be reported before tagging.
