### PR TITLE
feat(directus): read-only Directus reader over HTTP and MCP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,3 +34,11 @@ STATIC_DIR=./dist
 #   bun run scripts/generate-secret-key.ts
 #
 # INSTATIC_SECRET_KEY=
+
+# ─── Directus reader (optional) ─────────────────────────────────────────────
+# Read-only geography + workfields. The token must be a reader — this
+# layer never writes. Leave unset to disable the routes (they return 503).
+# Secret names only — never commit a token.
+#
+# MKP_CONTENT_SERVICE_DIRECTUS_URL=https://mkp-directus.dev.example.com
+# MKP_CONTENT_SERVICE_DIRECTUS_TOKEN=

--- a/docs/README.md
+++ b/docs/README.md
@@ -149,6 +149,7 @@ Three categories, three voices:
 | [features/spotlight.md](features/spotlight.md)                   | Cmd+K command palette                                                |
 | [features/agent.md](features/agent.md)                           | AI agent integration and provider-agnostic runtime                   |
 | [features/mcp-connectors.md](features/mcp-connectors.md)         | Instatic as an MCP server — external AI clients drive the CMS over MCP |
+| [features/directus.md](features/directus.md)                     | Read-only Directus reader: geography, workfields, strengths over HTTP + MCP |
 | [features/templates.md](features/templates.md)                   | Entry templates + dynamic bindings + token interpolation             |
 | [features/loops.md](features/loops.md)                           | `base.loop` + loop entity sources                                    |
 | [features/cms-native-forms.md](features/cms-native-forms.md)     | Visual form primitives and secure public submissions                 |

--- a/docs/features/auth-and-access.md
+++ b/docs/features/auth-and-access.md
@@ -135,6 +135,7 @@ export const CORE_CAPABILITIES = [
   'data.system.tables.read', 'data.system.tables.manage',
   'data.rows.move', 'data.export', 'data.import',
   'ai.chat', 'ai.tools.write', 'ai.providers.manage', 'ai.audit.read',
+  'directus.read',
 ] as const
 
 export type CoreCapability = typeof CORE_CAPABILITIES[number]

--- a/docs/features/directus.md
+++ b/docs/features/directus.md
@@ -1,0 +1,141 @@
+# Directus reader
+
+Server-side, **GET-only** reads of geography and workfields from the install's Directus instance. The content service stays the default for published workfield display; this layer covers the three things that service cannot answer: the climb above a municipality, every translation in one call, and draft pricing / demand / blog / FAQ rows.
+
+Nothing here writes. Authoring stays in Directus.
+
+## TL;DR
+
+- Env: `MKP_CONTENT_SERVICE_DIRECTUS_URL` + `MKP_CONTENT_SERVICE_DIRECTUS_TOKEN` (reader token — names only, never values in this repo).
+- HTTP: `GET /admin/api/cms/directus/*`, session + `directus.read`.
+- MCP: seven `directus_*` tools, `mutates: false`, same capability. Default-on in the token **Read** group.
+- The Directus token never reaches a browser. Callers authenticate with a session or MCP grant; Trustup WM proxies the read.
+- Allow-listed collections only. Unknown collection names are rejected, not forwarded.
+- Responses cached in-process for 60s. `count` uses Directus `filter_count`, never `total_count`.
+- Upstream bodies are validated with TypeBox (`ItemsEnvelopeSchema` in `client.ts`). A non-JSON success body is a 502.
+
+## Why this exists
+
+| Need | Why the content service cannot serve it |
+|---|---|
+| Province / region / country **above** a municipality | `/resolve` stops at municipality / locality |
+| **Every** translation of a name in one call | Reads are one-locale-at-a-time |
+| **Draft** pricing / demand / blog / FAQ rows | It filters to `published` by design |
+
+## Upstream contract
+
+The reader token can read exactly these collections (verified live against DEV, 2026-09-02). The allow-list in [`server/directus/collections.ts`](../../server/directus/collections.ts) is this list and nothing else; a name outside it is refused before any request goes out.
+
+| Collection | Identity | Notes |
+|---|---|---|
+| `countries` | `code` (`BE`, `FR`) | **No `id`, no `slug` column.** Filtering on `slug` is a Directus 403. The flattened row uses the code as both `id` and `slug`. |
+| `regions` · `provinces` · `municipalities` · `localities` | uuid `id` + `slug` | `country` is the ISO code; `region` / `province` / `municipality` are parent uuids. |
+| `workfield_content` | uuid `id` + `slug` | **No `status` column.** The published set is `is_deleted = false AND is_shadow = false` (468 of 473). `average_rating` is an integer ×100. Translations carry the 16 declensions and `localised_slugs`, a comma-separated history whose **last** entry is the marketplace URL segment. |
+| `workfield_pricing_items` · `workfield_example_demands` · `workfield_blog_content` | uuid `id` | Flat per-locale rows keyed by `workfield_content_id` + `languages_code`, each with its own `status`. |
+| `workfield_faq_content` | uuid `id` | `type` `generic` \| `location_specific`, `geography_type`, `geography_id`, `status`; translations carry `intro_text` + `qa_text`. |
+
+`status` on the detail and FAQ routes filters **those sub-rows**, never the workfield itself. That is what "draft rows" means here.
+
+## Routes
+
+| Method | Path | MCP tool |
+|---|---|---|
+| GET | `/admin/api/cms/directus/health` | `directus_health` |
+| GET | `/admin/api/cms/directus/strengths` | `directus_list_strengths` |
+| GET | `/admin/api/cms/directus/geography/:level` | `directus_list_geography` |
+| GET | `/admin/api/cms/directus/geography-ancestry` | `directus_get_geography_ancestry` |
+| GET | `/admin/api/cms/directus/workfields` | `directus_list_workfields` |
+| GET | `/admin/api/cms/directus/workfields/:slug` | `directus_get_workfield` |
+| GET | `/admin/api/cms/directus/workfields/:slug/faq` | `directus_get_workfield_faq` |
+
+`:level` ∈ `countries` · `regions` · `provinces` · `municipalities` · `localities`. Always page `municipalities` (35 311 rows on DEV).
+
+`include=faq` on the detail route returns **generic** FAQ only; a popular trade carries one `location_specific` row per municipality (`roofer` has 128). Name a geography on the FAQ route for those. Includes are fetched concurrently and scoped to the requested locale unless `all_locales` is set.
+
+Live parity with the content service and the Python WM report (2026-09-02, on-VPN): 468 published workfields (topic 219, service 77, product 72, category 57, trade 25, material 18); 2 countries, 16 regions, 107 provinces, 35 311 municipalities, 2 242 localities.
+
+## Strengths ("troeven")
+
+A **fixed, server-owned catalog** of 20 strengths from intake screen 21, in [`server/directus/strengths.ts`](../../server/directus/strengths.ts). It is static data — no Directus round-trip — so the route and the MCP tool answer even when the reader is unconfigured (200, not 503).
+
+Intake stores **3–6 ids** on `contentFacts.strengths`. Each row carries an `id`, an `icon` name, and a `names` map covering all 8 supported locales. **Never author the words on the site** — render the locale label from this catalog so the copy stays consistent and translatable.
+
+| Param | Meaning |
+|---|---|
+| `locale` | Resolve one supported locale into a flat `name` (in addition to `names`). Unknown locale → 400. |
+| `ids` | Comma-separated (HTTP) / array (MCP) subset, returned in catalog order. Unknown id → 400. |
+
+Ids: `owner-on-site` · `respect-deadlines` · `careful-work` · `free-quote` · `clean-sites` · `availability` · `ten-year-guarantee` · `vca-certified` · `ten-years-plus` · `family-business` · `custom-work` · `quality-materials` · `personal-advice` · `transparent-prices` · `fast-response` · `respect-budget` · `professional-team` · `local-sites` · `satisfaction-guaranteed` · `after-sales`.
+
+Labels are authored in the four BE locales; the shared translation fallback expands them to all 8 (`nl-NL` → `nl-BE`, `fr-FR` → `fr-BE`, and so on).
+
+## Locales
+
+`?locale=` accepts exactly the 8 supported locales — `fr-BE`, `nl-BE`, `de-BE`, `en-BE`, `fr-FR`, `en-FR`, `nl-NL`, `en-NL` — and anything else is a 400. The list is `SUPPORTED_LOCALES` in `src/core/locales.ts`, the single locale catalog the reader and the MCP tool enums share; `locale-enum-usage.test.ts` gates every other locale surface against it. `?all_locales=true` returns a `names` map that always carries all 8 keys.
+
+Fallback, in order: exact locale → same language other region (`nl-NL` → `nl-BE`) → country default (BE→`fr-BE`, FR→`fr-FR`) → any `fr-*` → first available. That is why `paris` resolves in `fr-BE` instead of a row of nulls.
+
+Belgian rows have four real names; French rows often have one. Both expand to eight keys.
+
+## Errors
+
+| Situation | Status |
+|---|---|
+| No / bad session | 401 |
+| Missing `directus.read` | 403 |
+| Unknown workfield or municipality | 404 |
+| Unknown geography level / bad uuid / control characters | 400 |
+| Directus rejects the query (4xx other than 401/403) | 400 |
+| Directus or a gateway in front of it rejects the **reader token** (401/403) | 502 |
+| Directus down, 5xx, or a non-JSON success body | 502 |
+| Not configured | 503 |
+
+Uuid and control-character guards are not decoration: Directus passes query values to Postgres, which errors on a NUL byte.
+
+### Upstream 401/403 is a 502, not a 400
+
+An upstream 401/403 is never the caller's fault, so it must not be reported as a bad query. The client tells the two causes apart by the body:
+
+| Upstream body | Meaning | Message prefix |
+|---|---|---|
+| JSON `{ errors: [{ message }] }` | Directus evaluated the token and refused | `Directus denied the reader token (…)` |
+| Anything else (typically `text/plain`) | The ingress in front of Directus stopped the request; the token was never evaluated | `A gateway in front of Directus refused the request (…)` |
+
+`GET /server/ping` is public in Directus. If **it** answers 403 without an `Authorization` header, the block is at the ingress, not in the token policy.
+
+On the Trustup DEV/ACC environments that ingress is Azure Container Apps IP restrictions (`exposure: private` in the infra `env.yaml`, enforced since 2026-08-10). Its literal answer is `403 text/plain` `RBAC: access denied`, and it admits only the non-prod VPN egress plus the spoke's own NAT egress. So a laptop or a CI runner off the VPN gets this on every path, including Directus's public `/server/ping`, with any token or none. The remedy is to connect the `trustup-nonprd` VPN (or run on an allow-listed egress); rotating the reader token changes nothing.
+
+### Health is honest
+
+`directus_health` / `GET …/health` returns `reachable: true` only when Directus itself answered `/server/health`. Any denial is `reachable: false` with `status` and a `reason` string in the same terms as above. The old behavior counted a 403 as healthy, which hid a blocked gateway behind a green probe.
+
+The flag is named `reachable`, not `ok`, on purpose. Server-executed MCP tools return a raw payload and `normaliseToolOutput` reads any `{ ok: boolean }` as the `AiToolOutput` envelope itself, so a domain payload with `ok: false` would surface to the MCP client as a bare `Tool failed.` with the `status`, `url`, and `reason` discarded.
+
+## Read-only invariant
+
+- [`server/directus/client.ts`](../../server/directus/client.ts) has no method parameter. It only GET.
+- The CMS route table registers GET only. POST is 405.
+- MCP tools do not set `mutates: true`.
+- Gate: [`src/__tests__/architecture/directus-read-only.test.ts`](../../src/__tests__/architecture/directus-read-only.test.ts).
+
+## Module layout
+
+| Path | Role |
+|---|---|
+| `server/config.ts` | `readDirectusConfig()` |
+| `server/directus/` | Client, locale fallback, flatteners, service |
+| `server/handlers/cms/directus.ts` | HTTP routes |
+| `server/ai/mcp/tools/directusTools.ts` | MCP tools |
+| `src/core/persistence/cmsDirectus.ts` | Browser client for the proxy (currently: the workfield list) |
+
+## Admin consumers
+
+The admin reads this proxy in one place today: **media workfield tags**. `useDirectusWorkfields(locale)` loads the workfield list per locale (cached per tab) so an image can be labelled with workfield **slugs**; the localized label is resolved at display time from here. See [Media](media.md) → "Workfield tags".
+
+`directus` is an install-wide CMS path segment, so it is exempt from the `/admin/api/cms/sites/<id>/…` site-scoped rewrite on both the client (`src/core/sites/activeSite.ts`) and the server (`server/handlers/cms/index.ts`).
+
+## Related
+
+- [Capabilities](../reference/capabilities.md) — `directus.read`
+- [Media](media.md) — workfield tagging on media assets
+- [MCP connections](mcp-connectors.md) — token picker Read group

--- a/docs/features/mcp-connectors.md
+++ b/docs/features/mcp-connectors.md
@@ -144,12 +144,13 @@ executeAiTool(...) / live editor bridge
 | `editorBridge.ts` | Per-user, per-scope live workspace bridge. |
 | `tools/publishTool.ts` | Explicit canonical full-site publish with MCP audit metadata. |
 | `tools/uploadMediaTool.ts` | Server-resolved image upload (`media_upload`) — inline base64 or SSRF-guarded `sourceUrl` download, through the shared media pipeline. |
+| `tools/directusTools.ts` | Read-only Directus geography + workfields (`directus_*`). Requires `directus.read`. Never writes. |
 
 ## Tool execution model
 
 MCP exposes the full deduplicated tool catalog, filtered by the connection's capabilities.
 
