### PR TITLE
fix(editor): let site panels undock independently

### DIFF
--- a/docs/editor.md
+++ b/docs/editor.md
@@ -532,25 +532,22 @@ Opens the rail-selected panel:
 - `PluginEditorPanel` — plugin-provided editor panels
 - `AgentPanel` — AI assistant
 
-Explorer, Selectors, Framework, Dependencies, and plugin panels use the shared
-`Panel` header contract and can be unpinned into one draggable canvas window.
-Switching among those rail items while unpinned replaces the window content
-without redocking it; the same header action docks the active panel back into
-the left sidebar. A keyboard-accessible bottom-right handle resizes the
-floating window in both axes (arrow keys resize by 10px; Shift+arrow by 40px).
-`leftSidebarMode`, the shared floating position, and its user-set width and
-height are persisted through `siteEditorLayoutPersistence` /
-`workspaceLayoutStorage`.
+Every built-in left-rail panel, including AI, can be undocked independently;
+the active plugin panel follows the same host contract. An undocked panel stays open as its own draggable canvas window
+while another rail item can open normally in the left sidebar. Its rail icon is
+muted while detached, and the panel header can dock it back into the sidebar.
+Each floating window has its own keyboard-accessible bottom-right resize handle
+(arrow keys resize by 10px; Shift+arrow by 40px). Built-in panel modes, open
+state, positions, and dimensions are persisted through
+`siteEditorLayoutPersistence` / `workspaceLayoutStorage`.
 
 The outer left-sidebar layout shell intentionally has no `z-index`, so it does
 not trap floating descendants in a sidebar stacking context. Its docked panel
-slot owns layer 85; the undocked slot and independent Agent panel participate
-directly in the shared floating tier at 90.
-
-The AI Assistant is an independent draggable and resizable floating window, so
-it can stay open beside Explorer/Layers or any other hosted panel. Its position,
-dimensions, and open state persist separately across reloads. Properties
-follows the same independent floating-window interaction contract on the right.
+slot owns layer 85; individually undocked panel hosts participate directly in
+the shared floating tier at 90. The AI Assistant is docked by default and uses
+the same per-panel contract as Explorer, Framework, Selectors, and Dependencies.
+Properties follows the equivalent independent floating-window interaction
+contract on the right.
 
 ### Right sidebar (`RightSidebar`)
 

