### PR TITLE
fix(tests): tolerate CRLF working-tree line endings in freshness and style gates

### DIFF
--- a/scripts/sync-plugin-bootstrap.ts
+++ b/scripts/sync-plugin-bootstrap.ts
@@ -85,7 +85,10 @@ async function bundleEntry(entry: string): Promise<string> {
       `[sync-plugin-bootstrap] expected exactly one output for ${entry}, got ${result.outputs.length}`,
     )
   }
-  return await result.outputs[0].text()
+  const text = await result.outputs[0].text()
+  // Normalize line endings so the emitted artifact (and the in-memory
+  // comparison in the freshness gate) is identical on LF and CRLF checkouts.
+  return text.replace(/\r\n/g, '\n')
 }
 
 /**

--- a/src/__tests__/architecture/plugin-bootstrap-fresh.test.ts
+++ b/src/__tests__/architecture/plugin-bootstrap-fresh.test.ts
@@ -30,7 +30,8 @@ describe('generated plugin bootstrap artifacts', () => {
     for (const { outFile, content } of built) {
       const path = join(GENERATED_DIR, outFile)
       expect(existsSync(path), `missing generated/${outFile}`).toBe(true)
-      const current = readFileSync(path, 'utf8')
+      // Tolerate CRLF working-tree line endings on Windows checkouts.
+      const current = readFileSync(path, 'utf8').replace(/\r\n/g, '\n')
       expect(
         current === content,
         `generated/${outFile} is stale — run \`bun run bootstrap:sync\``,

--- a/src/__tests__/site-explorer/siteExplorerPanel.test.tsx
+++ b/src/__tests__/site-explorer/siteExplorerPanel.test.tsx
@@ -400,7 +400,7 @@ describe('SiteExplorerPanel', () => {
     expect(treeDropCss).toContain('.dropInside')
     expect(css).toContain('.dragOverlayRow')
 
-    const beforeAfterBlock = treeDropCss.match(/\.dropBefore::before,\n\.dropAfter::after,\n\.dropRoot::after,\n\.rootDropGapActive::after\s*\{[^}]*\}/s)?.[0] ?? ''
+    const beforeAfterBlock = treeDropCss.match(/\.dropBefore::before,\r?\n\.dropAfter::after,\r?\n\.dropRoot::after,\r?\n\.rootDropGapActive::after\s*\{[^}]*\}/s)?.[0] ?? ''
     expect(beforeAfterBlock).toContain('position: absolute')
     expect(beforeAfterBlock).not.toMatch(/(?:^|\n)\s*(margin|padding)\b/)
 


### PR DESCRIPTION
On Windows checkouts (autocrlf), three gates compare raw bytes against
line-ending-sensitive patterns and fail spuriously:

```
$ bun test src/__tests__/architecture/plugin-bootstrap-fresh.test.ts
(fail) generated plugin bootstrap artifacts > match a fresh bundle of
      bootstrap/src/ (run `bun run bootstrap:sync` if this fails)
```

Root causes:

- `scripts/sync-plugin-bootstrap.ts` bundles from on-disk sources; on a CRLF
  working tree the CRLFs are carried into the bundle and JSON-escaped, so the
  in-memory artifact diverges from the committed (LF) artifact even with no
  source drift.
- `plugin-bootstrap-fresh.test.ts` compares the committed artifact
  byte-for-byte; a CRLF-checked-out file never equals the LF string.
- `siteExplorerPanel.test.tsx` matches a multi-line CSS selector block with a
  regex that hardcodes `\n` line breaks.

Changes:

- Normalize the bundled text to LF in `bundleEntry` so emitted artifacts stay
  platform-independent (no-op on LF checkouts; committed artifacts unchanged).
- EOL-normalize the file read in the freshness gate.
- Make the CSS block regex use `\r?\n`.

Verified on a Windows / autocrlf checkout: `plugin-bootstrap-fresh` 1 pass,
`siteExplorerPanel` 40/40 pass (was 39 + 1 fail), no prior `bootstrap:sync`,
`git status` clean on `generated/`. `bun run build` + `bun run lint` green.