-Server-resolved tools work without an editor open. They include content reads, `get_context`, `site_list_documents`, `site_read_styles`, `site_list_breakpoints`, `media_upload`, and explicit `site_publish`. Publishing requires `ai.tools.write` plus `pages.publish`, runs the canonical full-site pipeline, swaps the static slot atomically, and records the connection id in the publish audit event.
+Server-resolved tools work without an editor open. They include content reads, `get_context`, `site_list_documents`, `site_read_styles`, `site_list_breakpoints`, `media_upload`, Directus reads (`directus_health`, `directus_list_geography`, `directus_get_geography_ancestry`, `directus_list_workfields`, `directus_get_workfield`, `directus_get_workfield_faq`, `directus_list_strengths`), and explicit `site_publish`. Directus tools require `directus.read` (default-on in the token Read group) and never write. See [directus.md](directus.md). Publishing requires `ai.tools.write` plus `pages.publish`, runs the canonical full-site pipeline, swaps the static slot atomically, and records the connection id in the publish audit event.
 
 `media_upload` is the one server-resolved write that mutates outside the live editor draft: it adds an image to the Media library through the same `acceptUploadedMedia` core the HTTP route uses (magic-byte sniffing, SVG sanitisation, storage dispatch, responsive variants). Bytes arrive inline (base64) or via an https `sourceUrl` the host downloads under the plugin network layer's SSRF blocklist — https-only, DNS-resolved, per-redirect-hop re-validation, size-capped. It requires `ai.tools.write` plus `media.write`.
 

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -223,6 +223,14 @@ There are deliberately **no** whole-family "super-set" constants (e.g. one `MEDI
 
 ---
 
+### Directus
+
+Read-only reference data from the install's Directus instance (geography + workfields). There is no `directus.write`.
+
+| Capability       | Grants                                                              | Roles         |
+|------------------|---------------------------------------------------------------------|---------------|
+| `directus.read`  | Call `GET /admin/api/cms/directus/*` and the matching MCP tools. The Directus token stays on the server. | Owner, Admin |
+
 ## Cookbook
 
 ### Gate a handler

--- a/server/ai/mcp/registry.ts
+++ b/server/ai/mcp/registry.ts
@@ -32,6 +32,7 @@ import { contextMcpTools } from './tools/contextTool'
 import { documentMcpTools } from './tools/documentTools'
 import { createPublishMcpTool, type McpPublishRuntime } from './tools/publishTool'
 import { uploadMediaMcpTool } from './tools/uploadMediaTool'
+import { directusMcpTools } from './tools/directusTools'
 
 // Server-resolved site read tools whose handlers read the browser-posted
 // `ctx.snapshot`, which is null over MCP — they'd return nothing or throw.
@@ -54,6 +55,7 @@ function allMcpTools(runtime?: McpPublishRuntime): AiTool[] {
     ...documentMcpTools,
     createPublishMcpTool(runtime),
     uploadMediaMcpTool,
+    ...directusMcpTools,
     ...contentTools,
     ...siteTools,
   ]

--- a/server/ai/mcp/tools/directusTools.test.ts
+++ b/server/ai/mcp/tools/directusTools.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'bun:test'
+import { mcpToolsForCapabilities } from '../registry'
+import { defaultMcpReadCapabilities, MCP_CAPABILITY_GROUPS } from '../../../../src/admin/pages/ai/tabs/mcpCapabilities'
+
+const DIRECTUS_TOOLS = [
+  'directus_health',
+  'directus_list_geography',
+  'directus_get_geography_ancestry',
+  'directus_list_workfields',
+  'directus_get_workfield',
+  'directus_get_workfield_faq',
+  'directus_list_strengths',
+] as const
+
+describe('MCP Directus tools', () => {
+  it('are listed for directus.read without ai.tools.write', () => {
+    const names = mcpToolsForCapabilities(['directus.read']).map((tool) => tool.name)
+    for (const name of DIRECTUS_TOOLS) {
+      expect(names).toContain(name)
+    }
+    const tools = mcpToolsForCapabilities(['directus.read']).filter((tool) =>
+      DIRECTUS_TOOLS.includes(tool.name as (typeof DIRECTUS_TOOLS)[number]),
+    )
+    expect(tools.every((tool) => tool.mutates !== true)).toBe(true)
+    expect(tools.every((tool) => tool.execution === 'server')).toBe(true)
+  })
+
+  it('are absent without directus.read', () => {
+    const names = mcpToolsForCapabilities(['site.read', 'ai.tools.write']).map((tool) => tool.name)
+    for (const name of DIRECTUS_TOOLS) {
+      expect(names).not.toContain(name)
+    }
+  })
+
+  it('are in the default MCP Read grant', () => {
+    const defaults = defaultMcpReadCapabilities(MCP_CAPABILITY_GROUPS)
+    expect(defaults.has('directus.read')).toBe(true)
+  })
+})

--- a/server/ai/mcp/tools/directusTools.ts
+++ b/server/ai/mcp/tools/directusTools.ts
@@ -1,0 +1,273 @@
+/**
+ * Read-only Directus MCP tools. Never mutate. The Directus token stays
+ * on the server; callers authenticate with the connector grant.
+ */
+import { Type } from '@core/utils/typeboxHelpers'
+import { SupportedLocaleSchema, type SupportedLocale } from '@core/locales'
+import type { AiTool } from '../../runtime/types'
+import {
+  GEOGRAPHY_LEVELS,
+  STRENGTH_IDS,
+  SUB_ROW_STATUSES,
+  WORKFIELD_INCLUDES,
+  WORKFIELD_TYPES,
+  getDirectusService,
+  isDirectusError,
+  isGeographyLevel,
+} from '../../../directus'
+
+function fail(err: unknown): { ok: false; error: string } {
+  if (isDirectusError(err)) return { ok: false, error: err.message }
+  throw err
+}
+
+const LocaleFields = {
+  locale: Type.Optional(SupportedLocaleSchema),
+  all_locales: Type.Optional(Type.Boolean()),
+}
+
+export const directusMcpTools: AiTool[] = [
+  {
+    name: 'directus_health',
+    description:
+      'Probe Directus connectivity and configuration. Read-only. Headless.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object({}, { additionalProperties: false }),
+    requiredCapabilities: ['directus.read'],
+    handler: async () => {
+      try {
+        return await getDirectusService().health()
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+  {
+    name: 'directus_list_geography',
+    description:
+      'List one geography level (countries, regions, provinces, municipalities, localities). Always page municipalities. Read-only. Headless.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object(
+      {
+        level: Type.Union(GEOGRAPHY_LEVELS.map((level) => Type.Literal(level))),
+        parent_id: Type.Optional(Type.String()),
+        country: Type.Optional(Type.String()),
+        slug: Type.Optional(Type.String()),
+        search: Type.Optional(Type.String()),
+        ...LocaleFields,
+        limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+        page: Type.Optional(Type.Integer({ minimum: 1 })),
+      },
+      { additionalProperties: false },
+    ),
+    requiredCapabilities: ['directus.read'],
+    handler: async (input) => {
+      const body = input as {
+        level: string
+        parent_id?: string
+        country?: string
+        slug?: string
+        search?: string
+        locale?: SupportedLocale
+        all_locales?: boolean
+        limit?: number
+        page?: number
+      }
+      if (!isGeographyLevel(body.level)) return { ok: false, error: 'Unknown geography level' }
+      try {
+        return await getDirectusService().listGeography(body.level, {
+          parentId: body.parent_id,
+          country: body.country,
+          slug: body.slug,
+          search: body.search,
+          locale: body.locale,
+          allLocales: body.all_locales,
+          limit: body.limit,
+          page: body.page,
+        })
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+  {
+    name: 'directus_get_geography_ancestry',
+    description:
+      'Municipality → province → region → country in one call. The content-service /resolve stop at municipality. Read-only. Headless.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object(
+      {
+        slug: Type.Optional(Type.String()),
+        id: Type.Optional(Type.String()),
+        country: Type.Optional(Type.String()),
+        ...LocaleFields,
+      },
+      { additionalProperties: false },
+    ),
+    requiredCapabilities: ['directus.read'],
+    handler: async (input) => {
+      const body = input as {
+        slug?: string
+        id?: string
+        country?: string
+        locale?: SupportedLocale
+        all_locales?: boolean
+      }
+      try {
+        return await getDirectusService().getAncestry({
+          slug: body.slug,
+          id: body.id,
+          country: body.country,
+          locale: body.locale,
+          allLocales: body.all_locales,
+        })
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+  {
+    name: 'directus_list_workfields',
+    description:
+      'List published workfields (trades, services, products, topics, categories, materials). Read-only. Headless.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object(
+      {
+        type: Type.Optional(Type.Union(WORKFIELD_TYPES.map((type) => Type.Literal(type)))),
+        search: Type.Optional(Type.String()),
+        ...LocaleFields,
+        limit: Type.Optional(Type.Integer({ minimum: 1, maximum: 1000 })),
+        page: Type.Optional(Type.Integer({ minimum: 1 })),
+      },
+      { additionalProperties: false },
+    ),
+    requiredCapabilities: ['directus.read'],
+    handler: async (input) => {
+      const body = input as {
+        type?: (typeof WORKFIELD_TYPES)[number]
+        search?: string
+        locale?: SupportedLocale
+        all_locales?: boolean
+        limit?: number
+        page?: number
+      }
+      try {
+        return await getDirectusService().listWorkfields({
+          type: body.type,
+          search: body.search,
+          locale: body.locale,
+          allLocales: body.all_locales,
+          limit: body.limit,
+          page: body.page,
+        })
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+  {
+    name: 'directus_get_workfield',
+    description:
+      'One workfield by slug, optionally with pricing, demands, blog, or generic FAQ. status filters those included sub-rows (draft, published, archived), never the workfield itself. all_locales returns every locale including declensions. Read-only. Headless.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object(
+      {
+        slug: Type.String({ minLength: 1 }),
+        status: Type.Optional(Type.Union(SUB_ROW_STATUSES.map((status) => Type.Literal(status)))),
+        include: Type.Optional(Type.Array(Type.Union(WORKFIELD_INCLUDES.map((inc) => Type.Literal(inc))))),
+        ...LocaleFields,
+      },
+      { additionalProperties: false },
+    ),
+    requiredCapabilities: ['directus.read'],
+    handler: async (input) => {
+      const body = input as {
+        slug: string
+        status?: (typeof SUB_ROW_STATUSES)[number]
+        include?: Array<(typeof WORKFIELD_INCLUDES)[number]>
+        locale?: SupportedLocale
+        all_locales?: boolean
+      }
+      try {
+        return await getDirectusService().getWorkfield(body.slug, {
+          status: body.status,
+          include: body.include,
+          locale: body.locale,
+          allLocales: body.all_locales,
+        })
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+  {
+    name: 'directus_get_workfield_faq',
+    description:
+      'FAQ for a workfield. include=faq on the detail tool is generic only; name a geography here for location_specific rows. Read-only. Headless.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object(
+      {
+        slug: Type.String({ minLength: 1 }),
+        status: Type.Optional(Type.Union(SUB_ROW_STATUSES.map((status) => Type.Literal(status)))),
+        type: Type.Optional(Type.Union([Type.Literal('generic'), Type.Literal('location_specific')])),
+        geography_type: Type.Optional(Type.Union(GEOGRAPHY_LEVELS.map((level) => Type.Literal(level)))),
+        geography_id: Type.Optional(Type.String()),
+        locale: Type.Optional(SupportedLocaleSchema),
+      },
+      { additionalProperties: false },
+    ),
+    requiredCapabilities: ['directus.read'],
+    handler: async (input) => {
+      const body = input as {
+        slug: string
+        status?: (typeof SUB_ROW_STATUSES)[number]
+        type?: 'generic' | 'location_specific'
+        geography_type?: (typeof GEOGRAPHY_LEVELS)[number]
+        geography_id?: string
+        locale?: SupportedLocale
+      }
+      try {
+        return {
+          data: await getDirectusService().listWorkfieldFaq(body.slug, {
+            status: body.status,
+            type: body.type,
+            geographyType: body.geography_type,
+            geographyId: body.geography_id,
+            locale: body.locale,
+          }),
+        }
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+  {
+    name: 'directus_list_strengths',
+    description:
+      'The fixed strengths ("troeven") catalog from intake screen 21. Store 3–6 of these ids on contentFacts.strengths and render the locale label — never author the words on the site. Each row carries an icon name and a names map for all 8 supported locales. Read-only. Headless. Static — works even when Directus is unconfigured.',
+    scope: 'site',
+    execution: 'server',
+    inputSchema: Type.Object(
+      {
+        locale: Type.Optional(SupportedLocaleSchema),
+        ids: Type.Optional(Type.Array(Type.Union(STRENGTH_IDS.map((id) => Type.Literal(id))))),
+      },
+      { additionalProperties: false },
+    ),
+    requiredCapabilities: ['directus.read'],
+    handler: async (input) => {
+      const body = input as { locale?: SupportedLocale; ids?: string[] }
+      try {
+        return getDirectusService().listStrengths({ locale: body.locale, ids: body.ids })
+      } catch (err) {
+        return fail(err)
+      }
+    },
+  },
+]

--- a/server/auth/capabilities.ts
+++ b/server/auth/capabilities.ts
@@ -78,6 +78,7 @@ const adminCapabilities: CoreCapability[] = [
   'ai.tools.write',
   'ai.providers.manage',
   'ai.audit.read',
+  'directus.read',
 ]
 
 const clientCapabilities: CoreCapability[] = [

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,3 +1,8 @@
+export interface DirectusConfig {
+  url: string
+  token: string
+}
+
 interface ServerConfig {
   port: number
   databaseUrl: string
@@ -5,6 +10,7 @@ interface ServerConfig {
   staticDir: string
   trustedProxyCidrs: string[]
   publicOrigins: string[]
+  directus: DirectusConfig | null
 }
 
 function readCsvList(value: string | undefined): string[] {
@@ -85,6 +91,25 @@ export function resolvePublicOrigins(env: Record<string, string | undefined>): s
   return normalizeOrigins(derived)
 }
 
+/**
+ * Optional read-only Directus reader. Both variables must be set; a
+ * malformed URL disables the reader rather than pointing it somewhere odd.
+ */
+export function readDirectusConfig(
+  env: Record<string, string | undefined> = process.env,
+): DirectusConfig | null {
+  const url = (env.MKP_CONTENT_SERVICE_DIRECTUS_URL ?? '').trim().replace(/\/+$/, '')
+  const token = (env.MKP_CONTENT_SERVICE_DIRECTUS_TOKEN ?? '').trim()
+  if (!url || !token) return null
+  try {
+    const parsed = new URL(url)
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') return null
+  } catch {
+    return null
+  }
+  return { url, token }
+}
+
 export function readServerConfig(
   env: Record<string, string | undefined> = process.env,
 ): ServerConfig {
@@ -95,5 +120,6 @@ export function readServerConfig(
     staticDir: env.STATIC_DIR ?? './dist',
     trustedProxyCidrs: readCsvList(env.TRUSTED_PROXY_CIDRS),
     publicOrigins: resolvePublicOrigins(env),
+    directus: readDirectusConfig(env),
   }
 }

--- a/server/db/migrations-pg.ts
+++ b/server/db/migrations-pg.ts
@@ -1156,4 +1156,18 @@ export const pgMigrations: Migration[] = [
        where trim(lower(display_name)) = trim(lower(email));
     `,
   },
+  {
+    id: '025_directus_read_capability',
+    // Owner and Admin are force-resynced from SYSTEM_ROLES on every boot, so
+    // the code change alone grants them directus.read. This migration keeps
+    // the seeded snapshot in step with the code (cmsMigrations.test.ts) and
+    // covers a database that is migrated but not yet booted by the new code.
+    sql: `
+      update roles
+         set capabilities_json = capabilities_json || '["directus.read"]'::jsonb,
+             updated_at = current_timestamp
+       where id in ('owner', 'admin')
+         and not (capabilities_json ? 'directus.read');
+    `,
+  },
 ]

--- a/server/db/migrations-sqlite.ts
+++ b/server/db/migrations-sqlite.ts
@@ -1224,4 +1224,20 @@ export const sqliteMigrations: Migration[] = [
        where trim(lower(display_name)) = trim(lower(email));
     `,
   },
+  {
+    id: '025_directus_read_capability',
+    // Owner and Admin are force-resynced from SYSTEM_ROLES on every boot, so
+    // the code change alone grants them directus.read. This migration keeps
+    // the seeded snapshot in step with the code (cmsMigrations.test.ts) and
+    // covers a database that is migrated but not yet booted by the new code.
+    sql: `
+      update roles
+         set capabilities_json = json_insert(capabilities_json, '$[#]', 'directus.read'),
+             updated_at = current_timestamp
+       where id in ('owner', 'admin')
+         and not exists (
+           select 1 from json_each(roles.capabilities_json) where value = 'directus.read'
+         );
+    `,
+  },
 ]

--- a/server/directus/client.test.ts
+++ b/server/directus/client.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from 'bun:test'
+import { DIRECTUS_CACHE_TTL_MS, createDirectusClient } from './client'
+import { DirectusError } from './errors'
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  })
+}
+
+describe('Directus GET client', () => {
+  it('only issues GET and never forwards an unknown collection', async () => {
+    const methods: string[] = []
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      fetch: async (input, init) => {
+        methods.push(init.method)
+        expect(input).toContain('/items/municipalities')
+        return jsonResponse({ data: [], meta: { filter_count: 0 } })
+      },
+    })
+    await client.getItems('municipalities', { limit: '1' })
+    expect(methods).toEqual(['GET'])
+    await expect(client.getItems('workfields' as never)).rejects.toBeInstanceOf(DirectusError)
+    await expect(client.getItems('files' as never)).rejects.toBeInstanceOf(DirectusError)
+  })
+
+  it('maps Directus 4xx to 400 and 5xx to 502', async () => {
+    const four = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      fetch: async () => jsonResponse({ errors: [{ message: 'Invalid filter' }] }, 400),
+    })
+    try {
+      await four.getItems('workfield_content')
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DirectusError)
+      expect((err as DirectusError).status).toBe(400)
+      expect((err as DirectusError).message).toBe('Invalid filter')
+    }
+
+    const five = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      fetch: async () => jsonResponse({ error: 'boom' }, 503),
+    })
+    try {
+      await five.getItems('workfield_content')
+      throw new Error('expected throw')
+    } catch (err) {
+      expect((err as DirectusError).status).toBe(502)
+    }
+  })
+
+  it('reports an upstream 401/403 as 502, never as a bad query', async () => {
+    const gateway = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      fetch: async () => new Response('RBAC: access denied', {
+        status: 403,
+        headers: { 'content-type': 'text/plain' },
+      }),
+    })
+    try {
+      await gateway.getItems('countries')
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DirectusError)
+      expect((err as DirectusError).status).toBe(502)
+      expect((err as DirectusError).message).toContain('gateway in front of Directus')
+      expect((err as DirectusError).message).toContain('RBAC: access denied')
+      expect((err as DirectusError).message).toContain('never evaluated')
+      expect((err as DirectusError).message).toContain('connect the VPN')
+    }
+
+    const denied = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      fetch: async () => jsonResponse({ errors: [{ message: 'Invalid user credentials.' }] }, 401),
+    })
+    try {
+      await denied.getItems('countries')
+      throw new Error('expected throw')
+    } catch (err) {
+      expect((err as DirectusError).status).toBe(502)
+      expect((err as DirectusError).message).toContain('Directus denied the reader token')
+      expect((err as DirectusError).message).toContain('Invalid user credentials.')
+      expect((err as DirectusError).message).toContain('MKP_CONTENT_SERVICE_DIRECTUS_TOKEN')
+    }
+  })
+
+  it('health is reachable only when Directus itself answers', async () => {
+    const config = { url: 'https://cms.example.com', token: 'reader' }
+    const up = createDirectusClient({
+      config,
+      fetch: async () => jsonResponse({ status: 'ok' }),
+    })
+    expect(await up.getHealth()).toEqual({ reachable: true, status: 200 })
+
+    const blocked = createDirectusClient({
+      config,
+      fetch: async () => new Response('RBAC: access denied', { status: 403 }),
+    })
+    const probe = await blocked.getHealth()
+    expect(probe.reachable).toBe(false)
+    expect(probe.status).toBe(403)
+    expect(probe.reason).toContain('gateway in front of Directus')
+
+    const denied = createDirectusClient({
+      config,
+      fetch: async () => jsonResponse({ errors: [{ message: 'Invalid user credentials.' }] }, 401),
+    })
+    const deniedProbe = await denied.getHealth()
+    expect(deniedProbe.reachable).toBe(false)
+    expect(deniedProbe.reason).toContain('Directus denied the reader token')
+
+    const teapot = createDirectusClient({
+      config,
+      fetch: async () => new Response('', { status: 418 }),
+    })
+    expect((await teapot.getHealth()).reason).toBe('Directus health returned 418')
+  })
+
+  it('health never uses the `ok` key, which the MCP layer reads as the tool envelope', async () => {
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      fetch: async () => new Response('RBAC: access denied', { status: 403 }),
+    })
+    expect(Object.keys(await client.getHealth())).not.toContain('ok')
+  })
+
+  it('rejects a non-JSON success body as 502 and accepts a bare array', async () => {
+    const config = { url: 'https://cms.example.com', token: 'reader' }
+    const html = createDirectusClient({
+      config,
+      fetch: async () => new Response('<html>login</html>', { status: 200 }),
+    })
+    try {
+      await html.getItems('countries')
+      throw new Error('expected throw')
+    } catch (err) {
+      expect((err as DirectusError).status).toBe(502)
+      expect((err as DirectusError).message).toBe('Directus returned a non-JSON body')
+    }
+
+    const bare = createDirectusClient({
+      config,
+      fetch: async () => jsonResponse([{ id: '1' }]),
+    })
+    expect(await bare.getItems('countries')).toEqual({ data: [{ id: '1' }] })
+
+    const enveloped = createDirectusClient({
+      config,
+      fetch: async () => jsonResponse({ data: [{ id: '1' }], meta: { filter_count: 7, total_count: 9 } }),
+    })
+    expect(await enveloped.getItems('countries')).toEqual({
+      data: [{ id: '1' }],
+      meta: { filter_count: 7, total_count: 9 },
+    })
+  })
+
+  it('caches a successful GET for 60s', async () => {
+    let now = 1_000
+    let hits = 0
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 'reader' },
+      now: () => now,
+      fetch: async () => {
+        hits += 1
+        return jsonResponse({ data: [{ id: '1' }], meta: { filter_count: 1 } })
+      },
+    })
+    const first = await client.getItems('countries', { limit: '1' })
+    const second = await client.getItems('countries', { limit: '1' })
+    expect(hits).toBe(1)
+    expect(first).toEqual(second)
+    now += DIRECTUS_CACHE_TTL_MS + 1
+    await client.getItems('countries', { limit: '1' })
+    expect(hits).toBe(2)
+  })
+
+  it('throws 503 when unconfigured', async () => {
+    const client = createDirectusClient({ config: null })
+    try {
+      await client.getItems('countries')
+      throw new Error('expected throw')
+    } catch (err) {
+      expect((err as DirectusError).status).toBe(503)
+    }
+  })
+})

