### PR TITLE
feat(plugins): host-managed robots.txt and plugin-claimed root text files

### DIFF
--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -39,6 +39,7 @@ A plugin is a zip package containing a `plugin.json` manifest and one or more bu
 | Route request/response I/O     | `server/plugins/host/routeIo.ts`          |
 | Media extension handlers       | `server/plugins/host/handlers/media.ts`, `src/core/plugins/mediaStorageRegistry.ts`, `src/core/plugins/mediaVariantDelegateRegistry.ts` |
 | Published-page asset injection | `server/publish/frontendInjections.ts`    |
+| Site-root text files (`/robots.txt`, `/<name>.txt`) | `server/siteRoot.ts`, `src/core/plugin-sdk/siteRootSchemas.ts` |
 | Dashboard widget registry      | `src/core/dashboard/registry.ts`          |
 | Plugin asset path containment      | `server/util/pathWithin.ts`            |
 | Plugin lifecycle (boot, install, activate, uninstall) | `server/plugins/runtime.ts`, `package.ts` |
@@ -543,11 +544,40 @@ const name = await api.cms.hooks.emit('sync.done', { /* … */ })
 // name === 'plugin.<your-plugin-id>.sync.done'
 ```
 
-**Host-emitted events** (the reserved core list, `CORE_HOOK_EVENTS` in `src/core/plugins/hookBus.ts`): `publish.before`, `publish.after`, `content.entry.created`, `content.entry.updated`, `content.entry.deleted`, `settings.changed`. **Filters**: `publish.html`, `publish.headers`, `content.entry.cells`.
+**Host-emitted events** (the reserved core list, `CORE_HOOK_EVENTS` in `src/core/plugins/hookBus.ts`): `publish.before`, `publish.after`, `content.entry.created`, `content.entry.updated`, `content.entry.deleted`, `settings.changed`. **Filters**: `publish.html`, `publish.headers`, `content.entry.cells`, `site.robots`, `site.rootFiles`.
 
 Every filter handler returns the same runtime value type it received. `src/core/plugins/hookBus.ts` checks each result before passing it to the next handler; a mismatched result keeps the previous value and logs the offending plugin ID. For example, `publish.html` returns a string and `content.entry.cells` returns an object, never `null`.
 
 **Plugin emits are namespaced.** The host rewrites every `emit('<name>', …)` to `plugin.<your-plugin-id>.<name>` (a name already in your own namespace passes through unchanged), so event provenance is unforgeable — a plugin cannot fire `content.entry.created` or any other core event at other listeners, and emitting a name in *another* plugin's namespace (`plugin.<other-id>.*`) is rejected with an error. `emit` resolves to the canonical namespaced name. Cross-plugin eventing still works: subscribing is unrestricted, so a plugin listens to another plugin's events by their full namespaced name, e.g. `api.cms.hooks.on('plugin.acme.analytics.page-view', …)`.
+
+### Site-root text files — requires `cms.hooks`
+
+Two SEO standards authorize by file *location*, and a plugin's routes mount under `/admin/api/cms/plugins/<id>/runtime/*`: the sitemaps.org protocol scopes a sitemap to its own directory and below, and indexnow.org scopes a key file the same way. Both surfaces below close that gap with hook-bus filters — no new permission, because `publish.html` already lets a `cms.hooks` plugin rewrite every published page.
+
+`/robots.txt` is **host-managed**. The host serves it whether or not a plugin contributes, seeding the chain with `User-agent: *` / `Allow: /` — the same instruction to a crawler that its previous 404 carried (RFC 9309 §2.3.1.3). Plugins contribute *directives*, not text, and the host renders the document:
+
+```js
+api.cms.hooks.filter('site.robots', (doc) => {
+  doc.sitemaps.push('https://example.com/sitemap.xml')
+  doc.groups.push({ userAgent: 'BadBot', allow: [], disallow: ['/'] })
+  return doc
+})
+```
+
+Handlers chain in registration order. Every list entry is validated against `src/core/plugin-sdk/siteRootSchemas.ts` — a group is accepted or dropped as a unit, sitemap URLs one by one — so a value carrying whitespace, a `#`, or a CR/LF can never forge an extra directive line. Sitemap URLs are de-duplicated; when the filtered document has no valid group left, the host default one is re-inserted.
+
+`site.rootFiles` claims one root `.txt` path per file — the IndexNow key case:
+
+```js
+api.cms.hooks.filter('site.rootFiles', (doc) => {
+  doc.files.push({ path: `/${key}.txt`, content: key })
+  return doc
+})
+```
+
+Claimable paths are an allowlist: one root segment, `.txt`, starting with an alphanumeric (`/a1b2c3.txt`). Nested paths, dot segments, percent escapes, and any other extension are rejected, and `/robots.txt` is reserved for the host. Bodies are capped at 4 KiB and may not carry C0 control characters other than tab and newline. **A path claimed by two plugins is served by neither** — resolving it to one winner would silently authorize the wrong submitter — and the refusal is logged with the candidate plugin ids. Both responses go out as `text/plain` with `nosniff`, `default-src 'none'`, and `no-store`.
+
+Both handlers sit directly before `tryServePublicRoute` in the dispatcher, so every host-owned namespace still wins. They cannot shadow content either: `pageSlugError` rejects any page slug containing `.` and a data-row route needs at least `/<table>/<slug>`, so no published URL is ever a root `.txt` path. Neither response is baked into the published slot — both depend on which plugins are active right now, not on the published snapshot.
 
 ### Loop sources — requires `loops.register`
 

--- a/docs/features/publisher.md
+++ b/docs/features/publisher.md
@@ -52,6 +52,7 @@ server/publish/
 ├── publicRenderer.ts               — renderPublishedSnapshot, renderPublishedDataRowTemplate
 ├── publishedHtmlPipeline.ts        — post-process (sanitize + plugin filters + injections)
 ├── siteCssBundle.ts                — server-side hashing + file emission
+├── siteCssServer.ts                — serves `/_instatic/css/*` (disk-first, memoised DB-rebuild fallback)
 ├── frontendInjections.ts           — splice plugin <script>/<link>/<meta> into HTML
 ├── mediaPresentation.ts            — media URL materialization for originals + responsive variants
 ├── renderTreeWalk.ts               — walkRenderTree: visits every node that contributes to a rendered page (page nodes + VC definition trees, cycle-guarded); single source of truth for loop-prefetch and media-prefetch
@@ -313,10 +314,11 @@ statement right after the slot swap — so a baked `<instatic-hole data-instatic
 always matches what the hole endpoint expects (a mismatch would make the
 endpoint refuse to hydrate).
 
-The exclusive namespaces `/_instatic/css/*` (`serveSiteCss`) and `/_instatic/assets/*`
-(`tryServeRuntimeAsset`) are served **disk-first**, falling back to a rebuild
-(`serveSiteCss`) or the DB (`published_runtime_assets`) only for preview or a
-publish whose disk write failed. Unknown paths under either prefix 404 rather
+The exclusive namespaces `/_instatic/css/*` (`siteCssServer.ts`) and
+`/_instatic/assets/*` (`tryServeRuntimeAsset`) are served **disk-first**,
+falling back to a rebuild (`serveSiteCss`) or the DB
+(`published_runtime_assets`) only for preview or a publish whose disk write
+failed. Unknown paths under either prefix 404 rather
 than falling through.
 
 ---
@@ -389,6 +391,7 @@ Because `serializeCsp` sorts, the same plugins + adapters always emit a **byte-i
 | `server/publish/publicRenderer.ts`              | `renderPublishedSnapshot`, `renderPublishedDataRowTemplate` — thin wrappers (resolve + compose the template chain, seed the context) over one shared `renderMergedTemplate` (CSS bundle + loop/media prefetch + `publishPage` + publish-version stamping). The entry path also passes the row's `readEntrySeoOverride(...)` through as `documentMeta`. |
 | `server/publish/publishedHtmlPipeline.ts`       | Post-process: DOMPurify the final HTML, run plugin `publish.html` filter, splice in declarative tags from plugin manifests, inject runtime assets. Runs at publish time only — never per-request. |
 | `server/publish/siteCssBundle.ts`               | Hash the four CSS strings, write `uploads/css/...` files. The framework bundle's module-CSS half comes from the shared walk in `siteModuleAssets.ts`. |
+| `server/publish/siteCssServer.ts`               | `serveSiteCss` — answers `/_instatic/css/<bundle>-<hash>.css` disk-first, with a `(bundle, hash)`-memoised rebuild from the published snapshot as the preview fallback. |
 | `server/publish/siteModuleAssets.ts`            | `collectSiteModuleAssets` — the one full-site render walk whose accumulators feed BOTH the framework CSS bundle (`cssMap`) and the published module-JS map (`jsMap`). |
 | `server/publish/moduleJsBundle.ts`              | Module-JS channel: `buildSiteModuleJsMap` (fresh), `buildPublishedSiteModuleJsMap` (memoised per publishVersion + site, invalidated by `bumpPublishVersion()`), and `injectModuleScripts` (per-page `<script defer>` tags + CSP `script-src 'self'` relaxation). |
 | `server/publish/republish.ts`                   | Bulk re-publish on settings change (touches every page).            |

--- a/docs/server.md
+++ b/docs/server.md
@@ -89,7 +89,8 @@ const routes: readonly RouteHandler[] = [
   tryServePublicForm,              // /_instatic/form/*       → forms/handler.ts
   tryServeRuntimeAsset,            // /_instatic/assets/*     → published runtime assets
   tryServeRuntimePackageNamespace, // /_instatic/runtime/cache/<hash>/<...> → bun install workspace
-  tryServeSiteCssNamespace,        // /_instatic/css/*        → hashed CSS bundles
+  tryServeSiteCssNamespace,        // /_instatic/css/*        → publish/siteCssServer.ts
+                                   //   (hashed CSS bundles, disk-first)
   tryServeMediaRedirect,           // /_instatic/media/<adapterId>/<path> → 302 to signed read URL
   tryServeStaticAsset,             // /assets/* → dist/ (admin app)
   tryServeUpload,                  // /uploads/* → uploadsDir (with nosniff hardening)

--- a/docs/server.md
+++ b/docs/server.md
@@ -95,6 +95,10 @@ const routes: readonly RouteHandler[] = [
   tryServeStaticAsset,             // /assets/* → dist/ (admin app)
   tryServeUpload,                  // /uploads/* → uploadsDir (with nosniff hardening)
   tryServeAdminApp,                // /admin/* → dist/index.html (SPA fallback)
+  tryServeRobotsTxt,               // /robots.txt → server/siteRoot.ts (host document
+                                   //   plus the site.robots filter chain)
+  tryServeRootFile,                // /<name>.txt → plugin-claimed root text file
+                                   //   (site.rootFiles filter); null when unclaimed
   tryServePublicRoute,             // /<slug> OR /<route-base>/<row-slug>
                                    //   → server/publish/publicRouter.ts
                                    //   resolves to page snapshot OR data row + template,
@@ -110,6 +114,7 @@ Order matters. Two examples:
 
 - `tryServeAi` is matched **before** `tryServeCmsApi` so the AI endpoints (`/admin/api/ai/*`) aren't swallowed by the broader CMS dispatcher (`/admin/api/cms/*`).
 - `tryServeUpload` is matched **before** `tryServeAdminApp` because `/uploads/...` is a sub-tree the SPA fallback would otherwise consume.
+- `tryServeRobotsTxt` / `tryServeRootFile` are matched **after** every host-owned namespace and **before** `tryServePublicRoute`, so a plugin-claimed root file can shadow neither an admin path nor a built asset. It cannot shadow content either: page slugs may not contain `.` and a data-row route needs two segments, so no published URL is ever a root `.txt` path. An unclaimed `.txt` path returns null and keeps falling through.
 
 Adding a new endpoint is a one-line edit to `routes` plus a focused `tryServeX` function.
 
@@ -580,6 +585,8 @@ Three static handlers, in order:
 | `tryServeStaticAsset`  | `/assets/*` from `dist/` (Vite-built admin SPA assets)                |
 | `tryServeUpload`       | `/uploads/*` from `uploadsDir` with `hardenUploadResponse` (nosniff, attachment for non-inert MIMEs, CORS for plugin bundles) |
 | `tryServeAdminApp`     | `/admin/*` — serves the admin shell from `dist/index.html` with path-specific injections (see below) |
+
+The site-root text files (`/robots.txt` and plugin-claimed `/<name>.txt`) are served by `server/siteRoot.ts`, not from disk — see [docs/features/plugin-system.md](features/plugin-system.md) → "Site-root text files".
 
 `server/static.ts` owns all three. Key behaviors:
 

--- a/server/publish/siteCssServer.ts
+++ b/server/publish/siteCssServer.ts
@@ -1,0 +1,153 @@
+/**
+ * Serving side of the per-site CSS bundles — `/_instatic/css/<bundle>-<hash>.css`.
+ *
+ * `siteCssBundle.ts` BUILDS the bundle files; this module answers HTTP
+ * requests for them. It was extracted from `server/router.ts`, which had no
+ * business owning a DB-fallback rebuild walk and its memo — the dispatcher
+ * just forwards the path here.
+ */
+
+import type { DbClient } from '../db/client'
+import { registry } from '@core/module-engine'
+import type { CssBundleFile, SiteCssBundleId } from '@core/publisher'
+import { toArrayBuffer } from '../binary'
+import { getLatestSnapshotForVersion } from './publishedSnapshotCache'
+import { getPublishVersion, registerVersionedCacheReset } from './publishState'
+import { prefetchMediaAssets } from './mediaPrefetch'
+import { buildPublishedSiteCssBundle } from './siteCssBundle'
+import { readStaticAsset } from './staticArtefact'
+
+/**
+ * Serve one of the three site CSS bundle files (reset / framework / style).
+ *
+ * The URL path is `/_instatic/css/<bundle>-<hash>.css` where `<bundle>` is the
+ * logical layer name and `<hash>` is the 12-hex SHA-256 prefix that
+ * `buildSiteCssBundle` produces.
+ *
+ * Disk-first: a full publish bakes every referenced CSS file into the active
+ * slot, so this handler reads it straight off disk — no DB, no rebuild. The
+ * DB rebuild below is a fallback for preview (pre-publish) or a publish whose
+ * disk write failed.
+ *
+ *  - Browsers / CDNs cache the response for a year (`immutable`).
+ *  - When a hash changes (the site, its classes, or a stylesheet was edited),
+ *    HTML pages re-render with the new `<link href>` and visitors fetch the
+ *    new file exactly once.
+ *
+ * Stale hash → 404 so the browser falls back to refetching the HTML, which
+ * carries the current hash. Returning the new content under the old name
+ * would defeat `immutable` caching by serving different bytes for the same
+ * URL across the cache lifetime.
+ *
+ * `reset`/`framework`/`style` are page-invariant; `userStyles` is page-scoped
+ * (each stylesheet targets a subset of pages), so the fallback walks the
+ * published pages until one produces the requested hash.
+ *
+ * The DB fallback is memoised by `(bundle, hash)` — the hash is content-derived
+ * so an entry can never go stale; it can only stop being requested. Negative
+ * results are cached too (a crafted stale-hash URL would otherwise force the
+ * full rebuild walk per request). The memo resets when the publish version
+ * moves and concurrent first-hits share one in-flight rebuild.
+ */
+const cssFallbackCache = new Map<string, string | null>()
+const CSS_FALLBACK_CACHE_MAX = 256
+const cssFallbackInFlight = new Map<string, Promise<string | null>>()
+let cssFallbackVersion = -1
+registerVersionedCacheReset(() => {
+  cssFallbackCache.clear()
+  cssFallbackInFlight.clear()
+  cssFallbackVersion = -1
+})
+
+export async function serveSiteCss(db: DbClient, pathname: string, uploadsDir?: string): Promise<Response | null> {
+  const filename = pathname.slice('/_instatic/css/'.length)
+  const match = filename.match(/^(reset|framework|style|userStyles)-([a-f0-9]{12})\.css$/)
+  if (!match) return null
+
+  const [, requestedBundle, requestedHash] = match
+  const bundleId = requestedBundle as SiteCssBundleId
+
+  // Disk-first.
+  if (uploadsDir) {
+    const bytes = await readStaticAsset(uploadsDir, pathname)
+    if (bytes) {
+      return cssResponse(toArrayBuffer(bytes), requestedHash)
+    }
+  }
+
+  // Memoised DB fallback.
+  const version = getPublishVersion()
+  if (version !== cssFallbackVersion) {
+    cssFallbackCache.clear()
+    cssFallbackVersion = version
+  }
+  const cacheKey = `${bundleId}:${requestedHash}`
+  const cached = cssFallbackCache.get(cacheKey)
+  if (cached !== undefined) {
+    return cached === null ? new Response('Not found', { status: 404 }) : cssResponse(cached, requestedHash)
+  }
+
+  const inflight = cssFallbackInFlight.get(cacheKey)
+  const promise = inflight ?? (async (): Promise<string | null> => {
+    try {
+      const content = await rebuildSiteCssFromSnapshot(db, bundleId, requestedHash, version)
+      if (cssFallbackCache.size >= CSS_FALLBACK_CACHE_MAX) cssFallbackCache.clear()
+      cssFallbackCache.set(cacheKey, content)
+      return content
+    } finally {
+      cssFallbackInFlight.delete(cacheKey)
+    }
+  })()
+  if (!inflight) cssFallbackInFlight.set(cacheKey, promise)
+
+  const content = await promise
+  return content === null ? new Response('Not found', { status: 404 }) : cssResponse(content, requestedHash)
+}
+
+/**
+ * Rebuild the requested CSS bundle file from the latest published snapshot.
+ * Returns the file body, or `null` when no page (nor the page-agnostic view)
+ * produces the requested hash. The page-invariant trio comes from the
+ * version-keyed memo, so only `userStyles` does per-page work here.
+ */
+async function rebuildSiteCssFromSnapshot(
+  db: DbClient,
+  bundleId: SiteCssBundleId,
+  requestedHash: string,
+  version: number,
+): Promise<string | null> {
+  const snapshot = await getLatestSnapshotForVersion(db, version)
+  if (!snapshot) return null
+
+  const pages = bundleId === 'userStyles' ? snapshot.site.pages : snapshot.site.pages.slice(0, 1)
+  for (const page of pages) {
+    const mediaAssets = await prefetchMediaAssets(page, snapshot.site, registry, db)
+    const file: CssBundleFile = buildPublishedSiteCssBundle(snapshot.site, registry, page, version, { mediaAssets })[bundleId]
+    if (file.hash === requestedHash) return file.content
+  }
+  // Page-agnostic view (every enabled stylesheet) — covers a hash that
+  // predates a scope change but is still referenced somewhere.
+  const fallbackMediaAssets = snapshot.site.pages[0]
+    ? await prefetchMediaAssets(snapshot.site.pages[0], snapshot.site, registry, db)
+    : undefined
+  const fallback: CssBundleFile = buildPublishedSiteCssBundle(
+    snapshot.site,
+    registry,
+    undefined,
+    version,
+    { mediaAssets: fallbackMediaAssets },
+  )[bundleId]
+  if (fallback.hash === requestedHash) return fallback.content
+
+  return null
+}
+
+function cssResponse(body: BodyInit, hash: string): Response {
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/css; charset=utf-8',
+      'cache-control': 'public, max-age=31536000, immutable',
+      etag: `"${hash}"`,
+    },
+  })
+}

