### PR TITLE
chore(dev): install dependencies before the dev servers start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -298,7 +298,7 @@ Note: `@core/framework-schema` is a dependency of both `@core/page-tree` (for `F
 - Always use `bun` (not `npm` / `pnpm` / `yarn`) for installs, scripts, and tests.
 - Lockfile is `bun.lock`. Do not introduce `package-lock.json` or `yarn.lock`.
 - Server scripts run with `bun --watch server/index.ts`. Frontend dev runs with `vite`.
-- Run the full stack locally with `bun run dev` (defaults to SQLite at `.tmp/dev.db` — no external dependencies) or `docker compose up --build` (everything in containers with Postgres). Set `DATABASE_URL=postgres://...` before `bun run dev` to use Postgres instead.
+- Run the full stack locally with `bun run dev` (defaults to SQLite at `.tmp/dev.db` — no external dependencies; runs `bun install --frozen-lockfile` first, so a pull never leaves a stale `node_modules`) or `docker compose up --build` (everything in containers with Postgres). Set `DATABASE_URL=postgres://...` before `bun run dev` to use Postgres instead.
 - **`bun run build` runs `tsc -b && vite build`** — both type-checking and bundling. A change that runs in dev but fails `tsc` is not done.
 
 ## Verification

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ bun run dev
 
 The default local database is SQLite at `.tmp/dev.db`. Postgres mode is selected by setting `DATABASE_URL`.
 
+`bun run dev` runs `bun install --frozen-lockfile` before starting the servers, so after a `git pull` it is the only command you need.
+
 Useful checks:
 
 ```sh

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -401,7 +401,7 @@ See [docs/reference/architecture-tests.md](reference/architecture-tests.md) for 
 bun install
 
 # develop
-bun run dev              # SQLite at .tmp/dev.db, no Docker
+bun run dev              # SQLite at .tmp/dev.db, no Docker; runs bun install --frozen-lockfile first
 DATABASE_URL=postgres://… bun run dev   # Postgres mode
 
 # verify

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -221,6 +221,15 @@ DATABASE_URL=sqlite:./data/cms.db \
 
 Replace `DATABASE_URL` with a Postgres connection string for Postgres mode. `STATIC_DIR` must point at the built admin SPA (`dist/` after `bun run build`).
 
+Update a direct install by pulling, reinstalling dependencies, rebuilding, and restarting the process. `bun install` is not optional: a release can add a server dependency (0.0.18 added `jsdom` for the richtext sanitizer), and without it the server exits on startup with `Cannot find module`.
+
+```sh
+git pull
+bun install --frozen-lockfile
+bun run build
+# then restart the bun process under your supervisor
+```
+
 Wrap the command in a process supervisor (systemd, pm2, supervisord) for auto-restart on crash and on server boot. Put an HTTPS-capable reverse proxy (Caddy, Nginx, Cloudflare Tunnel) in front for TLS, and set `PUBLIC_ORIGIN=https://your-domain` so the CSRF origin check matches the public URL even though the proxy hands the Bun process plain HTTP. `TRUSTED_PROXY_CIDRS` is independent of CSRF: set it to the proxy's source CIDR only if you want real client IPs in audit logs and rate-limit keys, and leave it empty if the app is directly exposed.
 
 ## Data Safety

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -18,6 +18,8 @@
  *
  * Either way, the script then:
  *
+ *   - Runs `bun install --frozen-lockfile` so a checkout pulled after a
+ *     dependency change does not start a CMS that dies on its first import.
  *   - Pre-checks ports 3001 (cms) and 5173 (vite) and prints an
  *     actionable message if either is held by something we don't own.
  *   - Spawns the cms (`bun --watch server/index.ts`) and vite
@@ -29,6 +31,7 @@ import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isSqliteUrl } from '../server/db'
 import { bunCommand, viteCommand } from './lib/bunCommand'
+import { ensureDependencies } from './lib/ensureDependencies'
 import { ensurePortFree } from './lib/freePort'
 
 const CMS_PORT = Number(process.env.PORT ?? '3001')
@@ -222,6 +225,8 @@ if (isSqliteUrl(DATABASE_URL)) {
   stopAppContainerIfRunning()
   await waitForPostgresReady()
 }
+
+await ensureDependencies(log)
 
 await ensurePortFree(CMS_PORT, 'cms', log)
 await ensurePortFree(VITE_PORT, 'vite', log)

--- a/scripts/e2e-dev.ts
+++ b/scripts/e2e-dev.ts
@@ -14,11 +14,17 @@
  */
 import { mkdir, rm } from 'node:fs/promises'
 import { bunCommand, viteCommand } from './lib/bunCommand'