--- a/server/directus/client.ts
+++ b/server/directus/client.ts
@@ -1,0 +1,184 @@
+/**
+ * GET-only Directus REST client. No method parameter — a caller cannot
+ * POST or PATCH through this module.
+ */
+import { safeParseJson } from '@core/utils/jsonValidate'
+import { Type, safeParseValue, type Static } from '@core/utils/typeboxHelpers'
+import type { DirectusConfig } from '../config'
+import { isDirectusCollection, type DirectusCollection } from './collections'
+import { DirectusError, directusBadGateway, directusBadRequest, directusNotConfigured } from './errors'
+
+export const DIRECTUS_CACHE_TTL_MS = 60_000
+const CACHE_MAX = 256
+
+export type DirectusFetch = (input: string, init: { method: 'GET'; headers: Record<string, string> }) => Promise<Response>
+
+interface CacheEntry {
+  expiresAt: number
+  value: DirectusItemsResponse
+}
+
+/** Directus answers `/items/*` with `{ data, meta? }`. */
+const ItemsEnvelopeSchema = Type.Object({
+  data: Type.Unknown(),
+  meta: Type.Optional(
+    Type.Object({
+      filter_count: Type.Optional(Type.Number()),
+      total_count: Type.Optional(Type.Number()),
+    }),
+  ),
+})
+
+export type DirectusItemsResponse = Static<typeof ItemsEnvelopeSchema>
+
+const DirectusErrorBodySchema = Type.Object({
+  errors: Type.Optional(Type.Array(Type.Object({ message: Type.Optional(Type.String()) }))),
+  error: Type.Optional(Type.String()),
+})
+
+export interface DirectusHealth {
+  /**
+   * True only when Directus itself answered the probe. Deliberately not
+   * named `ok`: server tool handlers return raw payloads, and `{ ok: boolean }`
+   * would be read as the `AiToolOutput` envelope by the MCP layer.
+   */
+  reachable: boolean
+  status: number
+  /** Why `reachable` is false, in operator terms. */
+  reason?: string
+}
+
+export interface DirectusClient {
+  readonly url: string
+  getItems(collection: DirectusCollection, query?: Record<string, string>): Promise<DirectusItemsResponse>
+  getHealth(): Promise<DirectusHealth>
+}
+
+export function createDirectusClient(options: {
+  config: DirectusConfig | null
+  fetch?: DirectusFetch
+  now?: () => number
+  cache?: Map<string, CacheEntry>
+}): DirectusClient {
+  const cache = options.cache ?? new Map<string, CacheEntry>()
+  const now = options.now ?? Date.now
+  const fetchImpl = options.fetch ?? ((input, init) => fetch(input, init))
+
+  async function get(path: string, query?: Record<string, string>): Promise<DirectusItemsResponse> {
+    const config = options.config
+    if (!config) throw directusNotConfigured()
+
+    const url = new URL(path, `${config.url}/`)
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== '') url.searchParams.set(key, value)
+      }
+    }
+    const cacheKey = url.toString()
+    const cached = cache.get(cacheKey)
+    const t = now()
+    if (cached && cached.expiresAt > t) return cached.value
+
+    let res: Response
+    try {
+      res = await fetchImpl(url.toString(), {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${config.token}`,
+          Accept: 'application/json',
+        },
+      })
+    } catch (err) {
+      throw new DirectusError(502, err instanceof Error ? err.message : 'Directus unreachable')
+    }
+
+    if (res.status >= 500) throw directusBadGateway()
+    if (res.status === 404) {
+      return { data: [] }
+    }
+    if (res.status === 401 || res.status === 403) {
+      // Not the caller's fault: the reader token or the gateway in front
+      // of Directus is misconfigured. A 400 would blame the query.
+      throw directusBadGateway(await describeUpstreamDenial(res))
+    }
+    if (res.status >= 400) {
+      throw directusBadRequest(await readDirectusError(res))
+    }
+
+    const value = normalizeItemsBody(await res.text())
+    if (cache.size >= CACHE_MAX) cache.clear()
+    cache.set(cacheKey, { expiresAt: t + DIRECTUS_CACHE_TTL_MS, value })
+    return value
+  }
+
+  return {
+    url: options.config?.url ?? '',
+    async getItems(collection, query) {
+      if (!isDirectusCollection(collection)) {
+        throw directusBadRequest(`Unknown collection '${collection}'`)
+      }
+      return get(`items/${collection}`, query)
+    },
+    async getHealth() {
+      const config = options.config
+      if (!config) throw directusNotConfigured()
+      let res: Response
+      try {
+        res = await fetchImpl(new URL('server/health', `${config.url}/`).toString(), {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${config.token}`,
+            Accept: 'application/json',
+          },
+        })
+      } catch (err) {
+        throw new DirectusError(502, err instanceof Error ? err.message : 'Directus unreachable')
+      }
+      if (res.ok) return { reachable: true, status: res.status }
+      if (res.status === 401 || res.status === 403) {
+        return { reachable: false, status: res.status, reason: await describeUpstreamDenial(res) }
+      }
+      return { reachable: false, status: res.status, reason: `Directus health returned ${res.status}` }
+    },
+  }
+}
+
+/**
+ * A bare array is the shape some proxies unwrap to; any other non-envelope
+ * JSON is treated as the payload itself.
+ */
+function normalizeItemsBody(raw: string): DirectusItemsResponse {
+  const json = safeParseJson(raw, Type.Unknown())
+  if (!json.ok) throw directusBadGateway('Directus returned a non-JSON body')
+  const envelope = safeParseValue(ItemsEnvelopeSchema, json.value)
+  return envelope.ok ? envelope.value : { data: json.value }
+}
+
+async function readDirectusError(res: Response): Promise<string> {
+  const parsed = safeParseJson(await res.text(), DirectusErrorBodySchema)
+  if (parsed.ok) {
+    const first = parsed.value.errors?.[0]?.message
+    if (first) return first
+    if (parsed.value.error) return parsed.value.error
+  }
+  return `Directus rejected the query (${res.status})`
+}
+
+/**
+ * Distinguish "Directus said no" from "something in front of Directus said
+ * no". Directus denials are JSON envelopes; a text/plain body means the
+ * request was stopped at the ingress (Azure Container Apps IP restrictions
+ * answer exactly `RBAC: access denied`) and the reader token was never
+ * evaluated. That ingress admits the VPN egress IP, so the usual remedy is
+ * to reconnect the VPN, not to touch the token.
+ */
+async function describeUpstreamDenial(res: Response): Promise<string> {
+  const raw = (await res.text()).trim()
+  const parsed = safeParseJson(raw, DirectusErrorBodySchema)
+  const directusMessage = parsed.ok ? parsed.value.errors?.[0]?.message : undefined
+  if (directusMessage) {
+    return `Directus denied the reader token (${res.status}: ${directusMessage}). Check MKP_CONTENT_SERVICE_DIRECTUS_TOKEN and its policy.`
+  }
+  const detail = raw && raw.length <= 120 ? `: "${raw}"` : ''
+  return `A gateway in front of Directus refused the request (${res.status}${detail}). The reader token was never evaluated. This server's egress IP is not on the Directus ingress allow-list: connect the VPN that reaches the Directus environment, or have that IP allow-listed.`
+}

--- a/server/directus/collections.ts
+++ b/server/directus/collections.ts
@@ -1,0 +1,73 @@
+/**
+ * Allow-listed Directus collections. The instance hosts many more; this
+ * reader never forwards an unknown collection name.
+ */
+export const GEOGRAPHY_LEVELS = [
+  'countries',
+  'regions',
+  'provinces',
+  'municipalities',
+  'localities',
+] as const
+
+export type GeographyLevel = (typeof GEOGRAPHY_LEVELS)[number]
+
+export const WORKFIELD_TYPES = [
+  'category',
+  'trade',
+  'product',
+  'service',
+  'topic',
+  'material',
+] as const
+
+export type WorkfieldType = (typeof WORKFIELD_TYPES)[number]
+
+/**
+ * Status of the per-locale sub-rows (pricing, demands, blog, FAQ). The base
+ * `workfield_content` row has no status column: its published set is
+ * `is_deleted = false AND is_shadow = false`.
+ */
+export const SUB_ROW_STATUSES = ['draft', 'published', 'archived'] as const
+
+export type SubRowStatus = (typeof SUB_ROW_STATUSES)[number]
+
+/**
+ * Names as they exist in DEV Directus. The reader token can read exactly
+ * these; anything else is a 403 upstream and is refused here first.
+ */
+const DIRECTUS_COLLECTIONS = [
+  ...GEOGRAPHY_LEVELS,
+  'workfield_content',
+  'workfield_faq_content',
+  'workfield_pricing_items',
+  'workfield_example_demands',
+  'workfield_blog_content',
+] as const
+
+export type DirectusCollection = (typeof DIRECTUS_COLLECTIONS)[number]
+
+export function isGeographyLevel(value: string): value is GeographyLevel {
+  return (GEOGRAPHY_LEVELS as readonly string[]).includes(value)
+}
+
+export function isDirectusCollection(value: string): value is DirectusCollection {
+  return (DIRECTUS_COLLECTIONS as readonly string[]).includes(value)
+}
+
+export function isWorkfieldType(value: string): value is WorkfieldType {
+  return (WORKFIELD_TYPES as readonly string[]).includes(value)
+}
+
+export function isSubRowStatus(value: string): value is SubRowStatus {
+  return (SUB_ROW_STATUSES as readonly string[]).includes(value)
+}
+
+/** One level up from `level` — used for `parent_id` filters. */
+export const GEOGRAPHY_PARENT_FIELD: Record<GeographyLevel, string | null> = {
+  countries: null,
+  regions: 'country',
+  provinces: 'region',
+  municipalities: 'province',
+  localities: 'municipality',
+}

--- a/server/directus/errors.ts
+++ b/server/directus/errors.ts
@@ -1,0 +1,29 @@
+/**
+ * Typed Directus-reader failures. Handlers map `status` onto the HTTP
+ * envelope; MCP tools return `{ ok: false, error }`.
+ */
+export class DirectusError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'DirectusError'
+    this.status = status
+  }
+}
+
+export function directusNotConfigured(): DirectusError {
+  return new DirectusError(503, 'Directus is not configured')
+}
+
+export function directusBadRequest(message: string): DirectusError {
+  return new DirectusError(400, message)
+}
+
+export function directusNotFound(message: string): DirectusError {
+  return new DirectusError(404, message)
+}
+
+export function directusBadGateway(message = 'Directus upstream error'): DirectusError {
+  return new DirectusError(502, message)
+}

--- a/server/directus/geography.test.ts
+++ b/server/directus/geography.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'bun:test'
+import { createDirectusClient } from './client'
+import { flattenGeographyRow, getGeographyAncestry, listGeography } from './geography'
+
+const BRUXELLES_ID = '03af8c53-1111-4111-8111-000000000001'
+const PROVINCE_ID = 'd27566cb-1111-4111-8111-000000000002'
+const REGION_ID = 'aaaaaaaa-1111-4111-8111-000000000003'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+}
+
+describe('geography flattening', () => {
+  it('does not leak translation arrays', () => {
+    const row = flattenGeographyRow('municipalities', {
+      id: BRUXELLES_ID,
+      slug: 'bruxelles',
+      country: 'BE',
+      official_code: '21004',
+      population: 196828,
+      postal_codes: ['1000', '1020'],
+      latitude: 50.855,
+      longitude: 4.3512,
+      is_major: true,
+      province: PROVINCE_ID,
+      translations: [
+        { languages_code: 'fr-BE', name: 'Bruxelles' },
+        { languages_code: 'nl-BE', name: 'Brussel' },
+      ],
+    }, { locale: 'fr-BE' })
+    expect(row).toMatchObject({
+      type: 'municipalities',
+      slug: 'bruxelles',
+      name: 'Bruxelles',
+      country: 'BE',
+      officialCode: '21004',
+      population: 196828,
+      postalCodes: ['1000', '1020'],
+      isMajor: true,
+      provinceId: PROVINCE_ID,
+    })
+    expect(row).not.toHaveProperty('translations')
+  })
+
+  it('keys countries by code: no id, no slug column upstream', () => {
+    // Real DEV row shape: `countries` has `code` as its primary key and no
+    // `id`/`slug`. The old flattener required `id` and silently dropped every
+    // country, so `countries` listed as `{ data: [], count: 2 }`.
+    const row = flattenGeographyRow('countries', {
+      code: 'BE',
+      default_language: 'fr-BE',
+      population: 11763650,
+      flag_image: null,
+      translations: [
+        { languages_code: 'fr-BE', name: 'Belgique' },
+        { languages_code: 'nl-BE', name: 'België' },
+      ],
+    }, { locale: 'nl-BE' })
+    expect(row).toMatchObject({ type: 'countries', id: 'BE', slug: 'BE', country: 'BE', name: 'België', population: 11763650 })
+    expect(flattenGeographyRow('countries', { id: 'not-a-country-shape' }, {})).toBeNull()
+  })
+})
+
+describe('geography list + ancestry', () => {
+  it('filters countries on code, never on slug (which is a Directus 403)', async () => {
+    const urls: string[] = []
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async (input) => {
+        urls.push(input)
+        return jsonResponse({ data: [{ code: 'BE', translations: [] }], meta: { filter_count: 1 } })
+      },
+    })
+    await listGeography(client, 'countries', { slug: 'BE', limit: 10, page: 1 })
+    await listGeography(client, 'municipalities', { slug: 'bruxelles', limit: 10, page: 1 })
+    const countriesFilter = new URL(urls[0]).searchParams.get('filter')
+    const municipalitiesFilter = new URL(urls[1]).searchParams.get('filter')
+    expect(JSON.parse(countriesFilter ?? '{}')).toEqual({ code: { _eq: 'BE' } })
+    expect(countriesFilter).not.toContain('slug')
+    expect(JSON.parse(municipalitiesFilter ?? '{}')).toEqual({ slug: { _eq: 'bruxelles' } })
+  })
+
+  it('uses filter_count, not total_count', async () => {
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async () => jsonResponse({
+        data: [{ id: BRUXELLES_ID, slug: 'bruxelles', country: 'BE', translations: [] }],
+        meta: { filter_count: 12, total_count: 35311 },
+      }),
+    })
+    const listed = await listGeography(client, 'municipalities', { country: 'BE', limit: 1, page: 1 })
+    expect(listed.count).toBe(12)
+    expect(listed.pageSize).toBe(1)
+  })
+
+  it('climbs municipality → province → region → country', async () => {
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async (input) => {
+        if (input.includes('/items/municipalities')) {
+          return jsonResponse({
+            data: [{
+              id: BRUXELLES_ID,
+              slug: 'bruxelles',
+              country: 'BE',
+              province: PROVINCE_ID,
+              translations: [{ languages_code: 'fr-BE', name: 'Bruxelles' }],
+            }],
+            meta: { filter_count: 1 },
+          })
+        }
+        if (input.includes('/items/provinces')) {
+          return jsonResponse({
+            data: [{
+              id: PROVINCE_ID,
+              slug: 'bruxelles-capitale',
+              country: 'BE',
+              region: REGION_ID,
+              translations: [{ languages_code: 'fr-BE', name: 'Bruxelles-Capitale' }],
+            }],
+          })
+        }
+        if (input.includes('/items/regions')) {
+          return jsonResponse({
+            data: [{
+              id: REGION_ID,
+              slug: 'bruxelles-capitale',
+              country: 'BE',
+              translations: [{ languages_code: 'fr-BE', name: 'Région de Bruxelles-Capitale' }],
+            }],
+          })
+        }
+        return jsonResponse({
+          data: [{
+            code: 'BE',
+            translations: [{ languages_code: 'fr-BE', name: 'Belgique' }],
+          }],
+        })
+      },
+    })
+    const ancestry = await getGeographyAncestry(client, { slug: 'bruxelles', locale: 'fr-BE' })
+    expect(ancestry.municipality.name).toBe('Bruxelles')
+    expect(ancestry.province?.name).toBe('Bruxelles-Capitale')
+    expect(ancestry.region?.name).toBe('Région de Bruxelles-Capitale')
+    expect(ancestry.country?.name).toBe('Belgique')
+    expect(ancestry.country?.id).toBe('BE')
+  })
+})

