### PR TITLE
fix(media): route storage upload plans through the SSRF-safe fetch guard

### DIFF
--- a/docs/features/media.md
+++ b/docs/features/media.md
@@ -350,7 +350,7 @@ The redirect handler is `tryServeMediaRedirect` in `server/router.ts`. The redir
 
 ### Register a plugin storage adapter
 
-See [docs/features/plugin-system.md](plugin-system.md). The plugin SDK's `api.cms.media.registerStorageAdapter(adapter)` provides the registration surface and requires `media.storage.adapter`. Adapters declare a `servingMode` and either return public URLs, implement `getReadUrl(storagePath, ttlSeconds)` for signed redirects, or implement `readStream(storagePath)` for proxy reads. The host streams upload bytes to adapter-provided upload plans; ordinary writes do not move media bytes through the QuickJS heap.
+See [docs/features/plugin-system.md](plugin-system.md). The plugin SDK's `api.cms.media.registerStorageAdapter(adapter)` provides the registration surface and requires `media.storage.adapter`. Adapters declare a `servingMode` and either return public URLs, implement `getReadUrl(storagePath, ttlSeconds)` for signed redirects, or implement `readStream(storagePath)` for proxy reads. The host streams upload bytes to adapter-provided upload plans through the DNS-pinned SSRF guard (internal addresses refused on both the read and the write side); ordinary writes do not move media bytes through the QuickJS heap.
 
 ---
 

--- a/docs/features/plugin-system.md
+++ b/docs/features/plugin-system.md
@@ -858,7 +858,7 @@ api.cms.media.registerStorageAdapter({
 })
 ```
 
-Writes are two-phase. The adapter returns a signed upload plan from `beginWrite`; the **host** streams the bytes to the plan URLs; then the adapter confirms with `finalizeWrite`. Media bytes do not cross the QuickJS boundary for ordinary writes, which keeps large uploads out of the VM heap. `servingMode` controls reads: `public-url` emits the adapter URL directly, `signed-redirect` lets the host 302 to a short-lived URL, and `proxy` streams chunks through the host via `readStream`.
+Writes are two-phase. The adapter returns a signed upload plan from `beginWrite`; the **host** streams the bytes to the plan URLs; then the adapter confirms with `finalizeWrite`. The plan URLs are plugin-controlled, so the host streams them through the same DNS-pinned SSRF guard it uses for adapter reads — internal addresses are refused and every redirect hop is re-validated, so `media.storage.adapter` cannot be used as `network.outbound` reach. There is no host allowlist on either side: an object-store endpoint is an arbitrary operator-chosen public host. Media bytes do not cross the QuickJS boundary for ordinary writes, which keeps large uploads out of the VM heap. `servingMode` controls reads: `public-url` emits the adapter URL directly, `signed-redirect` lets the host 302 to a short-lived URL, and `proxy` streams chunks through the host via `readStream`.
 
 #### URL transformers — requires `media.url.transform`
 

--- a/server/handlers/cms/mediaUploadExecutor.ts
+++ b/server/handlers/cms/mediaUploadExecutor.ts
@@ -8,7 +8,12 @@
  *
  *   • `method: 'LOCAL'` (sentinel from `mediaStorageRegistry.LOCAL_DISK_STEP_METHOD`)
  *     → `writeFile` on the local filesystem. The "URL" carries `file://<absolute>`.
- *   • `method: 'PUT' | 'POST'` → `fetch(url, { method, headers, body })`.
+ *   • `method: 'PUT' | 'POST'` → `guardedFetch(url, …)`. The step URL is
+ *     plugin-controlled, so it goes through the SSRF guard exactly like the
+ *     read side (`mediaStorageReader`): internal addresses are refused, the
+ *     connection is pinned to the checked IP, and every redirect hop is
+ *     re-validated. Without this, `media.storage.adapter` would convey
+ *     `network.outbound` reach it never asked for (GHSA-9pq7).
  *     The body is the byte range declared by `step.range` (or the full
  *     buffer when `range` is omitted).
  *
