### PR TITLE
fix(forms): emit content event for public submissions

### DIFF
--- a/docs/features/cms-native-forms.md
+++ b/docs/features/cms-native-forms.md
@@ -52,7 +52,7 @@ CMS-native submission is a two-step public flow:
 1. The runtime requests a short-lived challenge from `/_instatic/form/challenge` when the form attaches in the browser.
 2. The runtime posts values plus the challenge to `/_instatic/form/submit`.
 
-The submit handler reloads the latest published site snapshot, derives the form snapshot from the published page tree, requires the target `DataTable` to be a non-system `data` table, validates fields against that table, and creates a `data_rows` record with `createDataRow`.
+The submit handler reloads the latest published site snapshot, derives the form snapshot from the published page tree, requires the target `DataTable` to be a non-system `data` table, validates fields against that table, and creates a `data_rows` record with `createDataRow`. After persistence, `server/forms/handler.ts` calls `emitContentEntryCreated` from `server/publish/contentEvents.ts` with the `system` actor, so plugins can react to successful submissions through the standard `content.entry.created` channel.
 
 Validation lives in `src/core/forms/validation.ts`. It rejects unknown fields, enforces required fields, coerces table field types, applies email/url/number/select checks, applies control min/max/pattern constraints, and caps payload size.
 

--- a/docs/features/content-storage.md
+++ b/docs/features/content-storage.md
@@ -311,7 +311,7 @@ Every successful content write fires one of three events on the hook bus alongsi
 
 | Event                       | Fires when                                                                 | Payload                                                                                  |
 |-----------------------------|-----------------------------------------------------------------------------|------------------------------------------------------------------------------------------|
-| `content.entry.created`     | A new row is inserted (admin CMS, plugin via `api.cms.content`)              | `{ tableSlug, entryId, actor }`                                                          |
+| `content.entry.created`     | A new row is inserted (admin CMS, public form, plugin via `api.cms.content`) | `{ tableSlug, entryId, actor }`                                                          |
 | `content.entry.updated`     | A row's cells / slug / status change (draft save, publish, schedule, move)  | `{ tableSlug, entryId, changedFieldIds, actor }`                                         |
 | `content.entry.deleted`     | A row is soft-deleted                                                       | `{ tableSlug, entryId, actor }`                                                          |
 
@@ -321,10 +321,10 @@ The `actor` shape:
 type ContentEntryActor =
   | { kind: 'user'; userId: string }
   | { kind: 'plugin'; pluginId: string }