--- a/server/directus/geography.ts
+++ b/server/directus/geography.ts
@@ -1,0 +1,285 @@
+import type { DirectusClient } from './client'
+import {
+  GEOGRAPHY_PARENT_FIELD,
+  isGeographyLevel,
+  type GeographyLevel,
+} from './collections'
+import { directusBadRequest, directusNotFound } from './errors'
+import {
+  expandNames,
+  parseTranslations,
+  resolveName,
+  type LocaleNames,
+  type SupportedLocale,
+} from './locales'
+import {
+  asRecord,
+  asRecords,
+  boolField,
+  filteredCount,
+  numberField,
+  relationCode,
+  relationId,
+  stringField,
+  stringList,
+} from './rows'
+import {
+  assertNoControlChars,
+  assertSupportedLocale,
+  assertUuid,
+  optionalLocale,
+  optionalNonEmpty,
+  optionalUuid,
+  parseBool,
+  parseLimit,
+  parsePage,
+} from './validate'
+
+export interface GeographyRow {
+  type: GeographyLevel
+  /** Uuid for every level except `countries`, whose id is its ISO code. */
+  id: string
+  slug: string
+  name?: string
+  names?: LocaleNames
+  country?: string
+  officialCode?: string
+  population?: number
+  postalCodes?: string[]
+  latitude?: number
+  longitude?: number
+  isMajor?: boolean
+  provinceId?: string
+  regionId?: string
+  municipalityId?: string
+}
+
+export interface GeographyListQuery {
+  parentId?: string
+  country?: string
+  slug?: string
+  search?: string
+  locale?: SupportedLocale
+  allLocales?: boolean
+  limit?: number
+  page?: number
+}
+
+export interface GeographyListResult {
+  data: GeographyRow[]
+  count: number
+  page: number
+  pageSize: number
+}
+
+export interface AncestryQuery {
+  slug?: string
+  id?: string
+  country?: string
+  locale?: SupportedLocale
+  allLocales?: boolean
+}
+
+export interface GeographyAncestry {
+  municipality: GeographyRow
+  province: GeographyRow | null
+  region: GeographyRow | null
+  country: GeographyRow | null
+}
+
+export function parseGeographyListQuery(
+  level: string,
+  params: URLSearchParams,
+): { level: GeographyLevel } & GeographyListQuery {
+  if (!isGeographyLevel(level)) throw directusBadRequest('Unknown geography level')
+  const country = optionalNonEmpty('country', params.get('country'))
+  if (country && !/^[A-Z]{2}$/i.test(country)) throw directusBadRequest("'country' must be a two-letter code")
+  return {
+    level,
+    parentId: optionalUuid('parent_id', params.get('parent_id')),
+    country: country?.toUpperCase(),
+    slug: optionalNonEmpty('slug', params.get('slug')),
+    search: optionalNonEmpty('search', params.get('search')),
+    locale: optionalLocale(params.get('locale')),
+    allLocales: parseBool(params.get('all_locales')),
+    limit: parseLimit(params.get('limit')),
+    page: parsePage(params.get('page')),
+  }
+}
+
+export function parseAncestryQuery(params: URLSearchParams): AncestryQuery {
+  const country = optionalNonEmpty('country', params.get('country'))
+  if (country && !/^[A-Z]{2}$/i.test(country)) throw directusBadRequest("'country' must be a two-letter code")
+  const slug = optionalNonEmpty('slug', params.get('slug'))
+  const id = optionalUuid('id', params.get('id'))
+  if (!slug && !id) throw directusBadRequest("Provide 'slug' or 'id'")
+  return {
+    slug,
+    id,
+    country: country?.toUpperCase(),
+    locale: optionalLocale(params.get('locale')),
+    allLocales: parseBool(params.get('all_locales')),
+  }
+}
+
+/**
+ * `countries` is keyed by `code` ("BE", "FR") and has no `id` or `slug`
+ * column; every other level has a uuid `id` and a `slug`. Filtering
+ * `countries` on `slug` is a Directus 403, so the identity column is chosen
+ * per level and never guessed.
+ */
+function identityOf(level: GeographyLevel, rec: Record<string, unknown>): { id: string; slug: string } | null {
+  if (level === 'countries') {
+    const code = stringField(rec, 'code')
+    return code ? { id: code, slug: code } : null
+  }
+  const id = stringField(rec, 'id')
+  if (!id) return null
+  return { id, slug: stringField(rec, 'slug') ?? id }
+}
+
+function identityFilter(level: GeographyLevel, value: string): Record<string, unknown> {
+  return level === 'countries' ? { code: { _eq: value } } : { slug: { _eq: value } }
+}
+
+export function flattenGeographyRow(
+  level: GeographyLevel,
+  raw: unknown,
+  options: { locale?: SupportedLocale; allLocales?: boolean },
+): GeographyRow | null {
+  const rec = asRecord(raw)
+  if (!rec) return null
+  const identity = identityOf(level, rec)
+  if (!identity) return null
+  const translations = parseTranslations(rec.translations)
+  const country = level === 'countries'
+    ? identity.id
+    : (relationCode(rec.country) ?? stringField(rec, 'country_code'))
+  const fallbackName = stringField(rec, 'name') ?? identity.slug
+  const locale = options.locale ?? (country === 'FR' ? 'fr-FR' : 'fr-BE')
+  const row: GeographyRow = {
+    type: level,
+    id: identity.id,
+    slug: identity.slug,
+    country,
+    officialCode: stringField(rec, 'official_code'),
+    population: numberField(rec, 'population'),
+    postalCodes: stringList(rec.postal_codes),
+    latitude: numberField(rec, 'latitude'),
+    longitude: numberField(rec, 'longitude'),
+    isMajor: boolField(rec, 'is_major') || undefined,
+    provinceId: relationId(rec.province),
+    regionId: relationId(rec.region),
+    municipalityId: relationId(rec.municipality),
+  }
+  if (options.allLocales) {
+    row.names = expandNames(translations, country, fallbackName)
+  } else {
+    row.name = resolveName(translations, locale, country, fallbackName)
+  }
+  return row
+}
+
+export async function listGeography(
+  client: DirectusClient,
+  level: GeographyLevel,
+  query: GeographyListQuery,
+): Promise<GeographyListResult> {
+  if (query.parentId) assertUuid('parent_id', query.parentId)
+  if (query.country) assertNoControlChars('country', query.country)
+  if (query.slug) assertNoControlChars('slug', query.slug)
+  if (query.search) assertNoControlChars('search', query.search)
+  if (query.locale) assertSupportedLocale(query.locale)
+  const filter: Record<string, unknown> = {}
+  const parentField = GEOGRAPHY_PARENT_FIELD[level]
+  if (query.parentId) {
+    if (!parentField) throw directusBadRequest("'parent_id' is not valid for countries")
+    filter[parentField] = { _eq: query.parentId }
+  }
+  if (query.country && level !== 'countries') {
+    filter.country = { _eq: query.country }
+  }
+  if (query.slug) {
+    Object.assign(filter, identityFilter(level, query.slug))
+  }
+
+  const params: Record<string, string> = {
+    fields: '*,translations.*',
+    meta: 'filter_count',
+    limit: String(query.limit ?? 100),
+    page: String(query.page ?? 1),
+  }
+  if (Object.keys(filter).length > 0) params.filter = JSON.stringify(filter)
+  if (query.search) params.search = query.search
+
+  const response = await client.getItems(level, params)
+  const rows = asRecords(response.data)
+    .map((row) => flattenGeographyRow(level, row, query))
+    .filter((row): row is GeographyRow => row !== null)
+  return {
+    data: rows,
+    count: filteredCount(response.meta, rows.length),
+    page: query.page ?? 1,
+    pageSize: query.limit ?? 100,
+  }
+}
+
+export async function getGeographyAncestry(
+  client: DirectusClient,
+  query: AncestryQuery,
+): Promise<GeographyAncestry> {
+  if (query.id) assertUuid('id', query.id)
+  if (query.slug) assertNoControlChars('slug', query.slug)
+  if (query.country) assertNoControlChars('country', query.country)
+  if (query.locale) assertSupportedLocale(query.locale)
+  if (!query.slug && !query.id) throw directusBadRequest("Provide 'slug' or 'id'")
+  const municipality = query.id
+    ? await loadLevel(client, 'municipalities', query.id, query)
+    : (await listGeography(client, 'municipalities', {
+        slug: query.slug,
+        country: query.country,
+        locale: query.locale,
+        allLocales: query.allLocales,
+        limit: 2,
+        page: 1,
+      })).data[0] ?? null
+  if (!municipality) throw directusNotFound('Municipality not found')
+
+  const province = municipality.provinceId
+    ? await loadLevel(client, 'provinces', municipality.provinceId, query)
+    : null
+  const regionId = province?.regionId
+  const region = regionId ? await loadLevel(client, 'regions', regionId, query) : null
+  const country = await loadCountry(client, municipality.country, query)
+
+  return { municipality, province, region, country }
+}
+
+async function loadLevel(
+  client: DirectusClient,
+  level: GeographyLevel,
+  id: string,
+  query: { locale?: SupportedLocale; allLocales?: boolean },
+): Promise<GeographyRow | null> {
+  const response = await client.getItems(level, {
+    fields: '*,translations.*',
+    filter: JSON.stringify({ id: { _eq: id } }),
+    limit: '1',
+  })
+  return flattenGeographyRow(level, asRecords(response.data)[0], query)
+}
+
+async function loadCountry(
+  client: DirectusClient,
+  code: string | undefined,
+  query: { locale?: SupportedLocale; allLocales?: boolean },
+): Promise<GeographyRow | null> {
+  if (!code) return null
+  const response = await client.getItems('countries', {
+    fields: '*,translations.*',
+    filter: JSON.stringify(identityFilter('countries', code)),
+    limit: '1',
+  })
+  return flattenGeographyRow('countries', asRecords(response.data)[0], query)
+}
+

--- a/server/directus/index.ts
+++ b/server/directus/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Public surface of the Directus reader. Everything outside `server/directus/`
+ * imports from here; files inside import each other relatively.
+ */
+export { GEOGRAPHY_LEVELS, SUB_ROW_STATUSES, WORKFIELD_TYPES, isGeographyLevel } from './collections'
+export {
+  createDirectusService,
+  getDirectusService,
+  isDirectusError,
+  setDirectusServiceForTests,
+  parseAncestryQuery,
+  parseGeographyListQuery,
+  parseStrengthListQuery,
+  parseWorkfieldDetailQuery,
+  parseWorkfieldFaqQuery,
+  parseWorkfieldListQuery,
+} from './service'
+export { STRENGTH_IDS } from './strengths'
+export { WORKFIELD_INCLUDES } from './workfields'

--- a/server/directus/live.test.ts
+++ b/server/directus/live.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Optional live probe against DEV Directus. GET only. Skips when the
+ * reader is unconfigured or offline. When the probe answers, it must be
+ * honest: a gateway denial is `reachable: false` with a reason, never
+ * `reachable: true`.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readDirectusConfig } from '../config'
+import { createDirectusClient } from './client'
+
+const config = readDirectusConfig()
+
+describe('live Directus reader', () => {
+  it('skips or reaches a configured instance without writing', async () => {
+    if (!config) return
+    const client = createDirectusClient({ config })
+    let health: Awaited<ReturnType<typeof client.getHealth>>
+    try {
+      health = await client.getHealth()
+    } catch {
+      // Offline checkout still passes.
+      return
+    }
+    if (health.reachable) {
+      expect(health.status).toBeLessThan(400)
+      expect(health.reason).toBeUndefined()
+      return
+    }
+    expect(health.reason).toBeString()
+    expect(health.reason?.length).toBeGreaterThan(0)
+  })
+})

--- a/server/directus/locales.test.ts
+++ b/server/directus/locales.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  SUPPORTED_LOCALES,
+  expandNames,
+  parseTranslations,
+  resolveName,
+} from './locales'
+
+const bruxelles = parseTranslations([
+  { languages_code: 'fr-BE', name: 'Bruxelles' },
+  { languages_code: 'nl-BE', name: 'Brussel' },
+  { languages_code: 'de-BE', name: 'Brüssel' },
+  { languages_code: 'en-BE', name: 'Brussels' },
+])
+
+const paris = parseTranslations([
+  { languages_code: 'fr-FR', name: 'Paris' },
+])
+
+describe('Directus locale fallback', () => {
+  it('uses the same language in another region before the country default', () => {
+    expect(resolveName(bruxelles, 'nl-NL', 'BE')).toBe('Brussel')
+    expect(resolveName(bruxelles, 'en-FR', 'BE')).toBe('Brussels')
+  })
+
+  it('resolves Paris in fr-BE instead of returning null', () => {
+    expect(resolveName(paris, 'fr-BE', 'FR')).toBe('Paris')
+    expect(resolveName(paris, 'nl-BE', 'FR')).toBe('Paris')
+  })
+
+  it('expands names to all 8 locales', () => {
+    const names = expandNames(bruxelles, 'BE')
+    expect(Object.keys(names).sort()).toEqual([...SUPPORTED_LOCALES].sort())
+    expect(names['fr-BE']).toBe('Bruxelles')
+    expect(names['nl-BE']).toBe('Brussel')
+    expect(names['nl-NL']).toBe('Brussel')
+    expect(names['fr-FR']).toBe('Bruxelles')
+    expect(names['en-NL']).toBe('Brussels')
+  })
+
+  it('fills every Paris locale with the one real name', () => {
+    const names = expandNames(paris, 'FR')
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(names[locale]).toBe('Paris')
+    }
+  })
+
+  it('reads a languages_code object', () => {
+    const rows = parseTranslations([{ languages_code: { code: 'fr-BE' }, name: 'Liège' }])
+    expect(resolveName(rows, 'fr-BE', 'BE')).toBe('Liège')
+  })
+})

--- a/server/directus/locales.ts
+++ b/server/directus/locales.ts
@@ -1,0 +1,122 @@
+/**
+ * Locale resolution for Directus translations.
+ *
+ * Deep-filtering a query to one hardcoded locale returns `name: null` for
+ * every foreign address. This layer fetches every translation and resolves
+ * in order: exact locale → same language other region → the row's country
+ * default → any fr-* → first available. `names` always carries all 8 keys.
+ */
+import { SUPPORTED_LOCALES, isSupportedLocale, type SupportedLocale } from '@core/locales'
+
+export { SUPPORTED_LOCALES, isSupportedLocale, type SupportedLocale }
+
+export type LocaleNames = Record<SupportedLocale, string>
+
+export interface DirectusTranslation {
+  /** Raw `languages_code` as Directus sent it — matched against the catalog, never trusted as one. */
+  languagesCode: string
+  name: string
+  fields: Record<string, string>
+}
+
+function countryDefaultLocale(country: string | undefined): SupportedLocale {
+  return country?.toUpperCase() === 'FR' ? 'fr-FR' : 'fr-BE'
+}
+
+function languageOf(tag: string): string {
+  return tag.split('-')[0]?.toLowerCase() ?? tag.toLowerCase()
+}
+
+function normalizeLocaleCode(raw: unknown): string | null {
+  if (typeof raw === 'string' && raw.trim()) return raw.trim()
+  if (raw && typeof raw === 'object') {
+    const rec = raw as Record<string, unknown>
+    if (typeof rec.code === 'string' && rec.code.trim()) return rec.code.trim()
+    if (typeof rec.languages_code === 'string' && rec.languages_code.trim()) return rec.languages_code.trim()
+  }
+  return null
+}
+
+export function parseTranslations(raw: unknown): DirectusTranslation[] {
+  if (!Array.isArray(raw)) return []
+  const out: DirectusTranslation[] = []
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue
+    const rec = entry as Record<string, unknown>
+    const languagesCode = normalizeLocaleCode(rec.languages_code)
+      ?? normalizeLocaleCode(rec.locale)
+      ?? normalizeLocaleCode(rec.language)
+    if (!languagesCode) continue
+    const name = typeof rec.name === 'string' ? rec.name : ''
+    const fields: Record<string, string> = {}
+    for (const [key, value] of Object.entries(rec)) {
+      if (typeof value === 'string') fields[key] = value
+    }
+    out.push({ languagesCode, name, fields })
+  }
+  return out
+}
+
+function pickTranslation(
+  translations: readonly DirectusTranslation[],
+  locale: SupportedLocale,
+  country: string | undefined,
+): DirectusTranslation | undefined {
+  if (translations.length === 0) return undefined
+  const exact = translations.find((row) => row.languagesCode === locale)
+  if (exact && (exact.name || Object.keys(exact.fields).length > 0)) return exact
+
+  const lang = languageOf(locale)
+  const sameLanguage = translations.find((row) => languageOf(row.languagesCode) === lang && row.name)
+  if (sameLanguage) return sameLanguage
+
+  const countryLocale = countryDefaultLocale(country)
+  const implied = translations.find((row) => row.languagesCode === countryLocale && row.name)
+  if (implied) return implied
+
+  const french = translations.find((row) => languageOf(row.languagesCode) === 'fr' && row.name)
+  if (french) return french
+
+  return translations.find((row) => row.name) ?? translations[0]
+}
+
+export function resolveName(
+  translations: readonly DirectusTranslation[],
+  locale: SupportedLocale,
+  country: string | undefined,
+  fallback = '',
+): string {
+  const picked = pickTranslation(translations, locale, country)
+  return picked?.name || fallback
+}
+
+export function resolveTranslationFields(
+  translations: readonly DirectusTranslation[],
+  locale: SupportedLocale,
+  country: string | undefined,
+): Record<string, string> {
+  return pickTranslation(translations, locale, country)?.fields ?? {}
+}
+
+export function expandNames(
+  translations: readonly DirectusTranslation[],
+  country: string | undefined,
+  fallback = '',
+): LocaleNames {
+  const names = {} as LocaleNames
+  for (const locale of SUPPORTED_LOCALES) {
+    names[locale] = resolveName(translations, locale, country, fallback)
+  }
+  return names
+}
+
+export function translationsByLocale(
+  translations: readonly DirectusTranslation[],
+  country: string | undefined,
+): Record<SupportedLocale, Record<string, string>> {
+  const out = {} as Record<SupportedLocale, Record<string, string>>
+  for (const locale of SUPPORTED_LOCALES) {
+    out[locale] = resolveTranslationFields(translations, locale, country)
+  }
+  return out
+}