@@ -21,6 +26,7 @@ import { mkdir, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import type { MediaStorageUploadPlan } from '@core/plugin-sdk'
 import { LOCAL_DISK_STEP_METHOD } from '@core/plugins/mediaStorageRegistry'
+import { guardedFetch } from '../../plugins/host/network'
 import { toArrayBuffer } from '../../binary'
 
 export interface StepReceipt {
@@ -70,12 +76,18 @@ async function executeStep(
   // Materialise a fresh ArrayBuffer (not SharedArrayBuffer; not a Uint8Array
   // view past byteLength) so the body slot accepts the value without TS
   // narrowing complaints.
-  const body = toArrayBuffer(bytes)
-  const response = await fetch(step.url, {
-    method: step.method,
-    headers,
-    body,
-  })
+  const body = new Uint8Array(toArrayBuffer(bytes))
+  // `step.url` comes from a storage-adapter plugin's `beginWrite` plan and is
+  // validated for SHAPE only. Route it through the SSRF-safe guard so the
+  // write path cannot reach loopback / private / link-local / metadata
+  // addresses — the read path's sibling gate (GHSA-rmm7, GHSA-9pq7). No host
+  // allowlist: an object-store endpoint is an arbitrary operator-chosen public
+  // host, same as the read side.
+  const response = await guardedFetch(
+    step.url,
+    { method: step.method, headers, body },
+    { label: 'Media storage upload' },
+  )
   if (!response.ok) {
     const text = await response.text().catch(() => '<no body>')
     throw new Error(

--- a/src/__tests__/architecture/media-storage-no-bytes-in-sandbox.test.ts
+++ b/src/__tests__/architecture/media-storage-no-bytes-in-sandbox.test.ts
@@ -53,9 +53,11 @@ describe('media storage — no bytes in sandbox', () => {
 
   it('the host-side executor is the only fetch-with-body site for storage uploads', async () => {
     const executor = await read('server/handlers/cms/mediaUploadExecutor.ts')
-    // The executor must use Bun's native fetch — NOT route through the
-    // QuickJS sandbox bridge.
-    expect(executor).toContain('await fetch(step.url')
+    // The executor must upload host-side — NOT route through the QuickJS
+    // sandbox bridge. The host call goes through `guardedFetch`, the SSRF-safe
+    // wrapper over Bun's native fetch: the plan URL is plugin-controlled, so it
+    // must not be able to reach internal addresses (GHSA-9pq7).
+    expect(executor).toMatch(/await guardedFetch\(\s*step\.url/)
     // No hostCall / QuickJS bridge usage in this file.
     expect(executor).not.toMatch(/__hostCall|callHostApi|quickjsHost/)
   })

--- a/src/__tests__/architecture/plugin-url-ssrf-guard.test.ts
+++ b/src/__tests__/architecture/plugin-url-ssrf-guard.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Architecture gate: every host-side fetch of a PLUGIN-CONTROLLED URL goes
+ * through `guardedFetch`.
+ *
+ * Storage-adapter plugins hand the host URLs to fetch — read URLs from
+ * `publicPath` / `getReadUrl`, write URLs from the `beginWrite` upload plan.
+ * Those URLs are validated for shape, never for target. A raw `fetch()` on any
+ * of them turns the `media.storage.adapter` grant into `network.outbound`
+ * reach it never asked for, and lets a plugin point the server at loopback,
+ * private, link-local, or cloud-metadata addresses.
+ *
+ * This gate exists because that bug was fixed once and shipped incomplete:
+ * GHSA-rmm7 closed the READ path in 0.0.18 and left the WRITE path open, which
+ * came straight back as GHSA-9pq7. Fixing one call site is not fixing the
+ * class. The rule is therefore file-scoped, not call-site-scoped: no bare
+ * global `fetch(` anywhere under `server/handlers/cms/`.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { readdir, readFile } from 'node:fs/promises'
+import { fileURLToPath } from 'node:url'
+import { join, dirname, relative } from 'node:path'
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..')
+const CMS_HANDLERS = join(ROOT, 'server', 'handlers', 'cms')
+
+/**
+ * Bare global `fetch(` — not `guardedFetch(`, not a method call such as
+ * `source.fetch(` or `handler.fetch(`. The lookbehind rejects a preceding
+ * word character (which excludes `guardedFetch`) or a dot (method calls).
+ */
+const BARE_FETCH = /(?<![.\w])fetch\s*\(/
+
+/** Strip comments and string literals so prose and error text can't trip the scan. */
+function stripNonCode(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '')
+    .replace(/`(?:\\.|[^`\\])*`/g, '``')
+    .replace(/'(?:\\.|[^'\\\n])*'/g, "''")
+    .replace(/"(?:\\.|[^"\\\n])*"/g, '""')
+}
+
+async function tsFilesIn(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true, recursive: true })
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith('.ts') && !e.name.endsWith('.test.ts'))
+    .map((e) => join(e.parentPath, e.name))
+}
+
+describe('plugin-controlled URL fetches are SSRF-guarded', () => {
+  it('no CMS handler calls bare global fetch()', async () => {
+    const offenders: string[] = []
+    for (const file of await tsFilesIn(CMS_HANDLERS)) {
+      const code = stripNonCode(await readFile(file, 'utf-8'))
+      if (BARE_FETCH.test(code)) offenders.push(relative(ROOT, file))
+    }
+    expect(offenders).toEqual([])
+  })
+
+  it('the media read path fetches through guardedFetch', async () => {
+    const source = await readFile(join(CMS_HANDLERS, 'mediaStorageReader.ts'), 'utf-8')
+    expect(source).toMatch(/await\s+guardedFetch\(/)
+  })
+
+  it('the media write path fetches through guardedFetch', async () => {
+    const source = await readFile(join(CMS_HANDLERS, 'mediaUploadExecutor.ts'), 'utf-8')
+    expect(source).toMatch(/await\s+guardedFetch\(/)
+    // The plan URL specifically — not some incidental guarded call elsewhere.
+    expect(source).toMatch(/guardedFetch\(\s*step\.url/)
+  })
+})

--- a/src/__tests__/server/mediaUploadSsrf.test.ts
+++ b/src/__tests__/server/mediaUploadSsrf.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { executeUploadPlan } from '../../../server/handlers/cms/mediaUploadExecutor'
+
+/**
+ * GHSA-9pq7: the write-side sibling of GHSA-rmm7.
+ *
+ * A storage-adapter plugin holds `media.storage.adapter`, not
+ * `network.outbound`. Its `beginWrite` returns an upload plan whose step URLs
+ * the host then fetches itself. That plan is validated for SHAPE only, so a
+ * malicious adapter could name any URL — loopback, link-local metadata, a
+ * private LAN service — and the host would issue a PUT/POST at it carrying
+ * plugin-chosen headers and the media bytes. GHSA-rmm7 closed this on the read
+ * path; the write path kept a raw `fetch()` until now.
+ *
+ * The plan URL now goes through the same SSRF guard: internal addresses are
+ * refused before a connection is opened, the connection is pinned to the
+ * checked IP, and every redirect hop is re-validated.
+ */
+describe('media upload plan execution (GHSA-9pq7)', () => {
+  const bytes = new Uint8Array([1, 2, 3, 4])
+
+  function plan(url: string, method: 'PUT' | 'POST' = 'PUT') {
+    return {
+      storagePath: 'asset.png',
+      expiresAt: Date.now() + 60_000,
+      steps: [{ method, url, headers: { 'x-canary': '1' } }],
+    }
+  }
+
+  it('refuses an upload step aimed at cloud metadata', async () => {
+    await expect(
+      executeUploadPlan(plan('http://169.254.169.254/latest/meta-data/'), bytes),
+    ).rejects.toThrow(/blocked address/i)
+  })
+
+  it('refuses an upload step aimed at loopback', async () => {
+    await expect(
+      executeUploadPlan(plan('http://127.0.0.1:8080/probe'), bytes),
+    ).rejects.toThrow(/blocked address/i)
+  })
+
+  it('refuses a POST step aimed at a private LAN address', async () => {
+    await expect(
+      executeUploadPlan(plan('http://192.168.1.1/admin', 'POST'), bytes),
+    ).rejects.toThrow(/blocked address/i)
+  })
+
+  it('refuses a non-canonical IPv6 loopback spelling', async () => {
+    await expect(
+      executeUploadPlan(plan('http://[0:0:0:0:0:0:0:1]:8080/probe'), bytes),
+    ).rejects.toThrow(/blocked address/i)
+  })
+
+  it('refuses a non-HTTP scheme', async () => {
+    await expect(
+      executeUploadPlan(plan('file:///etc/passwd'), bytes),
+    ).rejects.toThrow()
+  })
+})

--- a/src/core/plugins/mediaStorageRegistry.ts
+++ b/src/core/plugins/mediaStorageRegistry.ts
@@ -15,9 +15,11 @@
  * Two-phase upload contract:
  *
  *   1. `adapter.beginWrite(input)` — adapter issues a signed `MediaStorageUploadPlan`.
- *   2. Host streams bytes directly to the URLs in the plan via Bun's
- *      native `fetch` (gated by the same `networkAllowedHosts` allowlist
- *      the sandbox already enforces).
+ *   2. Host streams bytes directly to the URLs in the plan via `guardedFetch`
+ *      — the plan URL is plugin-controlled, so it gets the same SSRF gate the
+ *      read path uses: internal addresses refused, connection pinned to the
+ *      checked IP, every redirect hop re-validated. There is deliberately no
+ *      host allowlist (an object-store endpoint is an arbitrary public host).
  *   3. `adapter.finalizeWrite({ storagePath, uploadReceipts })` — adapter
  *      confirms the upload landed and returns the final shape persisted
  *      on the DB row.


### PR DESCRIPTION
## The bug

A plugin holding only `media.storage.adapter` supplies the step URLs in a media upload plan, and the executor fetched them with a raw `fetch()`. The grant therefore carried `network.outbound` reach it never asked for: arbitrary PUT/POST at loopback, private, link-local, or cloud-metadata addresses, with plugin-chosen headers and the media bytes as the body.

This is the write-side sibling of GHSA-rmm7. That fix guarded the read path in 0.0.18 and left the write path untouched, one call site away.

## The fix

`executeStep` now calls `guardedFetch`, the same guard `mediaStorageReader` uses: internal addresses refused before a connection opens, connection pinned to the validated IP, every redirect hop re-checked. No host allowlist on either side, since an object-store endpoint is an arbitrary operator-chosen public host.

The new architecture gate fails on any bare `fetch(` under `server/handlers/cms/`, not just this call site, because fixing one call site is what let the class reopen. Also corrects the `mediaStorageRegistry` doc comment that asserted a `networkAllowedHosts` gate the code never implemented.

Reported as GHSA-9pq7-m5wf-r7f6.

## Verification

Reproduced against a live loopback listener, before and after:

```
BEFORE  UPLOAD COMPLETED / listener: PUT /probe x-canary=1 bytes=[222,173,190,239]
AFTER   REFUSED: ... "127.0.0.1", which is a blocked address / listener: (none)
bun test   # 6851 pass, 0 fail
bun run build && bun run lint   # clean
```
