### PR TITLE
fix(release): boot compiled server artifacts off the build machine

### DIFF
--- a/docs/deployment/release-workflow.md
+++ b/docs/deployment/release-workflow.md
@@ -87,7 +87,19 @@ then the sharp `.node` — because the Windows loader resolves by-name imports
 from already-loaded modules but never searches a loaded DLL's own directory.
 The C++ DLL is loaded via `kernel32.LoadLibraryW` rather than `bun:ffi`'s
 `dlopen`: it exports only C++-mangled names, which cannot appear in the C
-wrapper `bun:ffi` generates per requested symbol.
+wrapper `bun:ffi` generates per requested symbol. jsdom and one of its
+dependencies resolve their own files at runtime, which works in dev and fails on
+boot inside the binary: jsdom reads `default-stylesheet.css` through `__dirname`
+and resolves its synchronous-XHR worker with `require.resolve` (a compiled
+binary bakes both as the build machine's absolute paths), and css-tree's ESM
+build loads its data through `createRequire(import.meta.url)` (which resolves
+against `/$bunfs`). `scripts/lib/serverArtifactPlugins.ts` inlines the
+stylesheet, drops the worker (the server never issues synchronous XHR), and
+routes `css-tree` to its CJS build, whose requires the bundler embeds.
+`scripts/lib/serverArtifactPlugins.test.ts` compiles the production sanitizer,
+checks the binary for the build machine's `node_modules` path, and boots it
+with `node_modules` reads denied, so a regression fails `bun test` rather than
+a release.
 
 Release notes should link to:
 

--- a/scripts/build-server-artifact.ts
+++ b/scripts/build-server-artifact.ts
@@ -4,8 +4,9 @@
  * `instatic-server-<version>-<platform>.tar.gz` with a sha256 checksums file.
  *
  * These assets let a release run anywhere Bun does, no container needed (a
- * release is "artifact-enabled" when they are present). The compile has two
- * requirements the CLI can't express, so the build goes through `Bun.build`:
+ * release is "artifact-enabled" when they are present). The compile has three
+ * requirements the CLI can't express, so the build goes through `Bun.build`
+ * (plugins in `scripts/lib/serverArtifactPlugins.ts`):
  *
  *  1. `sharp` must resolve to its CJS entry — the ESM entry loads the native
  *     binding via `createRequire(import.meta.url)`, which cannot resolve bare
@@ -14,6 +15,10 @@
  *  2. Every non-target `@img/*` package must be externalized — with all
  *     platforms installed (`bun install --os='*' --cpu='*'`), every
  *     platform's native blobs would otherwise embed into every binary.
+ *  3. jsdom's default stylesheet must be inlined, its sync-XHR worker dropped,
+ *     and css-tree routed to its CJS build — the originals resolve files
+ *     at runtime relative to `__dirname` / `import.meta.url`, which inside a
+ *     compiled binary name the build machine, not `/$bunfs`.
  *
  * Usage:
  *   bun scripts/build-server-artifact.ts [targets...] [--all] [--version <v>]