--- a/src/__tests__/layout/editorLayoutPersistence.test.tsx
+++ b/src/__tests__/layout/editorLayoutPersistence.test.tsx
@@ -102,7 +102,14 @@ function resetStore() {
     propertiesPanel: { collapsed: false, x: 0, y: 0, width: 360 },
     propertiesPanelMode: 'docked',
     leftSidebarWidth: 320,
-    leftSidebarMode: 'docked',
+    leftPanelModes: {
+      explorer: 'docked',
+      selectors: 'docked',
+      framework: 'docked',
+      dependencies: 'docked',
+      agent: 'docked',
+    },
+    pluginPanelMode: 'docked',
     focusedPanel: 'canvas',
     explorerPanelOpen: true,
     explorerPanelTab: 'layers',
@@ -339,9 +346,9 @@ describe('AdminCanvasLayout — persisted panel layout', () => {
             rightWidth: 390,
             rightOpen: true,
             propertiesPanelMode: 'floating',
-            leftSidebarMode: 'floating',
+            leftPanelModes: { explorer: 'floating' },
+            openLeftPanels: ['explorer', 'agent'],
             activeLeftPanel: 'explorer',
-            agentPanelOpen: true,
             explorerPanelTab: 'code',
             codeEditorPanelOpen: true,
             activeEditorFileId: 'file-1',
@@ -359,7 +366,8 @@ describe('AdminCanvasLayout — persisted panel layout', () => {
       expect(state.explorerPanelTab).toBe('code')
       expect(state.propertiesPanel.collapsed).toBe(false)
       expect(state.propertiesPanelMode).toBe('floating')
-      expect(state.leftSidebarMode).toBe('floating')
+      expect(state.leftPanelModes.explorer).toBe('floating')
+      expect(state.leftPanelModes.agent).toBe('docked')
       expect(state.propertiesPanel.width).toBe(390)
       expect(state.leftSidebarWidth).toBe(410)
       expect(state.codeEditorPanelOpen).toBe(true)
@@ -535,25 +543,34 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     fireEvent.click(within(rail).getByRole('button', { name: /open ai assistant panel/i }))
 
     expect(sidebar.getAttribute('data-expanded')).toBe('true')
-    expect(sidebar.getAttribute('data-active-panel')).toBe('dependencies')
+    expect(sidebar.getAttribute('data-active-panel')).toBe('agent')
     expect(sidebar.getAttribute('style')).toContain('--left-sidebar-panel-width: 320px')
     expect(useEditorStore.getState().isAgentOpen).toBe(true)
-    expect(useEditorStore.getState().dependenciesPanelOpen).toBe(true)
+    expect(useEditorStore.getState().dependenciesPanelOpen).toBe(false)
     expect(useEditorStore.getState().explorerPanelOpen).toBe(false)
-    const agentPanel = within(sidebar).getByTestId('agent-panel').closest('[data-panel]')
-    expect(agentPanel).not.toBeNull()
+    const agentHost = within(sidebar).getByTestId('left-panel-agent-host')
+    expect(agentHost.getAttribute('data-mode')).toBe('docked')
+    expect(within(agentHost).queryByRole('separator', {
+      name: /resize ai assistant panel/i,
+    })).toBeNull()
 
-    const agentResizeHandle = within(agentPanel as HTMLElement).getByRole('separator', {
+    fireEvent.click(within(agentHost).getByRole('button', { name: /undock ai assistant panel/i }))
+
+    expect(sidebar.getAttribute('data-expanded')).toBe('false')
+    expect(agentHost.getAttribute('data-mode')).toBe('floating')
+    expect(within(rail).getByTestId('panel-rail-agent').getAttribute('data-detached')).toBe('true')
+
+    const agentResizeHandle = within(agentHost).getByRole('separator', {
       name: /resize ai assistant panel/i,
     })
     fireEvent.keyDown(agentResizeHandle, { key: 'ArrowRight' })
     fireEvent.keyDown(agentResizeHandle, { key: 'ArrowDown' })
 
     await waitFor(() => {
-      expect((agentPanel as HTMLElement).style.getPropertyValue('--panel-w')).toBe('330px')
-      expect((agentPanel as HTMLElement).style.getPropertyValue('--panel-h')).toBe('490px')
+      expect(agentHost.style.getPropertyValue('--panel-w')).toBe('330px')
+      expect(agentHost.style.getPropertyValue('--panel-h')).toBe('530px')
       const stored = JSON.parse(localStorage.getItem(LAYOUT_STORAGE_KEY) ?? '{}')
-      expect(stored.panelSizes?.agent).toEqual({ width: 330, height: 490 })
+      expect(stored.panelSizes?.agent).toEqual({ width: 330, height: 530 })
     }, { timeout: 150 })
 
     fireEvent.click(within(rail).getByRole('button', { name: /open explorer panel/i }))
@@ -579,7 +596,7 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     expect(rightSidebar.getAttribute('style')).toContain('--right-sidebar-panel-width: 360px')
     expect(within(rightSidebar).getByTestId('properties-panel').getAttribute('data-variant')).toBe('docked')
 
-    fireEvent.click(within(rightSidebar).getByRole('button', { name: /unpin properties panel/i }))
+    fireEvent.click(within(rightSidebar).getByRole('button', { name: /undock properties panel/i }))
 
     await waitFor(() => {
       expect(useEditorStore.getState().propertiesPanelMode).toBe('floating')
@@ -612,32 +629,32 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     }, { timeout: 150 })
   })
 
-  it('can unpin hosted left-rail panels and keeps switching in the floating host', async () => {
+  it('undocks one panel while other rail panels keep using the docked sidebar', async () => {
     renderEditorLayout()
 
     const sidebar = await screen.findByTestId('left-sidebar')
     const rail = within(sidebar).getByRole('navigation', { name: /panel dock/i })
-    const panelSlot = within(sidebar).getByTestId('left-sidebar-panel-slot')
+    const explorerHost = within(sidebar).getByTestId('left-panel-explorer-host')
 
-    fireEvent.click(within(sidebar).getByRole('button', { name: /unpin explorer panel/i }))
+    fireEvent.click(within(sidebar).getByRole('button', { name: /undock explorer panel/i }))
 
     await waitFor(() => {
-      expect(useEditorStore.getState().leftSidebarMode).toBe('floating')
+      expect(useEditorStore.getState().leftPanelModes.explorer).toBe('floating')
       expect(sidebar.getAttribute('data-expanded')).toBe('false')
-      expect(panelSlot.getAttribute('data-mode')).toBe('floating')
+      expect(explorerHost.getAttribute('data-mode')).toBe('floating')
     }, { timeout: 150 })
 
-    const explorerResizeHandle = within(panelSlot).getByRole('separator', {
+    const explorerResizeHandle = within(explorerHost).getByRole('separator', {
       name: /resize explorer panel/i,
     })
     fireEvent.keyDown(explorerResizeHandle, { key: 'ArrowRight' })
     fireEvent.keyDown(explorerResizeHandle, { key: 'ArrowUp' })
 
     await waitFor(() => {
-      expect(panelSlot.style.getPropertyValue('--panel-w')).toBe('330px')
-      expect(panelSlot.style.getPropertyValue('--panel-h')).toBe('510px')
+      expect(explorerHost.style.getPropertyValue('--panel-w')).toBe('330px')
+      expect(explorerHost.style.getPropertyValue('--panel-h')).toBe('510px')
       const stored = JSON.parse(localStorage.getItem(LAYOUT_STORAGE_KEY) ?? '{}')
-      expect(stored.panelSizes?.site).toEqual({ width: 330, height: 510 })
+      expect(stored.panelSizes?.explorer).toEqual({ width: 330, height: 510 })
     }, { timeout: 150 })
 
     const railTargets = [
@@ -648,17 +665,19 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
 
     for (const [label, testId] of railTargets) {
       fireEvent.click(within(rail).getByRole('button', { name: new RegExp(`open ${label} panel`, 'i') }))
-      expect(within(panelSlot).getByTestId(testId)).toBeDefined()
-      expect(within(panelSlot).getByRole('button', { name: new RegExp(`dock ${label} panel`, 'i') })).toBeDefined()
-      expect(sidebar.getAttribute('data-expanded')).toBe('false')
+      expect(within(sidebar).getByTestId(testId)).toBeDefined()
+      expect(sidebar.getAttribute('data-active-panel')).toBe(label)
+      expect(sidebar.getAttribute('data-expanded')).toBe('true')
+      expect(explorerHost.getAttribute('data-mode')).toBe('floating')
     }
 
-    fireEvent.click(within(panelSlot).getByRole('button', { name: /dock dependencies panel/i }))
+    fireEvent.click(within(explorerHost).getByRole('button', { name: /dock explorer panel/i }))
 
     await waitFor(() => {
-      expect(useEditorStore.getState().leftSidebarMode).toBe('docked')
+      expect(useEditorStore.getState().leftPanelModes.explorer).toBe('docked')
       expect(sidebar.getAttribute('data-expanded')).toBe('true')
-      expect(panelSlot.getAttribute('data-mode')).toBe('docked')
+      expect(sidebar.getAttribute('data-active-panel')).toBe('explorer')
+      expect(explorerHost.getAttribute('data-mode')).toBe('docked')
     }, { timeout: 150 })
   })
 
@@ -674,7 +693,7 @@ describe('AdminCanvasLayout — permanent panel rail', () => {
     }, { timeout: 150 })
 
     const rightSidebar = screen.getByTestId('right-sidebar')
-    fireEvent.click(within(rightSidebar).getByRole('button', { name: /unpin properties panel/i }))
+    fireEvent.click(within(rightSidebar).getByRole('button', { name: /undock properties panel/i }))
 
     await waitFor(() => {
       expect(canvasStage!.getAttribute('data-right-sidebar-expanded')).toBe('false')

--- a/src/__tests__/layout/workspaceLayoutStorage.test.ts
+++ b/src/__tests__/layout/workspaceLayoutStorage.test.ts
@@ -50,12 +50,15 @@ describe('workspaceLayoutStorage — floating panel sizes', () => {
   })
 
   it('preserves workspace layout state when updating floating dimensions', () => {
-    writeWorkspaceLayout('site', { leftWidth: 380, leftSidebarMode: 'floating' })
+    writeWorkspaceLayout('site', {
+      leftWidth: 380,
+      leftPanelModes: { explorer: 'floating' },
+    })
     writeStoredPanelSize('properties', { width: 480, height: 620 })
 
     expect(readWorkspaceLayout('site')).toMatchObject({
       leftWidth: 380,
-      leftSidebarMode: 'floating',
+      leftPanelModes: { explorer: 'floating' },
     })
     expect(readStoredPanelSize('properties')).toEqual({ width: 480, height: 620 })
   })

--- a/src/admin/pages/site/layout/siteEditorLayoutPersistence.ts
+++ b/src/admin/pages/site/layout/siteEditorLayoutPersistence.ts
@@ -1,7 +1,11 @@
 import { rawReturn } from 'mutative'
 import type { StoreApi, UseBoundStore } from 'zustand'
 import type { EditorStore } from '@site/store/types'
-import type { ExplorerPanelTab } from '@site/store/slices/uiSlice'
+import type {
+  ExplorerPanelTab,
+  LeftPanelModes,
+  LeftSidebarPanelId,
+} from '@site/store/slices/uiSlice'
 import {
   readWorkspaceLayout,
   writeWorkspaceLayout,
@@ -25,7 +29,7 @@ export type SiteLayoutSelection = readonly [
   agentOpen: boolean,
   explorerTab: ExplorerPanelTab,
   propertiesMode: PanelMode,
-  leftSidebarMode: PanelMode,
+  leftPanelModes: LeftPanelModes,
   leftSidebarWidth: number,
   propertiesWidth: number,
   activeEditorFileId: string | null,
@@ -60,6 +64,24 @@ function storedPanelMode(value: unknown, currentMode: PanelMode): PanelMode {
   return value === 'floating' || value === 'docked' ? value : currentMode
 }
 
+const LEFT_PANEL_IDS: LeftSidebarPanelId[] = [
+  'explorer',
+  'selectors',
+  'framework',
+  'dependencies',
+  'agent',
+]
+
+function storedLeftPanelModes(
+  value: Record<string, PanelMode> | undefined,
+  currentModes: LeftPanelModes,
+): LeftPanelModes {
+  return Object.fromEntries(LEFT_PANEL_IDS.map((panel) => [
+    panel,
+    storedPanelMode(value?.[panel], currentModes[panel]),
+  ])) as LeftPanelModes
+}
+
 function leftSidebarWidth(layout: StoredWorkspaceLayout, currentWidth: number): number {
   return clampSidebarWidth(finiteNumberOrCurrent(
     layout.leftWidth,
@@ -78,7 +100,7 @@ export function selectSiteLayoutState(s: EditorStore): SiteLayoutSelection {
     s.isAgentOpen,
     s.explorerPanelTab,
     s.propertiesPanelMode,
-    s.leftSidebarMode,
+    s.leftPanelModes,
     s.leftSidebarWidth,
     s.propertiesPanel.width,
     s.activeEditorFileId,
@@ -98,11 +120,24 @@ function deriveSiteActiveLeftPanel(selection: SiteLayoutSelection): string | nul
     dependenciesOpen,
   ] = selection
 
-  if (explorerOpen) return 'explorer'
-  if (selectorsOpen) return 'selectors'
-  if (frameworkOpen) return 'framework'
-  if (dependenciesOpen) return 'dependencies'
+  const modes = selection[9]
+  if (explorerOpen && modes.explorer === 'docked') return 'explorer'
+  if (selectorsOpen && modes.selectors === 'docked') return 'selectors'
+  if (frameworkOpen && modes.framework === 'docked') return 'framework'
+  if (dependenciesOpen && modes.dependencies === 'docked') return 'dependencies'
+  if (selection[6] && modes.agent === 'docked') return 'agent'
   return null
+}
+
+function deriveOpenLeftPanels(selection: SiteLayoutSelection): LeftSidebarPanelId[] {
+  const [explorer, , selectors, framework, dependencies, , agent] = selection
+  return LEFT_PANEL_IDS.filter((panel) => ({
+    explorer,
+    selectors,
+    framework,
+    dependencies,
+    agent,
+  })[panel])
 }
 
 export function siteLayoutFromSelection(
@@ -115,10 +150,10 @@ export function siteLayoutFromSelection(
     ,
     ,
     codeEditorOpen,
-    agentOpen,
+    ,
     explorerTab,
     propertiesMode,
-    leftSidebarMode,
+    leftPanelModes,
     leftSidebarWidth,
     propertiesWidth,
     activeEditorFileId,
@@ -134,8 +169,8 @@ export function siteLayoutFromSelection(
     activeEditorFileId,
     codeEditorPanelOpen: codeEditorOpen,
     propertiesPanelMode: propertiesMode,
-    leftSidebarMode,
-    agentPanelOpen: agentOpen,
+    leftPanelModes,
+    openLeftPanels: deriveOpenLeftPanels(selection),
   }
 }
 
@@ -147,15 +182,17 @@ export function restoreStoredSiteEditorLayout(
     const propertiesOpen = boolOrCurrent(layout.rightOpen, !state.propertiesPanel.collapsed)
     const storedActivePanel = layout.activeLeftPanel
     const applyLeftPanel = storedActivePanel !== undefined
-    const storedAgentOpen = layout.agentPanelOpen
-      ?? (storedActivePanel === 'agent' ? true : state.isAgentOpen)
+    const openLeftPanels = layout.openLeftPanels
+    const isStoredOpen = (panel: LeftSidebarPanelId, current: boolean) => (
+      openLeftPanels ? openLeftPanels.includes(panel) : current
+    )
 
     const leftPanelPatch = applyLeftPanel
       ? {
-          explorerPanelOpen: storedActivePanel === 'explorer',
-          selectorsPanelOpen: storedActivePanel === 'selectors',
-          frameworkPanelOpen: storedActivePanel === 'framework',
-          dependenciesPanelOpen: storedActivePanel === 'dependencies',
+          explorerPanelOpen: isStoredOpen('explorer', storedActivePanel === 'explorer'),
+          selectorsPanelOpen: isStoredOpen('selectors', storedActivePanel === 'selectors'),
+          frameworkPanelOpen: isStoredOpen('framework', storedActivePanel === 'framework'),
+          dependenciesPanelOpen: isStoredOpen('dependencies', storedActivePanel === 'dependencies'),
         }
       : {}
 
@@ -166,11 +203,11 @@ export function restoreStoredSiteEditorLayout(
         width: finiteNumberOrCurrent(layout.rightWidth, state.propertiesPanel.width),
       },
       propertiesPanelMode: propertiesMode(layout, state.propertiesPanelMode),
-      leftSidebarMode: storedPanelMode(layout.leftSidebarMode, state.leftSidebarMode),
+      leftPanelModes: storedLeftPanelModes(layout.leftPanelModes, state.leftPanelModes),
       leftSidebarWidth: leftSidebarWidth(layout, state.leftSidebarWidth),
       explorerPanelTab: explorerTab(layout.explorerPanelTab, state.explorerPanelTab),
       codeEditorPanelOpen: boolOrCurrent(layout.codeEditorPanelOpen, state.codeEditorPanelOpen),
-      isAgentOpen: storedAgentOpen,
+      isAgentOpen: isStoredOpen('agent', state.isAgentOpen),
       activeEditorFileId: layout.activeEditorFileId !== undefined
         ? layout.activeEditorFileId
         : state.activeEditorFileId,

--- a/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
+++ b/src/admin/pages/site/panels/AgentPanel/AgentPanel.tsx
@@ -1,10 +1,8 @@
 /**
- * AgentPanel — self-contained floating AI assistant panel (Guideline #410).
+ * AgentPanel — AI assistant content for a docked or floating panel host.
  *
- * This component renders its own floating overlay container — positioned at
- * bottom-right of the canvas area. Visibility is controlled by `isAgentOpen`
- * in the agentSlice. Always-mounted (CSS display:none when closed) to preserve
- * Zustand conversation state across open/close cycles.
+ * Visibility is controlled by `isAgentOpen` in the agentSlice. The Site editor
+ * supplies per-panel dock/drag controls; Content embeds the same panel docked.
  *
  * Runtime model:
  * - Agent calls stream through `/admin/api/ai/chat/site`.
@@ -32,7 +30,8 @@ import { AiBoxSolidIcon } from 'pixel-art-icons/icons/ai-box-solid'
 import { AiSettingsSolidIcon } from 'pixel-art-icons/icons/ai-settings-solid'
 import { EditSolidIcon } from 'pixel-art-icons/icons/edit-solid'
 import { ArrowRightIcon } from 'pixel-art-icons/icons/arrow-right'
-import { PanelHeader } from '@admin/shared/PanelHeader'
+import { PanelHeader, PanelModeButton } from '@admin/shared/PanelHeader'
+import type { DockablePanelProps } from '@admin/shared/Panel'
 import { UserAvatar } from '@admin/shared/UserAvatar'
 import { Button } from '@ui/components/Button'
 import { EmptyState } from '@ui/components/EmptyState'
@@ -63,7 +62,7 @@ const PANEL_HEIGHT = 480
 const AI_SETTINGS_ROUTE = '/admin/ai'
 type PanelVariant = 'floating' | 'docked'
 
-interface AgentPanelProps {
+interface AgentPanelProps extends DockablePanelProps {
   variant?: PanelVariant
 }
 
@@ -78,7 +77,12 @@ interface AgentPanelProps {
  * (`.floatPanelClosed`) to preserve Zustand conversation state across open/close cycles.
  * Agent routes via Vite proxy `/admin/api/agent` → local Bun server → Claude SDK.
  */
-export function AgentPanel({ variant = 'floating' }: AgentPanelProps) {
+export function AgentPanel({
+  variant = 'floating',
+  mode = variant,
+  dragHandleProps,
+  onToggleMode,
+}: AgentPanelProps) {
   const agentStore = useAgentStoreApi()
   const isOpen = useAgentStore((s) => s.isAgentOpen)
   const isStreaming = useAgentStore((s) => s.isAgentStreaming)
@@ -239,7 +243,7 @@ export function AgentPanel({ variant = 'floating' }: AgentPanelProps) {
         panelId="agent"
         title="AI Assistant"
         onClose={closeAgent}
-        dragHandleProps={variant === 'floating' ? headerDragProps : undefined}
+        dragHandleProps={dragHandleProps ?? (variant === 'floating' ? headerDragProps : undefined)}
       >
         {/* History popover — list past chats, start a new one, delete. */}
         <ConversationHistory />
@@ -268,6 +272,14 @@ export function AgentPanel({ variant = 'floating' }: AgentPanelProps) {
           label="AI settings"
           data-testid="agent-settings-header-button"
         />
+        {onToggleMode && (
+          <PanelModeButton
+            mode={mode}
+            panelLabel="AI Assistant"
+            dockLocation="left sidebar"
+            onToggle={onToggleMode}
+          />
+        )}
       </PanelHeader>
 
       {/* ── Message thread ──────────────────────────────────────────────────── */}

--- a/src/admin/pages/site/panels/PropertiesPanel/PropertiesPanel.tsx
+++ b/src/admin/pages/site/panels/PropertiesPanel/PropertiesPanel.tsx
@@ -194,6 +194,7 @@ export function PropertiesPanel({ variant = 'floating' }: PropertiesPanelProps) 
           mode={variant}
           panelLabel="Properties"
           dockLocation="right sidebar"
+          dockSide="right"
           onToggle={() => data.setPropertiesPanelMode(variant === 'docked' ? 'floating' : 'docked')}
         />
       </PanelHeader>

--- a/src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.tsx
+++ b/src/admin/pages/site/sidebars/LeftSidebar/LeftSidebar.tsx
@@ -1,6 +1,6 @@
-import { lazy, Suspense, useRef, type CSSProperties } from 'react'
+import { lazy, Suspense, useRef, type CSSProperties, type ReactNode } from 'react'
 import { useEditorStore } from '@site/store/store'
-import type { LeftSidebarPanelId } from '@site/store/slices/uiSlice'
+import type { LeftSidebarPanelId, PanelMode } from '@site/store/slices/uiSlice'
 import { AgentStoreProvider } from '@admin/ai/AgentStoreContext'
 import { FrameworkPanel } from '@site/panels/FrameworkPanel'
 import { ExplorerPanel } from '@site/panels/ExplorerPanel'
@@ -11,69 +11,44 @@ import { SelectorsPanel } from '@site/panels/SelectorsPanel'
 import { FrameworkChangeConfirmProvider } from '@admin/shared/dialogs/FrameworkChangeConfirmDialog'
 import { VCDeletionConfirmProvider } from '@admin/shared/dialogs/VCDeletionConfirmDialog'
 import { SidebarResizeHandle } from '@admin/shared/SidebarResizeHandle'
-import {
-  PanelResizeHandle,
-  useDraggablePanel,
-  useResizablePanel,
-} from '@admin/shared/FloatingWindow'
+import { PanelResizeHandle, useDraggablePanel, useResizablePanel } from '@admin/shared/FloatingWindow'
+import type { DockablePanelProps } from '@admin/shared/Panel'
+import type { FloatingPanelId } from '@admin/state/workspaceLayoutStorage'
 import { cn } from '@ui/cn'
 import styles from './LeftSidebar.module.css'
 
-// Image preparation and provider catalogue code belong to the AI surface, not
-// the editor startup path. A nested boundary lets the sidebar/canvas render as
-// soon as their parent chunk is ready, then loads the always-mounted AgentPanel
-// independently so its local draft survives panel switches after first load.
 const AgentPanel = lazy(() =>
   import('@site/panels/AgentPanel').then((module) => ({ default: module.AgentPanel })),
 )
 
-type HostedLeftPanelId = Exclude<LeftSidebarPanelId, 'agent'>
-
-function selectActiveLeftSidebarPanel(
-  state: ReturnType<typeof useEditorStore.getState>,
-): HostedLeftPanelId | null {
-  // A plugin panel takes precedence over the built-in `*PanelOpen` flags;
-  // the LeftSidebar reads `activePluginPanelId` separately and shows the
-  // plugin mount when set.
-  if (state.activePluginPanelId !== null) return null
-  if (state.explorerPanelOpen) return 'explorer'
-  if (state.selectorsPanelOpen) return 'selectors'
-  if (state.frameworkPanelOpen) return 'framework'
-  if (state.dependenciesPanelOpen) return 'dependencies'
-  return null
-}
-
-interface LeftSidebarProps {
-  /** Drives the rail-button accent identity hash (`${workspace}:${id}:…`). */
-  workspace?: 'site' | 'content' | 'media'
-  railOnly?: boolean
-  /**
-   * Whether the caller can perform structural edits (DnD, add/remove nodes,
-   * pages, styles). Controls which side-panels are exposed in the rail.
-   *
-   * Falsy callers (Viewer / Client) still see the Explorer panel (Layers /
-   * Pages / Media navigation surfaces) — they're not editing tools. The
-   * structural Selectors / Framework / Dependencies panels stay hidden. The
-   * Agent panel is controlled separately by `canUseAiChat`.
-   *
-   * Each panel is responsible for respecting its own read-only state for
-   * the interactions it exposes (TreeNode drag, context menus, etc.).
-   */
-  editable?: boolean
-  canUseAiChat?: boolean
-}
-
-/**
- * Set of rail items that remain visible to read-only callers — purely
- * navigational / view surfaces. Anything not in this set is editing-only
- * and is dropped from the rail (and its panel mount) when `editable=false`.
- */
 const READ_ONLY_RAIL_IDS: ReadonlySet<LeftSidebarPanelId> = new Set(['explorer'])
-const PANEL_RESIZE_LABELS: Record<HostedLeftPanelId, string> = {
+const PANEL_LABELS: Record<LeftSidebarPanelId, string> = {
   explorer: 'Explorer',
   selectors: 'Selectors',
   framework: 'Framework',
   dependencies: 'Dependencies',
+  agent: 'AI Assistant',
+}
+
+interface LeftSidebarProps {
+  workspace?: 'site' | 'content' | 'media'
+  railOnly?: boolean
+  editable?: boolean
+  canUseAiChat?: boolean
+}
+
+function selectActiveDockedPanel(
+  state: ReturnType<typeof useEditorStore.getState>,
+): LeftSidebarPanelId | null {
+  const candidates: Array<[LeftSidebarPanelId, boolean]> = [
+    ['explorer', state.explorerPanelOpen],
+    ['selectors', state.selectorsPanelOpen],
+    ['framework', state.frameworkPanelOpen],
+    ['dependencies', state.dependenciesPanelOpen],
+    ['agent', state.isAgentOpen],
+  ]
+  return candidates.find(([panel, open]) => open && state.leftPanelModes[panel] === 'docked')?.[0]
+    ?? null
 }
 
 export function LeftSidebar({
@@ -83,57 +58,31 @@ export function LeftSidebar({
   canUseAiChat = true,
 }: LeftSidebarProps) {
   const sidebarRef = useRef<HTMLElement | null>(null)
-  const activePanel = useEditorStore(selectActiveLeftSidebarPanel)
+  const activeDockedPanel = useEditorStore(selectActiveDockedPanel)
   const activePluginPanelId = useEditorStore((s) => s.activePluginPanelId)
+  const pluginPanelMode = useEditorStore((s) => s.pluginPanelMode)
   const leftSidebarWidth = useEditorStore((s) => s.leftSidebarWidth)
-  const leftSidebarMode = useEditorStore((s) => s.leftSidebarMode)
   const setLeftSidebarWidth = useEditorStore((s) => s.setLeftSidebarWidth)
-  const setLeftSidebarMode = useEditorStore((s) => s.setLeftSidebarMode)
-  // When the user can't edit structure, drop them onto Layers if they had a
-  // hidden-for-them panel active (selectors, colors, …). Plugin panels are
-  // editing-only by definition.
-  const effectiveActivePanel =
-    activePanel && canShowBuiltInPanel(activePanel, editable, canUseAiChat)
-      ? activePanel
+  const setPluginPanelMode = useEditorStore((s) => s.setPluginPanelMode)
+  const explorerOpen = useEditorStore((s) => s.explorerPanelOpen)
+  const selectorsOpen = useEditorStore((s) => s.selectorsPanelOpen)
+  const frameworkOpen = useEditorStore((s) => s.frameworkPanelOpen)
+  const dependenciesOpen = useEditorStore((s) => s.dependenciesPanelOpen)
+  const agentOpen = useEditorStore((s) => s.isAgentOpen)
+
+  const effectiveActivePanel = activeDockedPanel === null
+    ? null
+    : canShowBuiltInPanel(activeDockedPanel, editable, canUseAiChat)
+      ? activeDockedPanel
       : editable
         ? null
         : 'explorer'
-  const effectivePluginPanelId = editable ? activePluginPanelId : null
-  // Sidebar is "expanded" whenever a built-in OR plugin panel is showing.
-  const sidebarOpen = Boolean(effectiveActivePanel) || effectivePluginPanelId !== null
-  const panelFloating = sidebarOpen && leftSidebarMode === 'floating'
-  const panelExpanded = sidebarOpen && leftSidebarMode === 'docked' && !railOnly
-  const panelVisible = panelExpanded || panelFloating
+  const dockedPluginPanelId = editable && pluginPanelMode === 'docked'
+    ? activePluginPanelId
+    : null
+  const panelExpanded = !railOnly
+    && (effectiveActivePanel !== null || dockedPluginPanelId !== null)
   const panelWidth = panelExpanded ? leftSidebarWidth : 0
-  const panelResizeLabel = effectivePluginPanelId !== null
-    ? 'plugin'
-    : effectiveActivePanel
-      ? PANEL_RESIZE_LABELS[effectiveActivePanel]
-      : 'left sidebar'
-  const {
-    panelRef,
-    setPanelRef,
-    headerDragProps,
-    panelPositionStyle,
-  } = useDraggablePanel('site', () => ({ x: 58, y: 64 }))
-  const {
-    panelSizeStyle,
-    resizeHandleProps,
-  } = useResizablePanel(
-    'site',
-    panelRef,
-    () => ({ width: leftSidebarWidth, height: 520 }),
-  )
-
-  const togglePanelMode = () => {
-    setLeftSidebarMode(leftSidebarMode === 'docked' ? 'floating' : 'docked')
-  }
-  const dockablePanelProps = {
-    mode: leftSidebarMode,
-    dragHandleProps: panelFloating ? headerDragProps : undefined,
-    onToggleMode: togglePanelMode,
-  } as const
-
   const style = {
     '--left-sidebar-panel-width': `${panelWidth}px`,
     '--left-sidebar-panel-layout-width': `${panelExpanded ? leftSidebarWidth : 0}px`,
@@ -146,8 +95,8 @@ export function LeftSidebar({
       data-testid="left-sidebar"
       data-expanded={panelExpanded ? 'true' : 'false'}
       data-rail-only={railOnly ? 'true' : undefined}
-      data-active-panel={effectivePluginPanelId !== null
-        ? `plugin:${effectivePluginPanelId}`
+      data-active-panel={dockedPluginPanelId !== null
+        ? `plugin:${dockedPluginPanelId}`
         : effectiveActivePanel ?? 'none'}
       style={style}
     >
@@ -160,66 +109,48 @@ export function LeftSidebar({
 
       <FrameworkChangeConfirmProvider>
       <VCDeletionConfirmProvider>
-        <div
-          ref={panelFloating ? setPanelRef : undefined}
-          className={cn(styles.panelSlot, panelFloating && styles.panelSlotFloating)}
-          data-testid="left-sidebar-panel-slot"
-          data-mode={leftSidebarMode}
-          inert={panelVisible ? undefined : true}
-          style={panelFloating ? { ...panelPositionStyle, ...panelSizeStyle } : undefined}
-        >
-          {/* Read-only-safe panels — always rendered for any role with
-              `site.read`. These are navigation/inspection surfaces, not
-              editing tools; each respects its own read-only state internally
-              (e.g. TreeNode disables drag + context menu via `editable`). */}
-          <div className={styles.panelMount} hidden={effectiveActivePanel !== 'explorer'}>
-            <ExplorerPanel editable={editable} {...dockablePanelProps} />
-          </div>
-          {/* Editor-only panels — only mounted when the caller can perform
-              structural edits. Mounting them for non-editors would expose
-              actions (style edits, framework token changes, plugin panels)
-              they have no capability to commit. */}
-          {editable && (
-            <>
-              <div className={styles.panelMount} hidden={effectiveActivePanel !== 'selectors'}>
-                <SelectorsPanel {...dockablePanelProps} />
-              </div>
-              <div className={styles.panelMount} hidden={effectiveActivePanel !== 'framework'}>
-                <FrameworkPanel {...dockablePanelProps} />
-              </div>
-              <div className={styles.panelMount} hidden={effectiveActivePanel !== 'dependencies'}>
-                <DependenciesPanel {...dockablePanelProps} />
-              </div>
-              {effectivePluginPanelId !== null && (
-                <div
-                  className={styles.panelMount}
-                  data-testid="left-sidebar-plugin-panel-mount"
-                >
-                  <PluginEditorPanel
-                    panelId={effectivePluginPanelId}
-                    {...dockablePanelProps}
-                  />
-                </div>
-              )}
-            </>
-          )}
-          {panelFloating && (
-            <PanelResizeHandle
-              panelLabel={panelResizeLabel}
-              resizeHandleProps={resizeHandleProps}
-            />
-          )}
-        </div>
+        <BuiltInPanelHost panel="explorer" open={explorerOpen} activeDockedPanel={effectiveActivePanel}>
+          {(props) => <ExplorerPanel editable={editable} {...props} />}
+        </BuiltInPanelHost>
+
+        {editable && (
+          <>
+            <BuiltInPanelHost panel="selectors" open={selectorsOpen} activeDockedPanel={effectiveActivePanel}>
+              {(props) => <SelectorsPanel {...props} />}
+            </BuiltInPanelHost>
+            <BuiltInPanelHost panel="framework" open={frameworkOpen} activeDockedPanel={effectiveActivePanel}>
+              {(props) => <FrameworkPanel {...props} />}
+            </BuiltInPanelHost>
+            <BuiltInPanelHost panel="dependencies" open={dependenciesOpen} activeDockedPanel={effectiveActivePanel}>
+              {(props) => <DependenciesPanel {...props} />}
+            </BuiltInPanelHost>
+            {activePluginPanelId !== null && (
+              <FloatingPanelHost
+                panelId="plugin"
+                label="Plugin"
+                mode={pluginPanelMode}
+                open
+                activeDocked={dockedPluginPanelId !== null}
+                onToggleMode={() => setPluginPanelMode(
+                  pluginPanelMode === 'docked' ? 'floating' : 'docked',
+                )}
+              >
+                {(props) => <PluginEditorPanel panelId={activePluginPanelId} {...props} />}
+              </FloatingPanelHost>
+            )}
+          </>
+        )}
+
         {canUseAiChat && (
-          /* The AI assistant stays independent from the hosted left panel so
-             users can keep Layers visible while following a conversation.
-             Keeping it mounted also preserves the current draft. */
-          // eslint-disable-next-line react-compiler/react-compiler
-          <AgentStoreProvider store={useEditorStore}>
-            <Suspense fallback={null}>
-              <AgentPanel />
-            </Suspense>
-          </AgentStoreProvider>
+          <BuiltInPanelHost panel="agent" open={agentOpen} activeDockedPanel={effectiveActivePanel}>
+            {(props) => (
+              <AgentStoreProvider store={useEditorStore}>
+                <Suspense fallback={null}>
+                  <AgentPanel variant="docked" {...props} />
+                </Suspense>
+              </AgentStoreProvider>
+            )}
+          </BuiltInPanelHost>
         )}
       </VCDeletionConfirmProvider>
       </FrameworkChangeConfirmProvider>
@@ -236,6 +167,87 @@ export function LeftSidebar({
         />
       )}
     </aside>
+  )
+}
+
+function BuiltInPanelHost({
+  panel,
+  open,
+  activeDockedPanel,
+  children,
+}: {
+  panel: LeftSidebarPanelId
+  open: boolean
+  activeDockedPanel: LeftSidebarPanelId | null
+  children: (props: DockablePanelProps) => ReactNode
+}) {
+  const mode = useEditorStore((s) => s.leftPanelModes[panel])
+  const setMode = useEditorStore((s) => s.setLeftSidebarPanelMode)
+  return (
+    <FloatingPanelHost
+      panelId={panel}
+      label={PANEL_LABELS[panel]}
+      mode={mode}
+      open={open}
+      activeDocked={activeDockedPanel === panel}
+      onToggleMode={() => setMode(panel, mode === 'docked' ? 'floating' : 'docked')}
+    >
+      {children}
+    </FloatingPanelHost>
+  )
+}
+
+function FloatingPanelHost({
+  panelId,
+  label,
+  mode,
+  open,
+  activeDocked,
+  onToggleMode,
+  children,
+}: {
+  panelId: FloatingPanelId
+  label: string
+  mode: PanelMode
+  open: boolean
+  activeDocked: boolean
+  onToggleMode: () => void
+  children: (props: DockablePanelProps) => ReactNode
+}) {
+  const floating = mode === 'floating'
+  const visible = floating ? open : activeDocked
+  const leftSidebarWidth = useEditorStore((s) => s.leftSidebarWidth)
+  const { panelRef, setPanelRef, headerDragProps, panelPositionStyle } = useDraggablePanel(
+    panelId,
+    () => ({ x: 58, y: 64 }),
+  )
+  const { panelSizeStyle, resizeHandleProps } = useResizablePanel(
+    panelId,
+    panelRef,
+    () => ({ width: leftSidebarWidth, height: 520 }),
+  )
+
+  return (
+    <div
+      ref={floating ? setPanelRef : undefined}
+      className={cn(styles.panelSlot, floating && styles.panelSlotFloating)}
+      data-testid={`left-panel-${panelId}-host`}
+      data-mode={mode}
+      hidden={!visible}
+      inert={visible ? undefined : true}
+      style={floating ? { ...panelPositionStyle, ...panelSizeStyle } : undefined}
+    >
+      <div className={styles.panelMount}>
+        {children({
+          mode,
+          dragHandleProps: floating ? headerDragProps : undefined,
+          onToggleMode,
+        })}
+      </div>
+      {floating && visible && (
+        <PanelResizeHandle panelLabel={label} resizeHandleProps={resizeHandleProps} />
+      )}
+    </div>
   )
 }
 

--- a/src/admin/pages/site/sidebars/PanelRail/PanelRail.module.css
+++ b/src/admin/pages/site/sidebars/PanelRail/PanelRail.module.css
@@ -55,6 +55,12 @@
     background: var(--rail-icon-active-bg);
 }
 
+.railButtonDetached .railIcon {
+    color: var(--text-disabled);
+    filter: grayscale(1);
+    opacity: 0.55;
+}
+
 .railIcon {
     color: var(--rail-icon-color);
     filter: drop-shadow(0 0 5px var(--rail-icon-glow));

--- a/src/admin/pages/site/sidebars/PanelRail/PanelRail.tsx
+++ b/src/admin/pages/site/sidebars/PanelRail/PanelRail.tsx
@@ -8,6 +8,7 @@ import { BoxStackSolidIcon } from 'pixel-art-icons/icons/box-stack-solid'
 import { PaintBucketSolidIcon } from 'pixel-art-icons/icons/paint-bucket-solid'
 import { ColorsSwatchSolidIcon } from 'pixel-art-icons/icons/colors-swatch-solid'
 import { Button } from '@ui/components/Button'
+import { cn } from '@ui/cn'
 import { assignRailAccents, railTintVar, type RailAccent } from '@ui/railAccent'
 import { pluginRuntime } from '@core/plugins/runtime'
 import { resolvePluginPanelIcon } from './pluginPanelIcons'
@@ -27,6 +28,7 @@ interface RailItem {
   iconName: string
   accent: RailAccent
   open: boolean
+  detached?: boolean
   disabled?: boolean
   onToggle: () => void
   disabledTitle?: string
@@ -94,7 +96,9 @@ export function PanelRail({
   const frameworkOpen = useEditorStore((s) => s.frameworkPanelOpen)
   const dependenciesOpen = useEditorStore((s) => s.dependenciesPanelOpen)
   const agentOpen = useEditorStore((s) => s.isAgentOpen)
+  const leftPanelModes = useEditorStore((s) => s.leftPanelModes)
   const activePluginPanelId = useEditorStore((s) => s.activePluginPanelId)
+  const pluginPanelMode = useEditorStore((s) => s.pluginPanelMode)
 
   const toggleLeftSidebarPanel = useEditorStore((s) => s.toggleLeftSidebarPanel)
   const setLeftSidebarPanel = useEditorStore((s) => s.setLeftSidebarPanel)
@@ -147,6 +151,7 @@ export function PanelRail({
     return {
       ...item,
       open: panelOpenById[item.id] && !railOnly,
+      detached: panelOpenById[item.id] && leftPanelModes[item.id] === 'floating',
       onToggle: () => {
         if (railOnly) {
           revealBuiltInPanel(item.id)
@@ -194,6 +199,7 @@ export function PanelRail({
         iconName: panel.iconName,
         accent: pluginAccents[index] ?? 'mint',
         open: activePluginPanelId === panel.id && !railOnly,
+        detached: activePluginPanelId === panel.id && pluginPanelMode === 'floating',
         onToggle: () => {
           if (railOnly) {
             revealPluginPanel(panel.id)
@@ -253,16 +259,17 @@ function RailButton({ item }: { item: RailItem }) {
       variant="ghost"
       size="md"
       iconOnly
-      pressed={item.open}
+      pressed={item.open && !item.detached}
       aria-label={`${action} ${item.label} panel`}
       disabled={item.disabled}
       tooltip={title}
       data-testid={`panel-rail-${item.id}`}
       data-icon={item.iconName}
       data-accent={item.accent}
+      data-detached={item.detached ? 'true' : undefined}
       style={style}
       onClick={item.onToggle}
-      className={styles.railButton}
+      className={cn(styles.railButton, item.detached && styles.railButtonDetached)}
     >
       <span className={styles.activeIndicator} aria-hidden="true" />
       <RailIcon size={16} className={styles.railIcon} />

--- a/src/admin/pages/site/store/slices/uiSlice.ts
+++ b/src/admin/pages/site/store/slices/uiSlice.ts
@@ -16,6 +16,7 @@ export type LeftSidebarPanelId =
   | 'framework'
   | 'dependencies'
   | 'agent'
+export type LeftPanelModes = Record<LeftSidebarPanelId, PanelMode>
 /** Tabs inside the consolidated Framework panel. */
 export type FrameworkPanelTab = 'home' | 'colors' | 'typography' | 'spacing'
 /**
@@ -81,7 +82,7 @@ interface UiSlice {
   propertiesPanelMode: PanelMode
   propertiesPanelAutoOpenSuppressed: boolean
   leftSidebarWidth: number
-  leftSidebarMode: PanelMode
+  leftPanelModes: LeftPanelModes
   focusedPanel: FocusedPanel
 
   // Settings modal state lives in `settingsSlice` (single source of truth) —
@@ -124,13 +125,13 @@ interface UiSlice {
 
   /**
    * Plugin-registered editor panel currently open in the left sidebar, or
-   * `null` when a built-in panel (or nothing) is active. Mutually exclusive
-   * with the built-in `*PanelOpen` flags — the setters below clear the
-   * other side automatically. The id is the full panel id registered by the
+   * `null` when no plugin panel is active. A floating plugin panel may remain
+   * open beside one docked built-in panel. The id is the full panel id registered by the
    * plugin (e.g. `acme.workflow.review`); the host looks it up in
    * `pluginRuntime.getPanel(id)` at render time.
    */
   activePluginPanelId: string | null
+  pluginPanelMode: PanelMode
 
   // CodeEditorPanel (Task #433) — whether the code editor floating panel is visible
   codeEditorPanelOpen: boolean
@@ -147,7 +148,7 @@ interface UiSlice {
   consumePropertiesPanelAutoOpenSuppression: () => boolean
   setPropertiesPanelMode: (mode: PanelMode) => void
   setLeftSidebarWidth: (width: number) => void
-  setLeftSidebarMode: (mode: PanelMode) => void
+  setLeftSidebarPanelMode: (panel: LeftSidebarPanelId, mode: PanelMode) => void
   togglePropertiesPanel: () => void
   setFocusedPanel: (panel: FocusedPanel) => void
   cycleFocusedPanel: () => void
@@ -182,6 +183,7 @@ interface UiSlice {
   setActivePluginPanel: (panelId: string | null) => void
   /** Toggle a plugin panel — open if not active, close if active. */
   toggleActivePluginPanel: (panelId: string) => void
+  setPluginPanelMode: (mode: PanelMode) => void
 
   /** Show / hide the CodeEditor floating panel. */
   setCodeEditorPanelOpen: (open: boolean) => void
@@ -280,16 +282,43 @@ const DEFAULT_PROPERTIES_PANEL: PanelState = {
   width: PROPERTIES_PANEL_DEFAULT_WIDTH,
 }
 
-function getActiveLeftSidebarPanel(state: EditorStore): LeftSidebarPanelId | null {
-  // A plugin panel takes precedence over every built-in panel — the
-  // built-in `*PanelOpen` flags are forced to false whenever a plugin
-  // panel is opened, so short-circuit here too.
-  if (state.activePluginPanelId !== null) return null
-  if (state.explorerPanelOpen) return 'explorer'
-  if (state.selectorsPanelOpen) return 'selectors'
-  if (state.frameworkPanelOpen) return 'framework'
-  if (state.dependenciesPanelOpen) return 'dependencies'
-  return null
+const DEFAULT_LEFT_PANEL_MODES: LeftPanelModes = {
+  explorer: 'docked',
+  selectors: 'docked',
+  framework: 'docked',
+  dependencies: 'docked',
+  agent: 'docked',
+}
+
+function setBuiltInPanelOpen(
+  state: EditorStore,
+  panel: LeftSidebarPanelId,
+  open: boolean,
+): void {
+  if (panel === 'agent') {
+    state.isAgentOpen = open
+    return
+  }
+  state.explorerPanelOpen = panel === 'explorer' ? open : state.explorerPanelOpen
+  state.selectorsPanelOpen = panel === 'selectors' ? open : state.selectorsPanelOpen
+  state.frameworkPanelOpen = panel === 'framework' ? open : state.frameworkPanelOpen
+  state.dependenciesPanelOpen = panel === 'dependencies' ? open : state.dependenciesPanelOpen
+}
+
+function isBuiltInPanelOpen(state: EditorStore, panel: LeftSidebarPanelId): boolean {
+  if (panel === 'agent') return state.isAgentOpen
+  if (panel === 'explorer') return state.explorerPanelOpen
+  if (panel === 'selectors') return state.selectorsPanelOpen
+  if (panel === 'framework') return state.frameworkPanelOpen
+  return state.dependenciesPanelOpen
+}
+
+function closeDockedBuiltInPanels(state: EditorStore, except: LeftSidebarPanelId): void {
+  for (const panel of Object.keys(DEFAULT_LEFT_PANEL_MODES) as LeftSidebarPanelId[]) {
+    if (panel !== except && state.leftPanelModes[panel] === 'docked') {
+      setBuiltInPanelOpen(state, panel, false)
+    }
+  }
 }
 
 // Contribute this slice's fields to the combined `EditorStore` type via TS
@@ -303,7 +332,7 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
   propertiesPanelMode: 'docked',
   propertiesPanelAutoOpenSuppressed: false,
   leftSidebarWidth: LEFT_SIDEBAR_DEFAULT_WIDTH,
-  leftSidebarMode: 'docked',
+  leftPanelModes: { ...DEFAULT_LEFT_PANEL_MODES },
   focusedPanel: 'canvas',
   previewOpen: false,
   formPreviewStates: {},
@@ -319,6 +348,7 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
   frameworkManagerOpen: false,
   dependenciesPanelOpen: false,
   activePluginPanelId: null,
+  pluginPanelMode: 'docked',
   codeEditorPanelOpen: false,
   activeEditorFileId: null,
   activeCodeBuffer: null,
@@ -366,9 +396,16 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
     set({ leftSidebarWidth: nextWidth })
   },
 
-  setLeftSidebarMode: (mode) => {
-    if (Object.is(get().leftSidebarMode, mode)) return
-    set({ leftSidebarMode: mode })
+  setLeftSidebarPanelMode: (panel, mode) => {
+    if (Object.is(get().leftPanelModes[panel], mode)) return
+    set((state) => {
+      state.leftPanelModes[panel] = mode
+      if (mode === 'docked') {
+        closeDockedBuiltInPanels(state, panel)
+        setBuiltInPanelOpen(state, panel, true)
+        state.activePluginPanelId = null
+      }
+    })
   },
 
   togglePropertiesPanel: () =>
@@ -447,48 +484,53 @@ export const createUiSlice: EditorStoreSliceCreator<UiSlice> = (set, get) => ({
 
   setLeftSidebarPanel: (panel) =>
     set((state) => {
-      if (panel === 'agent') {
-        state.isAgentOpen = true
+      if (panel === null) {
+        for (const id of Object.keys(DEFAULT_LEFT_PANEL_MODES) as LeftSidebarPanelId[]) {
+          if (state.leftPanelModes[id] === 'docked') setBuiltInPanelOpen(state, id, false)
+        }
         return
       }
-      state.explorerPanelOpen = panel === 'explorer'
-      state.selectorsPanelOpen = panel === 'selectors'
-      state.frameworkPanelOpen = panel === 'framework'
-      state.dependenciesPanelOpen = panel === 'dependencies'
-      // Built-in panels are mutually exclusive with plugin panels.
-      state.activePluginPanelId = null
+      if (state.leftPanelModes[panel] === 'docked') {
+        closeDockedBuiltInPanels(state, panel)
+        state.activePluginPanelId = null
+      }
+      setBuiltInPanelOpen(state, panel, true)
     }),
 
   toggleLeftSidebarPanel: (panel) => {
-    if (panel === 'agent') {
-      set((state) => {
-        state.isAgentOpen = !state.isAgentOpen
-      })
+    const state = get()
+    if (isBuiltInPanelOpen(state, panel)) {
+      set((draft) => setBuiltInPanelOpen(draft, panel, false))
       return
     }
-    // Account for the plugin-panel-takes-precedence rule in
-    // getActiveLeftSidebarPanel: if a plugin panel is currently active
-    // and the user clicks a built-in rail item, that should open the
-    // built-in panel (not toggle it closed because it "wasn't active").
-    const state = get()
-    const activePanel = state.activePluginPanelId === null
-      ? getActiveLeftSidebarPanel(state)
-      : null
-    get().setLeftSidebarPanel(activePanel === panel ? null : panel)
+    get().setLeftSidebarPanel(panel)
   },
 
   setActivePluginPanel: (panelId) =>
     set((state) => {
-      state.explorerPanelOpen = false
-      state.selectorsPanelOpen = false
-      state.frameworkPanelOpen = false
-      state.dependenciesPanelOpen = false
+      if (panelId !== null && state.pluginPanelMode === 'docked') {
+        for (const id of Object.keys(DEFAULT_LEFT_PANEL_MODES) as LeftSidebarPanelId[]) {
+          if (state.leftPanelModes[id] === 'docked') setBuiltInPanelOpen(state, id, false)
+        }
+      }
       state.activePluginPanelId = panelId
     }),
 
   toggleActivePluginPanel: (panelId) => {
     const current = get().activePluginPanelId
     get().setActivePluginPanel(current === panelId ? null : panelId)
+  },
+
+  setPluginPanelMode: (mode) => {
+    if (Object.is(get().pluginPanelMode, mode)) return
+    set((state) => {
+      state.pluginPanelMode = mode
+      if (mode === 'docked' && state.activePluginPanelId !== null) {
+        for (const id of Object.keys(DEFAULT_LEFT_PANEL_MODES) as LeftSidebarPanelId[]) {
+          if (state.leftPanelModes[id] === 'docked') setBuiltInPanelOpen(state, id, false)
+        }
+      }
+    })
   },
 
   setCodeEditorPanelOpen: (open) => set({ codeEditorPanelOpen: open }),

--- a/src/admin/shared/PanelHeader/PanelModeButton.module.css
+++ b/src/admin/shared/PanelHeader/PanelModeButton.module.css
@@ -1,0 +1,3 @@
+.rightDockIcon {
+  transform: scaleX(-1);
+}

--- a/src/admin/shared/PanelHeader/PanelModeButton.tsx
+++ b/src/admin/shared/PanelHeader/PanelModeButton.tsx
@@ -1,12 +1,14 @@
-import { DockSolidIcon } from 'pixel-art-icons/icons/dock-solid'
+import { LayoutSolidIcon } from 'pixel-art-icons/icons/layout-solid'
 import { OpenSolidIcon } from 'pixel-art-icons/icons/open-solid'
 import { Button } from '@ui/components/Button'
 import type { PanelMode } from '@admin/state/workspaceLayoutStorage'
+import styles from './PanelModeButton.module.css'
 
 interface PanelModeButtonProps {
   mode: PanelMode
   panelLabel: string
   dockLocation: string
+  dockSide?: 'left' | 'right'
   onToggle: () => void
 }
 
@@ -15,11 +17,12 @@ export function PanelModeButton({
   mode,
   panelLabel,
   dockLocation,
+  dockSide = 'left',
   onToggle,
 }: PanelModeButtonProps) {
   const floating = mode === 'floating'
-  const action = floating ? `Dock ${panelLabel} panel` : `Unpin ${panelLabel} panel`
-  const tooltip = floating ? `Dock in ${dockLocation}` : 'Unpin to floating panel'
+  const action = floating ? `Dock ${panelLabel} panel` : `Undock ${panelLabel} panel`
+  const tooltip = floating ? `Dock in ${dockLocation}` : 'Undock to canvas'
 
   return (
     <Button
@@ -31,7 +34,11 @@ export function PanelModeButton({
       tooltip={tooltip}
     >
       {floating ? (
-        <DockSolidIcon size={12} aria-hidden="true" />
+        <LayoutSolidIcon
+          size={12}
+          className={dockSide === 'right' ? styles.rightDockIcon : undefined}
+          aria-hidden="true"
+        />
       ) : (
         <OpenSolidIcon size={12} aria-hidden="true" />
       )}

--- a/src/admin/state/workspaceLayoutStorage.ts
+++ b/src/admin/state/workspaceLayoutStorage.ts
@@ -37,7 +37,9 @@ export interface PanelSize {
 export type FloatingPanelId =
   | 'properties'
   | 'site'
+  | 'explorer'
   | 'selectors'
+  | 'framework'
   | 'colors'
   | 'typography'
   | 'spacing'
@@ -45,6 +47,7 @@ export type FloatingPanelId =
   | 'dependencies'
   | 'codeeditor'
   | 'agent'
+  | 'plugin'
   | 'agentImagePreview'
   | 'mediaUploadQueue'
   | 'mediaDetachedInspector'
@@ -90,10 +93,10 @@ export interface StoredWorkspaceLayout {
   codeEditorPanelOpen?: boolean
   /** Properties panel docked vs floating (site only). */
   propertiesPanelMode?: PanelMode
-  /** Left-rail panel docked vs floating (site only). */
-  leftSidebarMode?: PanelMode
-  /** Whether the independent floating AI assistant is open (site only). */
-  agentPanelOpen?: boolean
+  /** Placement of each built-in left-rail panel (site only). */
+  leftPanelModes?: Record<string, PanelMode>
+  /** Built-in left-rail panels that are open, including floating panels. */
+  openLeftPanels?: string[]
 }
 
 interface StoredEditorLayout {
@@ -144,8 +147,8 @@ const StoredWorkspaceLayoutSchema = Type.Object(
     // Panel modes are string unions; keep them loose to avoid coupling this
     // persisted boundary to their exact membership.
     propertiesPanelMode: Type.Optional(Type.String()),
-    leftSidebarMode: Type.Optional(Type.String()),
-    agentPanelOpen: Type.Optional(Type.Boolean()),
+    leftPanelModes: Type.Optional(Type.Record(Type.String(), Type.String())),
+    openLeftPanels: Type.Optional(Type.Array(Type.String())),
   },
   { additionalProperties: true },
 )


### PR DESCRIPTION
## The bug

Undocking a Site editor panel switched the entire sidebar into floating mode. AI was forced to float, and opening another rail item replaced content instead of leaving other panels available.

## The fix

Each built-in panel now owns its docked or floating state, position, and size. AI starts docked, floating panels can coexist with a docked sibling, and rail state reflects panels that are currently detached. Dock and undock actions use the existing pixel-art icon pack, with the Properties dock icon oriented toward the right sidebar.

## Verification

```text
bun run build  # clean
bun test       # 6725 pass, 0 fail
bun run lint   # clean
focused layout and icon tests  # 60 pass, 0 fail
```