--- a/server/router.ts
+++ b/server/router.ts
@@ -15,6 +15,7 @@ import { isRuntimePackagePath, tryServeRuntimePackage } from './publish/runtime/
 import { jsonResponse } from './http'
 import { binaryResponse } from './binary'
 import { hardenUploadResponse, serveAdminApp, serveStaticFile } from './static'
+import { serveRobotsTxt, serveRootFile } from './siteRoot'
 import { serveSiteCss } from './publish/siteCssServer'
 import { mediaStorageRegistry } from '@core/plugins/mediaStorageRegistry'
 
@@ -86,6 +87,12 @@ const routes: readonly RouteHandler[] = [
   tryServeStaticAsset,
   tryServeUpload,
   tryServeAdminApp,
+  // Site-root text files — `/robots.txt` and plugin-claimed `/<name>.txt`.
+  // Matched after every host-owned namespace above and before slug
+  // resolution; page slugs can't contain `.` and data-row routes need two
+  // segments, so neither can collide with published content (issue #425).
+  tryServeRobotsTxt,
+  tryServeRootFile,
   tryServePublicRoute,
   trySetupRedirect,
   tryServeNotFoundPage,
@@ -482,6 +489,26 @@ async function tryServeAdminApp(
   // Admin SPA isn't served from this port (dev mode, or production missing a
   // build). Tell the developer where to actually find it.
   return adminUiNotBuiltResponse(pathname)
+}
+
+/**
+ * Host-managed `/robots.txt`. The document is assembled from the host
+ * default plus whatever plugins contribute through the `site.robots`
+ * filter; `server/siteRoot.ts` owns the serialization.
+ */
+function tryServeRobotsTxt(req: Request, _runtime: ServerRuntime, _url: URL, pathname: string): Promise<Response | null> | null {
+  if (req.method !== 'GET') return null
+  return serveRobotsTxt(pathname)
+}
+
+/**
+ * Plugin-claimed root text file — `/<name>.txt`. Returns null for any path
+ * no plugin claimed, so an unclaimed `.txt` path keeps falling through to
+ * slug resolution and, ultimately, the site's 404 page.
+ */
+function tryServeRootFile(req: Request, _runtime: ServerRuntime, _url: URL, pathname: string): Promise<Response | null> | null {
+  if (req.method !== 'GET') return null
+  return serveRootFile(pathname)
 }
 
 /**

--- a/server/router.ts
+++ b/server/router.ts
@@ -5,9 +5,6 @@ import { handleCmsRequest } from './handlers/cms'
 import type { DbClient } from './db/client'
 import { renderNotFoundResponse, renderPublicResolution } from './publish/publicRouter'
 import { readStaticAsset } from './publish/staticArtefact'
-import { getLatestSnapshotForVersion } from './publish/publishedSnapshotCache'
-import { getPublishVersion, registerVersionedCacheReset } from './publish/publishState'
-import { prefetchMediaAssets } from './publish/mediaPrefetch'
 import { getSetupStatusCached } from './repositories/setup'
 import { getPublishedRuntimeAsset } from './repositories/runtimeAsset'
 import { handleLoopRequest, isLoopRuntimeAssetPath, serveLoopRuntimeAsset } from './handlers/cms/loop'
@@ -16,11 +13,9 @@ import { handleModuleJsAssetRequest, isModuleJsAssetPath } from './handlers/cms/
 import { handlePublicFormRequest } from './forms/handler'
 import { isRuntimePackagePath, tryServeRuntimePackage } from './publish/runtime/packageServer'
 import { jsonResponse } from './http'
-import { binaryResponse, toArrayBuffer } from './binary'
+import { binaryResponse } from './binary'
 import { hardenUploadResponse, serveAdminApp, serveStaticFile } from './static'
-import { registry } from '@core/module-engine'
-import type { CssBundleFile, SiteCssBundleId } from '@core/publisher'
-import { buildPublishedSiteCssBundle } from './publish/siteCssBundle'
+import { serveSiteCss } from './publish/siteCssServer'
 import { mediaStorageRegistry } from '@core/plugins/mediaStorageRegistry'
 
 const VITE_DEV_URL = 'http://localhost:5173'
@@ -558,140 +553,5 @@ function adminUiNotBuiltResponse(pathname: string): Response {
   return new Response(html, {
     status: 404,
     headers: { 'content-type': 'text/html; charset=utf-8' },
-  })
-}
-
-/**
- * Serve one of the three site CSS bundle files (reset / framework / style).
- *
- * The URL path is `/_instatic/css/<bundle>-<hash>.css` where `<bundle>` is the
- * logical layer name and `<hash>` is the 12-hex SHA-256 prefix that
- * `buildSiteCssBundle` produces.
- *
- * Disk-first: a full publish bakes every referenced CSS file into the active
- * slot, so this handler reads it straight off disk — no DB, no rebuild. The
- * DB rebuild below is a fallback for preview (pre-publish) or a publish whose
- * disk write failed.
- *
- *  - Browsers / CDNs cache the response for a year (`immutable`).
- *  - When a hash changes (the site, its classes, or a stylesheet was edited),
- *    HTML pages re-render with the new `<link href>` and visitors fetch the
- *    new file exactly once.
- *
- * Stale hash → 404 so the browser falls back to refetching the HTML, which
- * carries the current hash. Returning the new content under the old name
- * would defeat `immutable` caching by serving different bytes for the same
- * URL across the cache lifetime.
- *
- * `reset`/`framework`/`style` are page-invariant; `userStyles` is page-scoped
- * (each stylesheet targets a subset of pages), so the fallback walks the
- * published pages until one produces the requested hash.
- *
- * The DB fallback is memoised by `(bundle, hash)` — the hash is content-derived
- * so an entry can never go stale; it can only stop being requested. Negative
- * results are cached too (a crafted stale-hash URL would otherwise force the
- * full rebuild walk per request). The memo resets when the publish version
- * moves and concurrent first-hits share one in-flight rebuild.
- */
-const cssFallbackCache = new Map<string, string | null>()
-const CSS_FALLBACK_CACHE_MAX = 256
-const cssFallbackInFlight = new Map<string, Promise<string | null>>()
-let cssFallbackVersion = -1
-registerVersionedCacheReset(() => {
-  cssFallbackCache.clear()
-  cssFallbackInFlight.clear()
-  cssFallbackVersion = -1
-})
-
-async function serveSiteCss(db: DbClient, pathname: string, uploadsDir?: string): Promise<Response | null> {
-  const filename = pathname.slice('/_instatic/css/'.length)
-  const match = filename.match(/^(reset|framework|style|userStyles)-([a-f0-9]{12})\.css$/)
-  if (!match) return null
-
-  const [, requestedBundle, requestedHash] = match
-  const bundleId = requestedBundle as SiteCssBundleId
-
-  // Disk-first.
-  if (uploadsDir) {
-    const bytes = await readStaticAsset(uploadsDir, pathname)
-    if (bytes) {
-      return cssResponse(toArrayBuffer(bytes), requestedHash)
-    }
-  }
-
-  // Memoised DB fallback.
-  const version = getPublishVersion()
-  if (version !== cssFallbackVersion) {
-    cssFallbackCache.clear()
-    cssFallbackVersion = version
-  }
-  const cacheKey = `${bundleId}:${requestedHash}`
-  const cached = cssFallbackCache.get(cacheKey)
-  if (cached !== undefined) {
-    return cached === null ? new Response('Not found', { status: 404 }) : cssResponse(cached, requestedHash)
-  }
-
-  const inflight = cssFallbackInFlight.get(cacheKey)
-  const promise = inflight ?? (async (): Promise<string | null> => {
-    try {
-      const content = await rebuildSiteCssFromSnapshot(db, bundleId, requestedHash, version)
-      if (cssFallbackCache.size >= CSS_FALLBACK_CACHE_MAX) cssFallbackCache.clear()
-      cssFallbackCache.set(cacheKey, content)
-      return content
-    } finally {
-      cssFallbackInFlight.delete(cacheKey)
-    }
-  })()
-  if (!inflight) cssFallbackInFlight.set(cacheKey, promise)
-
-  const content = await promise
-  return content === null ? new Response('Not found', { status: 404 }) : cssResponse(content, requestedHash)
-}
-
-/**
- * Rebuild the requested CSS bundle file from the latest published snapshot.
- * Returns the file body, or `null` when no page (nor the page-agnostic view)
- * produces the requested hash. The page-invariant trio comes from the
- * version-keyed memo, so only `userStyles` does per-page work here.
- */
-async function rebuildSiteCssFromSnapshot(
-  db: DbClient,
-  bundleId: SiteCssBundleId,
-  requestedHash: string,
-  version: number,
-): Promise<string | null> {
-  const snapshot = await getLatestSnapshotForVersion(db, version)
-  if (!snapshot) return null
-
-  const pages = bundleId === 'userStyles' ? snapshot.site.pages : snapshot.site.pages.slice(0, 1)
-  for (const page of pages) {
-    const mediaAssets = await prefetchMediaAssets(page, snapshot.site, registry, db)
-    const file: CssBundleFile = buildPublishedSiteCssBundle(snapshot.site, registry, page, version, { mediaAssets })[bundleId]
-    if (file.hash === requestedHash) return file.content
-  }
-  // Page-agnostic view (every enabled stylesheet) — covers a hash that
-  // predates a scope change but is still referenced somewhere.
-  const fallbackMediaAssets = snapshot.site.pages[0]
-    ? await prefetchMediaAssets(snapshot.site.pages[0], snapshot.site, registry, db)
-    : undefined
-  const fallback: CssBundleFile = buildPublishedSiteCssBundle(
-    snapshot.site,
-    registry,
-    undefined,
-    version,
-    { mediaAssets: fallbackMediaAssets },
-  )[bundleId]
-  if (fallback.hash === requestedHash) return fallback.content
-
-  return null
-}
-
-function cssResponse(body: BodyInit, hash: string): Response {
-  return new Response(body, {
-    headers: {
-      'content-type': 'text/css; charset=utf-8',
-      'cache-control': 'public, max-age=31536000, immutable',
-      etag: `"${hash}"`,
-    },
   })
 }

--- a/server/siteRoot.ts
+++ b/server/siteRoot.ts
@@ -1,0 +1,207 @@
+/**
+ * The site-root text surface — `/robots.txt` and plugin-claimed
+ * `/<name>.txt` files.
+ *
+ * Both exist because two SEO standards authorize by *file location*, and
+ * neither can be satisfied from a plugin's runtime path
+ * (`/admin/api/cms/plugins/<id>/runtime/...`): the sitemaps.org protocol
+ * scopes a sitemap to its own directory and below, and indexnow.org scopes
+ * a key file the same way. See issue #425.
+ *
+ * Two plugin surfaces, both hook-bus filters (`cms.hooks` permission):
+ *
+ *   • `site.robots`     — the host seeds a default document, plugins add
+ *                         directives (in practice `Sitemap:` URLs), the
+ *                         HOST renders the text. Plugins never write robots
+ *                         syntax, so they cannot inject comments, extra
+ *                         directives, or stray CR/LF.
+ *   • `site.rootFiles`  — plugins claim one root `.txt` path each with its
+ *                         body. The host validates the path against an
+ *                         allowlist pattern and serves the body as inert
+ *                         `text/plain`.
+ *
+ * Ordering in the dispatcher: both handlers sit directly BEFORE
+ * `tryServePublicRoute`, so every host-owned namespace (`/admin/*`,
+ * `/_instatic/*`, `/uploads/*`, `/assets/*` from `dist/`) still wins. They
+ * cannot shadow content either: `pageSlugError` in
+ * `src/core/page-tree/slugs.ts` rejects any slug containing `.`, and a
+ * data-row route needs at least `/<table>/<slug>`, so no published URL can
+ * ever be a root `.txt` path.
+ *
+ * Neither response is baked into the published slot (Layer A). Artefacts
+ * there are `.html` files named from page routes, written wholesale per
+ * publish; these two documents depend on which plugins are active right
+ * now, so a baked copy would keep serving a disabled plugin's sitemap
+ * reference or IndexNow key until the next publish. Same reasoning as the
+ * `no-store` on the signed media redirect in `server/router.ts`.
+ *
+ * The filters run per request rather than behind a memo: the
+ * `hasFiltersFor` short-circuit means a site with no contributing plugin
+ * does zero work, and a memo keyed on registration would go stale when a
+ * plugin's settings change the key it serves.
+ */
+
+import { filterArray } from '@core/utils/typeboxHelpers'
+import { hookBus } from '@core/plugins/hookBus'
+import {
+  MAX_ROBOTS_GROUPS,
+  MAX_ROBOTS_SITEMAPS,
+  MAX_ROOT_FILE_CLAIMS,
+  ROOT_FILE_PATH_PATTERN,
+  RobotsGroupSchema,
+  SiteRootFileSchema,
+  SitemapUrlSchema,
+  type RobotsDocument,
+  type SiteRootFile,
+} from '@core/plugin-sdk'
+
+const ROBOTS_PATH = '/robots.txt'
+const ROBOTS_FILTER = 'site.robots'
+const ROOT_FILES_FILTER = 'site.rootFiles'
+
+/**
+ * Root paths a plugin can never claim. `/robots.txt` is host-managed
+ * through the `site.robots` filter, and letting a plugin claim it as a raw
+ * file would be a second, conflicting way to write the same document.
+ */
+const RESERVED_ROOT_FILE_PATHS: ReadonlySet<string> = new Set([ROBOTS_PATH])
+
+const ROOT_FILE_PATH_RE = new RegExp(ROOT_FILE_PATH_PATTERN)
+
+/**
+ * The document the `site.robots` chain starts from, and the group the host
+ * re-inserts when the filtered document has no valid group left. Permissive
+ * on purpose: it is the same instruction to a crawler that the previous
+ * `/robots.txt` 404 carried (RFC 9309 §2.3.1.3 — an unavailable robots.txt
+ * means "crawl freely"), so adding the file changes no crawler's behaviour
+ * on a site with no plugins.
+ */
+function defaultRobotsDocument(): RobotsDocument {
+  return { groups: [{ userAgent: '*', allow: ['/'], disallow: [] }], sitemaps: [] }
+}
+
+/**
+ * Serialize a validated document. One group per block, `User-agent` first,
+ * then its `disallow` lines, then its `allow` lines; `Sitemap:` lines last
+ * because they are global rather than group-scoped.
+ */
+function renderRobotsTxt(document: RobotsDocument): string {
+  const blocks = document.groups.map((group) =>
+    [
+      `User-agent: ${group.userAgent}`,
+      ...group.disallow.map((path) => `Disallow: ${path}`),
+      ...group.allow.map((path) => `Allow: ${path}`),
+    ].join('\n'),
+  )
+  if (document.sitemaps.length > 0) {
+    blocks.push(document.sitemaps.map((url) => `Sitemap: ${url}`).join('\n'))
+  }
+  return `${blocks.join('\n\n')}\n`
+}
+
+/**
+ * Run the filter chain and keep only what validates. Entries are dropped
+ * one by one (`filterArray`) rather than failing the whole document,
+ * matching how the site document tolerates one corrupt font file — a group
+ * is the validation unit, so a stray `Disallow` drops its group and nothing
+ * else. Sitemap URLs are de-duplicated, first occurrence winning, so two
+ * plugins pushing the same sitemap emit one line.
+ */
+async function buildRobotsDocument(): Promise<RobotsDocument> {
+  const seed = defaultRobotsDocument()
+  if (!hookBus.hasFiltersFor(ROBOTS_FILTER)) return seed
+
+  const filtered = await hookBus.applyFilter<RobotsDocument>(ROBOTS_FILTER, seed)
+  const groups = filterArray(RobotsGroupSchema, filtered.groups).slice(0, MAX_ROBOTS_GROUPS)
+  const sitemaps = [...new Set(filterArray(SitemapUrlSchema, filtered.sitemaps))]
+    .slice(0, MAX_ROBOTS_SITEMAPS)
+  return {
+    // A document with no valid group would render as crawl rules the site
+    // owner never asked for, so the host default stands in.
+    groups: groups.length > 0 ? groups : defaultRobotsDocument().groups,
+    sitemaps,
+  }
+}
+
+/**
+ * Resolve the claimed root files, keyed by path. A path claimed by more
+ * than one handler is dropped and logged: serving one of two IndexNow keys
+ * would silently authorize the wrong submitter, so "refuse and say so" is
+ * the only deterministic answer. `applyFilter` chains handlers opaquely, so
+ * the log names every plugin registered on the filter as the candidates.
+ *
+ * Entries past `MAX_ROOT_FILE_CLAIMS` are discarded, so the accepted set is
+ * bounded no matter how many a handler appends.
+ */
+async function resolveRootFileClaims(): Promise<Map<string, string>> {
+  const filtered = await hookBus.applyFilter(ROOT_FILES_FILTER, { files: [] as SiteRootFile[] })
+  const claims = new Map<string, string>()
+  const contested = new Set<string>()
+  const accepted = filterArray(SiteRootFileSchema, filtered.files).slice(0, MAX_ROOT_FILE_CLAIMS)
+  for (const file of accepted) {
+    if (RESERVED_ROOT_FILE_PATHS.has(file.path)) {
+      console.error(
+        `[siteRoot] root file "${file.path}" is reserved by the host; ignoring the claim. ` +
+          `Registered by one of: ${hookBus.pluginsFor(ROOT_FILES_FILTER).join(', ')}`,
+      )
+      continue
+    }
+    if (claims.has(file.path) || contested.has(file.path)) {
+      contested.add(file.path)
+      claims.delete(file.path)
+      console.error(
+        `[siteRoot] root file "${file.path}" was claimed more than once; refusing to serve it. ` +
+          `Registered by one of: ${hookBus.pluginsFor(ROOT_FILES_FILTER).join(', ')}`,
+      )
+      continue
+    }
+    claims.set(file.path, file.content)
+  }
+  return claims
+}
+
+/**
+ * `text/plain` with the same hardening the published runtime assets get:
+ * `nosniff` so the body can never be re-interpreted as HTML or script, and
+ * a `default-src 'none'` CSP so it stays inert even if a browser navigates
+ * to it directly. `no-store` because the body reflects live plugin state.
+ */
+function textResponse(body: string): Response {
+  return new Response(body, {
+    headers: {
+      'content-type': 'text/plain; charset=utf-8',
+      'cache-control': 'no-store',
+      'x-content-type-options': 'nosniff',
+      'content-security-policy': "default-src 'none'",
+    },
+  })
+}
+
+/**
+ * Serve `/robots.txt`. Always answers for that exact path — the document is
+ * host-managed whether or not a plugin contributes to it.
+ */
+export async function serveRobotsTxt(pathname: string): Promise<Response | null> {
+  if (pathname !== ROBOTS_PATH) return null
+  return textResponse(renderRobotsTxt(await buildRobotsDocument()))
+}
+
+/**
+ * Serve a plugin-claimed root text file, or `null` when the path isn't
+ * claimable or isn't claimed.
+ *
+ * The pathname is matched raw, never percent-decoded: a registered path
+ * cannot contain `%` (the allowlist pattern excludes it), so an encoded
+ * request like `/%2e%2e/key.txt` fails the pattern instead of resolving to
+ * a claim.
+ */
+export async function serveRootFile(pathname: string): Promise<Response | null> {
+  if (!hookBus.hasFiltersFor(ROOT_FILES_FILTER)) return null
+  if (RESERVED_ROOT_FILE_PATHS.has(pathname)) return null
+  if (!ROOT_FILE_PATH_RE.test(pathname)) return null
+
+  const claims = await resolveRootFileClaims()
+  const content = claims.get(pathname)
+  if (content === undefined) return null
+  return textResponse(content)
+}

--- a/src/__tests__/plugins/pluginHookBus.test.ts
+++ b/src/__tests__/plugins/pluginHookBus.test.ts
@@ -83,6 +83,17 @@ describe('hookBus', () => {
     expect(hookBus.hasListenersFor('evt')).toBe(true) // y still registered
     expect(hookBus.hasFiltersFor('pipe')).toBe(false)
   })
+
+  it('pluginsFor lists the plugin ids on a filter, in registration order', () => {
+    hookBus.filter('zeta.x', 'pipe', (v) => v)
+    hookBus.filter('acme.x', 'pipe', (v) => v)
+
+    expect(hookBus.pluginsFor('pipe')).toEqual(['zeta.x', 'acme.x'])
+    expect(hookBus.pluginsFor('unregistered')).toEqual([])
+
+    hookBus.unregisterPlugin('zeta.x')
+    expect(hookBus.pluginsFor('pipe')).toEqual(['acme.x'])
+  })
 })
 
 describe('canonicalPluginEventName', () => {

--- a/src/__tests__/server/siteRoot.test.ts
+++ b/src/__tests__/server/siteRoot.test.ts
@@ -1,0 +1,404 @@
+/**
+ * The site-root text surface (`server/siteRoot.ts`) — issue #425.
+ *
+ * Two plugin surfaces are covered here:
+ *   - `site.robots`    — the host-managed `/robots.txt` document. Plugins
+ *     contribute directives; the HOST renders the text, so the tests pin
+ *     both the rendering and what happens to a contribution the host will
+ *     not accept.
+ *   - `site.rootFiles` — root-level `.txt` claims (the IndexNow key case).
+ *     The tests pin the claimable path allowlist, the reserved paths, and
+ *     the deterministic outcome when two plugins claim one path.
+ *
+ * The last block goes through `handleServerRequest` to pin the dispatcher
+ * ordering: both handlers sit after every host-owned namespace and before
+ * slug resolution, and an unclaimed path still falls through.
+ */
+import { afterEach, describe, expect, it, spyOn } from 'bun:test'
+import { hookBus } from '@core/plugins/hookBus'
+import { MAX_ROOT_FILE_CLAIMS, type RobotsDocument, type SiteRootFiles } from '@core/plugin-sdk'
+import { serveRobotsTxt, serveRootFile } from '../../../server/siteRoot'
+import { handleServerRequest } from '../../../server/router'
+import { createFakeDb } from './dbTestFake'
+
+afterEach(() => {
+  hookBus.reset()
+})
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Register a `site.robots` handler for a plugin id. */
+function onRobots(pluginId: string, fn: (doc: RobotsDocument) => RobotsDocument): void {
+  hookBus.filter(pluginId, 'site.robots', (value) => fn(value as RobotsDocument))
+}
+
+/** Register a `site.rootFiles` handler for a plugin id. */
+function onRootFiles(pluginId: string, fn: (doc: SiteRootFiles) => SiteRootFiles): void {
+  hookBus.filter(pluginId, 'site.rootFiles', (value) => fn(value as SiteRootFiles))
+}
+
+/** Claim one root file, the shape a plugin actually writes. */
+function claim(pluginId: string, path: string, content: string): void {
+  onRootFiles(pluginId, (doc) => {
+    doc.files.push({ path, content })
+    return doc
+  })
+}
+
+async function robotsBody(): Promise<string> {
+  const res = await serveRobotsTxt('/robots.txt')
+  expect(res).not.toBeNull()
+  return await res!.text()
+}
+
+/** The router needs a db only for the setup memo; nothing here queries. */
+function fakeDb() {
+  return createFakeDb(async () => ({ rows: [], rowCount: 0 }))
+}
+
+// ---------------------------------------------------------------------------
+// robots.txt — the host document
+// ---------------------------------------------------------------------------
+
+describe('robots.txt', () => {
+  it('serves the permissive host default when no plugin contributes', async () => {
+    const res = await serveRobotsTxt('/robots.txt')
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(200)
+    expect(await res!.text()).toBe('User-agent: *\nAllow: /\n')
+  })
+
+  it('serves it as inert text/plain that is never cached', async () => {
+    const res = await serveRobotsTxt('/robots.txt')
+    expect(res!.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+    expect(res!.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(res!.headers.get('content-security-policy')).toBe("default-src 'none'")
+    expect(res!.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('claims only its own path', async () => {
+    expect(await serveRobotsTxt('/robots')).toBeNull()
+    expect(await serveRobotsTxt('/about')).toBeNull()
+  })
+
+  it('appends a plugin Sitemap line after the groups', async () => {
+    onRobots('acme.seo', (doc) => {
+      doc.sitemaps.push('https://example.com/sitemap.xml')
+      return doc
+    })
+    expect(await robotsBody()).toBe(
+      'User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n',
+    )
+  })
+
+  it('chains several plugins in registration order and de-duplicates sitemaps', async () => {
+    onRobots('acme.seo', (doc) => {
+      doc.sitemaps.push('https://example.com/a.xml')
+      return doc
+    })
+    onRobots('zeta.seo', (doc) => {
+      doc.sitemaps.push('https://example.com/b.xml', 'https://example.com/a.xml')
+      return doc
+    })
+    expect(await robotsBody()).toBe(
+      'User-agent: *\nAllow: /\n\n' +
+        'Sitemap: https://example.com/a.xml\nSitemap: https://example.com/b.xml\n',
+    )
+  })
+
+  it('renders a contributed group as User-agent, then disallow, then allow', async () => {
+    onRobots('acme.seo', (doc) => {
+      doc.groups.push({ userAgent: 'BadBot', allow: ['/public'], disallow: ['/search'] })
+      return doc
+    })
+    expect(await robotsBody()).toBe(
+      'User-agent: *\nAllow: /\n\nUser-agent: BadBot\nDisallow: /search\nAllow: /public\n',
+    )
+  })
+
+  it('re-inserts the host default group when the filtered document has none', async () => {
+    onRobots('acme.seo', () => ({
+      groups: [],
+      sitemaps: ['https://example.com/sitemap.xml'],
+    }))
+    expect(await robotsBody()).toBe(
+      'User-agent: *\nAllow: /\n\nSitemap: https://example.com/sitemap.xml\n',
+    )
+  })
+
+  it('drops a group whose directives would forge extra robots.txt lines', async () => {
+    onRobots('acme.bad', (doc) => {
+      // A newline in either field would open a second directive block.
+      doc.groups.push({ userAgent: '*\nDisallow: /', allow: [], disallow: [] })
+      doc.groups.push({ userAgent: 'A', allow: [], disallow: ['/x\nDisallow: /'] })
+      // A `#` would turn the rest of the line into a robots.txt comment.
+      doc.groups.push({ userAgent: 'B', allow: [], disallow: ['/x # comment'] })
+      // Paths are anchored at the site root.
+      doc.groups.push({ userAgent: 'C', allow: [], disallow: ['no-leading-slash'] })
+      doc.groups.push({ userAgent: 'GoodBot', allow: [], disallow: ['/search'] })
+      return doc
+    })
+    // A group is validated as a unit, so one bad directive drops the group
+    // it belongs to — never the whole document.
+    expect(await robotsBody()).toBe(
+      'User-agent: *\nAllow: /\n\nUser-agent: GoodBot\nDisallow: /search\n',
+    )
+  })
+
+  it('drops individual sitemap values that carry line breaks', async () => {
+    onRobots('acme.bad', (doc) => {
+      doc.sitemaps.push('https://example.com/ok.xml', 'https://evil\r\nX-Injected: 1')
+      return doc
+    })
+    expect(await robotsBody()).toBe(
+      'User-agent: *\nAllow: /\n\nSitemap: https://example.com/ok.xml\n',
+    )
+  })
+
+  it('drops sitemap values that are not absolute http(s) URLs', async () => {
+    onRobots('acme.bad', (doc) => {
+      doc.sitemaps.push('/sitemap.xml', 'javascript:alert(1)', 'file:///etc/passwd')
+      return doc
+    })
+    expect(await robotsBody()).toBe('User-agent: *\nAllow: /\n')
+  })
+
+  it('keeps the host default when a handler throws', async () => {
+    const errorLog = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      onRobots('acme.bad', () => {
+        throw new Error('boom')
+      })
+      expect(await robotsBody()).toBe('User-agent: *\nAllow: /\n')
+    } finally {
+      errorLog.mockRestore()
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Root text files
+// ---------------------------------------------------------------------------
+
+describe('root text files', () => {
+  it('does nothing when no plugin registers the filter', async () => {
+    expect(await serveRootFile('/abc123.txt')).toBeNull()
+  })
+
+  it('serves a claimed path as inert text/plain', async () => {
+    claim('acme.seo', '/a1b2c3d4.txt', 'a1b2c3d4')
+    const res = await serveRootFile('/a1b2c3d4.txt')
+    expect(res).not.toBeNull()
+    expect(res!.status).toBe(200)
+    expect(await res!.text()).toBe('a1b2c3d4')
+    expect(res!.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+    expect(res!.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(res!.headers.get('content-security-policy')).toBe("default-src 'none'")
+    expect(res!.headers.get('cache-control')).toBe('no-store')
+  })
+
+  it('serves HTML-looking content as text, never as a document', async () => {
+    claim('acme.seo', '/key.txt', '<script>alert(1)</script>')
+    const res = await serveRootFile('/key.txt')
+    expect(res!.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+    expect(res!.headers.get('x-content-type-options')).toBe('nosniff')
+    expect(await res!.text()).toBe('<script>alert(1)</script>')
+  })
+
+  it('returns null for a path nobody claimed', async () => {
+    claim('acme.seo', '/key.txt', 'key')
+    expect(await serveRootFile('/other.txt')).toBeNull()
+  })
+
+  it('matches the claimed path exactly — case-sensitive, no query, no trailing slash', async () => {
+    claim('acme.seo', '/AbC.txt', 'AbC')
+    expect(await serveRootFile('/abc.txt')).toBeNull()
+    expect(await serveRootFile('/AbC.txt/')).toBeNull()
+    expect(await serveRootFile('/AbC.txt')).not.toBeNull()
+  })
+
+  it('refuses claims outside the single-segment .txt allowlist', async () => {
+    for (const path of [
+      '/../secret.txt',
+      '/a/../b.txt',
+      '/nested/key.txt',
+      '/.hidden.txt',
+      '/-leading.txt',
+      '/index.html',
+      '/favicon.svg',
+      '/sitemap.xml',
+      '/key.txt.html',
+      '/',
+      'key.txt',
+    ]) {
+      claim('acme.bad', path, 'payload')
+      expect(await serveRootFile(path)).toBeNull()
+      hookBus.reset()
+    }
+  })
+
+  it('never resolves a percent-encoded request to a claim', async () => {
+    claim('acme.seo', '/key.txt', 'key')
+    // Pathnames arrive un-decoded and a claimable path cannot contain `%`,
+    // so an encoded traversal fails the allowlist instead of matching.
+    expect(await serveRootFile('/%2e%2e%2fkey.txt')).toBeNull()
+    expect(await serveRootFile('/%6bey.txt')).toBeNull()
+  })
+
+  it('refuses a claim on the host-managed /robots.txt and says so', async () => {
+    const errorLog = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      onRootFiles('acme.bad', (doc) => {
+        doc.files.push({ path: '/robots.txt', content: 'User-agent: *\nDisallow: /' })
+        doc.files.push({ path: '/ok.txt', content: 'ok' })
+        return doc
+      })
+      expect(await serveRootFile('/robots.txt')).toBeNull()
+      // Resolving any claimable path surfaces the rejected claim; the
+      // plugin's own file is unaffected.
+      const own = await serveRootFile('/ok.txt')
+      expect(await own!.text()).toBe('ok')
+      expect(errorLog).toHaveBeenCalledWith(
+        '[siteRoot] root file "/robots.txt" is reserved by the host; ignoring the claim. ' +
+          'Registered by one of: acme.bad',
+      )
+    } finally {
+      errorLog.mockRestore()
+    }
+    // The host document is unaffected by the attempted claim.
+    expect(await robotsBody()).toBe('User-agent: *\nAllow: /\n')
+  })
+
+  it('refuses a path two plugins claim, naming the candidates', async () => {
+    const errorLog = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      claim('acme.seo', '/key.txt', 'acme-key')
+      claim('zeta.seo', '/key.txt', 'zeta-key')
+      expect(await serveRootFile('/key.txt')).toBeNull()
+      expect(errorLog).toHaveBeenCalledWith(
+        '[siteRoot] root file "/key.txt" was claimed more than once; refusing to serve it. ' +
+          'Registered by one of: acme.seo, zeta.seo',
+      )
+    } finally {
+      errorLog.mockRestore()
+    }
+  })
+
+  it('keeps the uncontested claims of a plugin that also contests one', async () => {
+    const errorLog = spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      claim('acme.seo', '/shared.txt', 'acme')
+      onRootFiles('zeta.seo', (doc) => {
+        doc.files.push({ path: '/shared.txt', content: 'zeta' })
+        doc.files.push({ path: '/zeta-only.txt', content: 'zeta-only' })
+        return doc
+      })
+      expect(await serveRootFile('/shared.txt')).toBeNull()
+      const own = await serveRootFile('/zeta-only.txt')
+      expect(await own!.text()).toBe('zeta-only')
+    } finally {
+      errorLog.mockRestore()
+    }
+  })
+
+  it('drops content over the 4 KiB cap and keeps the valid claims', async () => {
+    onRootFiles('acme.bad', (doc) => {
+      doc.files.push({ path: '/huge.txt', content: 'x'.repeat(4097) })
+      doc.files.push({ path: '/small.txt', content: 'x'.repeat(4096) })
+      return doc
+    })
+    expect(await serveRootFile('/huge.txt')).toBeNull()
+    expect(await serveRootFile('/small.txt')).not.toBeNull()
+  })
+
+  it('drops content carrying control characters but allows tabs and newlines', async () => {
+    onRootFiles('acme.bad', (doc) => {
+      doc.files.push({ path: '/nul.txt', content: 'key\u0000padding' })
+      doc.files.push({ path: '/esc.txt', content: 'key\u001b[2J' })
+      doc.files.push({ path: '/lines.txt', content: 'line1\nline2\tcol' })
+      return doc
+    })
+    expect(await serveRootFile('/nul.txt')).toBeNull()
+    expect(await serveRootFile('/esc.txt')).toBeNull()
+    const ok = await serveRootFile('/lines.txt')
+    expect(await ok!.text()).toBe('line1\nline2\tcol')
+  })
+
+  it('discards claims past the cap so the accepted set stays bounded', async () => {
+    onRootFiles('acme.bad', (doc) => {
+      for (let i = 0; i < MAX_ROOT_FILE_CLAIMS + 5; i++) {
+        doc.files.push({ path: `/k${i}.txt`, content: `${i}` })
+      }
+      return doc
+    })
+    expect(await serveRootFile('/k0.txt')).not.toBeNull()
+    expect(await serveRootFile(`/k${MAX_ROOT_FILE_CLAIMS - 1}.txt`)).not.toBeNull()
+    expect(await serveRootFile(`/k${MAX_ROOT_FILE_CLAIMS}.txt`)).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Dispatcher ordering
+// ---------------------------------------------------------------------------
+
+describe('site-root files in the dispatcher', () => {
+  it('serves /robots.txt through the router', async () => {
+    const res = await handleServerRequest(new Request('http://localhost/robots.txt'), { db: fakeDb() })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+    expect(await res.text()).toBe('User-agent: *\nAllow: /\n')
+  })
+
+  it('serves a claimed root file through the router', async () => {
+    claim('acme.seo', '/a1b2c3.txt', 'a1b2c3')
+    const res = await handleServerRequest(new Request('http://localhost/a1b2c3.txt'), { db: fakeDb() })
+    expect(res.status).toBe(200)
+    expect(await res.text()).toBe('a1b2c3')
+  })
+
+  it('lets an unclaimed .txt path keep falling through', async () => {
+    claim('acme.seo', '/a1b2c3.txt', 'a1b2c3')
+    const res = await handleServerRequest(new Request('http://localhost/nobody.txt'), { db: fakeDb() })
+    expect(res.status).not.toBe(200)
+  })
+
+  it('does not answer non-GET requests for the site-root paths', async () => {
+    claim('acme.seo', '/a1b2c3.txt', 'a1b2c3')
+    for (const method of ['POST', 'DELETE']) {
+      const robots = await handleServerRequest(
+        new Request('http://localhost/robots.txt', { method }),
+        { db: fakeDb() },
+      )
+      expect(robots.status).toBe(404)
+      const file = await handleServerRequest(
+        new Request('http://localhost/a1b2c3.txt', { method }),
+        { db: fakeDb() },
+      )
+      expect(file.status).toBe(404)
+    }
+  })
+
+  it('answers HEAD the same way it answers GET', async () => {
+    claim('acme.seo', '/a1b2c3.txt', 'a1b2c3')
+    const res = await handleServerRequest(
+      new Request('http://localhost/a1b2c3.txt', { method: 'HEAD' }),
+      { db: fakeDb() },
+    )
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toBe('text/plain; charset=utf-8')
+  })
+
+  it('cannot claim a path inside a host-owned namespace', async () => {
+    // `/admin/...` and `/uploads/...` are claimed by earlier routes, and the
+    // allowlist pattern rejects any path with a second segment anyway.
+    claim('acme.bad', '/uploads/evil.txt', 'payload')
+    expect(await serveRootFile('/uploads/evil.txt')).toBeNull()
+    const res = await handleServerRequest(
+      new Request('http://localhost/admin/api/cms/setup/status'),
+      { db: fakeDb() },
+    )
+    expect(res.headers.get('content-type')).toContain('application/json')
+  })
+})

--- a/src/core/plugin-sdk/index.ts
+++ b/src/core/plugin-sdk/index.ts
@@ -1,6 +1,7 @@
 export * from './types'
 export * from './storageSchemas'
 export * from './contentSchemas'
+export * from './siteRootSchemas'
 export * from './capabilities'
 export * from './guards'
 export * from './modules'

--- a/src/core/plugin-sdk/siteRootSchemas.ts
+++ b/src/core/plugin-sdk/siteRootSchemas.ts
@@ -1,0 +1,128 @@
+/**
+ * TypeBox schemas for the site-root text surface — the host-managed
+ * `/robots.txt` document and the root-level text files plugins can claim.
+ *
+ * These schemas are the source of truth for both `site.*` filter payloads.
+ * All types are derived from them via `Static<>`.
+ *
+ * Used across:
+ *   - `src/core/plugin-sdk/types/hooks.ts` — the `CmsServerFilters` entries
+ *   - `server/siteRoot.ts`                 — host validation + rendering
+ *
+ * Why the payloads are structured rather than raw text: a filter that
+ * returned a finished `robots.txt` string would let one plugin inject
+ * arbitrary lines (comments, `Sitemap:` entries pointing anywhere, stray
+ * CR/LF) that the host has no way to audit. Here the host owns the
+ * serialization and every field carries a pattern, so a plugin can only
+ * contribute values that render to exactly one directive line.
+ */
+
+import { Type, type Static } from '@core/utils/typeboxHelpers'
+
+// ---------------------------------------------------------------------------
+// robots.txt
+// ---------------------------------------------------------------------------
+
+/**
+ * A path prefix for an `Allow:` / `Disallow:` directive. Must start at the
+ * site root and carry no whitespace (which would split the directive line)
+ * and no `#` (which would open a robots.txt comment).
+ */
+export const RobotsPathSchema = Type.String({ pattern: '^/[^\\s#]{0,511}$' })
+
+/**
+ * A `Sitemap:` URL. Absolute by protocol requirement — a sitemap reference
+ * is resolved against the origin, not the robots.txt file.
+ */
+export const SitemapUrlSchema = Type.String({
+  maxLength: 2048,
+  pattern: '^https?://[^\\s#]+$',
+})
+
+/**
+ * Caps on how much one document can carry. The host validates list entries
+ * one by one — a group with a bad `Disallow` is dropped without costing the
+ * plugin its `Sitemap` lines — so these bounds are also what it truncates
+ * the accepted lists to; a hostile handler cannot grow the response without
+ * limit.
+ */
+export const MAX_ROBOTS_GROUPS = 20
+export const MAX_ROBOTS_SITEMAPS = 50
+const MAX_ROBOTS_PATHS_PER_GROUP = 100
+
+/**
+ * One `User-agent` group. The user-agent value is a product token (`*`,
+ * `Googlebot`), so the same no-whitespace / no-comment rule applies.
+ */
+export const RobotsGroupSchema = Type.Object(
+  {
+    userAgent: Type.String({ maxLength: 200, pattern: '^[^\\s#]+$' }),
+    allow: Type.Array(RobotsPathSchema, { maxItems: MAX_ROBOTS_PATHS_PER_GROUP }),
+    disallow: Type.Array(RobotsPathSchema, { maxItems: MAX_ROBOTS_PATHS_PER_GROUP }),
+  },
+  { additionalProperties: false },
+)
+
+export type RobotsGroup = Static<typeof RobotsGroupSchema>
+
+/**
+ * The whole `/robots.txt` document, as the `site.robots` filter sees it.
+ * Handlers mutate and return it; the host renders the result.
+ */
+export const RobotsDocumentSchema = Type.Object(
+  {
+    groups: Type.Array(RobotsGroupSchema, { maxItems: MAX_ROBOTS_GROUPS }),
+    sitemaps: Type.Array(SitemapUrlSchema, { maxItems: MAX_ROBOTS_SITEMAPS }),
+  },
+  { additionalProperties: false },
+)
+
+export type RobotsDocument = Static<typeof RobotsDocumentSchema>
+
+// ---------------------------------------------------------------------------
+// Root-level text files
+// ---------------------------------------------------------------------------
+
+/**
+ * The paths a plugin may claim: one root segment, `.txt` only, no percent
+ * escapes, no dot segments (the leading character class rules out `.` and
+ * `-`). Deliberately narrow — the site root is shared with page slugs,
+ * the admin app, and every reserved namespace, so the claimable surface is
+ * an allowlist rather than a denylist.
+ */
+export const ROOT_FILE_PATH_PATTERN = '^/[A-Za-z0-9][A-Za-z0-9._-]{0,62}\\.txt$'
+
+/** Most claims the host accepts, and the bound it truncates the list to. */
+export const MAX_ROOT_FILE_CLAIMS = 20
+
+/**
+ * A single claimed file. `content` allows tabs and newlines but no other C0
+ * control characters, so the body can never carry NUL padding or terminal
+ * escapes; 4 KiB is well above the largest legitimate case (an IndexNow key
+ * is 8–128 characters).
+ */
+export const SiteRootFileSchema = Type.Object(
+  {
+    path: Type.String({ pattern: ROOT_FILE_PATH_PATTERN }),
+    content: Type.String({
+      maxLength: 4096,
+      pattern: '^[^\\u0000-\\u0008\\u000B\\u000C\\u000E-\\u001F]*$',
+    }),
+  },
+  { additionalProperties: false },
+)
+
+export type SiteRootFile = Static<typeof SiteRootFileSchema>
+
+/**
+ * The claim list, as the `site.rootFiles` filter sees it. Handlers append
+ * their own entries and return it; the host resolves the claims.
+ */
+export const SiteRootFilesSchema = Type.Object(
+  {
+    files: Type.Array(SiteRootFileSchema, { maxItems: MAX_ROOT_FILE_CLAIMS }),
+  },
+  { additionalProperties: false },
+)
+
+export type SiteRootFiles = Static<typeof SiteRootFilesSchema>

--- a/src/core/plugin-sdk/types/hooks.ts
+++ b/src/core/plugin-sdk/types/hooks.ts
@@ -2,6 +2,8 @@
 // CMS server-side hook event surface
 // ---------------------------------------------------------------------------
 
+import type { RobotsDocument, SiteRootFiles } from '../siteRootSchemas'
+
 /**
  * Actor that originated a content mutation. Carried on every
  * `content.entry.*` event so listeners can filter their own writes
@@ -59,6 +61,44 @@ export interface CmsServerFilters {
    * entry id (or `'new'` for create), and the actor.
    */
   'content.entry.cells': Record<string, unknown>
+  /**
+   * The host-managed `/robots.txt` document, run through every registered
+   * handler on each request for that path. The host owns the serialization,
+   * so a handler contributes directives — most often a `Sitemap:` URL —
+   * rather than text:
+   *
+   * ```ts
+   * api.cms.hooks.filter('site.robots', (doc) => {
+   *   doc.sitemaps.push('https://example.com/sitemap.xml')
+   *   return doc
+   * })
+   * ```
+   *
+   * The host seeds the chain with its default `User-agent: *` / `Allow: /`
+   * group, then validates every list entry: a group is accepted or dropped
+   * as a unit (`RobotsGroupSchema`), sitemap URLs one by one, and the
+   * sitemap list is de-duplicated. When the filtered document has no valid
+   * group left the host default one is re-inserted.
+   */
+  'site.robots': RobotsDocument
+  /**
+   * Root-level text files plugins claim, run through every registered
+   * handler on each request for a `/<name>.txt` path. Covers standards
+   * that authorize by file location — the IndexNow key file being the
+   * motivating case:
+   *
+   * ```ts
+   * api.cms.hooks.filter('site.rootFiles', (doc) => {
+   *   doc.files.push({ path: `/${key}.txt`, content: key })
+   *   return doc
+   * })
+   * ```
+   *
+   * Claims are validated against `SiteRootFileSchema`; `/robots.txt` is
+   * reserved for the host, and a path claimed more than once is refused
+   * rather than resolved to an arbitrary winner.
+   */
+  'site.rootFiles': SiteRootFiles
   // Plugin-defined filters fall through.
   [key: string]: unknown
 }

--- a/src/core/plugins/hookBus.ts
+++ b/src/core/plugins/hookBus.ts
@@ -204,6 +204,16 @@ class HookBus {
     return (this.filters.get(name)?.length ?? 0) > 0
   }
 
+  /**
+   * Plugin ids with a handler on a filter pipeline, in registration order.
+   * `applyFilter` chains handlers opaquely, so a host that has to report a
+   * bad contribution (e.g. two plugins claiming the same root file path)
+   * uses this to name the candidates in the log line.
+   */
+  pluginsFor(name: string): string[] {
+    return (this.filters.get(name) ?? []).map((entry) => entry.pluginId)
+  }
+
   // Test-only introspection
   __debug__(): { events: string[]; filters: string[] } {
     return {


### PR DESCRIPTION
## Summary

Closes #425 with Option B.

Two SEO standards authorize by file *location*, and plugin routes mount under
`/admin/api/cms/plugins/<id>/runtime/*`. The sitemaps.org protocol scopes a sitemap to its own
path and below, and indexnow.org scopes a key file the same way — so a plugin can register both
endpoints and have neither take effect. There was no root-level surface at all, and no way to add
a `Sitemap:` line to a `robots.txt` that did not exist.

**`/robots.txt` is now host-managed.** The host serves it whether or not a plugin contributes,
seeding the document with `User-agent: *` / `Allow: /` — the same instruction to a crawler that
the previous 404 already carried (RFC 9309 §2.3.1.3), so no crawler behaviour changes on a site
with no plugins. Plugins contribute *directives*, not text, through a new `site.robots` filter:

```js
api.cms.hooks.filter('site.robots', (doc) => {
  doc.sitemaps.push('https://example.com/sitemap.xml')
  return doc
})
```

The host owns serialization, so a value carrying whitespace, a `#`, or a CR/LF cannot forge an
extra directive line. Handlers chain in registration order; groups are validated as a unit and
sitemap URLs one by one (`filterArray`, the same tolerance as a corrupt font entry); sitemaps are
de-duplicated; the host default group is re-inserted if the filtered document has none left.

**A new `site.rootFiles` filter claims one root `.txt` path per file**, which covers the IndexNow
key:

```js
api.cms.hooks.filter('site.rootFiles', (doc) => {
  doc.files.push({ path: `/${key}.txt`, content: key })
  return doc
})
```

Claimable paths are an allowlist — one root segment, `.txt`, leading alphanumeric — so nested
paths, dot segments, percent escapes and every other extension are rejected, and `/robots.txt`
stays reserved for the host. Bodies are capped at 4 KiB and may not carry C0 control characters
other than tab and newline. **A path claimed by two plugins is served by neither**: resolving it
to one winner would silently authorize the wrong IndexNow submitter. The refusal is logged with
the candidate plugin ids, which is what the new `hookBus.pluginsFor` exists for.

### Design notes

- **No new permission.** Both filters ride `cms.hooks`. `publish.html` already lets a `cms.hooks`
  plugin rewrite every published page, which is strictly more power than serving one inert root
  text file — a separate permission would add a consent line without adding safety, and would
  have required editing the locked `EXPECTED_TARGET_PERMISSIONS` table.
- **Structured payloads, not raw text**, following `media.url.transform`. TypeBox schemas in
  `src/core/plugin-sdk/siteRootSchemas.ts` are the source of truth; every list bound is enforced
  by a host-side `slice` as well as `maxItems`, because `applyFilter` only checks the value's
  runtime type category.
- **Runtime registration, not manifest declaration.** An IndexNow key is generated per install
  and lives in plugin settings, so a static manifest path cannot carry it. Riding `hooks.filter`
  also means `hookBus.unregisterPlugin` already handles teardown on disable, uninstall and crash
  recovery — no new call sites.
- **Dispatcher position:** both handlers sit after every host-owned namespace and before
  `tryServePublicRoute`. They cannot shadow content — `pageSlugError` rejects any page slug
  containing `.`, and a data-row route needs at least `/<table>/<slug>`, so no published URL is
  ever a root `.txt` path. An unclaimed `.txt` path returns null and keeps falling through to the
  site's 404.
- **Not baked into the published slot.** Layer A artefacts are `.html` files named from page
  routes and rewritten wholesale per publish; both of these documents depend on which plugins are
  active *now*, so a baked copy would keep serving a disabled plugin's sitemap line or key file.
  Responses go out `text/plain` with `nosniff`, `default-src 'none'` and `no-store`.

### On the preparatory commit, and PR scope

`server/router.ts` was three lines under the 700-line ceiling `module-size-budgets.test.ts`
enforces, so any new route had to displace something first. The first commit moves `serveSiteCss`
— with its `(bundle, hash)` memo, in-flight de-duplication and published-snapshot rebuild walk —
into `server/publish/siteCssServer.ts`, next to the `siteCssBundle.ts` that builds what it
serves. Verbatim move, no behaviour change, separate commit so it reviews independently.

Flagging this against `AGENTS.md`'s "keep PR scope coherent": the extraction is not opportunistic
cleanup, it is forced by your own size gate, and `AGENTS.md` also says not to justify a workaround
with "to keep this PR small". If you would rather have a `GRANDFATHERED` entry than the
extraction, that swap is trivial and I will make it.

### Security

Every case below has a test in `src/__tests__/server/siteRoot.test.ts`: robots.txt directive
injection via CR/LF; `#` comment smuggling; response-header injection (plugins never supply
headers or raw text); path traversal, raw and percent-encoded (the pathname is matched raw and
never decoded, and a claimable path cannot contain `%`); a plugin claiming `/index.html`,
`/favicon.svg`, `/sitemap.xml` or a host-owned namespace; a plugin hijacking `/robots.txt`; one
plugin stealing another's path; unbounded content size (4 KiB per body, 20 claims, 20 groups, 50
sitemaps, 100 paths per group); control-character and terminal-escape payloads; content-type
confusion (forced `text/plain`, `nosniff`); a `javascript:`/`file:` sitemap URL; a buggy or
throwing plugin emptying robots.txt; and method confusion.

### Known trade-offs

1. **`/robots.txt` returns 200 where it returned 404** — the one intentional behaviour change,
   argued above as a no-op for conforming crawlers. If you disagree, the fix is one line:
   `return null` from `serveRobotsTxt` when `!hasFiltersFor('site.robots')`.
2. **Group-level validation granularity** — one bad `Disallow` drops the whole `User-agent`
   group, not just that line. Matches `filterArray` granularity elsewhere.
3. **No per-entry plugin attribution on conflicts.** `applyFilter` chains handlers opaquely, so
   the duplicate-claim log names all plugins registered on `site.rootFiles` as candidates rather
   than the two actual claimants. This is the one place Option A would genuinely be better.
4. **No memoisation.** Every root `.txt` GET on a site with a `site.rootFiles` plugin costs one
   worker round-trip. A revision-keyed memo would go stale when a plugin's settings change the
   key it serves; reasoning is in the module header.
5. **No Playwright coverage** — the existing e2e specs do not cover public-route serving.

Docs updated in the same change: the filter table and a new "Site-root text files" section in
`docs/features/plugin-system.md`, the route table and ordering notes in `docs/server.md`, and the
module tables in `docs/features/publisher.md`.

## Verification

- [x] `bun run build` — `tsc -b && vite build`, `✓ built in 14.05s`, no type errors
- [x] `bun test` — `6867 pass / 0 fail across 739 files`
- [x] `bun run lint` — clean, exit 0
- [ ] Docker/deployment check — not run; this change adds no config, env var or deployment surface

Baseline on `3a9543ed` was `6818 pass / 1 skip / 0 fail`. The +48 reconciles as +31 new tests here
(30 in `siteRoot.test.ts`, 1 in `pluginHookBus.test.ts`) and +17 from `bundle-size-budgets.test.ts`,
which logs `dist/assets/ missing — bundle gates skipped` on a clean tree and runs its 18 tests once
`bun run build` has produced `dist/`.

One caveat worth stating: a single baseline run before this change failed with a QuickJS
`Aborted(Assertion failed: list_empty(&rt->gc_obj_list))` in the plugin-VM tests. Subsequent runs
were clean, so that flake looks pre-existing and unrelated, but you may already know about it.

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