+import { ensureDependencies } from './lib/ensureDependencies'
 
 const DATABASE_PATH = './.tmp/e2e-agent.db'
 const UPLOADS_DIR = './.tmp/e2e-uploads'
 const CMS_PORT = process.env.E2E_CMS_PORT ?? '3002'
 const VITE_PORT = process.env.E2E_VITE_PORT ?? '5174'
+
+// Same guard as `bun run dev`: Playwright starts this stack right after a
+// `git pull`, and a stale node_modules would otherwise surface as a CMS crash
+// on its first import instead of a missing install.
+await ensureDependencies((msg) => console.error(`[e2e-dev] ${msg}`))
 
 await mkdir('./.tmp', { recursive: true })
 await rm(DATABASE_PATH, { force: true })

--- a/scripts/lib/ensureDependencies.ts
+++ b/scripts/lib/ensureDependencies.ts
@@ -1,0 +1,48 @@
+import { existsSync } from 'node:fs'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { bunCommand } from './bunCommand'
+
+const repoRoot = fileURLToPath(new URL('../..', import.meta.url))
+const lockfilePath = join(repoRoot, 'bun.lock')
+const markerPath = join(repoRoot, 'node_modules', '.instatic-lockfile-hash')
+
+/**
+ * Bring `node_modules` in line with `bun.lock` before the dev servers start.
+ *
+ * A checkout pulled after a dependency change starts the CMS child, which
+ * then dies on the first import it cannot resolve ("Cannot find module
+ * 'jsdom'") with nothing pointing at `bun install`. Installing here fixes
+ * that at the source. `--frozen-lockfile` keeps the dev script from
+ * rewriting `bun.lock` when `package.json` was edited by hand.
+ *
+ * The lockfile's hash is remembered in `node_modules/.instatic-lockfile-hash`
+ * after a successful install, so the common case (nothing changed) costs one
+ * file read. Running bun unconditionally would be simpler, but bun re-copies
+ * `file:` dependencies such as the vendored `pixel-art-icons` on every
+ * install, which is 50 to 150 ms of churn and a spurious "1 package
+ * installed" line on every start. Deleting `node_modules` deletes the marker,
+ * so a fresh clone installs too.
+ *
+ * Uses the running bun binary (`bunCommand`) so it works on Windows, where
+ * spawning `bun` by name fails with ENOENT.
+ */
+export async function ensureDependencies(log: (msg: string) => void): Promise<void> {
+  const lockfileHash = Bun.hash(await readFile(lockfilePath)).toString(16)
+  const installedHash = existsSync(markerPath) ? (await readFile(markerPath, 'utf8')).trim() : null
+  if (installedHash === lockfileHash) return
+
+  log('bun.lock changed since the last install, running `bun install --frozen-lockfile`')
+  const result = Bun.spawnSync(bunCommand('install', '--frozen-lockfile'), {
+    cwd: repoRoot,
+    stdin: 'inherit',
+    stdout: 'inherit',
+    stderr: 'inherit',
+  })
+  if (result.exitCode !== 0) {
+    log('`bun install --frozen-lockfile` failed. If you changed package.json, run `bun install` once to update bun.lock, then start again.')
+    process.exit(result.exitCode || 1)
+  }
+  await writeFile(markerPath, `${lockfileHash}\n`)
+}


### PR DESCRIPTION
## The bug

`bun run dev` and `bun run e2e:dev` start the servers without checking that `node_modules` matches `bun.lock`. After a pull that adds a dependency (0.0.18 added `jsdom` for the richtext sanitizer) the CMS child dies on its first import with `Cannot find module 'jsdom'`, and nothing points at `bun install`. The direct-install deployment doc covers first install but not updating, so a self-hoster outside Docker hits the same crash in production.

## The fix

Both dev scripts hash `bun.lock` and compare it with a marker written to `node_modules` after the last successful install. When it differs they run `bun install --frozen-lockfile` through the shared bun helper and rewrite the marker, so a current tree costs one file read. Running bun unconditionally was simpler but re-copies the vendored `file:` icons package on every start. A `package.json` edited without updating `bun.lock` exits with a hint instead of rewriting the lockfile.

`docs/deployment/vps.md` gains an update procedure for direct installs, and the dev docs mention the install step.

## Verification

```
bun run build      # tsc -b && vite build, clean
bun run lint       # clean, and bunx eslint scripts is clean
bun test           # 6757 pass, 0 fail
bun run e2e:dev    # no marker: installs then boots; marker current: silent boot
bun run e2e:dev    # bun.lock out of step with package.json: exits 1 with the hint
```
