### PR TITLE
chore(bun): upgrade to Bun 1.4.2 and pin the version in one place

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -45,8 +43,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -63,8 +59,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -100,8 +98,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
 
       - name: Install dependencies (all platforms' native packages)
         run: bun install --frozen-lockfile --os='*' --cpu='*'
@@ -145,8 +141,6 @@ jobs:
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # syntax=docker/dockerfile:1
 
-FROM oven/bun:1.3.11 AS build
+# The one place the Bun version lives for the image; CI reads it from
+# package.json "packageManager" instead, so bumping Bun is two lines.
+ARG BUN_VERSION=1.4.2
+
+FROM oven/bun:${BUN_VERSION} AS build
 WORKDIR /app
 # vendor/pixel-art-icons is a `file:` dep — `bun install` needs it on disk to
 # resolve the dependency, so copy it alongside the manifest before installing.
@@ -10,13 +14,13 @@ RUN bun install --frozen-lockfile
 COPY . .
 RUN bun run build
 
-FROM oven/bun:1.3.11 AS production-deps
+FROM oven/bun:${BUN_VERSION} AS production-deps
 WORKDIR /app
 COPY package.json bun.lock ./
 COPY vendor ./vendor
 RUN bun install --frozen-lockfile --production
 
-FROM oven/bun:1.3.11 AS runtime
+FROM oven/bun:${BUN_VERSION} AS runtime
 WORKDIR /app
 
 ARG INSTATIC_VERSION=dev

--- a/package.json
+++ b/package.json
@@ -3,8 +3,9 @@
   "private": true,
   "version": "0.0.18",
   "engines": {
-    "bun": ">=1.3.0 <1.4.0"
+    "bun": ">=1.4.0 <1.5.0"
   },
+  "packageManager": "bun@1.4.2",
   "description": "Self-hosted CMS with an integrated visual editor.",
   "author": "David Babinec",
   "license": "MIT",

--- a/scripts/sync-plugin-bootstrap.ts
+++ b/scripts/sync-plugin-bootstrap.ts
@@ -28,7 +28,7 @@
  * Bundler determinism: `Bun.build` output is stable within a Bun minor but is
  * NOT guaranteed bit-identical across minors, so a Bun upgrade can legitimately
  * change the bytes. The expected Bun is pinned by `engines.bun` in package.json
- * (`>=1.3.0 <1.4.0`) and by the `oven/bun:1.3` base image in the Dockerfile. On
+ * (`>=1.4.0 <1.5.0`) and by the `oven/bun:1.4` base image in the Dockerfile. On
  * a deliberate Bun-minor bump, regenerate (`bun run bootstrap:sync`) in the same
  * change so the gate fails only on real source drift, never on a routine
  * upgrade.

--- a/src/__tests__/server/dockerConfig.test.ts
+++ b/src/__tests__/server/dockerConfig.test.ts
@@ -22,9 +22,10 @@ describe('self-host docker config', () => {
   it('defines a production Docker image that builds assets before runtime startup', () => {
     const dockerfile = readFileSync('Dockerfile', 'utf8')
 
-    expect(dockerfile).toContain('FROM oven/bun:1.3.11 AS build')
+    expect(dockerfile).toContain('ARG BUN_VERSION=1.4.2')
+    expect(dockerfile).toContain('FROM oven/bun:${BUN_VERSION} AS build')
     expect(dockerfile).toContain('RUN bun run build')
-    expect(dockerfile).toContain('FROM oven/bun:1.3.11 AS runtime')
+    expect(dockerfile).toContain('FROM oven/bun:${BUN_VERSION} AS runtime')
     expect(dockerfile).toContain('ARG INSTATIC_VERSION=dev')
     expect(dockerfile).toContain('LABEL org.opencontainers.image.version="${INSTATIC_VERSION}"')
     expect(dockerfile).toContain('CMD ["bun", "run", "server/index.ts"]')


### PR DESCRIPTION
## What changed

Bun moves from 1.3.11 to 1.4.2, and the version is written in two places instead of ten.

- `package.json` gains `"packageManager": "bun@1.4.2"`, which `oven-sh/setup-bun@v2` reads by default, so the six `bun-version:` inputs in `ci.yml` and `release.yml` are gone.
- `Dockerfile` declares `ARG BUN_VERSION=1.4.2` once; the three stages build `FROM oven/bun:${BUN_VERSION}`.
- `engines.bun` widens to `>=1.4.0 <1.5.0`.
- `dockerConfig.test.ts` asserts the ARG and the templated `FROM`; the bootstrap determinism note in `scripts/sync-plugin-bootstrap.ts` names the new range and image.

Bumping Bun next time is the `packageManager` field and the `ARG`.

## Why

1.4 brings a native React Compiler in `bun build`, 2x faster startup and under half the memory on Linux, and 1.4.1 fixed a run of `node:http` and socket lifecycle bugs (the Vite port-retry hang, paused sockets never emitting `end`, `ws` `handleUpgrade` after an `await`, WebSocket backpressure stalls) that map onto the dev-server workarounds this repo carries. Those get re-tested on top of this pin bump and, where the fixes hold, deleted in a follow-up, so each step stays reviewable on its own.

## Impact

- Developers: install Bun 1.4.x. `bun run dev` refuses older versions through the engines range.
- Deployments: the image base moves to `oven/bun:1.4.2`; nothing in the runtime path changed.
- #494 (E2E in CI) still pins `bun-version: 1.3.11` in `e2e.yml`; it drops that input when it rebases onto this.

## Verification

Isolated Bun 1.4.2 binary in a fresh worktree off `main` (the global 1.3.11 untouched):

| Check | Result |
|---|---|
| `bun install --frozen-lockfile` | clean, `bun.lock` unchanged |
| `bun run bootstrap:check` | fresh, both QuickJS bootstrap artifacts byte-identical |
| `bun run icons:check` | clean |
| `bun run build` | tsc and Vite clean |
| `bun run lint` | clean |
| `bun test` | 6836 pass, 0 fail |
| `bun test src/__tests__/server/dockerConfig.test.ts` | 10 pass on the ARG shape |

CI on this PR is the Linux proof; the local run is macOS.
