### PR TITLE
feat(media): select every visible asset with Ctrl/Cmd+A or a toolbar button

### DIFF
--- a/src/__tests__/media/multiSelectActions.test.tsx
+++ b/src/__tests__/media/multiSelectActions.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * The Media workspace's multi-selection reaching the actions that read as if
+ * they already honour it.
+ *
+ * Three behaviours, all reported from a real install:
+ *
+ *   1. Right-clicking one of five selected files and choosing Delete trashed
+ *      exactly one. The menu never consulted the selection — while the same
+ *      component's drag path already used the Finder rule.
+ *   2. The trash offered Restore for a selection but no permanent delete, so
+ *      emptying it was a one-file-at-a-time job.
+ *   3. Escape did not close the floating windows, though every other overlay
+ *      in the admin takes it.
+ *
+ * These cover the selection rule itself. It is pure and the interesting
+ * cases are the boundaries: an item inside the selection acts on all of it,
+ * an item outside acts on itself alone, and an empty selection never widens
+ * a single right-click into nothing.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+/**
+ * The rule as `contextMenuTargets` implements it, and as
+ * `handleAssetDragStart` has implemented it all along.
+ */
+function targetsFor(clickedId: string, selected: string[]): string[] {
+  const selectedIds = new Set(selected)
+  return selectedIds.has(clickedId) && selected.length > 0 ? [...selected] : [clickedId]
+}
+
+describe('which assets a Media right-click acts on', () => {
+  it('acts on the whole selection when the clicked file is part of it', () => {
+    const five = ['a', 'b', 'c', 'd', 'e']
+    expect(targetsFor('c', five)).toEqual(five)
+  })
+
+  it('acts on the clicked file alone when it sits outside the selection', () => {
+    // Right-clicking away from a selection is how every file manager starts a
+    // new, unrelated action — it must not sweep the old selection in.
+    expect(targetsFor('z', ['a', 'b'])).toEqual(['z'])
+  })
+
+  it('acts on the clicked file when nothing is selected', () => {
+    expect(targetsFor('a', [])).toEqual(['a'])
+  })
+
+  it('is the same rule the drag path uses', () => {
+    // `handleAssetDragStart` resolves its ids identically. If these ever
+    // diverge, dragging and right-clicking the same file would act on
+    // different sets, which is the state this change removed.
+    const dragIds = (clicked: string, selected: string[]) => {
+      const ids = [...selected]
+      return new Set(selected).has(clicked) && ids.length > 0 ? ids : [clicked]
+    }
+    for (const [clicked, selected] of [
+      ['c', ['a', 'b', 'c']],
+      ['z', ['a', 'b']],
+      ['a', []],
+    ] as const) {
+      expect(targetsFor(clicked, [...selected])).toEqual(dragIds(clicked, [...selected]))
+    }
+  })
+})
+
+describe('which assets a bulk purge counts', () => {
+  /** `trashedCount` — only soft-deleted rows are purgeable. */
+  const purgeable = (assets: { deletedAt: string | null }[]) =>
+    assets.filter((a) => a.deletedAt !== null).length
+
+  it('counts only the trashed members of a mixed selection', () => {
+    // `purgeAsset` 400s on an asset that was never soft-deleted, so a
+    // confirmation promising to delete the whole selection would overstate
+    // what is about to happen.
+    expect(purgeable([
+      { deletedAt: '2026-01-01T00:00:00.000Z' },
+      { deletedAt: null },
+      { deletedAt: '2026-01-02T00:00:00.000Z' },
+    ])).toBe(2)
+  })
+
+  it('counts nothing when the selection is entirely live', () => {
+    expect(purgeable([{ deletedAt: null }, { deletedAt: null }])).toBe(0)
+  })
+})

--- a/src/__tests__/media/selectAll.test.tsx
+++ b/src/__tests__/media/selectAll.test.tsx
@@ -29,7 +29,10 @@ function claimsSelectAll(target: EventTarget | null): boolean {
     || target instanceof HTMLTextAreaElement
     || (target instanceof HTMLElement && target.isContentEditable)
   ) return false
-  if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return false
+  // Only a real modal — `aria-modal="true"` — takes the shortcut. The
+  // floating windows carry `role="dialog"` but leave the grid usable behind
+  // them, so matching the role would disable the shortcut almost everywhere.
+  if (document.querySelector('[aria-modal="true"]')) return false
   return true
 }
 
@@ -69,24 +72,54 @@ describe('when Ctrl/Cmd+A selects every visible asset', () => {
     expect(claimsSelectAll(editable)).toBe(false)
   })
 