@@ -25,6 +30,7 @@ import { existsSync, readdirSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
+import { serverArtifactPlugins } from './lib/serverArtifactPlugins'
 
 const ROOT = resolve(import.meta.dir, '..')
 const OUT_DIR = join(ROOT, '.tmp', 'server-artifacts')
@@ -189,7 +195,6 @@ async function compileBinary(target: ArtifactTarget, outfile: string): Promise<v
   await mkdir(ENTRY_DIR, { recursive: true })
   await writeFile(entryPath, entrySource(target), 'utf-8')
 
-  const sharpCjs = join(ROOT, 'node_modules', 'sharp', 'dist', 'index.cjs')
   const external = readdirSync(join(ROOT, 'node_modules', '@img'))
     .filter((name) => name.startsWith('sharp-') && !name.endsWith(`-${sharpTarget(target)}`))
     .flatMap((name) => [`@img/${name}`, `@img/${name}/*`])
@@ -198,14 +203,7 @@ async function compileBinary(target: ArtifactTarget, outfile: string): Promise<v
     entrypoints: [entryPath],
     external,
     compile: { outfile, target: `bun-${target}` },
-    plugins: [
-      {
-        name: 'force-sharp-cjs',
-        setup(build) {
-          build.onResolve({ filter: /^sharp$/ }, () => ({ path: sharpCjs }))
-        },
-      },
-    ],
+    plugins: serverArtifactPlugins(ROOT),
   })
   if (!result.success) {
     throw new Error(`Compile failed for ${target}:\n${result.logs.join('\n')}`)

--- a/scripts/lib/serverArtifactPlugins.test.ts
+++ b/scripts/lib/serverArtifactPlugins.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, describe, expect, it } from 'bun:test'
+import { realpathSync } from 'node:fs'
+import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve, sep } from 'node:path'
+import { serverArtifactPlugins } from './serverArtifactPlugins'
+
+const ROOT = resolve(import.meta.dir, '../..')
+// Under `.tmp/` like the real compile entry, so `@core/*` paths resolve the same way.
+const WORK_DIR = join(ROOT, '.tmp', 'server-artifact-plugins-test')
+
+// Boots the production sanitizer the way `server/index.ts` does, with one addition:
+// reading any `node_modules` path throws. Inside a compiled binary such a read can only
+// mean a build-machine path was baked in, and on the build machine that read would
+// otherwise succeed and hide the defect, which is how v0.0.19 shipped unbootable.
+const ENTRY = `
+import fs from 'node:fs'
+const readFileSync = fs.readFileSync
+fs.readFileSync = ((path, ...rest) => {
+  if (String(path).includes('node_modules')) throw new Error('compiled binary read a build-machine path: ' + path)
+  return readFileSync(path, ...rest)
+}) as typeof fs.readFileSync
+await import('../../server/richtextSanitizer')
+const { sanitizeRichtext } = await import('../../src/core/sanitize')
+console.log(JSON.stringify(sanitizeRichtext('<p>kept</p><img src=x onerror=alert(1)><script>alert(1)</script>')))
+`
+
+describe('serverArtifactPlugins', () => {
+  afterAll(() => rm(WORK_DIR, { recursive: true, force: true }))
+
+  it("compiles a server binary that boots the jsdom sanitizer without the build machine's files", async () => {
+    await mkdir(WORK_DIR, { recursive: true })
+    const entry = join(WORK_DIR, 'entry.ts')
+    const outfile = join(WORK_DIR, 'sanitizer-binary')
+    await writeFile(entry, ENTRY, 'utf-8')
+
+    const build = await Bun.build({
+      entrypoints: [entry],
+      compile: { outfile, target: `bun-${process.platform}-${process.arch}` },
+      plugins: serverArtifactPlugins(ROOT),
+    })
+    expect(build.logs.map(String)).toEqual([])
+    expect(build.success).toBe(true)
+
+    // Structural check first: no absolute path into the build machine's
+    // `node_modules` may survive into the binary. `require.resolve` bake-ins
+    // bypass `fs`, so the boot below passes them on the build machine, where
+    // the path exists; this catches them anywhere.
+    // The real location: bake-ins carry resolved paths, and a worktree's
+    // `node_modules` is a symlink into the main checkout.
+    const buildNodeModules = Buffer.from(realpathSync(join(ROOT, 'node_modules')) + sep)
+    const binary = Buffer.from(await Bun.file(outfile).arrayBuffer())
+    const bakedAt = binary.indexOf(buildNodeModules)
+    if (bakedAt !== -1) {
+      throw new Error(`build-machine path baked into the binary: ${binary.subarray(Math.max(0, bakedAt - 80), bakedAt + 160).toString()}`)
+    }
+
+    // Run from an unrelated cwd: the binary must carry everything it needs.
+    const run = Bun.spawnSync({ cmd: [outfile], cwd: tmpdir(), stdout: 'pipe', stderr: 'pipe' })
+    const stderr = run.stderr.toString()
+    if (run.exitCode !== 0) throw new Error(`compiled sanitizer exited ${run.exitCode}:\n${stderr}`)
+
+    const sanitized = JSON.parse(run.stdout.toString().trim()) as string
+    expect(sanitized).toContain('<p>kept</p>')
+    expect(sanitized).not.toContain('<script')
+    expect(sanitized).not.toContain('onerror')
+  }, 60_000)
+})

