### PR TITLE
test(architecture): icon gates cover src/admin instead of dead roots

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -446,7 +446,7 @@ Rules:
 
 - No barrel import (`import { X } from 'pixel-art-icons'`) — always `pixel-art-icons/icons/<name>`.
 - No `lucide-react`, `heroicons`, `phosphor-icons`, or other catalogs. Gated by `no-third-party-icons.test.ts`.
-- No inline SVG strings in components. Gated by `direct-icon-imports.test.ts`.
+- No lazy `Icon` wrapper (`pixel-art-icons/Icon`, `<Icon name="…">`) — import the concrete icon component directly. Gated by `direct-icon-imports.test.ts`.
 - Icons in the panel rail or equivalent identity surfaces are colored via `--rail-icon-color` (which is derived from `--rail-icon-tint`). Don't hardcode `color` on the icon itself.
 - Adding a new icon: import it normally, then run `bun run icons:sync`. The vendored set is gated for freshness by `vendor-icons-fresh.test.ts`.
 
@@ -623,7 +623,7 @@ The HTML `title` attribute is banned for hover hints — gated by `no-native-tit
   - `src/__tests__/architecture/button-primitive-usage.test.ts` — every button goes through `Button`
   - `src/__tests__/architecture/ui-primitives-location.test.ts` — primitives live in `src/ui/components/`
   - `src/__tests__/architecture/no-third-party-icons.test.ts` — icons come from `pixel-art-icons`
-  - `src/__tests__/architecture/direct-icon-imports.test.ts` — no inline SVG strings
+  - `src/__tests__/architecture/direct-icon-imports.test.ts` — no lazy `Icon` wrapper; concrete icons imported directly
   - `src/__tests__/architecture/vendor-icons-fresh.test.ts` — vendored icon set is fresh
   - `src/__tests__/architecture/no-native-browser-dialogs.test.ts` — no `alert` / `confirm` / `prompt`
   - `src/__tests__/architecture/no-native-title-tooltips.test.ts` — no `title=` hover hints

--- a/src/__tests__/architecture/close-icon-correctness.test.ts
+++ b/src/__tests__/architecture/close-icon-correctness.test.ts
@@ -63,11 +63,16 @@ function collectFiles(dir: string, exts = ['.ts', '.tsx', '.js', '.jsx', '.mts',
 
 // Scan production source only — not __tests__ (test files contain the banned
 // pattern as regex strings and would false-positive).
-const PROD_DIRS = ['editor', 'core', 'modules', 'ui', 'app', 'lib'].map((d) =>
-  join(SRC_ROOT, d)
-)
+const PROD_DIRS = ['admin', 'core', 'modules', 'ui'].map((d) => join(SRC_ROOT, d))
 
 function collectProdFiles(): string[] {
+  for (const dir of PROD_DIRS) {
+    if (!existsSync(dir)) {
+      throw new Error(
+        `Scan root missing: ${dir} — update PROD_DIRS to the directories that exist under src/.`
+      )
+    }
+  }
   return PROD_DIRS.flatMap((dir) => collectFiles(dir))
 }
 

--- a/src/__tests__/architecture/direct-icon-imports.test.ts
+++ b/src/__tests__/architecture/direct-icon-imports.test.ts
@@ -28,25 +28,33 @@ function collectFiles(dir: string, exts = ['.ts', '.tsx', '.js', '.jsx', '.mts',
   return results
 }
 
-const PROD_DIRS = ['editor', 'core', 'modules', 'ui', 'app', 'lib'].map((d) =>
-  join(SRC_ROOT, d),
-)
+const PROD_DIRS = ['admin', 'core', 'modules', 'ui'].map((d) => join(SRC_ROOT, d))
 
 function collectProdFiles(): string[] {
+  for (const dir of PROD_DIRS) {
+    if (!existsSync(dir)) {
+      throw new Error(
+        `Scan root missing: ${dir} — update PROD_DIRS to the directories that exist under src/.`,
+      )
+    }
+  }
   return PROD_DIRS.flatMap((dir) => collectFiles(dir))
 }
 
 describe('Direct icon imports — no lazy Icon wrapper in production UI', () => {
-  it('production source does not import a lazy pixel-art-icons/Icon wrapper or render <Icon>', () => {
+  it('production source does not import a lazy pixel-art-icons/Icon wrapper or render <Icon name=…>', () => {
     const violations: string[] = []
 
     for (const filePath of collectProdFiles()) {
       const rel = filePath.replace(SRC_ROOT, 'src/')
 
       const source = readFileSync(filePath, 'utf8')
+      // `<Icon name="…">` is the lazy wrapper's API. A local
+      // `const Icon = SomeConcreteIcon` rendered as `<Icon size={…}/>` is the
+      // allowed direct-import idiom and must not match.
       if (
         /from\s+['"]pixel-art-icons\/Icon['"]/.test(source) ||
-        /<Icon\b/.test(source)
+        /<Icon\b[^>]*\bname=/.test(source)
       ) {
         violations.push(rel)
       }

--- a/src/__tests__/architecture/no-third-party-icons.test.ts
+++ b/src/__tests__/architecture/no-third-party-icons.test.ts
@@ -59,11 +59,16 @@ function collectFiles(dir: string, exts = ['.ts', '.tsx', '.js', '.jsx', '.mts',
 
 // Scan production source only — not __tests__ (test files contain banned
 // strings as regex patterns and would false-positive).
-const PROD_DIRS = ['editor', 'core', 'modules', 'ui', 'app', 'lib'].map((d) =>
-  join(SRC_ROOT, d)
-)
+const PROD_DIRS = ['admin', 'core', 'modules', 'ui'].map((d) => join(SRC_ROOT, d))
 
 function collectProdFiles(): string[] {
+  for (const dir of PROD_DIRS) {
+    if (!existsSync(dir)) {
+      throw new Error(
+        `Scan root missing: ${dir} — update PROD_DIRS to the directories that exist under src/.`
+      )
+    }
+  }
   return PROD_DIRS.flatMap((dir) => collectFiles(dir))
 }
 


### PR DESCRIPTION
The `no-third-party-icons`, `direct-icon-imports`, and `close-icon-correctness` gates scanned `src/{editor,app,lib}`, which no longer exist, and never scanned `src/admin`, so the largest production tree had no icon coverage. All three now scan `src/{admin,core,modules,ui}` and throw when a scan root is missing, so a future rename fails the gate instead of silently shrinking coverage. `direct-icon-imports` now flags `<Icon name=...>` (the lazy wrapper's API) instead of any `<Icon`, because admin's allowed `const Icon = ConcreteIcon` idiom would false-positive. Scanning admin surfaced no violations: no third-party icon imports, no lazy wrapper, no `XIcon`. `docs/design.md` also claimed `direct-icon-imports` gates inline SVG strings, which it never did; corrected here.

## Verification

```
bun test <the three gate files>   # 7 pass, 0 fail; a canary file in src/admin trips all four checks
bun test                          # 6688 pass, 19 fail (fail on base too)
bun run build                     # clean
bun run lint                      # clean
```

## Notes

The 19 full-suite failures are pre-existing: `icon-catalog-integrity.test.ts` (18, missing dist entries, fails on the base commit) and the Windows launcher test. Several non-icon architecture tests still reference the dead roots (`codemirror-lazy-only`, `css-token-policy`, and friends); left for a follow-up.