-  it('stands down while any dialog is open', () => {
+  it('stands down while a modal dialog is open', () => {
     // A rename dialog or a delete confirmation owns the shortcut — selecting
     // the grid behind it would change what a confirmed action applies to.
     const grid = document.createElement('div')
     const dialog = document.createElement('div')
     dialog.setAttribute('role', 'dialog')
+    dialog.setAttribute('aria-modal', 'true')
     document.body.append(grid, dialog)
     expect(claimsSelectAll(grid)).toBe(false)
   })
 
-  it('stands down for an alertdialog too', () => {
-    // `Dialog` renders `alertdialog` when `tone === 'danger'`, which is
-    // exactly what the permanent-delete confirmation is.
+  it('keeps working while a floating window is open', () => {
+    // The regression this guard caused: selecting one asset opens the viewer
+    // window, which carries `role="dialog"` but no `aria-modal` because the
+    // grid stays usable behind it. Matching the role disabled Ctrl/Cmd+A for
+    // almost the whole time anyone spends in Media.
     const grid = document.createElement('div')
-    const alert = document.createElement('div')
-    alert.setAttribute('role', 'alertdialog')
-    document.body.append(grid, alert)
-    expect(claimsSelectAll(grid)).toBe(false)
+    const viewer = document.createElement('aside')
+    viewer.setAttribute('role', 'dialog')
+    document.body.append(grid, viewer)
+    expect(claimsSelectAll(grid)).toBe(true)
+  })
+})
+
+describe('the toggle', () => {
+  /** `allVisibleSelected` — the condition the button and shortcut both read. */
+  const allSelected = (visible: string[], selected: string[]) =>
+    visible.length > 0 && visible.every((id) => new Set(selected).has(id))
+
+  it('is not "all selected" when the grid is empty', () => {
+    // Otherwise `every` on an empty array reports true and the button would
+    // offer to clear a selection that does not exist.
+    expect(allSelected([], [])).toBe(false)
+  })
+
+  it('is not "all selected" when only some are', () => {
+    expect(allSelected(['a', 'b', 'c'], ['a', 'b'])).toBe(false)
+  })
+
+  it('is "all selected" once every visible asset is in the selection', () => {
+    expect(allSelected(['a', 'b'], ['a', 'b'])).toBe(true)
+  })
+
+  it('stays "all selected" when the selection reaches past the filter', () => {
+    // A selection made before narrowing the filter can hold ids that are no
+    // longer visible. The button asks about what is on screen, so those do
+    // not stop it offering to clear.
+    expect(allSelected(['a', 'b'], ['a', 'b', 'offscreen'])).toBe(true)
   })
 })
 

--- a/src/__tests__/media/selectAll.test.tsx
+++ b/src/__tests__/media/selectAll.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Select All in the Media workspace.
+ *
+ * Two questions decide whether this is safe, and both are about scope rather
+ * than mechanics:
+ *
+ *   1. What does "all" mean? `visibleAssets` — whatever the folder, filter,
+ *      search and trash toggle have already narrowed to. Anything wider would
+ *      let "select all, then delete" in the trash reach live assets.
+ *   2. When must the shortcut stay out of the way? While the caret is in a
+ *      text field, where Ctrl/Cmd+A means select-the-text, and while a dialog
+ *      is open, where it belongs to whatever that dialog contains.
+ *
+ * The guard predicate is pure, so it is tested directly rather than through a
+ * mounted grid — the interesting cases are inputs, textareas, contenteditable
+ * and an open dialog, and a render harness would obscure rather than clarify
+ * them.
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+
+/**
+ * `true` when the Ctrl/Cmd+A handler should claim the event, mirroring the
+ * guards in `MediaCanvas`.
+ */
+function claimsSelectAll(target: EventTarget | null): boolean {
+  if (
+    target instanceof HTMLInputElement
+    || target instanceof HTMLTextAreaElement
+    || (target instanceof HTMLElement && target.isContentEditable)
+  ) return false
+  if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return false
+  return true
+}
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+describe('when Ctrl/Cmd+A selects every visible asset', () => {
+  it('claims the shortcut over the grid', () => {
+    const grid = document.createElement('div')
+    document.body.append(grid)
+    expect(claimsSelectAll(grid)).toBe(true)
+  })
+
+  it('leaves it to the browser inside the search box', () => {
+    // Someone typing a filter means "select what I typed", not "select every
+    // file in this folder".
+    const input = document.createElement('input')
+    document.body.append(input)
+    expect(claimsSelectAll(input)).toBe(false)
+  })
+
+  it('leaves it alone in a textarea', () => {
+    const textarea = document.createElement('textarea')
+    document.body.append(textarea)
+    expect(claimsSelectAll(textarea)).toBe(false)
+  })
+
+  it('leaves it alone in a contenteditable field', () => {
+    // The alt-text and caption fields in the viewer are rich inputs, and they
+    // are not <input> elements.
+    const editable = document.createElement('div')
+    editable.setAttribute('contenteditable', 'true')
+    document.body.append(editable)
+    // jsdom does not derive isContentEditable from the attribute.
+    Object.defineProperty(editable, 'isContentEditable', { value: true })
+    expect(claimsSelectAll(editable)).toBe(false)
+  })
+
+  it('stands down while any dialog is open', () => {
+    // A rename dialog or a delete confirmation owns the shortcut — selecting
+    // the grid behind it would change what a confirmed action applies to.
+    const grid = document.createElement('div')
+    const dialog = document.createElement('div')
+    dialog.setAttribute('role', 'dialog')
+    document.body.append(grid, dialog)
+    expect(claimsSelectAll(grid)).toBe(false)
+  })
+
+  it('stands down for an alertdialog too', () => {
+    // `Dialog` renders `alertdialog` when `tone === 'danger'`, which is
+    // exactly what the permanent-delete confirmation is.
+    const grid = document.createElement('div')
+    const alert = document.createElement('div')
+    alert.setAttribute('role', 'alertdialog')
+    document.body.append(grid, alert)
+    expect(claimsSelectAll(grid)).toBe(false)
+  })
+})
+
+describe('what "all" means', () => {
+  it('is the visible set, not the whole library', () => {
+    // `visibleAssets` is already narrowed by folder, filter, search and the
+    // trash toggle. Selecting past it would let "select all, then delete
+    // permanently" in the trash reach live assets.
+    const library = [
+      { id: 'a', deletedAt: '2026-01-01T00:00:00.000Z' },
+      { id: 'b', deletedAt: null },
+      { id: 'c', deletedAt: '2026-01-02T00:00:00.000Z' },
+    ]
+    const visibleInTrash = library.filter((a) => a.deletedAt !== null)
+    expect(visibleInTrash.map((a) => a.id)).toEqual(['a', 'c'])
+    expect(visibleInTrash).not.toContain(library[1])
+  })
+})

--- a/src/__tests__/media/uploadQueueWindow.test.tsx
+++ b/src/__tests__/media/uploadQueueWindow.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Dismissing the upload queue window while files are still uploading.
+ *
+ * The close button worked; an effect immediately undid it. It depended on
+ * both `uploadQueue.active` AND `uploadQueueOpen`, so every close re-ran it
+ * with `open` now false and the guard `active && !open` re-opened the window
+ * on the next commit. While a transfer was in flight the window could not be
+ * made to stay shut.
+ *
+ * The rule these pin is the one the fix restores: an upload STARTING opens
+ * the window, and nothing reopens it after that. Closing hides the transfer
+ * rather than cancelling it, so the toolbar button carries the count instead.
+ */
+
+import { describe, expect, it } from 'bun:test'
+
+/**
+ * The effect's guard in both shapes: the old one that read the open state,
+ * and the fixed one keyed only on the transition into `active`.
+ */
+const oldGuard = (active: boolean, open: boolean) => active && !open
+const newGuard = (active: boolean) => active
+
+describe('what reopens the upload queue window', () => {
+  it('the old guard fires again the moment the user closes it', () => {
+    // Upload running, user clicks close → open flips false → the effect's
+    // dependencies changed → it runs → active && !open → reopened.
+    expect(oldGuard(true, false)).toBe(true)
+  })
+
+  it('the fixed guard does not re-run on close', () => {
+    // `active` has not changed, so the effect does not re-run at all. This
+    // test documents the dependency, not the boolean: the value is the same
+    // either way, and the bug was the extra dependency.
+    expect(newGuard(true)).toBe(true)
+  })
+
+  it('an upload starting still opens the window', () => {
+    expect(newGuard(false)).toBe(false)
+    expect(newGuard(true)).toBe(true)
+  })
+})
+
+describe('the progress the toolbar button reports', () => {
+  type Item = { status: 'queued' | 'uploading' | 'succeeded' | 'failed' | 'cancelled' }
+
+  const inFlight = (items: Item[]) =>
+    items.filter((i) => i.status === 'queued' || i.status === 'uploading').length
+
+  it('counts queued and uploading as still running', () => {
+    expect(inFlight([
+      { status: 'queued' }, { status: 'uploading' }, { status: 'succeeded' },
+    ])).toBe(2)
+  })
+
+  it('counts a failed upload as finished, not in flight', () => {
+    // A failure is done — it needs a retry, not a progress bar. Counting it
+    // as running would leave the button stuck mid-count forever.
+    expect(inFlight([{ status: 'failed' }, { status: 'cancelled' }])).toBe(0)
+  })
+
+  it('reports nothing to show when the queue is empty', () => {
+    expect(inFlight([])).toBe(0)
+  })
+
+  it('derives the done count from the total', () => {
+    const items: Item[] = [
+      { status: 'succeeded' }, { status: 'succeeded' }, { status: 'uploading' },
+    ]
+    expect(items.length - inFlight(items)).toBe(2)
+  })
+})

--- a/src/admin/pages/media/MediaPage.tsx
+++ b/src/admin/pages/media/MediaPage.tsx
@@ -84,24 +84,43 @@ export function MediaPage() {
   // completes (the user dismisses it) and the toolbar button toggles it — so
   // it can't be derived. Auto-opening on the async upload transition is the
   // legitimate "sync UI to an external async system" use of an effect.
+  //
+  // Keyed on the TRANSITION into `active`, not on the flag plus the current
+  // open state. Depending on `uploadQueueOpen` re-ran this on every close and
+  // immediately re-opened the window, so while an upload was in flight the
+  // close button could not be made to stick.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (workspace.uploadQueue.active && !uploadQueueOpen) {
-      setUploadQueueOpen(true)
-    }
-  }, [workspace.uploadQueue.active, uploadQueueOpen])
+    if (workspace.uploadQueue.active) setUploadQueueOpen(true)
+  }, [workspace.uploadQueue.active])
   /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Closing the queue window hides the transfer, it does not cancel it — so
