### PR TITLE
fix(data): creating a table holds only the mandatory built-ins, matching patch

### DIFF
--- a/server/repositories/data/tables.ts
+++ b/server/repositories/data/tables.ts
@@ -208,15 +208,29 @@ export async function getDataTableBySlug(db: DbClient, slug: string): Promise<Da
  * (the data API, an MCP connector, an import) used to arrive unroutable.
  * Seeding here makes the invariant hold for every caller instead.
  *
+ * Only the mandatory two are held — the same rule `keepPostTypeBuiltIns`
+ * enforces on PATCH. The optional built-ins (body, featured media, the SEO
+ * pair) are deliberately removable, and the New collection dialog lets the
+ * author drop them before creating; re-adding them here silently overrode
+ * that choice. A caller that supplies no fields at all still gets the full
+ * canonical set, matching the dialog's starting state.
+ *
  * Caller-supplied fields win on id collision, so an explicit `title` override
- * (a different label, say) survives; omitted built-ins are prepended in their
+ * (a different label, say) survives; held built-ins are prepended in their
  * canonical order.
  */
 function withPostTypeBuiltIns(kind: DataTableKind | undefined, fields: DataField[]): DataField[] {
   if (kind !== 'postType') return fields
+  if (fields.length === 0) return buildPostTypeDefaultFields()
   const supplied = new Set(fields.map((field) => field.id))
-  const missing = buildPostTypeDefaultFields().filter((field) => !supplied.has(field.id))
-  return [...missing, ...fields]
+  const canonical = new Map(buildPostTypeDefaultFields().map((field) => [field.id, field]))
+  const held: DataField[] = []
+  for (const id of POST_TYPE_MANDATORY_FIELD_IDS) {
+    if (supplied.has(id)) continue
+    const field = canonical.get(id)
+    if (field) held.push(field)
+  }
+  return held.length === 0 ? fields : [...held, ...fields]
 }
 
 /**

--- a/src/__tests__/server/postTypeBuiltInFields.test.ts
+++ b/src/__tests__/server/postTypeBuiltInFields.test.ts
@@ -25,6 +25,7 @@ import type { DbClient } from '../../../server/db/client'
 import { createDataTable, getDataTable, updateDataTable } from '../../../server/repositories/data'
 import { insertDataTableIfAbsent } from '../../../server/repositories/data/tables'
 import { slugForTable } from '@core/data/cells'
+import { buildPostTypeDefaultFields } from '@core/data/fields'
 import {
   POST_TYPE_MANDATORY_FIELD_IDS,
   POST_TYPE_OPTIONAL_BUILTIN_FIELD_IDS,
@@ -64,6 +65,54 @@ describe('createDataTable — post-type built-in fields', () => {
       expect(ids).toContain('crop')
       // Built-ins lead so the Content editor renders them in canonical order.
       expect(ids.indexOf('title')).toBeLessThan(ids.indexOf('crop'))
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('respects removal of the optional built-ins, matching the PATCH rule', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const supplied = buildPostTypeDefaultFields().filter(
+        (field) => !['featuredMedia', 'seoTitle', 'seoDescription'].includes(field.id),
+      )
+      const table = await createDataTable(db, {
+        name: 'Catalog',
+        slug: 'catalog',
+        kind: 'postType',
+        routeBase: '/catalog',
+        singularLabel: 'Product',
+        pluralLabel: 'Catalog',
+        fields: supplied,
+      })
+
+      const ids = table.fields.map((field) => field.id)
+      expect(ids).not.toContain('featuredMedia')
+      expect(ids).not.toContain('seoTitle')
+      expect(ids).not.toContain('seoDescription')
+      for (const required of POST_TYPE_MANDATORY_FIELD_IDS) {
+        expect(ids).toContain(required)
+      }
+    } finally {
+      await cleanup()
+    }
+  })
+
+  it('seeds the full canonical set when no fields are supplied at all', async () => {
+    const { db, cleanup } = await setupDb()
+    try {
+      const table = await createDataTable(db, {
+        name: 'Notes',
+        slug: 'notes',
+        kind: 'postType',
+        routeBase: '/notes',
+        singularLabel: 'Note',
+        pluralLabel: 'Notes',
+        fields: [],
+      })
+
+      const canonicalIds = buildPostTypeDefaultFields().map((field) => field.id)
+      expect(table.fields.map((field) => field.id)).toEqual(canonicalIds)
     } finally {
       await cleanup()
     }


### PR DESCRIPTION
Creating a post type re-added every missing built-in field, including the optional ones (body, featured media, SEO title, SEO description). The New collection dialog lets an author delete those before creating, so the server silently overrode the author's explicit choice: the created table carried all three deleted fields again. The PATCH path already enforces the intended rule and documents it (only `title` and `slug` are held; the optional built-ins are deliberately removable).

The create path now holds only the mandatory two, exactly like PATCH. A caller that supplies no fields at all still receives the full canonical set, so bare creates through the data API or an MCP connector stay routable and useful.

Found by the CONTENT-006 e2e spec while repairing the suite: it deletes the three optional fields during creation and then checks the new entry's settings panel, and the created table in the database still contained all three.

Verification: two new regression tests in postTypeBuiltInFields.test.ts (removal respected; empty list still seeds the canonical set), bun test 6703 pass, bun run build and bun run lint clean.