--- a/server/directus/rows.ts
+++ b/server/directus/rows.ts
@@ -1,0 +1,92 @@
+/** Shared row-shape helpers — no Directus arrays leak out of flatteners. */
+
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? value as Record<string, unknown>
+    : null
+}
+
+export function asRecords(value: unknown): Record<string, unknown>[] {
+  return Array.isArray(value)
+    ? value.flatMap((entry) => {
+        const rec = asRecord(entry)
+        return rec ? [rec] : []
+      })
+    : []
+}
+
+export function relationId(value: unknown): string | undefined {
+  if (typeof value === 'string' && value) return value
+  const rec = asRecord(value)
+  if (typeof rec?.id === 'string' && rec.id) return rec.id
+  return undefined
+}
+
+export function relationCode(value: unknown): string | undefined {
+  if (typeof value === 'string' && /^[A-Z]{2}$/i.test(value)) return value.toUpperCase()
+  const rec = asRecord(value)
+  if (typeof rec?.code === 'string' && rec.code) return rec.code.toUpperCase()
+  if (typeof rec?.slug === 'string' && /^[A-Z]{2}$/i.test(rec.slug)) return rec.slug.toUpperCase()
+  return undefined
+}
+
+export function stringField(rec: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = rec[key]
+    if (typeof value === 'string' && value) return value
+  }
+  return undefined
+}
+
+export function numberField(rec: Record<string, unknown>, ...keys: string[]): number | undefined {
+  for (const key of keys) {
+    const value = rec[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+    if (typeof value === 'string' && value.trim() && Number.isFinite(Number(value))) return Number(value)
+  }
+  return undefined
+}
+
+export function boolField(rec: Record<string, unknown>, ...keys: string[]): boolean {
+  for (const key of keys) {
+    const value = rec[key]
+    if (value === true || value === 1 || value === '1' || value === 'true') return true
+  }
+  return false
+}
+
+export function stringList(value: unknown): string[] | undefined {
+  if (Array.isArray(value)) {
+    const items = value.filter((entry): entry is string => typeof entry === 'string' && entry.length > 0)
+    return items.length > 0 ? items : undefined
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value.split(/[\s,]+/).filter(Boolean)
+  }
+  return undefined
+}
+
+export function assetUrl(baseUrl: string, value: unknown): string | undefined {
+  if (typeof value === 'string') {
+    if (value.startsWith('http://') || value.startsWith('https://')) return value
+    if (value) return `${baseUrl.replace(/\/+$/, '')}/assets/${value}`
+    return undefined
+  }
+  const rec = asRecord(value)
+  if (!rec) return undefined
+  if (typeof rec.filename_download === 'string' && typeof rec.id === 'string') {
+    return `${baseUrl.replace(/\/+$/, '')}/assets/${rec.id}`
+  }
+  if (typeof rec.id === 'string' && rec.id) {
+    return `${baseUrl.replace(/\/+$/, '')}/assets/${rec.id}`
+  }
+  if (typeof rec.url === 'string' && rec.url) return rec.url
+  return undefined
+}
+
+export function filteredCount(meta: { filter_count?: number; total_count?: number } | undefined, fallback: number): number {
+  if (typeof meta?.filter_count === 'number' && Number.isFinite(meta.filter_count)) {
+    return meta.filter_count
+  }
+  return fallback
+}

--- a/server/directus/service.ts
+++ b/server/directus/service.ts
@@ -1,0 +1,107 @@
+import { readDirectusConfig, type DirectusConfig } from '../config'
+import { createDirectusClient, type DirectusClient, type DirectusFetch } from './client'
+import type { GeographyLevel } from './collections'
+import { DirectusError, directusNotConfigured } from './errors'
+import {
+  getGeographyAncestry,
+  listGeography,
+  parseAncestryQuery,
+  parseGeographyListQuery,
+  type AncestryQuery,
+  type GeographyAncestry,
+  type GeographyListQuery,
+  type GeographyListResult,
+} from './geography'
+import {
+  listStrengths,
+  parseStrengthListQuery,
+  type StrengthListQuery,
+  type StrengthRow,
+} from './strengths'
+import {
+  getWorkfield,
+  listWorkfieldFaq,
+  listWorkfields,
+  parseWorkfieldDetailQuery,
+  parseWorkfieldFaqQuery,
+  parseWorkfieldListQuery,
+  type WorkfieldDetail,
+  type WorkfieldDetailQuery,
+  type WorkfieldFaqQuery,
+  type WorkfieldFaqRow,
+  type WorkfieldListQuery,
+  type WorkfieldListResult,
+} from './workfields'
+
+export interface DirectusService {
+  health(): Promise<{ reachable: boolean; configured: true; status: number; url: string; reason?: string }>
+  listGeography(level: GeographyLevel, query: GeographyListQuery): Promise<GeographyListResult>
+  getAncestry(query: AncestryQuery): Promise<GeographyAncestry>
+  listWorkfields(query: WorkfieldListQuery): Promise<WorkfieldListResult>
+  getWorkfield(slug: string, query: WorkfieldDetailQuery): Promise<WorkfieldDetail>
+  listWorkfieldFaq(slug: string, query: WorkfieldFaqQuery): Promise<WorkfieldFaqRow[]>
+  /** Static catalog — served even when Directus is unconfigured. */
+  listStrengths(query: StrengthListQuery): { data: StrengthRow[]; count: number }
+}
+
+export function createDirectusService(options: {
+  config?: DirectusConfig | null
+  fetch?: DirectusFetch
+  now?: () => number
+  client?: DirectusClient
+}): DirectusService {
+  const config = options.config === undefined ? readDirectusConfig() : options.config
+  const client = options.client ?? createDirectusClient({
+    config,
+    fetch: options.fetch,
+    now: options.now,
+  })
+
+  if (!config && !options.client) {
+    return {
+      async health() { throw directusNotConfigured() },
+      async listGeography() { throw directusNotConfigured() },
+      async getAncestry() { throw directusNotConfigured() },
+      async listWorkfields() { throw directusNotConfigured() },
+      async getWorkfield() { throw directusNotConfigured() },
+      async listWorkfieldFaq() { throw directusNotConfigured() },
+      listStrengths: (query) => listStrengths(query),
+    }
+  }
+
+  return {
+    async health() {
+      const probe = await client.getHealth()
+      return { reachable: probe.reachable, configured: true, status: probe.status, url: client.url, reason: probe.reason }
+    },
+    listGeography: (level, query) => listGeography(client, level, query),
+    getAncestry: (query) => getGeographyAncestry(client, query),
+    listWorkfields: (query) => listWorkfields(client, query),
+    getWorkfield: (slug, query) => getWorkfield(client, slug, query),
+    listWorkfieldFaq: (slug, query) => listWorkfieldFaq(client, slug, query),
+    listStrengths: (query) => listStrengths(query),
+  }
+}
+
+let serviceOverride: DirectusService | null = null
+
+export function setDirectusServiceForTests(service: DirectusService | null): void {
+  serviceOverride = service
+}
+
+export function getDirectusService(): DirectusService {
+  return serviceOverride ?? createDirectusService({})
+}
+
+export function isDirectusError(err: unknown): err is DirectusError {
+  return err instanceof DirectusError
+}
+
+export {
+  parseStrengthListQuery,
+  parseAncestryQuery,
+  parseGeographyListQuery,
+  parseWorkfieldDetailQuery,
+  parseWorkfieldFaqQuery,
+  parseWorkfieldListQuery,
+}

--- a/server/directus/strengths.test.ts
+++ b/server/directus/strengths.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import { isStrengthId, listStrengths, parseStrengthListQuery, STRENGTH_IDS } from './strengths'
+import { SUPPORTED_LOCALES } from './locales'
+import { isDirectusError } from './service'
+
+describe('strengths catalog', () => {
+  it('exposes the 20 intake ids', () => {
+    expect(STRENGTH_IDS.length).toBe(20)
+    expect(STRENGTH_IDS[0]).toBe('owner-on-site')
+    expect(isStrengthId('after-sales')).toBe(true)
+    expect(isStrengthId('nope')).toBe(false)
+  })
+
+  it('fills every supported locale and an icon', () => {
+    for (const row of listStrengths().data) {
+      expect(row.icon.length).toBeGreaterThan(0)
+      for (const locale of SUPPORTED_LOCALES) {
+        expect(row.names[locale].length).toBeGreaterThan(0)
+      }
+    }
+  })
+
+  it('uses the authored BE labels and falls back for other regions', () => {
+    const [owner] = listStrengths({ ids: ['owner-on-site'] }).data
+    expect(owner?.names['nl-BE']).toBe('Zaakvoerder op de werf')
+    expect(owner?.names['fr-FR']).toBe('Le patron sur le chantier')
+    expect(owner?.names['nl-NL']).toBe('Zaakvoerder op de werf')
+  })
+
+  it('resolves one locale into name', () => {
+    const { data, count } = listStrengths({ locale: 'de-BE', ids: ['free-quote'] })
+    expect(count).toBe(1)
+    expect(data[0]?.name).toBe('Kostenloses Angebot')
+  })
+
+  it('rejects an unknown id', () => {
+    try {
+      listStrengths({ ids: ['owner-on-site', 'bogus'] })
+      throw new Error('expected throw')
+    } catch (err) {
+      expect(isDirectusError(err)).toBe(true)
+      expect((err as Error).message).toContain('bogus')
+    }
+  })
+
+  it('parses the query string', () => {
+    const q = parseStrengthListQuery(new URLSearchParams('locale=nl-BE&ids=free-quote,%20careful-work'))
+    expect(q).toEqual({ locale: 'nl-BE', ids: ['free-quote', 'careful-work'] })
+    expect(parseStrengthListQuery(new URLSearchParams())).toEqual({ locale: undefined, ids: undefined })
+  })
+})

--- a/server/directus/strengths.ts
+++ b/server/directus/strengths.ts
@@ -1,0 +1,123 @@
+/**
+ * Fixed strengths ("troeven") catalog — intake screen 21.
+ *
+ * A closed, server-owned list. Intake stores 3–6 ids on
+ * `contentFacts.strengths`; labels are locale maps resolved at render time so
+ * the words are never authored on the site.
+ *
+ * Static data: no Directus round-trip, so these reads work even when the
+ * Directus reader is unconfigured.
+ */
+import {
+  expandNames,
+  resolveName,
+  type DirectusTranslation,
+  type LocaleNames,
+  type SupportedLocale,
+} from './locales'
+import { optionalLocale, optionalNonEmpty } from './validate'
+import { directusBadRequest } from './errors'
+
+export interface StrengthRow {
+  id: string
+  icon: string
+  /** All 8 supported locales, filled by the shared translation fallback. */
+  names: LocaleNames
+  /** Present only when a single `locale` was requested. */
+  name?: string
+}
+
+interface StrengthSource {
+  id: string
+  icon: string
+  names: Record<string, string>
+}
+
+const STRENGTH_SOURCES: readonly StrengthSource[] = [
+  { id: 'owner-on-site', icon: 'hard-hat', names: { 'nl-BE': 'Zaakvoerder op de werf', 'fr-BE': 'Le patron sur le chantier', 'de-BE': 'Inhaber vor Ort', 'en-BE': 'Owner on site' } },
+  { id: 'respect-deadlines', icon: 'calendar-check', names: { 'nl-BE': 'Respect voor deadlines', 'fr-BE': 'Respect des délais', 'de-BE': 'Termintreue', 'en-BE': 'Respect for deadlines' } },
+  { id: 'careful-work', icon: 'sparkles', names: { 'nl-BE': 'Verzorgd werk', 'fr-BE': 'Travail soigné', 'de-BE': 'Sorgfältige Arbeit', 'en-BE': 'Careful work' } },
+  { id: 'free-quote', icon: 'file-text', names: { 'nl-BE': 'Gratis offerte', 'fr-BE': 'Devis gratuit', 'de-BE': 'Kostenloses Angebot', 'en-BE': 'Free quote' } },
+  { id: 'clean-sites', icon: 'brush-cleaning', names: { 'nl-BE': 'Nette werven', 'fr-BE': 'Chantiers propres', 'de-BE': 'Saubere Baustellen', 'en-BE': 'Clean sites' } },
+  { id: 'availability', icon: 'message-circle-more', names: { 'nl-BE': 'Beschikbaarheid & reactiviteit', 'fr-BE': 'Disponibilité & réactivité', 'de-BE': 'Verfügbarkeit & Reaktivität', 'en-BE': 'Availability & responsiveness' } },
+  { id: 'ten-year-guarantee', icon: 'shield-check', names: { 'nl-BE': 'Tienjarige garantie', 'fr-BE': 'Garantie décennale', 'de-BE': 'Zehnjahresgarantie', 'en-BE': 'Ten-year guarantee' } },
+  { id: 'vca-certified', icon: 'badge-check', names: { 'nl-BE': 'VCA-gecertificeerd', 'fr-BE': 'Certifié VCA', 'de-BE': 'VCA-zertifiziert', 'en-BE': 'VCA certified' } },
+  { id: 'ten-years-plus', icon: 'award', names: { 'nl-BE': 'Meer dan 10 jaar ervaring', 'fr-BE': "Plus de 10 ans d'expérience", 'de-BE': 'Mehr als 10 Jahre Erfahrung', 'en-BE': 'More than 10 years of experience' } },
+  { id: 'family-business', icon: 'house-heart', names: { 'nl-BE': 'Familiebedrijf', 'fr-BE': 'Entreprise familiale', 'de-BE': 'Familienbetrieb', 'en-BE': 'Family business' } },
+  { id: 'custom-work', icon: 'ruler', names: { 'nl-BE': 'Maatwerk', 'fr-BE': 'Sur mesure', 'de-BE': 'Maßarbeit', 'en-BE': 'Custom work' } },
+  { id: 'quality-materials', icon: 'gem', names: { 'nl-BE': 'Kwaliteitsmaterialen', 'fr-BE': 'Matériaux de qualité', 'de-BE': 'Qualitätsmaterialien', 'en-BE': 'Quality materials' } },
+  { id: 'personal-advice', icon: 'handshake', names: { 'nl-BE': 'Persoonlijk advies', 'fr-BE': 'Conseil personnalisé', 'de-BE': 'Persönliche Beratung', 'en-BE': 'Personal advice' } },
+  { id: 'transparent-prices', icon: 'tag', names: { 'nl-BE': 'Transparante prijzen', 'fr-BE': 'Prix transparents', 'de-BE': 'Transparente Preise', 'en-BE': 'Transparent prices' } },
+  { id: 'fast-response', icon: 'zap', names: { 'nl-BE': 'Snelle interventie', 'fr-BE': 'Intervention rapide', 'de-BE': 'Schneller Einsatz', 'en-BE': 'Fast response' } },
+  { id: 'respect-budget', icon: 'wallet', names: { 'nl-BE': 'Respect voor het budget', 'fr-BE': 'Respect du budget', 'de-BE': 'Budgettreue', 'en-BE': 'Respect for the budget' } },
+  { id: 'professional-team', icon: 'users-round', names: { 'nl-BE': 'Professioneel team', 'fr-BE': 'Équipe professionnelle', 'de-BE': 'Professionelles Team', 'en-BE': 'Professional team' } },
+  { id: 'local-sites', icon: 'map-pin', names: { 'nl-BE': 'Lokale werven', 'fr-BE': 'Chantiers locaux', 'de-BE': 'Lokale Baustellen', 'en-BE': 'Local sites' } },
+  { id: 'satisfaction-guaranteed', icon: 'smile', names: { 'nl-BE': 'Tevredenheid gegarandeerd', 'fr-BE': 'Satisfaction garantie', 'de-BE': 'Zufriedenheit garantiert', 'en-BE': 'Satisfaction guaranteed' } },
+  { id: 'after-sales', icon: 'headset', names: { 'nl-BE': 'Dienst na verkoop', 'fr-BE': 'Service après-vente', 'de-BE': 'After-Sales-Service', 'en-BE': 'After-sales service' } },
+] as const
+
+/** Every valid `contentFacts.strengths` id, in intake order. */
+export const STRENGTH_IDS = STRENGTH_SOURCES.map((row) => row.id) as readonly string[]
+
+const STRENGTH_ID_SET: ReadonlySet<string> = new Set(STRENGTH_IDS)
+
+export function isStrengthId(value: string): boolean {
+  return STRENGTH_ID_SET.has(value)
+}
+
+function translationsOf(names: Record<string, string>): DirectusTranslation[] {
+  return Object.entries(names).map(([languagesCode, name]) => ({
+    languagesCode,
+    name,
+    fields: { name },
+  }))
+}
+
+/** Authored BE labels expanded to all 8 supported locales via the shared fallback. */
+const STRENGTHS: readonly StrengthRow[] = STRENGTH_SOURCES.map((source) => ({
+  id: source.id,
+  icon: source.icon,
+  names: expandNames(translationsOf(source.names), 'BE'),
+}))
+
+const STRENGTH_BY_ID = new Map(STRENGTHS.map((row) => [row.id, row]))
+
+/** `names` is already all-8; the shared fallback chain still fills a blank entry. */
+function resolveStrengthName(row: StrengthRow, locale: SupportedLocale): string {
+  const translations: DirectusTranslation[] = Object.entries(row.names).map(([code, name]) => ({
+    languagesCode: code,
+    name,
+    fields: { name },
+  }))
+  return resolveName(translations, locale, 'BE')
+}
+
+export interface StrengthListQuery {
+  /** Resolve one locale into `name`. Omit for the full `names` map only. */
+  locale?: SupportedLocale
+  /** Restrict to these ids, in catalog order. Unknown ids are a 400. */
+  ids?: string[]
+}
+
+export function parseStrengthListQuery(params: URLSearchParams): StrengthListQuery {
+  const locale = optionalLocale(params.get('locale'))
+  const rawIds = optionalNonEmpty('ids', params.get('ids'))
+  const ids = rawIds?.split(',').map((id) => id.trim()).filter(Boolean)
+  return { locale, ids: ids?.length ? ids : undefined }
+}
+
+export function listStrengths(query: StrengthListQuery = {}): { data: StrengthRow[]; count: number } {
+  let rows: readonly StrengthRow[] = STRENGTHS
+  if (query.ids) {
+    const wanted = new Set(query.ids)
+    for (const id of wanted) {
+      if (!STRENGTH_BY_ID.has(id)) throw directusBadRequest(`Unknown strength id '${id}'`)
+    }
+    rows = STRENGTHS.filter((row) => wanted.has(row.id))
+  }
+  const locale = query.locale
+  const data = locale
+    ? rows.map((row) => ({ ...row, name: resolveStrengthName(row, locale) }))
+    : rows.map((row) => ({ ...row }))
+  return { data, count: data.length }
+}

--- a/server/directus/validate.test.ts
+++ b/server/directus/validate.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { DirectusError } from './errors'
+import { assertNoControlChars, assertUuid, optionalLocale, parseLimit, parsePage } from './validate'
+
+describe('Directus input guards', () => {
+  it('rejects a NUL byte so Postgres never sees it', () => {
+    expect(() => assertNoControlChars('search', 'brux\u0000elles')).toThrow(DirectusError)
+    try {
+      assertNoControlChars('search', 'brux\u0000elles')
+    } catch (err) {
+      expect(err).toBeInstanceOf(DirectusError)
+      expect((err as DirectusError).status).toBe(400)
+      expect((err as DirectusError).message).toBe("'search' contains control characters")
+    }
+  })
+
+  it('only accepts the 8 supported locales', () => {
+    expect(optionalLocale(null)).toBeUndefined()
+    expect(optionalLocale('  ')).toBeUndefined()
+    expect(optionalLocale(' nl-BE ')).toBe('nl-BE')
+    expect(() => optionalLocale('en')).toThrow(DirectusError)
+    expect(() => optionalLocale('en-GB')).toThrow("'locale' must be one of fr-BE, nl-BE, de-BE, en-BE, fr-FR, en-FR, nl-NL, en-NL")
+  })
+
+  it('requires a uuid', () => {
+    expect(() => assertUuid('geography_id', 'not-a-uuid')).toThrow("'geography_id' must be a uuid")
+    expect(() => assertUuid('parent_id', '03af8c53-1111-4111-8111-000000000001')).not.toThrow()
+  })
+
+  it('clamps limit to 1..1000', () => {
+    expect(parseLimit(null)).toBe(100)
+    expect(parseLimit('25')).toBe(25)
+    expect(() => parseLimit('0')).toThrow(DirectusError)
+    expect(() => parseLimit('1001')).toThrow(DirectusError)
+  })
+
+  it('requires a 1-based page', () => {
+    expect(parsePage(undefined)).toBe(1)
+    expect(() => parsePage('0')).toThrow(DirectusError)
+  })
+})

--- a/server/directus/validate.ts
+++ b/server/directus/validate.ts
@@ -1,0 +1,80 @@
+import { SUPPORTED_LOCALES, isSupportedLocale, type SupportedLocale } from '@core/locales'
+import { directusBadRequest } from './errors'
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+function hasControlChars(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    const code = value.charCodeAt(i)
+    if (code <= 0x1f || code === 0x7f) return true
+  }
+  return false
+}
+
+export function assertNoControlChars(field: string, value: string): void {
+  if (hasControlChars(value)) {
+    throw directusBadRequest(`'${field}' contains control characters`)
+  }
+}
+
+export function assertUuid(field: string, value: string): void {
+  assertNoControlChars(field, value)
+  if (!UUID_RE.test(value)) {
+    throw directusBadRequest(`'${field}' must be a uuid`)
+  }
+}
+
+export function optionalNonEmpty(field: string, raw: string | null | undefined): string | undefined {
+  if (raw == null) return undefined
+  const value = raw.trim()
+  if (!value) return undefined
+  assertNoControlChars(field, value)
+  return value
+}
+
+export function optionalUuid(field: string, raw: string | null | undefined): string | undefined {
+  const value = optionalNonEmpty(field, raw)
+  if (value === undefined) return undefined
+  assertUuid(field, value)
+  return value
+}
+
+export function parseLimit(raw: string | null | undefined, fallback = 100): number {
+  if (raw == null || raw === '') return fallback
+  assertNoControlChars('limit', raw)
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 1 || n > 1000) {
+    throw directusBadRequest("'limit' must be an integer from 1 to 1000")
+  }
+  return n
+}
+
+export function parsePage(raw: string | null | undefined, fallback = 1): number {
+  if (raw == null || raw === '') return fallback
+  assertNoControlChars('page', raw)
+  const n = Number(raw)
+  if (!Number.isInteger(n) || n < 1) {
+    throw directusBadRequest("'page' must be a 1-based integer")
+  }
+  return n
+}
+
+export function parseBool(raw: string | null | undefined): boolean {
+  if (raw == null || raw === '') return false
+  assertNoControlChars('all_locales', raw)
+  return raw === 'true' || raw === '1'
+}
+
+export function assertSupportedLocale(value: string): SupportedLocale {
+  if (!isSupportedLocale(value)) {
+    throw directusBadRequest(`'locale' must be one of ${SUPPORTED_LOCALES.join(', ')}`)
+  }
+  return value
+}
+
+/** `?locale=` query param: absent/blank → undefined, anything outside the catalog → 400. */
+export function optionalLocale(raw: string | null | undefined): SupportedLocale | undefined {
+  const value = optionalNonEmpty('locale', raw)
+  if (value === undefined) return undefined
+  return assertSupportedLocale(value)
+}