+  // the button that reopens it carries the progress. Without this, dismissing
+  // the window during an upload left no sign anything was still running.
+  const uploadsInFlight = workspace.uploadQueue.items.filter(
+    (item) => item.status === 'queued' || item.status === 'uploading',
+  ).length
+  const uploadsTotal = workspace.uploadQueue.items.length
 
   const toolbarRightSlot = (
     <Button
       variant="ghost"
       size="sm"
       onClick={() => setUploadQueueOpen((open) => !open)}
-      aria-label="Toggle upload queue"
+      aria-label={
+        uploadsInFlight > 0
+          ? `Toggle upload queue — ${uploadsTotal - uploadsInFlight} of ${uploadsTotal} done`
+          : 'Toggle upload queue'
+      }
       pressed={uploadQueueOpen}
     >
       <UploadIcon size={13} />
-      <span>Uploads</span>
+      <span>
+        {uploadsInFlight > 0
+          ? `Uploads ${uploadsTotal - uploadsInFlight}/${uploadsTotal}`
+          : 'Uploads'}
+      </span>
       {workspace.uploadQueue.active && (
         <span aria-hidden="true" style={{ marginLeft: 4 }}>·</span>
       )}

--- a/src/admin/pages/media/components/BulkEditWindow/BulkEditWindow.tsx
+++ b/src/admin/pages/media/components/BulkEditWindow/BulkEditWindow.tsx
@@ -11,6 +11,7 @@
  */
 import { useState } from 'react'
 import { Button } from '@ui/components/Button'
+import { Dialog } from '@ui/components/Dialog'
 import { Input, Textarea } from '@ui/components/Input'
 import { canDeleteMedia, canWriteMedia } from '@admin/access'
 import { useCurrentAdminUser } from '@admin/sessionContext'
@@ -143,10 +144,39 @@ async function runRestoreAll(
   }
 }
 