--- a/scripts/lib/serverArtifactPlugins.ts
+++ b/scripts/lib/serverArtifactPlugins.ts
@@ -1,0 +1,133 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import type { BunPlugin } from 'bun'
+
+/**
+ * Bundler plugins for the compiled server binary (`scripts/build-server-artifact.ts`).
+ *
+ * A `bun build --compile` binary is one bundled file under `/$bunfs/root`, and
+ * two things stop being true for code inside it: `__dirname` is rewritten to a
+ * string literal naming the source directory on the *build machine*, and
+ * `createRequire(import.meta.url)` resolves against `/$bunfs`, where there is
+ * no `node_modules`. A dependency that reads one of its own files at runtime
+ * through either route works in dev and dies on boot everywhere the artifact
+ * actually runs. v0.0.19, the first release to ship artifacts, could not start
+ * on any machine for this reason. The compile step is what changes those
+ * semantics, so it is also where they are repaired: at bundle time each such
+ * read is replaced with the file's contents, redirected to a build of the
+ * package that has none, or, for a worker the server never uses, removed.
+ *
+ * Every rewrite throws when its anchor is missing, so a dependency upgrade that
+ * moves or removes a read fails the release build rather than the next boot.
+ * `serverArtifactPlugins.test.ts` compiles the production sanitizer with these
+ * plugins, checks the binary for the build machine's `node_modules` path, and
+ * boots it with `node_modules` reads denied.
+ */
+export function serverArtifactPlugins(root: string): BunPlugin[] {
+  return [forceSharpCjs(root), forceCssTreeCjs(root), inlineJsdomDefaultStylesheet(), disableJsdomSyncXhrWorker()]
+}
+
+/**
+ * `sharp`'s ESM entry loads its native binding via `createRequire(import.meta.url)`,
+ * which cannot resolve bare specifiers inside a compiled binary. The CJS entry
+ * uses literal `require()` calls the bundler embeds.
+ */
+function forceSharpCjs(root: string): BunPlugin {
+  const sharpCjs = join(root, 'node_modules', 'sharp', 'dist', 'index.cjs')
+  return {
+    name: 'force-sharp-cjs',
+    setup(build) {
+      build.onResolve({ filter: /^sharp$/ }, () => ({ path: sharpCjs }))
+    },
+  }
+}
+
+/**
+ * `jsdom/lib/jsdom/living/css/helpers/computed-style.js` reads the UA stylesheet
+ * with `fs.readFileSync(path.resolve(__dirname, "../../../browser/default-stylesheet.css"))`
+ * at module load. Bundled, `__dirname` is the build machine's absolute path, so
+ * the binary boots only where it was built. Inline the 12 KB file instead.
+ */
+function inlineJsdomDefaultStylesheet(): BunPlugin {
+  const read = /fs\.readFileSync\(\s*path\.resolve\(__dirname,\s*"([^"]+)"\),\s*\{\s*encoding:\s*"utf-8"\s*\}\s*\)/
+  return {
+    name: 'inline-jsdom-default-stylesheet',
+    setup(build) {
+      build.onLoad({ filter: /[\\/]jsdom[\\/]lib[\\/]jsdom[\\/]living[\\/]css[\\/]helpers[\\/]computed-style\.js$/ }, (args) => {
+        const source = readFileSync(args.path, 'utf-8')
+        const match = read.exec(source)
+        if (!match) {
+          throw new Error(
+            `${args.path} no longer reads its stylesheet through __dirname; update inlineJsdomDefaultStylesheet in scripts/lib/serverArtifactPlugins.ts`,
+          )
+        }
+        const stylesheet = readFileSync(resolve(dirname(args.path), match[1]), 'utf-8')
+        return { contents: source.replace(read, JSON.stringify(stylesheet)), loader: 'js' }
+      })
+    },
+  }
+}
+
+/**
+ * css-tree's ESM build (`lib/`, which `@asamuzakjp/dom-selector` imports) loads
+ * its data files through `createRequire(import.meta.url)` in `data.js`,
+ * `data-patch.js`, and `version.js`. The bundler cannot follow those, and at
+ * runtime they resolve against `/$bunfs`, so the binary fails on every machine,
+ * the build machine included. The CJS build (`cjs/`) uses literal `require()`
+ * calls the bundler embeds, so every `css-tree` specifier is routed to the
+ * `require` target of its export map, the same treatment `sharp` gets above.
+ */
+function forceCssTreeCjs(root: string): BunPlugin {
+  const pkgDir = join(root, 'node_modules', 'css-tree')
+  const exportsMap = (JSON.parse(readFileSync(join(pkgDir, 'package.json'), 'utf-8')) as { exports: Record<string, string | { require?: string }> }).exports
+  return {
+    name: 'force-css-tree-cjs',
+    setup(build) {
+      build.onResolve({ filter: /^css-tree(\/.*)?$/ }, (args) => {
+        const subpath = args.path === 'css-tree' ? '.' : `.${args.path.slice('css-tree'.length)}`
+        const entry = exportsMap[subpath]
+        const target = typeof entry === 'string' ? entry : entry?.require
+        if (!target) {
+          throw new Error(
+            `css-tree's export map has no require target for ${args.path}; update forceCssTreeCjs in scripts/lib/serverArtifactPlugins.ts`,
+          )
+        }
+        return { path: join(pkgDir, target) }
+      })
+    },
+  }
+}
+
+/**
+ * `jsdom/lib/jsdom/living/xhr/XMLHttpRequest-impl.js` resolves the worker behind
+ * synchronous XHR with `require.resolve("./xhr-sync-worker.js")` at module load.
+ * Bundled, that is the worker's absolute path on the build machine, resolved
+ * again at boot from `/$bunfs`, which throws everywhere else. The server never
+ * issues synchronous XHR (DOMPurify only parses), so the path becomes null and
+ * the worker constructor a clear error rather than a dependency on the build
+ * machine's disk.
+ */
+function disableJsdomSyncXhrWorker(): BunPlugin {
+  const resolveWorker = 'require.resolve("./xhr-sync-worker.js")'
+  const newWorker = 'new Worker(syncWorkerFile)'
+  return {
+    name: 'disable-jsdom-sync-xhr-worker',
+    setup(build) {
+      build.onLoad({ filter: /[\\/]jsdom[\\/]lib[\\/]jsdom[\\/]living[\\/]xhr[\\/]XMLHttpRequest-impl\.js$/ }, (args) => {
+        const source = readFileSync(args.path, 'utf-8')
+        if (!source.includes(resolveWorker) || !source.includes(newWorker)) {
+          throw new Error(
+            `${args.path} no longer resolves its sync-XHR worker as expected; update disableJsdomSyncXhrWorker in scripts/lib/serverArtifactPlugins.ts`,
+          )
+        }
+        const contents = source
+          .replace(resolveWorker, 'null')
+          .replace(
+            newWorker,
+            '(() => { throw new Error("Synchronous XMLHttpRequest is not available inside the compiled Instatic server binary") })()',
+          )
+        return { contents, loader: 'js' }
+      })
+    },
+  }
+}