--- a/server/directus/workfields.test.ts
+++ b/server/directus/workfields.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'bun:test'
+import { createDirectusClient } from './client'
+import { DirectusError } from './errors'
+import {
+  canonicalLocalizedSlug,
+  flattenWorkfieldRow,
+  getWorkfield,
+  listWorkfieldFaq,
+  listWorkfields,
+} from './workfields'
+
+const ARCHITECT_ID = '14fbde9b-7575-4dea-ae02-644b86f6dced'
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } })
+}
+
+/** Real DEV row shape for `workfield_content` (trimmed). */
+function architectRow() {
+  return {
+    id: ARCHITECT_ID,
+    slug: 'architect',
+    type: 'trade',
+    is_deleted: false,
+    is_shadow: false,
+    professional_count: 47,
+    average_rating: 479,
+    thumbnail: '753e56e7-11d6-452b-81aa-a446977202d5',
+    demand_banner: '32374472-3999-4330-aabb-aa1418b91adb',
+    listing_banner: '6503ed6f-4b9c-4fbd-a396-2257a0406ce4',
+    translations: [
+      { languages_code: 'fr-BE', name: 'Architecte', localised_slugs: 'architecte', a_trade_singular: 'un architecte', thumbnail: null },
+      { languages_code: 'nl-BE', name: 'Architect', localised_slugs: 'oud-architect,architect', a_trade_singular: 'een architect' },
+    ],
+  }
+}
+
+describe('workfield flattening', () => {
+  it('reads the real column names: hundredths rating, localised_slugs history, thumbnail asset', () => {
+    const row = flattenWorkfieldRow(architectRow(), { locale: 'nl-BE', assetBase: 'https://cms.example.com' })
+    expect(row).toEqual({
+      id: ARCHITECT_ID,
+      slug: 'architect',
+      type: 'trade',
+      name: 'Architect',
+      localizedSlug: 'architect',
+      professionalCount: 47,
+      averageRating: 4.79,
+      thumbnailUrl: 'https://cms.example.com/assets/753e56e7-11d6-452b-81aa-a446977202d5',
+    })
+  })
+
+  it('localised_slugs: the marketplace routes on the LAST entry of the history', () => {
+    expect(canonicalLocalizedSlug('prevention-inondation,prevention-inondations')).toBe('prevention-inondations')
+    expect(canonicalLocalizedSlug(' a , b ,')).toBe('b')
+    expect(canonicalLocalizedSlug('')).toBeUndefined()
+    expect(canonicalLocalizedSlug(null)).toBeUndefined()
+  })
+
+  it('all_locales expands names to all 8 keys and slugs only where a locale has one', () => {
+    const row = flattenWorkfieldRow(architectRow(), { allLocales: true, assetBase: 'https://cms.example.com' })
+    expect(Object.keys(row?.names ?? {})).toHaveLength(8)
+    expect(row?.names?.['nl-NL']).toBe('Architect')
+    expect(row?.localizedSlugs?.['fr-BE']).toBe('architecte')
+    expect(row?.localizedSlugs?.['nl-BE']).toBe('architect')
+    expect(row?.localizedSlugs?.['fr-FR']).toBe('architecte')
+  })
+})
+
+describe('workfield reads', () => {
+  it('lists from workfield_content with the content-service published filter, never a status column', async () => {
+    const urls: string[] = []
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async (input) => {
+        urls.push(input)
+        return jsonResponse({ data: [architectRow()], meta: { filter_count: 25 } })
+      },
+    })
+    const listed = await listWorkfields(client, { type: 'trade', locale: 'fr-BE', limit: 5, page: 1 })
+    expect(listed.count).toBe(25)
+    expect(listed.data[0]?.name).toBe('Architecte')
+    const url = new URL(urls[0])
+    expect(url.pathname).toBe('/items/workfield_content')
+    expect(JSON.parse(url.searchParams.get('filter') ?? '{}')).toEqual({
+      is_deleted: { _eq: false },
+      is_shadow: { _eq: false },
+      type: { _eq: 'trade' },
+    })
+    expect(url.searchParams.get('filter')).not.toContain('status')
+    expect(url.searchParams.get('sort')).toBe('slug')
+  })
+
+  it('detail: fetches includes from the flat per-locale collections, generic FAQ only', async () => {
+    const urls: string[] = []
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async (input) => {
+        urls.push(input)
+        const url = new URL(input)
+        if (url.pathname === '/items/workfield_content') return jsonResponse({ data: [architectRow()] })
+        if (url.pathname === '/items/workfield_pricing_items') {
+          return jsonResponse({ data: [{ id: 'p1', sort: 1, status: 'published', label: 'Plans', price_indication: 'de 2500€ à 4000€' }] })
+        }
+        if (url.pathname === '/items/workfield_faq_content') {
+          return jsonResponse({ data: [{
+            id: 'f1', type: 'generic', status: 'published', geography_type: null, geography_id: null,
+            translations: [{ languages_code: 'fr-BE', intro_text: null, qa_text: '<h2>Quel est le rôle ?</h2>' }],
+          }] })
+        }
+        return jsonResponse({ data: [] })
+      },
+    })
+    const detail = await getWorkfield(client, 'architect', { include: ['pricing', 'faq'], locale: 'fr-BE' })
+    expect(detail.name).toBe('Architecte')
+    expect(detail.isShadow).toBe(false)
+    expect(detail.translation?.a_trade_singular).toBe('un architecte')
+    expect(detail.translation).not.toHaveProperty('thumbnail')
+    expect(detail.images.demandBannerUrl).toBe('https://cms.example.com/assets/32374472-3999-4330-aabb-aa1418b91adb')
+    expect(detail.pricing).toEqual([{ id: 'p1', sort: 1, status: 'published', label: 'Plans', price_indication: 'de 2500€ à 4000€' }])
+    expect(detail.faq).toEqual([{
+      id: 'f1', type: 'generic', status: 'published', geographyType: undefined, geographyId: undefined,
+      locale: 'fr-BE', introText: undefined, qaText: '<h2>Quel est le rôle ?</h2>',
+    }])
+
+    const pricing = new URL(urls.find((u) => u.includes('workfield_pricing_items')) ?? '')
+    expect(JSON.parse(pricing.searchParams.get('filter') ?? '{}')).toEqual({
+      workfield_content_id: { _eq: ARCHITECT_ID },
+      languages_code: { _eq: 'fr-BE' },
+    })
+    const faq = new URL(urls.find((u) => u.includes('workfield_faq_content')) ?? '')
+    expect(JSON.parse(faq.searchParams.get('filter') ?? '{}')).toEqual({
+      workfield_content_id: { _eq: ARCHITECT_ID },
+      type: { _eq: 'generic' },
+    })
+  })
+
+  it('detail: unknown slug is a 404, and status only filters sub-rows', async () => {
+    const urls: string[] = []
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async (input) => {
+        urls.push(input)
+        const url = new URL(input)
+        if (url.pathname === '/items/workfield_content') {
+          return jsonResponse({ data: url.searchParams.get('filter')?.includes('nope') ? [] : [architectRow()] })
+        }
+        return jsonResponse({ data: [] })
+      },
+    })
+    await expect(getWorkfield(client, 'nope', {})).rejects.toMatchObject({ status: 404 })
+    await getWorkfield(client, 'architect', { include: ['blog'], status: 'draft' })
+    const base = new URL(urls.find((u) => u.includes('workfield_content?')) ?? urls[0])
+    expect(base.searchParams.get('filter')).not.toContain('status')
+    const blog = new URL(urls.find((u) => u.includes('workfield_blog_content')) ?? '')
+    expect(JSON.parse(blog.searchParams.get('filter') ?? '{}')).toMatchObject({ status: { _eq: 'draft' } })
+  })
+
+  it('faq route: filters by slug relation + geography, 404s an unknown workfield', async () => {
+    const urls: string[] = []
+    const client = createDirectusClient({
+      config: { url: 'https://cms.example.com', token: 't' },
+      fetch: async (input) => {
+        urls.push(input)
+        const url = new URL(input)
+        if (url.pathname === '/items/workfield_faq_content') {
+          return jsonResponse({ data: url.searchParams.get('filter')?.includes('roofer') ? [{
+            id: 'l1', type: 'location_specific', status: 'published', geography_type: 'municipalities',
+            geography_id: 'a107d1e4-84c8-45ae-b79e-7e206b055649',
+            translations: [{ languages_code: 'fr-BE', intro_text: 'Intro', qa_text: 'QA' }],
+          }] : [] })
+        }
+        return jsonResponse({ data: url.searchParams.get('filter')?.includes('roofer') ? [{ id: 'r' }] : [] })
+      },
+    })
+    const rows = await listWorkfieldFaq(client, 'roofer', {
+      type: 'location_specific', geographyType: 'municipalities', geographyId: 'a107d1e4-84c8-45ae-b79e-7e206b055649', locale: 'fr-BE',
+    })
+    expect(rows).toHaveLength(1)
+    expect(rows[0]?.introText).toBe('Intro')
+    const faq = new URL(urls[0])
+    expect(JSON.parse(faq.searchParams.get('filter') ?? '{}')).toEqual({
+      workfield_content_id: { slug: { _eq: 'roofer' } },
+      type: { _eq: 'location_specific' },
+      geography_type: { _eq: 'municipalities' },
+      geography_id: { _eq: 'a107d1e4-84c8-45ae-b79e-7e206b055649' },
+    })
+    await expect(listWorkfieldFaq(client, 'nope', {})).rejects.toBeInstanceOf(DirectusError)
+  })
+})