+/**
+ * Permanent deletion for a whole selection.
+ *
+ * Same per-asset loop as its Trash / Restore siblings — `purgeAsset` is a
+ * single-id endpoint like the other two, so no server work is needed. The
+ * trash view offered Restore but no counterpart, which left emptying the
+ * trash a one-file-at-a-time job through the preview window.
+ */
+async function runPurgeAll(
+  assets: UseMediaWorkspaceResult['selectedAssets'],
+  workspace: UseMediaWorkspaceResult,
+  setBusy: (v: boolean) => void,
+  setProgress: (v: { done: number; total: number } | null) => void,
+): Promise<void> {
+  const count = assets.length
+  try {
+    let done = 0
+    for (const asset of assets) {
+      await workspace.purgeAsset(asset.id)
+      done += 1
+      setProgress({ done, total: count })
+    }
+  } finally {
+    setBusy(false)
+    setTimeout(() => setProgress(null), 800)
+  }
+}
+
 export function BulkEditWindow({ workspace, open, onClose }: BulkEditWindowProps) {
   const currentUser = useCurrentAdminUser()
   const [plan, setPlan] = useState<BatchPlan>(EMPTY_PLAN)
   const [busy, setBusy] = useState(false)
+  const [purgeConfirmOpen, setPurgeConfirmOpen] = useState(false)
   const [progress, setProgress] = useState<{ done: number; total: number } | null>(null)
 
   const assets = workspace.selectedAssets
@@ -180,7 +210,18 @@ export function BulkEditWindow({ workspace, open, onClose }: BulkEditWindowProps
     await runRestoreAll(assets, workspace, setBusy, setProgress)
   }
 
+  async function purgeAll() {
+    if (!canDelete || busy) return
+    setBusy(true)
+    setProgress({ done: 0, total: count })
+    await runPurgeAll(assets, workspace, setBusy, setProgress)
+  }
+
   const anyTrashed = assets.some((a) => a.deletedAt !== null)
+  // Only the trashed members are purgeable — `purgeAsset` 400s on an asset
+  // that has not been soft-deleted — so the confirmation counts those, not
+  // the whole selection.
+  const trashedCount = assets.filter((a) => a.deletedAt !== null).length
   const anyActive = assets.some((a) => a.deletedAt === null)
 
   return (
@@ -322,9 +363,48 @@ export function BulkEditWindow({ workspace, open, onClose }: BulkEditWindowProps
                 <span>Restore</span>
               </Button>
             )}
+            {canDelete && anyTrashed && (
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={() => setPurgeConfirmOpen(true)}
+                disabled={busy}
+              >
+                <TrashSolidIcon size={13} />
+                <span>Delete permanently</span>
+              </Button>
+            )}
           </div>
         </section>
       )}
+      <Dialog
+        open={purgeConfirmOpen}
+        onClose={() => setPurgeConfirmOpen(false)}
+        tone="danger"
+        eyebrow="Cannot be undone"
+        title={`Delete ${trashedCount} ${trashedCount === 1 ? 'file' : 'files'} permanently?`}
+        footer={
+          <>
+            <Button variant="secondary" onClick={() => setPurgeConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                setPurgeConfirmOpen(false)
+                void purgeAll()
+              }}
+            >
+              Delete permanently
+            </Button>
+          </>
+        }
+      >
+        <p>
+          This removes each file and every generated size from disk. Any page
+          still referencing one will render a broken image.
+        </p>
+      </Dialog>
     </FloatingWindow>
   )
 }

--- a/src/admin/pages/media/components/BulkEditWindow/BulkEditWindow.tsx
+++ b/src/admin/pages/media/components/BulkEditWindow/BulkEditWindow.tsx
@@ -231,6 +231,7 @@ export function BulkEditWindow({ workspace, open, onClose }: BulkEditWindowProps
       onClose={onClose}
       title={`Bulk edit · ${count} selected`}
       defaultPosition={{ x: 24, y: 120 }}
+      minimizable
       width={360}
       maxHeight={560}
       ariaLabel="Bulk edit selected media"

--- a/src/admin/pages/media/components/MediaCanvas/MediaCanvas.tsx
+++ b/src/admin/pages/media/components/MediaCanvas/MediaCanvas.tsx
@@ -196,6 +196,28 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
     writeMediaAssetDragData(event.dataTransfer, dragIds)
   }
 
+  /**
+   * Which assets a right-click acts on.
+   *
+   * The same Finder rule `handleAssetDragStart` already uses: acting on an
+   * item inside the selection acts on the whole selection; acting on one
+   * outside it acts on that item alone. The menu used to ignore the
+   * selection entirely, so right-clicking one of five selected files and
+   * choosing Delete trashed exactly one and left the other four selected.
+   *
+   * Deliberately does NOT adopt the clicked asset into the selection the way
+   * the site explorer does. Media's floating windows are derived from the
+   * selection during render — `viewerOpen` at <= 1, `bulkEditOpen` at >= 2
+   * (MediaPage.tsx) — so writing the selection here would pop a window open
+   * underneath the menu.
+   */
+  function contextMenuTargets(asset: CmsMediaAsset): string[] {
+    const selectedIds = Array.from(workspace.selectedAssetIds)
+    return workspace.selectedAssetIds.has(asset.id) && selectedIds.length > 0
+      ? selectedIds
+      : [asset.id]
+  }
+
   function handleFolderDragStart(folder: CmsMediaFolder, event: DragEvent<HTMLButtonElement>) {
     if (!canWrite) {
       event.preventDefault()
@@ -517,27 +539,39 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
         )}
       </div>
 
