### PR TITLE
chore(changelog): open 0.0.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Instatic will be documented here.
 
 This project is pre-1.0. Breaking changes may appear in minor or patch releases until a stable release line exists.
 
+## 0.0.18
+
 ## 0.0.17 - 2026-08-30
 
 ### AI and integrations


### PR DESCRIPTION
Opens the 0.0.18 bucket at the top of the changelog now that 0.0.17 is tagged and released, keeping the no-Unreleased-section convention.