--- a/server/directus/workfields.ts
+++ b/server/directus/workfields.ts
@@ -1,0 +1,482 @@
+/**
+ * Workfields, read from the collections the DEV reader can actually see.
+ *
+ * Upstream contract (verified live, 2026-09-02):
+ * - `workfield_content` is the base row. It has NO `status` column; the
+ *   content service's "published" set is `is_deleted = false AND
+ *   is_shadow = false` (468 of 473 rows).
+ * - Translations live on `workfield_content.translations` (one row per
+ *   locale, 8 per workfield). `localised_slugs` is a comma-separated history,
+ *   oldest first; the marketplace routes on the LAST entry.
+ * - Pricing, example demands and blog are flat per-locale collections keyed
+ *   by `workfield_content_id` + `languages_code`, each with its own `status`.
+ * - FAQ is `workfield_faq_content` (`type` generic | location_specific,
+ *   `geography_type`, `geography_id`, `status`) with `translations`
+ *   (`intro_text`, `qa_text`).
+ * - `average_rating` is an integer x100 (479 = 4.79).
+ */
+import type { DirectusClient } from './client'
+import {
+  isGeographyLevel,
+  isSubRowStatus,
+  isWorkfieldType,
+  type GeographyLevel,
+  type SubRowStatus,
+  type WorkfieldType,
+} from './collections'
+import { directusBadRequest, directusNotFound } from './errors'
+import {
+  expandNames,
+  parseTranslations,
+  resolveName,
+  resolveTranslationFields,
+  translationsByLocale,
+  SUPPORTED_LOCALES,
+  isSupportedLocale,
+  type DirectusTranslation,
+  type LocaleNames,
+  type SupportedLocale,
+} from './locales'
+import {
+  asRecord,
+  asRecords,
+  assetUrl,
+  boolField,
+  filteredCount,
+  numberField,
+  stringField,
+} from './rows'
+import {
+  assertNoControlChars,
+  assertSupportedLocale,
+  assertUuid,
+  optionalLocale,
+  optionalNonEmpty,
+  optionalUuid,
+  parseBool,
+  parseLimit,
+  parsePage,
+} from './validate'
+
+export const WORKFIELD_INCLUDES = ['pricing', 'demands', 'blog', 'faq'] as const
+export type WorkfieldInclude = (typeof WORKFIELD_INCLUDES)[number]
+
+/** Per-locale sub-collections keyed by `workfield_content_id` + `languages_code`. */
+const FLAT_LOCALE_COLLECTIONS = {
+  pricing: { collection: 'workfield_pricing_items', fields: 'id,sort,status,label,price_indication' },
+  demands: { collection: 'workfield_example_demands', fields: 'id,sort,status,thumbnail,title,location,professionals' },
+  blog: { collection: 'workfield_blog_content', fields: 'id,sort,status,thumbnail,url,title,date_label' },
+} as const
+
+const WORKFIELD_BASE_FIELDS = 'id,slug,type,is_deleted,is_shadow,professional_count,average_rating,thumbnail,demand_banner,listing_banner'
+const WORKFIELD_LIST_FIELDS = `${WORKFIELD_BASE_FIELDS},translations.languages_code,translations.name,translations.localised_slugs`
+const WORKFIELD_DETAIL_FIELDS = `${WORKFIELD_BASE_FIELDS},translations.*`
+const FAQ_FIELDS = 'id,type,geography_type,geography_id,status,translations.languages_code,translations.intro_text,translations.qa_text'
+
+/** The content service's published set: not deleted, not shadow. */
+const PUBLISHED_FILTER = { is_deleted: { _eq: false }, is_shadow: { _eq: false } } as const
+
+export interface WorkfieldRow {
+  id: string
+  slug: string
+  type: string
+  name?: string
+  names?: LocaleNames
+  localizedSlug?: string
+  localizedSlugs?: LocaleNames
+  professionalCount?: number
+  averageRating?: number
+  thumbnailUrl?: string
+}
+
+export interface WorkfieldDetail extends WorkfieldRow {
+  isShadow: boolean
+  /** The resolved locale's translation row, minus asset ids. */
+  translation?: Record<string, string>
+  /** Every locale's translation row, when `all_locales` is set. */
+  translations?: Record<SupportedLocale, Record<string, string>>
+  images: WorkfieldImages
+  pricing?: Record<string, unknown>[]
+  demands?: Record<string, unknown>[]
+  blog?: Record<string, unknown>[]
+  faq?: WorkfieldFaqRow[]
+}
+
+export interface WorkfieldImages {
+  thumbnailUrl?: string
+  demandBannerUrl?: string
+  listingBannerUrl?: string
+}
+
+export interface WorkfieldFaqRow {
+  id: string
+  type: string
+  status?: string
+  geographyType?: string
+  geographyId?: string
+  /** The locale whose translation row was picked (after fallback). */
+  locale: SupportedLocale
+  introText?: string
+  qaText?: string
+}
+
+export interface WorkfieldListQuery {
+  locale?: SupportedLocale
+  type?: WorkfieldType
+  search?: string
+  allLocales?: boolean
+  limit?: number
+  page?: number
+}
+
+export interface WorkfieldListResult {
+  data: WorkfieldRow[]
+  count: number
+  page: number
+  pageSize: number
+}
+
+export interface WorkfieldDetailQuery {
+  locale?: SupportedLocale
+  /** Filters the included pricing / demands / blog / faq rows, not the base row. */
+  status?: SubRowStatus
+  include?: WorkfieldInclude[]
+  allLocales?: boolean
+}
+
+export interface WorkfieldFaqQuery {
+  locale?: SupportedLocale
+  status?: SubRowStatus
+  type?: 'generic' | 'location_specific'
+  geographyType?: GeographyLevel
+  geographyId?: string
+}
+
+function parseSubRowStatus(raw: string | null): SubRowStatus | undefined {
+  const value = optionalNonEmpty('status', raw)
+  if (value === undefined) return undefined
+  if (!isSubRowStatus(value)) throw directusBadRequest("Unknown 'status'")
+  return value
+}
+
+export function parseWorkfieldListQuery(params: URLSearchParams): WorkfieldListQuery {
+  const rawType = optionalNonEmpty('type', params.get('type'))
+  let type: WorkfieldType | undefined
+  if (rawType !== undefined) {
+    if (!isWorkfieldType(rawType)) throw directusBadRequest("Unknown workfield 'type'")
+    type = rawType
+  }
+  return {
+    locale: optionalLocale(params.get('locale')),
+    type,
+    search: optionalNonEmpty('search', params.get('search')),
+    allLocales: parseBool(params.get('all_locales')),
+    limit: parseLimit(params.get('limit')),
+    page: parsePage(params.get('page')),
+  }
+}
+
+export function parseWorkfieldDetailQuery(params: URLSearchParams): WorkfieldDetailQuery {
+  const includeRaw = optionalNonEmpty('include', params.get('include'))
+  const include: WorkfieldInclude[] = []
+  if (includeRaw) {
+    for (const part of includeRaw.split(',').map((entry) => entry.trim()).filter(Boolean)) {
+      if (!(WORKFIELD_INCLUDES as readonly string[]).includes(part)) {
+        throw directusBadRequest(`Unknown include '${part}'`)
+      }
+      include.push(part as WorkfieldInclude)
+    }
+  }
+  return {
+    locale: optionalLocale(params.get('locale')),
+    status: parseSubRowStatus(params.get('status')),
+    include,
+    allLocales: parseBool(params.get('all_locales')),
+  }
+}
+
+export function parseWorkfieldFaqQuery(params: URLSearchParams): WorkfieldFaqQuery {
+  const rawType = optionalNonEmpty('type', params.get('type'))
+  let type: 'generic' | 'location_specific' | undefined
+  if (rawType !== undefined) {
+    if (rawType !== 'generic' && rawType !== 'location_specific') {
+      throw directusBadRequest("FAQ 'type' must be generic or location_specific")
+    }
+    type = rawType
+  }
+  const rawGeography = optionalNonEmpty('geography_type', params.get('geography_type'))
+  let geographyType: GeographyLevel | undefined
+  if (rawGeography !== undefined) {
+    if (!isGeographyLevel(rawGeography)) throw directusBadRequest('Unknown geography level')
+    geographyType = rawGeography
+  }
+  return {
+    locale: optionalLocale(params.get('locale')),
+    status: parseSubRowStatus(params.get('status')),
+    type,
+    geographyType,
+    geographyId: optionalUuid('geography_id', params.get('geography_id')),
+  }
+}
+
+/**
+ * `localised_slugs` holds a comma-separated history, oldest first
+ * ("prevention-inondation,prevention-inondations"). The content service
+ * routes on the last entry; earlier ones are superseded spellings kept for
+ * redirects. Taking the first would 404 in the marketplace.
+ */
+export function canonicalLocalizedSlug(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const parts = value.split(',').map((part) => part.trim()).filter(Boolean)
+  return parts.at(-1)
+}
+
+/** `average_rating` is an integer x100 in Directus (479 = 4.79). */
+function rating(value: number | undefined): number | undefined {
+  return value === undefined ? undefined : Math.round(value) / 100
+}
+
+function localizedSlugFor(
+  translations: readonly DirectusTranslation[],
+  locale: SupportedLocale,
+): string | undefined {
+  return canonicalLocalizedSlug(resolveTranslationFields(translations, locale, undefined).localised_slugs)
+}
+
+function expandLocalizedSlugs(translations: readonly DirectusTranslation[]): LocaleNames | undefined {
+  const out = {} as LocaleNames
+  let any = false
+  for (const locale of SUPPORTED_LOCALES) {
+    const slug = localizedSlugFor(translations, locale)
+    if (slug) {
+      out[locale] = slug
+      any = true
+    }
+  }
+  return any ? out : undefined
+}
+
+export function flattenWorkfieldRow(
+  raw: unknown,
+  options: { locale?: SupportedLocale; allLocales?: boolean; assetBase: string },
+): WorkfieldRow | null {
+  const rec = asRecord(raw)
+  const id = rec ? stringField(rec, 'id') : undefined
+  if (!rec || !id) return null
+  const translations = parseTranslations(rec.translations)
+  const slug = stringField(rec, 'slug') ?? id
+  const locale = options.locale ?? 'fr-BE'
+  const row: WorkfieldRow = {
+    id,
+    slug,
+    type: stringField(rec, 'type') ?? '',
+    professionalCount: numberField(rec, 'professional_count'),
+    averageRating: rating(numberField(rec, 'average_rating')),
+    thumbnailUrl: assetUrl(options.assetBase, rec.thumbnail),
+  }
+  if (options.allLocales) {
+    row.names = expandNames(translations, undefined, slug)
+    row.localizedSlugs = expandLocalizedSlugs(translations)
+  } else {
+    row.name = resolveName(translations, locale, undefined, slug)
+    row.localizedSlug = localizedSlugFor(translations, locale)
+  }
+  return row
+}
+
+export async function listWorkfields(
+  client: DirectusClient,
+  query: WorkfieldListQuery,
+): Promise<WorkfieldListResult> {
+  if (query.search) assertNoControlChars('search', query.search)
+  if (query.locale) assertSupportedLocale(query.locale)
+  const filter: Record<string, unknown> = { ...PUBLISHED_FILTER }
+  if (query.type) filter.type = { _eq: query.type }
+
+  const params: Record<string, string> = {
+    fields: WORKFIELD_LIST_FIELDS,
+    meta: 'filter_count',
+    filter: JSON.stringify(filter),
+    sort: 'slug',
+    limit: String(query.limit ?? 100),
+    page: String(query.page ?? 1),
+  }
+  if (query.search) params.search = query.search
+
+  const response = await client.getItems('workfield_content', params)
+  const rows = asRecords(response.data)
+    .map((row) => flattenWorkfieldRow(row, { ...query, assetBase: client.url }))
+    .filter((row): row is WorkfieldRow => row !== null)
+  return {
+    data: rows,
+    count: filteredCount(response.meta, rows.length),
+    page: query.page ?? 1,
+    pageSize: query.limit ?? 100,
+  }
+}
+
+/** Asset ids on a translation row become URLs on `images`, not raw strings on `translation`. */
+const TRANSLATION_ASSET_KEYS = new Set(['thumbnail', 'listing_banner'])
+
+function withoutAssetKeys(fields: Record<string, string>): Record<string, string> {
+  return Object.fromEntries(Object.entries(fields).filter(([key]) => !TRANSLATION_ASSET_KEYS.has(key)))
+}
+
+export async function getWorkfield(
+  client: DirectusClient,
+  slug: string,
+  query: WorkfieldDetailQuery,
+): Promise<WorkfieldDetail> {
+  assertNoControlChars('slug', slug)
+  if (query.locale) assertSupportedLocale(query.locale)
+  const response = await client.getItems('workfield_content', {
+    fields: WORKFIELD_DETAIL_FIELDS,
+    filter: JSON.stringify({ slug: { _eq: slug } }),
+    limit: '1',
+  })
+  const raw = asRecords(response.data)[0]
+  const base = raw && flattenWorkfieldRow(raw, { locale: query.locale, allLocales: query.allLocales, assetBase: client.url })
+  if (!raw || !base) throw directusNotFound('Workfield not found')
+
+  const locale = query.locale ?? 'fr-BE'
+  const translations = parseTranslations(raw.translations)
+  const picked = resolveTranslationFields(translations, locale, undefined)
+  const detail: WorkfieldDetail = {
+    ...base,
+    isShadow: boolField(raw, 'is_shadow'),
+    images: {
+      thumbnailUrl: assetUrl(client.url, picked.thumbnail ?? raw.thumbnail),
+      demandBannerUrl: assetUrl(client.url, raw.demand_banner),
+      listingBannerUrl: assetUrl(client.url, picked.listing_banner ?? raw.listing_banner),
+    },
+  }
+  if (query.allLocales) {
+    const byLocale = translationsByLocale(translations, undefined)
+    detail.translations = Object.fromEntries(
+      Object.entries(byLocale).map(([code, fields]) => [code, withoutAssetKeys(fields)]),
+    ) as Record<SupportedLocale, Record<string, string>>
+  } else {
+    detail.translation = withoutAssetKeys(picked)
+  }
+
+  const include = new Set(query.include ?? [])
+  const subRowLocale = query.allLocales ? undefined : locale
+  const loads: Promise<void>[] = []
+  for (const name of ['pricing', 'demands', 'blog'] as const) {
+    if (!include.has(name)) continue
+    loads.push(loadFlatLocaleRows(client, name, base.id, subRowLocale, query.status).then((rows) => {
+      detail[name] = rows
+    }))
+  }
+  if (include.has('faq')) {
+    // Generic only. A popular workfield carries a location_specific row per
+    // municipality (roofer has 128), so an unscoped include would return the
+    // whole country. The FAQ route takes a geography for the local ones.
+    loads.push(queryFaq(client, { workfieldId: base.id, type: 'generic', status: query.status, locale }).then((rows) => {
+      detail.faq = rows
+    }))
+  }
+  await Promise.all(loads)
+  return detail
+}
+
+async function loadFlatLocaleRows(
+  client: DirectusClient,
+  name: keyof typeof FLAT_LOCALE_COLLECTIONS,
+  workfieldId: string,
+  locale: SupportedLocale | undefined,
+  status: SubRowStatus | undefined,
+): Promise<Record<string, unknown>[]> {
+  const { collection, fields } = FLAT_LOCALE_COLLECTIONS[name]
+  const filter: Record<string, unknown> = { workfield_content_id: { _eq: workfieldId } }
+  if (locale) filter.languages_code = { _eq: locale }
+  if (status) filter.status = { _eq: status }
+  const response = await client.getItems(collection, {
+    fields,
+    filter: JSON.stringify(filter),
+    sort: 'sort',
+    limit: '1000',
+  })
+  return asRecords(response.data).map((row) => {
+    if (typeof row.thumbnail === 'string') {
+      return { ...row, thumbnailUrl: assetUrl(client.url, row.thumbnail), thumbnail: undefined }
+    }
+    return row
+  })
+}
+
+function flattenFaqRow(raw: unknown, locale: SupportedLocale): WorkfieldFaqRow | null {
+  const rec = asRecord(raw)
+  const id = rec ? stringField(rec, 'id') : undefined
+  if (!rec || !id) return null
+  const fields = resolveTranslationFields(parseTranslations(rec.translations), locale, undefined)
+  const picked = fields.languages_code
+  return {
+    id,
+    type: stringField(rec, 'type') ?? 'generic',
+    status: stringField(rec, 'status'),
+    geographyType: stringField(rec, 'geography_type'),
+    geographyId: stringField(rec, 'geography_id'),
+    locale: isSupportedLocale(picked) ? picked : locale,
+    introText: fields.intro_text,
+    qaText: fields.qa_text,
+  }
+}
+
+async function queryFaq(
+  client: DirectusClient,
+  options: {
+    workfieldId?: string
+    workfieldSlug?: string
+    type?: 'generic' | 'location_specific'
+    status?: SubRowStatus
+    geographyType?: GeographyLevel
+    geographyId?: string
+    locale: SupportedLocale
+  },
+): Promise<WorkfieldFaqRow[]> {
+  const filter: Record<string, unknown> = options.workfieldId
+    ? { workfield_content_id: { _eq: options.workfieldId } }
+    : { workfield_content_id: { slug: { _eq: options.workfieldSlug } } }
+  if (options.type) filter.type = { _eq: options.type }
+  if (options.status) filter.status = { _eq: options.status }
+  if (options.geographyType) filter.geography_type = { _eq: options.geographyType }
+  if (options.geographyId) filter.geography_id = { _eq: options.geographyId }
+  const response = await client.getItems('workfield_faq_content', {
+    fields: FAQ_FIELDS,
+    filter: JSON.stringify(filter),
+    sort: 'type',
+    limit: '1000',
+  })
+  return asRecords(response.data)
+    .map((row) => flattenFaqRow(row, options.locale))
+    .filter((row): row is WorkfieldFaqRow => row !== null)
+}
+
+export async function listWorkfieldFaq(
+  client: DirectusClient,
+  slug: string,
+  query: WorkfieldFaqQuery,
+): Promise<WorkfieldFaqRow[]> {
+  assertNoControlChars('slug', slug)
+  if (query.geographyId) assertUuid('geography_id', query.geographyId)
+  if (query.locale) assertSupportedLocale(query.locale)
+  const rows = await queryFaq(client, {
+    workfieldSlug: slug,
+    type: query.type ?? (query.geographyId ? 'location_specific' : undefined),
+    status: query.status,
+    geographyType: query.geographyType,
+    geographyId: query.geographyId,
+    locale: query.locale ?? 'fr-BE',
+  })
+  if (rows.length === 0) {
+    // Distinguish "no FAQ" from "no such workfield" so callers get the 404.
+    const exists = await client.getItems('workfield_content', {
+      fields: 'id',
+      filter: JSON.stringify({ slug: { _eq: slug } }),
+      limit: '1',
+    })
+    if (asRecords(exists.data).length === 0) throw directusNotFound('Workfield not found')
+  }
+  return rows
+}

--- a/server/handlers/cms/directus.ts
+++ b/server/handlers/cms/directus.ts
@@ -1,0 +1,126 @@
+/**
+ * Read-only Directus proxy. GET only — geography, workfields, FAQ.
+ * The Directus token never leaves the server.
+ */
+import { requireCapability } from '../../auth/authz'
+import { jsonResponse } from '../../http'
+import {
+  getDirectusService,
+  isDirectusError,
+  parseAncestryQuery,
+  parseGeographyListQuery,
+  parseStrengthListQuery,
+  parseWorkfieldDetailQuery,
+  parseWorkfieldFaqQuery,
+  parseWorkfieldListQuery,
+} from '../../directus'
+import type { DbClient } from '../../db/client'
+import { CMS_API_PREFIX } from './shared'
+import { runRouteTable, type Route, type RouteParams } from './routeTable'
+
+const PREFIX = `${CMS_API_PREFIX}/directus`
+
+async function gate(req: Request, db: DbClient) {
+  return requireCapability(req, db, 'directus.read')
+}
+
+function respondError(err: unknown): Response {
+  if (isDirectusError(err)) {
+    return jsonResponse({ error: err.message }, { status: err.status })
+  }
+  console.error('[directus]', err)
+  return jsonResponse({ error: 'Directus upstream error' }, { status: 502 })
+}
+
+async function handleHealth(req: Request, db: DbClient): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    return jsonResponse(await getDirectusService().health())
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+async function handleGeography(req: Request, db: DbClient, params: RouteParams): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    const parsed = parseGeographyListQuery(params.level ?? '', new URL(req.url).searchParams)
+    const { level, ...query } = parsed
+    return jsonResponse(await getDirectusService().listGeography(level, query))
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+async function handleAncestry(req: Request, db: DbClient): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    const query = parseAncestryQuery(new URL(req.url).searchParams)
+    return jsonResponse(await getDirectusService().getAncestry(query))
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+async function handleWorkfields(req: Request, db: DbClient): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    const query = parseWorkfieldListQuery(new URL(req.url).searchParams)
+    return jsonResponse(await getDirectusService().listWorkfields(query))
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+async function handleWorkfield(req: Request, db: DbClient, params: RouteParams): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    const query = parseWorkfieldDetailQuery(new URL(req.url).searchParams)
+    return jsonResponse(await getDirectusService().getWorkfield(params.slug ?? '', query))
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+async function handleWorkfieldFaq(req: Request, db: DbClient, params: RouteParams): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    const query = parseWorkfieldFaqQuery(new URL(req.url).searchParams)
+    return jsonResponse({
+      data: await getDirectusService().listWorkfieldFaq(params.slug ?? '', query),
+    })
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+async function handleStrengths(req: Request, db: DbClient): Promise<Response> {
+  const user = await gate(req, db)
+  if (user instanceof Response) return user
+  try {
+    const query = parseStrengthListQuery(new URL(req.url).searchParams)
+    return jsonResponse(getDirectusService().listStrengths(query))
+  } catch (err) {
+    return respondError(err)
+  }
+}
+
+const ROUTES: readonly Route<[]>[] = [
+  { method: 'GET', pattern: `${PREFIX}/health`, handler: handleHealth },
+  { method: 'GET', pattern: `${PREFIX}/strengths`, handler: handleStrengths },
+  { method: 'GET', pattern: `${PREFIX}/geography-ancestry`, handler: handleAncestry },
+  { method: 'GET', pattern: new RegExp(`^${PREFIX}/geography/(?<level>[^/]+)$`), handler: handleGeography },
+  { method: 'GET', pattern: new RegExp(`^${PREFIX}/workfields/(?<slug>[^/]+)/faq$`), handler: handleWorkfieldFaq },
+  { method: 'GET', pattern: new RegExp(`^${PREFIX}/workfields/(?<slug>[^/]+)$`), handler: handleWorkfield },
+  { method: 'GET', pattern: `${PREFIX}/workfields`, handler: handleWorkfields },
+]
+
+export async function handleDirectusRoutes(req: Request, db: DbClient): Promise<Response | null> {
+  return runRouteTable(req, db, ROUTES)
+}

--- a/server/handlers/cms/index.ts
+++ b/server/handlers/cms/index.ts
@@ -49,6 +49,7 @@ import { handleMediaStorageAdminRoutes } from './mediaStorageAdmin'
 import { handlePluginsRoutes } from './plugins'
 import { handleDataRoutes } from './data'
 import { handleDashboardRoutes } from './dashboard'
+import { handleDirectusRoutes } from './directus'
 import { handleFontsRoutes } from './fonts'
 import { handlePublishRoutes } from './publish'
 import { handleExportRoute } from './export'