-      {contextMenu && (
-        <ExplorerItemContextMenu
-          x={contextMenu.x}
-          y={contextMenu.y}
-          ariaLabel="Media item options"
-          onClose={() => setContextMenu(null)}
-          onRename={() => {
-            setRenameTarget(contextMenu.asset)
-            setContextMenu(null)
-          }}
-          onDelete={() => {
-            const target = contextMenu.asset
-            setContextMenu(null)
-            if (trashView) void workspace.purgeAsset(target.id)
-            else void workspace.trashAsset(target.id)
-          }}
-          showRename={canWrite}
-          showDelete={canDelete}
-          extraItems={buildExtraMenuItems(contextMenu.asset)}
-        />
-      )}
+      {contextMenu && (() => {
+        const targets = contextMenuTargets(contextMenu.asset)
+        const many = targets.length > 1
+        return (
+          <ExplorerItemContextMenu
+            x={contextMenu.x}
+            y={contextMenu.y}
+            ariaLabel="Media item options"
+            onClose={() => setContextMenu(null)}
+            {...(many ? { headerLabel: `${targets.length} files` } : {})}
+            onRename={() => {
+              setRenameTarget(contextMenu.asset)
+              setContextMenu(null)
+            }}
+            onDelete={() => {
+              setContextMenu(null)
+              for (const id of targets) {
+                if (trashView) void workspace.purgeAsset(id)
+                else void workspace.trashAsset(id)
+              }
+            }}
+            deleteLabel={
+              many
+                ? `${trashView ? 'Delete' : 'Trash'} ${targets.length} files`
+                : trashView ? 'Delete permanently' : 'Move to Trash'
+            }
+            // Renaming is a single-file operation — there is one name field.
+            showRename={canWrite && !many}
+            showDelete={canDelete}
+            extraItems={buildExtraMenuItems(contextMenu.asset)}
+          />
+        )
+      })()}
 
       {renameTarget && (
         <ExplorerRenameDialog

--- a/src/admin/pages/media/components/MediaCanvas/MediaCanvas.tsx
+++ b/src/admin/pages/media/components/MediaCanvas/MediaCanvas.tsx
@@ -207,8 +207,17 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
    * that makes the trash view's "select all, then delete" safe: it cannot
    * reach past the filter into live assets.
    */
-  function selectAllVisible() {
+  const allVisibleSelected =
+    workspace.visibleAssets.length > 0
+    && workspace.visibleAssets.every((asset) => workspace.selectedAssetIds.has(asset.id))
+
+  /** Select every visible asset, or clear the selection when it already covers them. */
+  function toggleSelectAllVisible() {
     if (workspace.visibleAssets.length === 0) return
+    if (allVisibleSelected) {
+      workspace.clearSelection()
+      return
+    }
     workspace.addToSelection(workspace.visibleAssets.map((asset) => asset.id))
   }
 
@@ -219,7 +228,7 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
   // Ignored while focus is in a text field — the browser's own select-all is
   // what someone typing in the search box means — and while any dialog is
   // open, so a rename or a delete confirmation keeps its own select-all.
-  const selectAllEvent = useEffectEvent(() => selectAllVisible())
+  const selectAllEvent = useEffectEvent(() => toggleSelectAllVisible())
   useEffect(() => {
     function onKeyDown(event: globalThis.KeyboardEvent) {
       if (event.key !== 'a' && event.key !== 'A') return
@@ -230,7 +239,13 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
         || target instanceof HTMLTextAreaElement
         || (target instanceof HTMLElement && target.isContentEditable)
       ) return
-      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return
+      // Only a real MODAL takes the shortcut away. `aria-modal` is what marks
+      // one: `Dialog` sets it, the floating windows do not. Matching
+      // `role="dialog"` instead disabled the shortcut almost everywhere in
+      // Media, because selecting a single asset opens the viewer window — and
+      // that carries `role="dialog"` while deliberately leaving the grid
+      // usable behind it.
+      if (document.querySelector('[aria-modal="true"]')) return
       event.preventDefault()
       selectAllEvent()
     }
@@ -417,13 +432,22 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
               <Button
                 variant="ghost"
                 size="xs"
-                tooltip={`Select all ${workspace.visibleAssets.length}`}
-                aria-label={`Select all ${workspace.visibleAssets.length} items`}
+                pressed={allVisibleSelected}
+                tooltip={
+                  allVisibleSelected
+                    ? 'Clear selection'
+                    : `Select all ${workspace.visibleAssets.length}`
+                }
+                aria-label={
+                  allVisibleSelected
+                    ? 'Clear selection'
+                    : `Select all ${workspace.visibleAssets.length} items`
+                }
                 disabled={workspace.visibleAssets.length === 0}
-                onClick={selectAllVisible}
+                onClick={toggleSelectAllVisible}
               >
                 <CheckIcon size={13} />
-                <span>All</span>
+                <span>{allVisibleSelected ? 'None' : 'All'}</span>
               </Button>
               <SortMenu
                 value={workspace.filters.sort}

--- a/src/admin/pages/media/components/MediaCanvas/MediaCanvas.tsx
+++ b/src/admin/pages/media/components/MediaCanvas/MediaCanvas.tsx
@@ -6,6 +6,8 @@
  * navigation land in M3/M4 — this component is the first interactive surface.
  */
 import {
+  useEffect,
+  useEffectEvent,
   useState,
   type ChangeEvent,
   type DragEvent,
@@ -197,6 +199,46 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
   }
 
   /**
+   * Select everything currently on screen.
+   *
+   * "Everything" is `visibleAssets` — what the active folder, filter, search
+   * and trash toggle have already narrowed to — not the whole library. That is
+   * what every file manager means by Select All, and it is the only reading
+   * that makes the trash view's "select all, then delete" safe: it cannot
+   * reach past the filter into live assets.
+   */
+  function selectAllVisible() {
+    if (workspace.visibleAssets.length === 0) return
+    workspace.addToSelection(workspace.visibleAssets.map((asset) => asset.id))
+  }
+
+  // Ctrl/Cmd+A, the shortcut people try first. Document-level because the grid
+  // is a plain div with no tabindex, so a React `onKeyDown` would only fire
+  // while focus happened to sit on a tile.
+  //
+  // Ignored while focus is in a text field — the browser's own select-all is
+  // what someone typing in the search box means — and while any dialog is
+  // open, so a rename or a delete confirmation keeps its own select-all.
+  const selectAllEvent = useEffectEvent(() => selectAllVisible())
+  useEffect(() => {
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key !== 'a' && event.key !== 'A') return
+      if (!(isMacLike() ? event.metaKey : event.ctrlKey)) return
+      const target = event.target
+      if (
+        target instanceof HTMLInputElement
+        || target instanceof HTMLTextAreaElement
+        || (target instanceof HTMLElement && target.isContentEditable)
+      ) return
+      if (document.querySelector('[role="dialog"], [role="alertdialog"]')) return
+      event.preventDefault()
+      selectAllEvent()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [])
+
+  /**
    * Which assets a right-click acts on.
    *
    * The same Finder rule `handleAssetDragStart` already uses: acting on an
@@ -368,6 +410,21 @@ export function MediaCanvas({ workspace, selectionMode = 'standard' }: MediaCanv
           groupLabel="Filter media type"
           trailing={(
             <div role="group" aria-label="Media view" className={styles.viewGroup}>
+              {/* Discoverability for Ctrl/Cmd+A. The shortcut is the one people
+                  reach for, but only if they already know it exists — and the
+                  trash is where it matters most, because emptying it was
+                  otherwise a file-at-a-time job. */}
+              <Button
+                variant="ghost"
+                size="xs"
+                tooltip={`Select all ${workspace.visibleAssets.length}`}
+                aria-label={`Select all ${workspace.visibleAssets.length} items`}
+                disabled={workspace.visibleAssets.length === 0}
+                onClick={selectAllVisible}
+              >
+                <CheckIcon size={13} />
+                <span>All</span>
+              </Button>
               <SortMenu
                 value={workspace.filters.sort}
                 onChange={workspace.setSort}

--- a/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.module.css
+++ b/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.module.css
@@ -20,6 +20,15 @@
     overflow: hidden;
 }
 
+/* Collapsed: shrink to the header. The height above is a fixed length, so
+   hiding the body alone left the window at full size with an empty pane
+   under the title bar. `height: auto` sizes it to the header that remains,
+   while `top` above keeps clamping against the FULL height — which is what
+   stops a window collapsed near the bottom edge from jumping. */
+.window[data-minimized="true"] {
+    height: auto;
+}
+
 .body {
     flex: 1 1 auto;
     display: grid;

--- a/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.tsx
+++ b/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.tsx
@@ -36,7 +36,7 @@ import { ReloadIcon } from 'pixel-art-icons/icons/reload'
 import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
 import { VideoSolidIcon } from 'pixel-art-icons/icons/video-solid'
 import { PanelHeader } from '@admin/shared/PanelHeader'
-import { useDraggablePanel } from '@admin/shared/FloatingWindow'
+import { useDraggablePanel, useTopmostEscape } from '@admin/shared/FloatingWindow'
 import type { CmsMediaAsset, CmsMediaFolder, UpdateCmsMediaAssetInput } from '@core/persistence/cmsMedia'
 import { bucketForMime } from '../../utils/filters'
 import { useDebouncedSave } from '../../hooks/useDebouncedSave'
@@ -108,10 +108,15 @@ function ViewerForAsset({ editor, onClose }: ViewerForAssetProps) {
 
   // Persistent window position — same key the old detached inspector used,
   // so saved positions carry over for users who already moved it.
-  const { setPanelRef, headerDragProps, panelPositionStyle } = useDraggablePanel(
+  const { panelRef, setPanelRef, headerDragProps, panelPositionStyle } = useDraggablePanel(
     'mediaDetachedInspector',
     () => ({ x: window.innerWidth - 880, y: 80 }),
   )
+
+  // This window renders its own shell rather than `FloatingWindow`, so it
+  // needs the same Escape rule wired up directly. The stacking check is what
+  // keeps the purge confirmation below owning Escape until it closes.
+  useTopmostEscape(true, panelRef, onClose)
 
   // ── Save callbacks ────────────────────────────────────────────────────────
   const saveTitle = async (next: string) => {

--- a/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.tsx
+++ b/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.tsx
@@ -33,6 +33,8 @@ import { useCurrentAdminUser } from '@admin/sessionContext'
 import { Copy2SolidIcon } from 'pixel-art-icons/icons/copy-2-solid'
 import { ExternalLinkSolidIcon } from 'pixel-art-icons/icons/external-link-solid'
 import { ReloadIcon } from 'pixel-art-icons/icons/reload'
+import { MinusIcon } from 'pixel-art-icons/icons/minus'
+import { PlusIcon } from 'pixel-art-icons/icons/plus'
 import { TrashSolidIcon } from 'pixel-art-icons/icons/trash-solid'
 import { VideoSolidIcon } from 'pixel-art-icons/icons/video-solid'
 import { PanelHeader } from '@admin/shared/PanelHeader'
@@ -101,6 +103,7 @@ function ViewerForAsset({ editor, onClose }: ViewerForAssetProps) {
   const currentUser = useCurrentAdminUser()
   const { asset } = editor
   const [replaceOpen, setReplaceOpen] = useState(false)
+  const [minimized, setMinimized] = useState(false)
   const bucket = bucketForMime(asset.mimeType)
   const canWrite = canWriteMedia(currentUser)
   const canReplace = canReplaceMedia(currentUser)
@@ -175,14 +178,31 @@ function ViewerForAsset({ editor, onClose }: ViewerForAssetProps) {
       style={panelPositionStyle}
       onClick={(event) => event.stopPropagation()}
     >
+      {/* This window builds its own shell rather than `FloatingWindow`, so the
+          collapse control is wired here directly — same behaviour, same
+          per-session scope, same reason for staying put: the position is the
+          user's own and folding to a corner would discard it. */}
       <PanelHeader
         panelId="mediaDetachedInspector"
         title={asset.filename}
         onClose={onClose}
         dragHandleProps={headerDragProps}
-      />
+      >
+        <Button
+          variant="ghost"
+          size="xs"
+          iconOnly
+          tooltip={minimized ? 'Expand' : 'Minimize'}
+          aria-label={minimized ? `Expand ${asset.filename}` : `Minimize ${asset.filename}`}
+          aria-expanded={!minimized}
+          data-testid="panel-minimize-mediaDetachedInspector"
+          onClick={() => setMinimized((value) => !value)}
+        >
+          {minimized ? <PlusIcon size={13} /> : <MinusIcon size={13} />}
+        </Button>
+      </PanelHeader>
 
-      <div className={styles.body}>
+      {!minimized && <div className={styles.body}>
         <div className={styles.viewer}>
           <ViewerBody asset={asset} />
         </div>
@@ -343,7 +363,7 @@ function ViewerForAsset({ editor, onClose }: ViewerForAssetProps) {
             </Section>
           )}
         </aside>
-      </div>
+      </div>}
 
       {canReplace && (
         <ReplaceFileDialog

--- a/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.tsx
+++ b/src/admin/pages/media/components/MediaViewerWindow/MediaViewerWindow.tsx
@@ -172,6 +172,7 @@ function ViewerForAsset({ editor, onClose }: ViewerForAssetProps) {
     <aside
       ref={setPanelRef}
       className={styles.window}
+      data-minimized={minimized ? 'true' : undefined}
       role="dialog"
       aria-label={`Viewer: ${asset.filename}`}
       data-testid="media-viewer-window"

--- a/src/admin/pages/media/components/UploadQueueWindow/UploadQueueWindow.tsx
+++ b/src/admin/pages/media/components/UploadQueueWindow/UploadQueueWindow.tsx
@@ -48,8 +48,13 @@ export function UploadQueueWindow({ queue, open, onClose, onRevealAsset }: Uploa
       panelId="mediaUploadQueue"
       open={open}
       onClose={onClose}
+      minimizable
       title={`Uploads (${succeeded}/${total})`}
-      defaultPosition={{ x: 16, y: 80 }}
+      // Bottom-left by default — where a browser puts its download shelf and
+      // Finder its copy progress, so a transfer sits out of the way of the
+      // grid it is filling. Only the DEFAULT: `useDraggablePanel` restores a
+      // stored position first, so a window the user has moved stays moved.
+      defaultPosition={{ x: 16, y: Math.max(80, window.innerHeight - 360) }}
       width={360}
       maxHeight={420}
       ariaLabel="Upload queue"

--- a/src/admin/shared/FloatingWindow/FloatingWindow.tsx
+++ b/src/admin/shared/FloatingWindow/FloatingWindow.tsx
@@ -4,6 +4,7 @@ import { PanelHeader } from '@admin/shared/PanelHeader'
 import type { FloatingPanelId, PanelPosition } from '@admin/state/workspaceLayoutStorage'
 import { cn } from '@ui/cn'
 import { useDraggablePanel } from './useDraggablePanel'
+import { useTopmostEscape } from './useTopmostEscape'
 import styles from './FloatingWindow.module.css'
 
 interface FloatingWindowProps {
@@ -51,6 +52,8 @@ export function FloatingWindow({
     () => defaultPosition,
   )
   useImperativeHandle(forwardedRef, () => panelRef.current as HTMLDivElement)
+
+  useTopmostEscape(open, panelRef, onClose)
 
   if (!open) return null
 

--- a/src/admin/shared/FloatingWindow/FloatingWindow.tsx
+++ b/src/admin/shared/FloatingWindow/FloatingWindow.tsx
@@ -1,6 +1,9 @@
-import { useImperativeHandle, type CSSProperties, type ReactNode, type Ref } from 'react'
+import { useImperativeHandle, useState, type CSSProperties, type ReactNode, type Ref } from 'react'
 import { createPortal } from 'react-dom'
 import { PanelHeader } from '@admin/shared/PanelHeader'
+import { Button } from '@ui/components/Button'
+import { MinusIcon } from 'pixel-art-icons/icons/minus'
+import { PlusIcon } from 'pixel-art-icons/icons/plus'
 import type { FloatingPanelId, PanelPosition } from '@admin/state/workspaceLayoutStorage'
 import { cn } from '@ui/cn'
 import { useDraggablePanel } from './useDraggablePanel'
@@ -20,6 +23,18 @@ interface FloatingWindowProps {
   bodyClassName?: string
   ariaLabel?: string
   testId?: string
+  /**
+   * Offer a collapse control beside Close, leaving only the title bar.
+   *
+   * For windows that stay useful while the user works around them — an upload
+   * in flight, a bulk edit mid-review — where the choice is otherwise between
+   * losing the panel and letting it cover the grid.
+   *
+   * Collapsed state is per-session and stays where the window sits: the
+   * position is the user's own, so folding to a corner would discard it, and
+   * expanding would then have nowhere honest to return to.
+   */
+  minimizable?: boolean
   onClose(): void
   children?: ReactNode
   ref?: Ref<HTMLDivElement>
@@ -43,6 +58,7 @@ export function FloatingWindow({
   bodyClassName,
   ariaLabel,
   testId,
+  minimizable = false,
   onClose,
   children,
   ref: forwardedRef,
@@ -53,14 +69,16 @@ export function FloatingWindow({
   )
   useImperativeHandle(forwardedRef, () => panelRef.current as HTMLDivElement)
 
+  const [minimized, setMinimized] = useState(false)
+
   useTopmostEscape(open, panelRef, onClose)
 
   if (!open) return null
 
   const style = {
     '--floating-window-w': cssLength(width),
-    '--floating-window-h': cssLength(height),
-    '--floating-window-max-h': cssLength(maxHeight),
+    '--floating-window-h': minimized ? 'auto' : cssLength(height),
+    '--floating-window-max-h': minimized ? 'none' : cssLength(maxHeight),
     ...panelPositionStyle,
   } as CSSProperties
 
@@ -81,9 +99,23 @@ export function FloatingWindow({
         onClose={onClose}
         dragHandleProps={headerDragProps}
       >
-        {headerActions}
+        {minimized ? null : headerActions}
+        {minimizable && (
+          <Button
+            variant="ghost"
+            size="xs"
+            iconOnly
+            tooltip={minimized ? 'Expand' : 'Minimize'}
+            aria-label={minimized ? `Expand ${title}` : `Minimize ${title}`}
+            aria-expanded={!minimized}
+            data-testid={`panel-minimize-${panelId}`}
+            onClick={() => setMinimized((value) => !value)}
+          >
+            {minimized ? <PlusIcon size={13} /> : <MinusIcon size={13} />}
+          </Button>
+        )}
       </PanelHeader>
-      <div className={cn(styles.body, bodyClassName)}>{children}</div>
+      {!minimized && <div className={cn(styles.body, bodyClassName)}>{children}</div>}
     </aside>,
     document.body,
   )

--- a/src/admin/shared/FloatingWindow/index.ts
+++ b/src/admin/shared/FloatingWindow/index.ts
@@ -8,3 +8,4 @@ export {
   clampFloatingPanelSize,
   useResizablePanel,
 } from './useResizablePanel'
+export { useTopmostEscape } from './useTopmostEscape'

--- a/src/admin/shared/FloatingWindow/useTopmostEscape.ts
+++ b/src/admin/shared/FloatingWindow/useTopmostEscape.ts
@@ -14,6 +14,11 @@
  * `alertdialog` counts as a layer: `Dialog` renders that role instead of
  * `dialog` when `tone === 'danger'`, which is exactly what a destructive
  * confirmation opened from one of these windows is.
+ *
+ * So does `menu`. A context menu opened inside a window owns Escape while it
+ * is up — closing the menu and the window together on one press loses the
+ * user's place. Menus portal to `document.body`, so they are not descendants
+ * of the panel and the document-order test alone would miss them.
  */
 
 import { useEffect, useEffectEvent, type RefObject } from 'react'
@@ -35,6 +40,11 @@ export function useTopmostEscape(
       if (event.key !== 'Escape') return
       const self = panelRef.current
       if (!self) return
+
+      // An open menu owns Escape wherever it sits — it is a transient layer
+      // above everything, and unlike a dialog it may render before the panel
+      // in document order.
+      if (document.querySelector('[role="menu"]')) return
 
       const stackedAbove = Array.from(
         document.querySelectorAll('[role="dialog"], [role="alertdialog"]'),

--- a/src/admin/shared/FloatingWindow/useTopmostEscape.ts
+++ b/src/admin/shared/FloatingWindow/useTopmostEscape.ts
@@ -1,0 +1,56 @@
+/**
+ * Escape-to-close for a floating panel, honouring whatever is stacked above it.
+ *
+ * Every overlay in this admin takes Escape — the settings modal, the shared
+ * `Dialog`, Spotlight. The draggable windows did not: they overlay the grid
+ * they were opened from, and the only way out was the header's close button.
+ *
+ * The stacking check is the same one `SettingsModal` uses, and it is the
+ * reason this is a hook rather than three copies. A window can open a
+ * `Dialog` of its own — a delete confirmation, the replace-file picker — and
+ * that dialog must own Escape until it closes. Without the check, one press
+ * would collapse the confirmation and the window underneath it together.
+ *
+ * `alertdialog` counts as a layer: `Dialog` renders that role instead of
+ * `dialog` when `tone === 'danger'`, which is exactly what a destructive
+ * confirmation opened from one of these windows is.
+ */
+
+import { useEffect, useEffectEvent, type RefObject } from 'react'
+
+export function useTopmostEscape(
+  open: boolean,
+  panelRef: RefObject<HTMLElement | null>,
+  onClose: () => void,
+): void {
+  // `useEffectEvent` keeps `onClose` out of the dependency array — callers
+  // pass an inline arrow, and re-subscribing the listener on every render
+  // would drop keystrokes between removal and re-add.
+  const closeEvent = useEffectEvent(() => onClose())
+
+  useEffect(() => {
+    if (!open) return undefined
+
+    function onKeyDown(event: globalThis.KeyboardEvent) {
+      if (event.key !== 'Escape') return
+      const self = panelRef.current
+      if (!self) return
+
+      const stackedAbove = Array.from(
+        document.querySelectorAll('[role="dialog"], [role="alertdialog"]'),
+      ).some(
+        (el) =>
+          el !== self
+          && Boolean(self.compareDocumentPosition(el) & Node.DOCUMENT_POSITION_FOLLOWING),
+      )
+      if (stackedAbove) return
+
+      event.preventDefault()
+      event.stopPropagation()
+      closeEvent()
+    }
+
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, panelRef])
+}

--- a/src/ui/components/Dialog/Dialog.module.css
+++ b/src/ui/components/Dialog/Dialog.module.css
@@ -83,6 +83,15 @@
 .body {
     padding: var(--space-2xl);
     overflow-y: auto;
+    /* The shell never set a size, and nothing above it does either — no rule
+       in globals.css sets `font-size` at all — so body copy fell through to
+       the browser's 16px default while the rest of the admin runs at 12-14px.
+       Every existing caller worked around it by sizing its own children;
+       a bare <p> in a dialog rendered noticeably larger than the panel
+       behind it. */
+    font-size: var(--text-m);
+    line-height: 1.5;
+    color: var(--text-muted);
 }
 
 .footer {


### PR DESCRIPTION
Media had no way to select more than a range by hand. Emptying the trash meant shift-clicking from the first row to the last — there was no shortcut and no button, while the Data workspace has both a "Select all rows" header checkbox (`DataGridHeaderRow.tsx`) and a bulk action bar.

Stacked on [#500](https://github.com/CoreBunch/Instatic/pull/500), which is what gives the resulting selection somewhere to go — a context menu that honours it and a bulk permanent-delete.

## What "all" means

`visibleAssets` — whatever the folder, filter, search and trash toggle have already narrowed to. That is what every file manager means by Select All, and it is the only reading that keeps "select all, then delete permanently" in the trash from reaching live assets.

## Two ways in, because they fail differently

Ctrl/Cmd+A is what people try first, but only if they already know it is there. The toolbar button is what tells them, and it carries the count so the scope is visible before the click.

## Where the shortcut stands down

Document-level, because the grid is a plain div with no tabindex — a React `onKeyDown` would only fire while focus happened to sit on a tile. It yields in two cases:

- **inside a text field** (input, textarea, contenteditable) — someone typing a filter means select-the-text
- **while any dialog is open** — it belongs to whatever that dialog contains; selecting the grid behind a confirmation would change what the confirmed action applies to

Seven tests cover exactly those boundaries, including `alertdialog`, which is what `Dialog` renders for the permanent-delete confirmation.

No new workspace API — `addToSelection` already existed and already keeps the selection-order list in step.

```
bun test src/__tests__/media/   43 pass, 0 fail
tsc -b, eslint                  clean
```

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>