### PR TITLE
fix(plugins): reject mismatched filter results

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -543,6 +543,8 @@ const name = await api.cms.hooks.emit('sync.done', { /* … */ })
 
 **Host-emitted events** (the reserved core list, `CORE_HOOK_EVENTS` in `src/core/plugins/hookBus.ts`): `publish.before`, `publish.after`, `content.entry.created`, `content.entry.updated`, `content.entry.deleted`, `settings.changed`. **Filters**: `publish.html`, `publish.headers`, `content.entry.cells`.
 
+Every filter handler returns the same runtime value type it received. `src/core/plugins/hookBus.ts` checks each result before passing it to the next handler; a mismatched result keeps the previous value and logs the offending plugin ID. For example, `publish.html` returns a string and `content.entry.cells` returns an object, never `null`.
+
 **Plugin emits are namespaced.** The host rewrites every `emit('<name>', …)` to `plugin.<your-plugin-id>.<name>` (a name already in your own namespace passes through unchanged), so event provenance is unforgeable — a plugin cannot fire `content.entry.created` or any other core event at other listeners, and emitting a name in *another* plugin's namespace (`plugin.<other-id>.*`) is rejected with an error. `emit` resolves to the canonical namespaced name. Cross-plugin eventing still works: subscribing is unrestricted, so a plugin listens to another plugin's events by their full namespaced name, e.g. `api.cms.hooks.on('plugin.acme.analytics.page-view', …)`.
 
 ### Loop sources — requires `loops.register`

--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -425,6 +425,7 @@ applyPublishedHtmlPipeline(renderedOutput, db)
 ```
 
 Plugins shouldn't need to know about the publisher internals — they get the HTML string and return the transformed string.
+`src/core/plugins/hookBus.ts` rejects a non-string `publish.html` result, logs the plugin ID, and keeps the previous HTML so one invalid plugin result cannot blank the page.
 
 ---
 

--- a/src/__tests__/plugins/pluginHookBus.test.ts
+++ b/src/__tests__/plugins/pluginHookBus.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it, spyOn } from 'bun:test'
 import { canonicalPluginEventName, hookBus } from '@core/plugins/hookBus'
 
 afterEach(() => {
@@ -46,6 +46,23 @@ describe('hookBus', () => {
     })
     hookBus.filter('plugin.good', 'pipe', (value) => `${value}-good`)
     expect(await hookBus.applyFilter('pipe', 'seed')).toBe('seed-good')
+  })
+
+  it('falls back to the previous HTML if a filter returns null', async () => {
+    const errorLog = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      hookBus.filter('plugin.bad', 'publish.html', () => null)
+      hookBus.filter('plugin.good', 'publish.html', (value) => `${value}-good`)
+
+      expect(await hookBus.applyFilter('publish.html', '<main>page</main>')).toBe(
+        '<main>page</main>-good',
+      )
+      expect(errorLog).toHaveBeenCalledWith(
+        '[plugin:plugin.bad] filter "publish.html" returned a different value type; keeping the previous value.',
+      )
+    } finally {
+      errorLog.mockRestore()
+    }
   })
 
   it('delivers host emits of core events to listeners on the bare core name', async () => {

--- a/src/core/plugins/hookBus.ts
+++ b/src/core/plugins/hookBus.ts
@@ -91,6 +91,12 @@ interface RegisteredFilter {
   handler: HookFilterHandler
 }
 
+function runtimeValueType(value: unknown): string {
+  if (value === null) return 'null'
+  if (Array.isArray(value)) return 'array'
+  return typeof value
+}
+
 class HookBus {
   private listeners = new Map<string, RegisteredListener[]>()
   private filters = new Map<string, RegisteredFilter[]>()
@@ -154,8 +160,9 @@ class HookBus {
   /**
    * Run a value through every registered handler for a filter pipeline.
    * Each handler receives the previous handler's output and the context
-   * merged from `{ pluginId }` + the optional `contextExtras`. Errors are
-   * logged and the value is left unchanged.
+   * merged from `{ pluginId }` + the optional `contextExtras`. Errors and
+   * results of a different runtime type are logged and leave the value
+   * unchanged.
    *
    * @param contextExtras  Additional context fields forwarded to every
    *   handler alongside `{ pluginId }`. Used by `publish.html` and
@@ -175,6 +182,12 @@ class HookBus {
           ? { pluginId: entry.pluginId, ...contextExtras }
           : { pluginId: entry.pluginId }
         const next = await entry.handler(current, context)
+        if (runtimeValueType(next) !== runtimeValueType(current)) {
+          console.error(
+            `[plugin:${entry.pluginId}] filter "${name}" returned a different value type; keeping the previous value.`,
+          )
+          continue
+        }
         current = next
       } catch (err) {
         console.error(`[plugin:${entry.pluginId}] filter "${name}" threw:`, err)


### PR DESCRIPTION
Fixes #394

## What changed

- Reject filter results whose runtime value type differs from the current pipeline value.
- Keep the previous value, identify the offending plugin in the error log, and continue later filters.
- Document the runtime filter contract for plugin authors and the publisher.

## Why

A plain JavaScript `publish.html` filter could return `null`, bypass the static bake, and make the live renderer serve an empty 200 response. Validation belongs in the hook bus so every filter pipeline gets the same fallback and plugin-aware diagnostics.

## Verification

- Before: targeted regression test failed, 10 pass / 1 fail
- Control without source fix: failed with the same `null-good` result
- `bun run build` (exit 0)
- `bun run lint` (exit 0)
- `bun test` (exit 0, 6,726 pass / 0 fail)