@@ -109,6 +110,7 @@ export async function handleCmsRequest(
     // dashboard widgets. Lives after data routes so future routes
     // under `/data/...` can never accidentally shadow it.
     ?? (await handleDashboardRoutes(req, db, options))
+    ?? (await handleDirectusRoutes(req, db))
     ?? (await handleFontsRoutes(req, db, options))
     ?? (await handlePublishRoutes(req, db, options))
     // Export and import are registered after data routes so their exact paths

--- a/src/__tests__/architecture/directus-read-only.test.ts
+++ b/src/__tests__/architecture/directus-read-only.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Architecture gate — the Directus reader is GET-only.
+ *
+ * A write helper or a POST/PATCH/PUT/DELETE route would turn this layer
+ * into an open gateway against a content database. Live installations
+ * use a reader token; the code must not be able to spend it on a write.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { extname, join } from 'path'
+
+const REPO_ROOT = join(import.meta.dir, '../../../')
+
+function collectTs(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const s = statSync(full)
+    if (s.isDirectory()) out.push(...collectTs(full))
+    else if (s.isFile() && extname(entry) === '.ts' && !entry.endsWith('.test.ts')) out.push(full)
+  }
+  return out
+}
+
+const WRITE_RE = /\b(POST|PATCH|PUT|DELETE)\b/
+const METHOD_PARAM_RE = /method:\s*['"](?:POST|PATCH|PUT|DELETE)['"]/
+
+describe('directus-read-only gate', () => {
+  it('server/directus never issues a write', () => {
+    const files = collectTs(join(REPO_ROOT, 'server/directus'))
+    expect(files.length).toBeGreaterThan(0)
+    const violations: string[] = []
+    for (const file of files) {
+      const src = readFileSync(file, 'utf8')
+      if (METHOD_PARAM_RE.test(src) || /fetch\([^)]*\{\s*method:\s*['"]POST/.test(src)) {
+        violations.push(file.slice(REPO_ROOT.length))
+      }
+    }
+    expect(violations).toEqual([])
+  })
+
+  it('CMS Directus routes are GET-only', () => {
+    const src = readFileSync(join(REPO_ROOT, 'server/handlers/cms/directus.ts'), 'utf8')
+    expect(src).toContain("method: 'GET'")
+    expect(WRITE_RE.test(src.replace(/GET/g, ''))).toBe(false)
+    expect(src).not.toContain("method: 'POST'")
+    expect(src).not.toContain("method: 'PATCH'")
+    expect(src).not.toContain("method: 'PUT'")
+    expect(src).not.toContain("method: 'DELETE'")
+  })
+})

--- a/src/__tests__/architecture/locale-enum-usage.test.ts
+++ b/src/__tests__/architecture/locale-enum-usage.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Architecture gate — locales are a closed enum.
+ *
+ * Every language / locale the product handles must be one of the 8 BCP 47
+ * tags the Directus API client supports. The catalog lives once, in
+ * `src/core/locales.ts` (`SUPPORTED_LOCALES` / `SupportedLocaleSchema`), and
+ * feeds the Directus reader, its MCP tool enums, and every locale picker or
+ * `ogLocale` field that lands after it. This gate stops a new surface from
+ * re-opening the field to any string.
+ *
+ * Assertions:
+ *   1. The catalog is exactly the 8 Directus locales.
+ *   2. No TypeBox schema under `src/` or `server/` types a `locale` /
+ *      `ogLocale` property as `Type.String` — it must use the enum.
+ *   3. No type or interface under `src/core/` or `server/` declares a
+ *      `locale` / `ogLocale` member as `string` — it must be `SupportedLocale`.
+ *   4. No file other than the catalog builds locale names from `Intl.DisplayNames`.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { extname, join, relative } from 'path'
+import { SUPPORTED_LOCALES } from '@core/locales'
+
+const REPO_ROOT = join(import.meta.dir, '../../../')
+const CATALOG = 'src/core/locales.ts'
+
+function collectSources(dir: string): string[] {
+  const out: string[] = []
+  for (const entry of readdirSync(dir)) {
+    if (entry === 'node_modules' || entry === '__tests__') continue
+    const full = join(dir, entry)
+    const s = statSync(full)
+    if (s.isDirectory()) out.push(...collectSources(full))
+    else if (
+      s.isFile() &&
+      ['.ts', '.tsx'].includes(extname(entry)) &&
+      !entry.endsWith('.test.ts') &&
+      !entry.endsWith('.test.tsx')
+    ) {
+      out.push(full)
+    }
+  }
+  return out
+}
+
+function rel(file: string): string {
+  return relative(REPO_ROOT, file)
+}
+
+function violations(files: string[], pattern: RegExp): string[] {
+  const out: string[] = []
+  for (const file of files) {
+    const path = rel(file)
+    if (path === CATALOG) continue
+    const src = readFileSync(file, 'utf8')
+    src.split('\n').forEach((line, index) => {
+      if (pattern.test(line)) out.push(`${path}:${index + 1}: ${line.trim()}`)
+    })
+  }
+  return out
+}
+
+/** `locale: Type.String(` / `ogLocale: Type.Optional(Type.String(` — a schema that accepts any tag. */
+const SCHEMA_STRING_LOCALE_RE = /\b(?:og)?[lL]ocale\??\s*:\s*Type\.(?:Optional\(\s*)?Type\.String\b/
+
+/** `locale?: string` / `ogLocale: string` in a type, interface, or signature. */
+const TYPE_STRING_LOCALE_RE = /\b(?:og)?[lL]ocale\??\s*:\s*string\b/
+
+describe('locale enum gate', () => {
+  it('the catalog is exactly the 8 Directus locales', () => {
+    expect([...SUPPORTED_LOCALES]).toEqual([
+      'fr-BE', 'nl-BE', 'de-BE', 'en-BE', 'fr-FR', 'en-FR', 'nl-NL', 'en-NL',
+    ])
+  })
+
+  it('no TypeBox schema types a locale as a free string', () => {
+    const files = [...collectSources(join(REPO_ROOT, 'src')), ...collectSources(join(REPO_ROOT, 'server'))]
+    expect(violations(files, SCHEMA_STRING_LOCALE_RE)).toEqual([])
+  })
+
+  it('no engine or server type declares a locale as a free string', () => {
+    const files = [...collectSources(join(REPO_ROOT, 'src/core')), ...collectSources(join(REPO_ROOT, 'server'))]
+    expect(violations(files, TYPE_STRING_LOCALE_RE)).toEqual([])
+  })
+
+  it('only the catalog derives locale display names', () => {
+    const files = [...collectSources(join(REPO_ROOT, 'src')), ...collectSources(join(REPO_ROOT, 'server'))]
+    expect(violations(files, /Intl\.DisplayNames\([^)]*type:\s*['"]language['"]/)).toEqual([])
+  })
+})

--- a/src/__tests__/server/cmsDirectus.test.ts
+++ b/src/__tests__/server/cmsDirectus.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { createDirectusService, setDirectusServiceForTests } from '../../../server/directus'
+import { syncSystemRoles } from '../../../server/repositories/roles'
+import { createCapabilityTestHarness, expectForbidden, readJson } from '../helpers/capabilityHarness'
+
+afterEach(() => {
+  setDirectusServiceForTests(null)
+})
+
+async function harnessWithRoles() {
+  const harness = await createCapabilityTestHarness()
+  await syncSystemRoles(harness.db)
+  return harness
+}
+
+describe('CMS Directus routes', () => {
+  it('returns 401 without a session', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const res = await harness.cms('/admin/api/cms/directus/health')
+      expect(res.status).toBe(401)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('returns 403 without directus.read', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      await harness.setupOwner()
+      const user = await harness.createRoleUser({
+        name: 'Site reader',
+        slug: 'site-reader',
+        capabilities: ['site.read'],
+      })
+      const res = await harness.cms('/admin/api/cms/directus/health', { cookie: user.cookie })
+      await expectForbidden(res)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('returns 503 when Directus is not configured', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const cookie = await harness.setupOwner()
+      setDirectusServiceForTests(createDirectusService({ config: null }))
+      const res = await harness.cms('/admin/api/cms/directus/health', { cookie })
+      expect(res.status).toBe(503)
+      const body = await readJson<{ error: string }>(res)
+      expect(body.error).toBe('Directus is not configured')
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('serves the strengths catalog even when Directus is not configured', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const cookie = await harness.setupOwner()
+      setDirectusServiceForTests(createDirectusService({ config: null }))
+      const res = await harness.cms('/admin/api/cms/directus/strengths?locale=nl-BE', { cookie })
+      expect(res.status).toBe(200)
+      const body = await readJson<{ count: number; data: Array<{ id: string; icon: string; name: string }> }>(res)
+      expect(body.count).toBe(20)
+      expect(body.data[0]).toMatchObject({
+        id: 'owner-on-site',
+        icon: 'hard-hat',
+        name: 'Zaakvoerder op de werf',
+      })
+
+      const bad = await harness.cms('/admin/api/cms/directus/strengths?ids=nope', { cookie })
+      expect(bad.status).toBe(400)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('rejects an unknown geography level and a bad uuid', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const cookie = await harness.setupOwner()
+      setDirectusServiceForTests(createDirectusService({
+        config: { url: 'https://cms.example.com', token: 't' },
+        fetch: async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      }))
+      const unknown = await harness.cms('/admin/api/cms/directus/geography/continents', { cookie })
+      expect(unknown.status).toBe(400)
+      const badUuid = await harness.cms(
+        '/admin/api/cms/directus/geography/municipalities?parent_id=not-a-uuid',
+        { cookie },
+      )
+      expect(badUuid.status).toBe(400)
+      const body = await readJson<{ error: string }>(badUuid)
+      expect(body.error).toBe("'parent_id' must be a uuid")
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('rejects control characters', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const cookie = await harness.setupOwner()
+      setDirectusServiceForTests(createDirectusService({
+        config: { url: 'https://cms.example.com', token: 't' },
+        fetch: async () => new Response(JSON.stringify({ data: [] }), { status: 200 }),
+      }))
+      const res = await harness.cms(
+        `/admin/api/cms/directus/workfields?search=${encodeURIComponent('foo\u0000bar')}`,
+        { cookie },
+      )
+      expect(res.status).toBe(400)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('returns 405 for POST', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const cookie = await harness.setupOwner()
+      const res = await harness.cms('/admin/api/cms/directus/health', { method: 'POST', cookie, json: {} })
+      expect(res.status).toBe(405)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+
+  it('returns health when the reader is configured', async () => {
+    const harness = await harnessWithRoles()
+    try {
+      const cookie = await harness.setupOwner()
+      setDirectusServiceForTests(createDirectusService({
+        config: { url: 'https://cms.example.com', token: 't' },
+        fetch: async () => new Response(JSON.stringify({ status: 'ok' }), { status: 200 }),
+      }))
+      const res = await harness.cms('/admin/api/cms/directus/health', { cookie })
+      expect(res.status).toBe(200)
+      const body = await readJson<{ reachable: boolean; configured: true }>(res)
+      expect(body.reachable).toBe(true)
+      expect(body.configured).toBe(true)
+    } finally {
+      await harness.cleanup()
+    }
+  })
+})

--- a/src/__tests__/server/serverConfig.test.ts
+++ b/src/__tests__/server/serverConfig.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'bun:test'
-import { normalizeOrigin, readServerConfig, resolvePublicOrigins } from '../../../server/config'
+import {
+  normalizeOrigin,
+  readDirectusConfig,
+  readServerConfig,
+  resolvePublicOrigins,
+} from '../../../server/config'
 
 describe('normalizeOrigin', () => {
   it('lowercases scheme and host and strips the trailing slash', () => {
@@ -126,6 +131,7 @@ describe('readServerConfig', () => {
       staticDir: './dist',
       trustedProxyCidrs: [],
       publicOrigins: [],
+      directus: null,
     })
   })
 
@@ -148,6 +154,36 @@ describe('readServerConfig', () => {
       staticDir: '/srv/instatic/dist',
       trustedProxyCidrs: ['10.0.0.0/8', '192.168.0.0/16'],
       publicOrigins: ['https://cms.example.com', 'http://localhost:5173'],
+      directus: null,
     })
+  })
+})
+
+describe('readDirectusConfig', () => {
+  it('returns null when url or token is missing', () => {
+    expect(readDirectusConfig({})).toBeNull()
+    expect(readDirectusConfig({ MKP_CONTENT_SERVICE_DIRECTUS_URL: 'https://cms.example.com' })).toBeNull()
+    expect(readDirectusConfig({ MKP_CONTENT_SERVICE_DIRECTUS_TOKEN: 'reader' })).toBeNull()
+  })
+
+  it('reads the reader URL and token and strips a trailing slash', () => {
+    expect(readDirectusConfig({
+      MKP_CONTENT_SERVICE_DIRECTUS_URL: 'https://mkp-directus.dev.example.com/',
+      MKP_CONTENT_SERVICE_DIRECTUS_TOKEN: 'reader-token',
+    })).toEqual({
+      url: 'https://mkp-directus.dev.example.com',
+      token: 'reader-token',
+    })
+  })
+
+  it('rejects a non-http(s) or unparsable url', () => {
+    expect(readDirectusConfig({
+      MKP_CONTENT_SERVICE_DIRECTUS_URL: 'ftp://cms.example.com',
+      MKP_CONTENT_SERVICE_DIRECTUS_TOKEN: 'reader',
+    })).toBeNull()
+    expect(readDirectusConfig({
+      MKP_CONTENT_SERVICE_DIRECTUS_URL: 'not a url',
+      MKP_CONTENT_SERVICE_DIRECTUS_TOKEN: 'reader',
+    })).toBeNull()
   })
 })

--- a/src/admin/pages/ai/tabs/mcpCapabilities.ts
+++ b/src/admin/pages/ai/tabs/mcpCapabilities.ts
@@ -6,7 +6,7 @@ import type { CapabilityPickerGroup } from '@admin/shared/CapabilityPicker'
 export const MCP_CAPABILITY_GROUPS: readonly CapabilityPickerGroup[] = [
   {
     title: 'Read',
-    capabilities: ['site.read', 'content.manage', 'data.custom.tables.read', 'data.system.tables.read', 'media.read'],
+    capabilities: ['site.read', 'content.manage', 'data.custom.tables.read', 'data.system.tables.read', 'media.read', 'directus.read'],
   },
   {
     title: 'Allow writes',

--- a/src/admin/pages/users/utils/capabilities.ts
+++ b/src/admin/pages/users/utils/capabilities.ts
@@ -68,6 +68,10 @@ export const CAPABILITY_GROUPS: CapabilityGroup[] = [
   },
   { title: 'Users & Roles', capabilities: ['users.manage', 'roles.manage'] },
   { title: 'Audit', capabilities: ['audit.read'] },
+  {
+    title: 'Directus',
+    capabilities: ['directus.read'],
+  },
 ]
 
 /**

--- a/src/admin/shared/CapabilityPicker/capabilityMeta.ts
+++ b/src/admin/shared/CapabilityPicker/capabilityMeta.ts
@@ -184,6 +184,10 @@ export const CAPABILITY_META: Record<CoreCapability, CapabilityMeta> = {
     label: 'Read AI audit log',
     description: 'View site-wide AI usage, cost, and error events across all users.',
   },
+  'directus.read': {
+    label: 'Read Directus reference data',
+    description: 'Read geography and workfields from Directus. Never writes.',
+  },
 }
 
 /**

--- a/src/core/capabilities.ts
+++ b/src/core/capabilities.ts
@@ -72,6 +72,8 @@ export const CORE_CAPABILITIES = [
   'ai.tools.write',
   'ai.providers.manage',
   'ai.audit.read',
+  // Directus reference data — geography + workfields. Read-only; there is no write.
+  'directus.read',
 ] as const
 
 export type CoreCapability = typeof CORE_CAPABILITIES[number]

--- a/src/core/locales.ts
+++ b/src/core/locales.ts
@@ -1,0 +1,36 @@
+/**
+ * Locale catalog.
+ *
+ * Exactly the 8 BCP 47 tags the Directus API client supports. It is the
+ * single source of truth for every locale surface: the Directus reader and
+ * its translation fallback, MCP tool enums, and (as they land) the Page and
+ * Content settings pickers. `locale-enum-usage.test.ts` gates every other
+ * surface against it, so a new feature cannot re-open the field to any string.
+ */
+import { Type } from '@core/utils/typeboxHelpers'
+
+export const SUPPORTED_LOCALES = [
+  'fr-BE',
+  'nl-BE',
+  'de-BE',
+  'en-BE',
+  'fr-FR',
+  'en-FR',
+  'nl-NL',
+  'en-NL',
+] as const
+
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number]
+
+const SUPPORTED_LOCALE_SET: ReadonlySet<string> = new Set(SUPPORTED_LOCALES)
+
+const SUPPORTED_LOCALE_ENUM = Object.fromEntries(SUPPORTED_LOCALES.map((code) => [code, code])) as {
+  [K in SupportedLocale]: K
+}
+
+/** Compact JSON Schema `enum` so MCP / API clients see every allowed tag. */
+export const SupportedLocaleSchema = Type.Enum(SUPPORTED_LOCALE_ENUM)
+
+export function isSupportedLocale(value: unknown): value is SupportedLocale {
+  return typeof value === 'string' && SUPPORTED_LOCALE_SET.has(value)
+}


### PR DESCRIPTION
## What changed

Read-only Directus reader: seven `directus_*` MCP tools and `GET /admin/api/cms/directus/*` (health, strengths, geography levels, geography ancestry, workfields list/detail/FAQ), gated by a new `directus.read` capability. GET-only end to end; `directus-read-only.test.ts` gates that nothing in `server/directus/**` or the route table ever writes.

## Why

The content service cannot answer three things Website Manager needs: the province / region / country above a municipality, every translation of a name in one call, and draft pricing / demand / blog / FAQ rows. This layer reads raw Directus for those, server-side, so the reader token never reaches a browser (W33 in `deegitalbe/azure` decisions).

## Impact

- **Users:** Owner/Admin roles gain `directus.read` (migration `025_directus_read_capability`, idempotent in both dialects; boot-time `SYSTEM_ROLES` sync also grants it). MCP token picker's Read group includes it by default.
- **Developers:** new `src/core/locales.ts` is the single 8-locale catalog (`SUPPORTED_LOCALES`), gated by `locale-enum-usage.test.ts`. `server/config.ts` gains `readDirectusConfig()`; env `MKP_CONTENT_SERVICE_DIRECTUS_URL` / `_TOKEN` (unset = routes answer 503, strengths still 200).
- **Ops:** DEV/ACC Directus sits behind Azure Container Apps IP restrictions. Off-VPN, every upstream call answers `403 text/plain RBAC: access denied`; the reader maps that to a 502 whose message says to connect the VPN, and `directus_health` reports `reachable: false` with the reason. Docs: `docs/features/directus.md`.

## Verification

```sh
bun test          # 6774 pass, 0 fail, 1 skip
bun run build     # tsc -b && vite build, clean
bun run lint      # clean
```

Live, on the nonprd VPN, against DEV Directus, through a real server + real PAT + curl to `/_instatic/mcp` and the admin routes: countries (2), regions, provinces (107), municipalities (35 311), localities (2 242), Bruxelles and Paris ancestry chains, 468 published workfields with type counts identical to the content service, `architect` with 8 names / 8 translation rows / 24 pricing rows, 128 `location_specific` roofer FAQs, unknown place and unknown workfield → 404, every validation error raised locally (bad uuid, control chars, unknown level, limit > 1000, unknown include/status), anonymous 401, PAT on admin HTTP 401, POST 405.

Migration 025 verified idempotent on a real Postgres 16 cluster and on SQLite (first run updates only rows lacking the capability, second run updates 0, `client` untouched).
