### PR TITLE
fix(settings): make the Esc keycap close the modal it advertises

### DIFF
--- a/src/__tests__/settings/settingsModal.test.tsx
+++ b/src/__tests__/settings/settingsModal.test.tsx
@@ -186,6 +186,16 @@ describe('SettingsModal — backdrop', () => {
     fireEvent.click(backdrop)
     expect(useEditorStore.getState().isSettingsOpen).toBe(false)
   })
+
+  it('clicking the Esc keycap closes the modal it advertises', () => {
+    // The keycap depresses on `:active` like every other `Kbd`, and sits
+    // beside the word "close". It used to be inert markup, so clicking it
+    // played the press animation and did nothing.
+    openModal()
+    render(<SettingsModal />)
+    fireEvent.click(screen.getByRole('button', { name: /esc\s*close/i }))
+    expect(useEditorStore.getState().isSettingsOpen).toBe(false)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/admin/modals/Settings/SettingsModal.module.css
+++ b/src/admin/modals/Settings/SettingsModal.module.css
@@ -163,11 +163,19 @@
   border-top: 1px solid var(--overlay-10);
 }
 
+/* Sits on the footer's close Button. Keeps the row reading as a quiet hint
+   rather than a control — the keycap already carries the affordance — while
+   the element underneath is a real button. `justify-content: start` because a
+   Button centres its content by default and this row aligns with the nav
+   above it. */
 .shortcutHint {
   display: flex;
   align-items: center;
+  justify-content: start;
   gap: var(--space-xs);
   flex-wrap: wrap;
+  width: 100%;
+  padding: 0;
   color: var(--text-subtle);
   font-size: var(--text-s);
 }

--- a/src/admin/modals/Settings/SettingsModal.tsx
+++ b/src/admin/modals/Settings/SettingsModal.tsx
@@ -4,8 +4,8 @@
  * Shares the visual language of the Spotlight palette and the Module
  * Inserter: a direct-token panel shell, an `--bg-surface-2` rail with
  * categorical accent icon chips, an accent-bar section header, and a
- * shared `Esc` keycap affordance (backdrop click / Esc both close — there
- * is no dedicated close button, matching the other two modals).
+ * shared `Esc` keycap affordance, which is also the close button — backdrop
+ * click and Esc close it too.
  *
  * Guideline #225 (Modal Shell Requirements, WCAG 2.1 AA):
  * - role="dialog" + aria-modal="true" + aria-labelledby
@@ -230,11 +230,22 @@ export function SettingsModal() {
 
             <div className={s.railSpring} />
 
-            <div className={s.shortcutFooter} aria-label="Settings keyboard shortcuts">
-              <div className={s.shortcutHint}>
+            {/* The keycap reads as a button — it depresses on :active like every
+                other `Kbd` — so it has to behave like one. It was a hint beside
+                the word "close", which meant clicking it played the press
+                animation and did nothing, and the pointer over the label turned
+                into a text caret. Backdrop click and Esc still work; this just
+                stops the affordance lying about itself. */}
+            <div className={s.shortcutFooter}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleClose}
+                className={s.shortcutHint}
+              >
                 <Kbd>Esc</Kbd>
                 <span>close</span>
-              </div>
+              </Button>
             </div>
           </div>
 


### PR DESCRIPTION
The settings modal's footer reads `[Esc] close`, and the keycap looks like a button because every `Kbd` depresses on `:active`.

Clicking it played that press animation and did nothing. The pointer over the word "close" turned into a text caret, and a click just selected the text.

Both dismissal paths already worked — backdrop click and Escape — so nothing was broken. But a control that animates under the cursor and then ignores the click answers the question *wrongly*: an operator who tries it concludes the modal cannot be dismissed with the mouse and stops looking. That is what happened, which is how this was found.

So the hint becomes the button it already looked like.

`Kbd` itself is untouched. Six other surfaces render it as a genuine keyboard hint — Spotlight, its footer and rows, the module inserter and its shortcut list, the keybindings help — where the press styling is right and there is nothing to click. Only this one sits next to the word "close".

The file header claimed there was no dedicated close button; there is one now, so it says so.

One test added beside the existing backdrop-close case.

```
bun test src/__tests__/settings/   57 pass, 0 fail
tsc -b, eslint                     clean
```

Verified by hand on a live install before submitting.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>