### PR DESCRIPTION
## Summary

Every `instatic-server-0.0.19-*` artifact exits 1 on startup: `ENOENT` for `/Users/runner/work/Instatic/Instatic/node_modules/jsdom/lib/jsdom/browser/default-stylesheet.css`. It is the first release with artifacts, so Instatic Desktop installs of it never start.

`bun build --compile` bakes `__dirname` as the build machine's path and resolves `createRequire(import.meta.url)` against `/$bunfs`, breaking three reads in jsdom's graph: the stylesheet, css-tree's ESM data loaders, and jsdom's sync-XHR worker `require.resolve`. The compile plugins (`scripts/lib/serverArtifactPlugins.ts`) inline the stylesheet, route css-tree to its CJS build, and drop the worker path; each throws when its anchor moves. The test compiles the production sanitizer, rejects a binary containing the build machine's `node_modules` path, and boots it with those reads denied. esbuild's `__dirname` is baked too but only matters at publish time; left for its own change.

## Verification

- [x] `bun run build` clean
- [x] `bun test`: 6844 pass; 8 unrelated tests timed out on a loaded machine and pass in isolation on this branch and on main
- [x] `bun run lint` clean
- [x] `bun run release:server-artifacts darwin-arm64` boots with `node_modules` hidden (`sandbox-exec`); the test fails with any one plugin removed

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