-  | { kind: 'system' }  // schedulers, scheduled-publish tick
+  | { kind: 'system' }  // public forms, schedulers, scheduled-publish tick
 ```
 
-There's also one filter — `content.entry.cells` — that runs over the cell bag BEFORE persistence. All write paths — admin HTTP handlers (`rows.ts`, `tables.ts`) and the plugin `api.cms.content.*` surface — apply it via `applyContentEntryCellsFilter` from `server/publish/contentEvents.ts`. Plugins use it to validate, normalize, or auto-fill cells:
+There's also one filter — `content.entry.cells` — that runs over the cell bag BEFORE persistence. Admin HTTP handlers (`rows.ts`, `tables.ts`) and the plugin `api.cms.content.*` surface apply it via `applyContentEntryCellsFilter` from `server/publish/contentEvents.ts`. Plugins use it to validate, normalize, or auto-fill cells:
 
 ```ts
 api.cms.hooks.filter('content.entry.cells', (cells, { tableSlug, entryId, actor }) => {
@@ -337,7 +337,7 @@ api.cms.hooks.filter('content.entry.cells', (cells, { tableSlug, entryId, actor 
 })
 ```
 
-Events are emitted from `server/publish/contentEvents.ts`, which also exports `applyContentEntryCellsFilter`. Admin CMS handlers and plugin handlers both call these helpers directly; the publish scheduler emits the `system` actor variant.
+Events are emitted from `server/publish/contentEvents.ts`, which also exports `applyContentEntryCellsFilter`. Admin CMS handlers, the public form handler, and plugin handlers call these helpers directly; public submissions and the publish scheduler emit the `system` actor variant.
 
 ---
 

--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -756,6 +756,8 @@ The host protocol names the per-table entry calls as `cms.content.entries.list`,
 
 Three event channels fire alongside every content write. Plugins use `actor` to skip their own writes (avoid feedback loops):
 
+Successful CMS-native public form submissions emit `content.entry.created` with `{ kind: 'system' }`, so notification and automation plugins observe them through the same channel as other row creation.
+
 ```js
 api.cms.hooks.on('content.entry.updated', async ({ tableSlug, entryId, changedFieldIds, actor }) => {
   if (actor.kind === 'plugin' && actor.pluginId === api.plugin.id) return

--- a/server/forms/handler.ts
+++ b/server/forms/handler.ts
@@ -11,6 +11,7 @@ import {
 } from '../http'
 import { createDataRow, getDataTable } from '../repositories/data'
 import { getLatestPublishedSiteSnapshot } from '../repositories/publish'
+import { emitContentEntryCreated } from '../publish/contentEvents'
 import {
   PublicFormChallengeBodySchema,
   PublicFormSubmitBodySchema,
@@ -138,6 +139,7 @@ async function handleSubmit(req: Request, db: DbClient): Promise<Response> {
     cells: validation.cells,
     slug: '',
   })
+  await emitContentEntryCreated(db, row.id, { kind: 'system' })
   return jsonResponse({ ok: true, rowId: row.id })
 }
 

--- a/src/__tests__/server/publicForms.test.ts
+++ b/src/__tests__/server/publicForms.test.ts
@@ -10,6 +10,7 @@ import {
 } from '../../../server/forms/challenge'
 import { publicFormPerFormRateLimit, publicFormPerIpRateLimit } from '../../../server/forms/rateLimit'
 import { configurePublicOrigins, resetPublicOrigins, stampSocketIp } from '../../../server/auth/security'
+import { hookBus } from '@core/plugins/hookBus'
 import { createFakeDb } from './dbTestFake'
 import type { PublishedPageSnapshot } from '../../../server/repositories/publish'
 
@@ -159,6 +160,11 @@ function makeDb(options: {
       })
       return { rows: [{ id: params[0] }], rowCount: 1 }
     }
+    if (sql.startsWith('select data_tables.slug')) {
+      const row = createdRows.find((candidate) => candidate.id === params[0])
+      const table = row ? tableRows[String(row.table_id)] : undefined
+      return table ? { rows: [{ slug: table.slug }], rowCount: 1 } : { rows: [], rowCount: 0 }
+    }
     if (sql.startsWith('select data_rows.id') && sql.includes('from data_rows')) {
       const row = createdRows.find((candidate) => candidate.id === params[0])
       if (!row) return { rows: [], rowCount: 0 }
@@ -220,6 +226,7 @@ function pageToken(): string {
 describe('public CMS-native form endpoint', () => {
   afterEach(() => {
     resetPublicOrigins()
+    hookBus.reset()
   })
 
   it('router owns public form challenge URLs before public-route/setup fallthrough', async () => {
@@ -409,11 +416,15 @@ describe('public CMS-native form endpoint', () => {
     })).toBeNull()
   })
 
-  it('creates a data row for a valid challenged submission', async () => {
+  it('creates a data row and emits its content event for a valid challenged submission', async () => {
     resetPublicFormChallenges()
     publicFormPerIpRateLimit.reset('unknown')
     publicFormPerFormRateLimit.reset('unknown|newsletter')
     const { db, createdRows } = makeDb()
+    const createdEvents: unknown[] = []
+    hookBus.on('test.notifications', 'content.entry.created', (payload) => {
+      createdEvents.push(payload)
+    })
     const challengeResponse = await handlePublicFormRequest(
       makeRequest('/_instatic/form/challenge', { formId: 'newsletter', pageId: 'page-home', pageToken: pageToken() }),
       db,
@@ -437,6 +448,11 @@ describe('public CMS-native form endpoint', () => {
     expect(createdRows).toHaveLength(1)
     expect(createdRows[0].table_id).toBe('newsletter_submissions')
     expect(createdRows[0].cells_json).toEqual({ email: 'ai@example.com' })
+    expect(createdEvents).toEqual([{
+      tableSlug: 'newsletter-submissions',
+      entryId: createdRows[0].id,
+      actor: { kind: 'system' },
+    }])
   })
 
   it('rejects oversized submit payloads before consuming form rate-limit quota', async () => {

--- a/src/core/plugin-sdk/types/hooks.ts
+++ b/src/core/plugin-sdk/types/hooks.ts
@@ -11,9 +11,9 @@
  *                CMS handlers.
  *   - `plugin` — a plugin acting via `api.cms.content.*`; the host fills
  *                in the plugin's id from the dispatcher context.
- *   - `system` — schedulers and other unattended jobs (e.g. the
- *                publish-scheduler tick once `scheduled_publish_at` is in
- *                the past).
+ *   - `system` — unattended server paths (e.g. public form submissions and
+ *                the publish-scheduler tick once `scheduled_publish_at` is
+ *                in the past).
  */
 export type ContentEntryActor =
   | { kind: 'user'; userId: string }


### PR DESCRIPTION
Fixes #372

## What changed

- Emit `content.entry.created` after a successful public form row is persisted.
- Use the existing centralized content-event helper and `{ kind: 'system' }` actor.
- Extend the real challenged-submission test to verify the table slug, row ID, and actor payload.
- Document public submissions in the forms, content storage, and plugin event contracts.

## Why

The public form handler returned immediately after creating its row, bypassing the event channel used by every other content creation path. Notification and automation plugins could not observe successful submissions. Rejected-submission observability remains separate from this fix.

## Verification

- Before: targeted test failed, 12 pass / 1 fail
- Fixed: targeted test passed, 13 pass / 0 fail
- Control without handler fix: failed, 12 pass / 1 fail
- `bun run build` and `bun run lint` (exit 0)
- `bun test` (exit 0, 6,725 pass / 0 fail)
