### PR TITLE
fix(release): ship esbuild's binary inside the server artifact

### DIFF
--- a/docs/deployment/release-workflow.md
+++ b/docs/deployment/release-workflow.md
@@ -99,7 +99,12 @@ routes `css-tree` to its CJS build, whose requires the bundler embeds.
 `scripts/lib/serverArtifactPlugins.test.ts` compiles the production sanitizer,
 checks the binary for the build machine's `node_modules` path, and boots it
 with `node_modules` reads denied, so a regression fails `bun test` rather than
-a release.
+a release. esbuild, which the publisher runs at publish time, spawns a Go
+binary it locates relative to `__dirname`; the artifact embeds the target's
+binary, extracts it at boot to a per-version temp directory
+(`scripts/lib/serverArtifactRuntime.ts`), and points `ESBUILD_BINARY_PATH` at
+it. The compile itself fails if the finished binary still contains the build
+machine's `node_modules` path.
 
 Release notes should link to:
 

--- a/scripts/build-server-artifact.ts
+++ b/scripts/build-server-artifact.ts
@@ -4,7 +4,7 @@
  * `instatic-server-<version>-<platform>.tar.gz` with a sha256 checksums file.
  *
  * These assets let a release run anywhere Bun does, no container needed (a
- * release is "artifact-enabled" when they are present). The compile has three
+ * release is "artifact-enabled" when they are present). The compile has four
  * requirements the CLI can't express, so the build goes through `Bun.build`
  * (plugins in `scripts/lib/serverArtifactPlugins.ts`):
  *
@@ -19,6 +19,11 @@
  *     and css-tree routed to its CJS build — the originals resolve files
  *     at runtime relative to `__dirname` / `import.meta.url`, which inside a
  *     compiled binary name the build machine, not `/$bunfs`.
+ *  4. esbuild's Go binary must be embedded and extracted at boot, with
+ *     `ESBUILD_BINARY_PATH` pointing at it: esbuild otherwise locates the
+ *     binary relative to `__dirname`. After compiling, the binary is scanned
+ *     for this machine's `node_modules` path and the build fails if any
+ *     survived.
  *
  * Usage:
  *   bun scripts/build-server-artifact.ts [targets...] [--all] [--version <v>]
@@ -26,10 +31,10 @@
  * Targets: darwin-arm64 | darwin-x64 | linux-x64 (default: host platform).
  * Cross-target builds need `bun install --os='*' --cpu='*'` first.
  */
-import { existsSync, readdirSync } from 'node:fs'
+import { existsSync, readdirSync, readFileSync, realpathSync } from 'node:fs'
 import { spawnSync } from 'node:child_process'
 import { cp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { basename, join, resolve, sep } from 'node:path'
 import { serverArtifactPlugins } from './lib/serverArtifactPlugins'
 
 const ROOT = resolve(import.meta.dir, '..')
@@ -39,8 +44,8 @@ const ENTRY_DIR = join(ROOT, '.tmp')
 const SUPPORTED_TARGETS = ['darwin-arm64', 'darwin-x64', 'linux-x64', 'windows-x64'] as const
 type ArtifactTarget = (typeof SUPPORTED_TARGETS)[number]
 
-/** npm platform suffix for `@img/sharp-*` packages (windows is `win32` there). */
-function sharpTarget(target: ArtifactTarget): string {
+/** npm platform suffix for `@img/sharp-*` and `@esbuild/*` packages (windows is `win32` there). */
+function npmPlatform(target: ArtifactTarget): string {
   return target === 'windows-x64' ? 'win32-x64' : target
 }
 
@@ -83,10 +88,10 @@ async function resolveVersion(explicit: string | null): Promise<string> {
 
 /** libvips binary filename inside the sharp platform package is versioned — discover it. */
 function findLibvips(target: ArtifactTarget): { pkgDir: string; file: string } {
-  const pkgDir = join(ROOT, 'node_modules', '@img', `sharp-libvips-${sharpTarget(target)}`, 'lib')
+  const pkgDir = join(ROOT, 'node_modules', '@img', `sharp-libvips-${npmPlatform(target)}`, 'lib')
   if (!existsSync(pkgDir)) {
     throw new Error(
-      `Missing @img/sharp-libvips-${sharpTarget(target)}. Cross-target builds need: bun install --os='*' --cpu='*'`,
+      `Missing @img/sharp-libvips-${npmPlatform(target)}. Cross-target builds need: bun install --os='*' --cpu='*'`,
     )
   }
   const file = readdirSync(pkgDir).find((name) => name.startsWith('libvips-cpp.'))
@@ -107,7 +112,21 @@ function findWindowsDlls(): { base: string; cpp: string } {
   return { base, cpp }
 }
 
+/** esbuild's Go binary for a target; embedded and extracted at boot (see serverArtifactRuntime.ts). */
+function findEsbuildBinary(target: ArtifactTarget): { file: string; version: string } {
+  const file = target === 'windows-x64' ? 'esbuild.exe' : 'bin/esbuild'
+  if (!existsSync(join(ROOT, 'node_modules', '@esbuild', npmPlatform(target), file))) {
+    throw new Error(`Missing @esbuild/${npmPlatform(target)}. Cross-target builds need: bun install --os='*' --cpu='*'`)
+  }
+  const pkg = JSON.parse(readFileSync(join(ROOT, 'node_modules', 'esbuild', 'package.json'), 'utf-8')) as { version: string }
+  return { file, version: pkg.version }
+}
+
 function entrySource(target: ArtifactTarget): string {
+  const esbuild = findEsbuildBinary(target)
+  const esbuildEmbed = `// @ts-expect-error file embed
+import esbuildBinaryPath from '../node_modules/@esbuild/${npmPlatform(target)}/${esbuild.file}' with { type: 'file' }`
+  const esbuildInstall = `await installEsbuildBinary(esbuildBinaryPath, '${esbuild.version}', '${basename(esbuild.file)}')`
   if (target === 'windows-x64') {
     const { base, cpp } = findWindowsDlls()
     const libvipsVersion = /^libvips-cpp-(.+)\.dll$/.exec(cpp)?.[1] ?? cpp
@@ -119,39 +138,20 @@ function entrySource(target: ArtifactTarget): string {
 // (and never searches the loaded DLL's own directory), so preload
 // bottom-up: ${base} ← ${cpp} ← sharp.node. Extraction is per-libvips
 // version and tolerant of a sibling server holding the same DLLs mapped
-// (writing to a mapped DLL is a sharing violation).
+// (extraction lives in scripts/lib/serverArtifactRuntime.ts).
 // @ts-expect-error file embed
 import libvipsBasePath from '../node_modules/@img/sharp-win32-x64/lib/${base}' with { type: 'file' }
 // @ts-expect-error file embed
 import libvipsCppPath from '../node_modules/@img/sharp-win32-x64/lib/${cpp}' with { type: 'file' }
+${esbuildEmbed}
 import { dlopen, ptr } from 'bun:ffi'
-import { mkdirSync, renameSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { extractEmbeddedFile, installEsbuildBinary } from '../scripts/lib/serverArtifactRuntime'
 
 const libDir = join(tmpdir(), 'instatic-native', '${libvipsVersion}')
-mkdirSync(libDir, { recursive: true })
-
-async function extractDll(name: string, embedded: string): Promise<string> {
-  const target = join(libDir, name)
-  const source = Bun.file(embedded)
-  const existing = Bun.file(target)
-  if ((await existing.exists()) && existing.size === source.size) return target
-  const tmp = target + '.' + process.pid + '.tmp'
-  try {
-    await Bun.write(tmp, source)
-    renameSync(tmp, target)
-  } catch (err) {
-    rmSync(tmp, { force: true })
-    // A running sibling server holds the same-version DLL mapped; the file
-    // on disk is identical, so load it as-is.
-    if (!(await existing.exists())) throw err
-  }
-  return target
-}
-
-const baseDll = await extractDll('${base}', libvipsBasePath)
-const cppDll = await extractDll('${cpp}', libvipsCppPath)
+const baseDll = await extractEmbeddedFile(libDir, '${base}', libvipsBasePath)
+const cppDll = await extractEmbeddedFile(libDir, '${cpp}', libvipsCppPath)
 // Belt-and-braces: PATH is the loader's fallback should a preload be bypassed.
 process.env.PATH = libDir + ';' + (process.env.PATH ?? '')
 dlopen(baseDll, { vips_version: { args: ['i32'], returns: 'i32' } })
@@ -167,37 +167,47 @@ if (!kernel32.symbols.LoadLibraryW(ptr(cppDllWide))) {
   throw new Error('Failed to load ' + cppDll)
 }
 require('@img/sharp-win32-x64/sharp.node')
+${esbuildInstall}
 await import('../server/index.ts')
 `
   }
   const { file: libvipsFile } = findLibvips(target)
   return `// GENERATED by scripts/build-server-artifact.ts — compile entry for ${target}.
 // Embeds libvips, preloads it via dlopen (the .node's loader dependency is
-// then satisfied in-process), embeds the sharp native binding, then boots
-// the server. See the script header for why this wrapper exists.
+// then satisfied in-process), embeds the sharp native binding, extracts
+// esbuild's binary, then boots the server. See the script header for why
+// this wrapper exists.
 // @ts-expect-error file embed
 import libvipsPath from '../node_modules/@img/sharp-libvips-${target}/lib/${libvipsFile}' with { type: 'file' }
+${esbuildEmbed}
 import { dlopen } from 'bun:ffi'
+import { installEsbuildBinary } from '../scripts/lib/serverArtifactRuntime'
 dlopen(libvipsPath, { vips_version: { args: ['i32'], returns: 'i32' } })
 require('@img/sharp-${target}/sharp.node')
+${esbuildInstall}
 await import('../server/index.ts')
 `
 }
 
 async function compileBinary(target: ArtifactTarget, outfile: string): Promise<void> {
-  const sharpNative = join(ROOT, 'node_modules', '@img', `sharp-${sharpTarget(target)}`)
+  const sharpNative = join(ROOT, 'node_modules', '@img', `sharp-${npmPlatform(target)}`)
   if (!existsSync(sharpNative)) {
     throw new Error(
-      `Missing @img/sharp-${sharpTarget(target)}. Cross-target builds need: bun install --os='*' --cpu='*'`,
+      `Missing @img/sharp-${npmPlatform(target)}. Cross-target builds need: bun install --os='*' --cpu='*'`,
     )
   }
   const entryPath = join(ENTRY_DIR, `server-artifact-entry-${target}.ts`)
   await mkdir(ENTRY_DIR, { recursive: true })
   await writeFile(entryPath, entrySource(target), 'utf-8')
 
-  const external = readdirSync(join(ROOT, 'node_modules', '@img'))
-    .filter((name) => name.startsWith('sharp-') && !name.endsWith(`-${sharpTarget(target)}`))
-    .flatMap((name) => [`@img/${name}`, `@img/${name}/*`])
+  const external = [
+    ...readdirSync(join(ROOT, 'node_modules', '@img'))
+      .filter((name) => name.startsWith('sharp-') && !name.endsWith(`-${npmPlatform(target)}`))
+      .flatMap((name) => [`@img/${name}`, `@img/${name}/*`]),
+    ...readdirSync(join(ROOT, 'node_modules', '@esbuild'))
+      .filter((name) => name !== npmPlatform(target))
+      .flatMap((name) => [`@esbuild/${name}`, `@esbuild/${name}/*`]),
+  ]
 
   const result = await Bun.build({
     entrypoints: [entryPath],
@@ -207,6 +217,18 @@ async function compileBinary(target: ArtifactTarget, outfile: string): Promise<v
   })
   if (!result.success) {
     throw new Error(`Compile failed for ${target}:\n${result.logs.join('\n')}`)
+  }
+
+  // No absolute path into this machine's node_modules may survive into the
+  // binary: it would resolve only here. The same check runs in
+  // serverArtifactPlugins.test.ts; this one guards the release build.
+  const buildNodeModules = Buffer.from(realpathSync(join(ROOT, 'node_modules')) + sep)
+  const binary = Buffer.from(await Bun.file(outfile).arrayBuffer())
+  const bakedAt = binary.indexOf(buildNodeModules)
+  if (bakedAt !== -1) {
+    throw new Error(
+      `${target}: build-machine path baked into the binary: ${binary.subarray(Math.max(0, bakedAt - 80), bakedAt + 160).toString()}`,
+    )
   }
 }
 

--- a/scripts/lib/serverArtifactPlugins.test.ts
+++ b/scripts/lib/serverArtifactPlugins.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from 'bun:test'
-import { realpathSync } from 'node:fs'
+import { readFileSync, realpathSync } from 'node:fs'
 import { mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve, sep } from 'node:path'
@@ -8,61 +8,102 @@ import { serverArtifactPlugins } from './serverArtifactPlugins'
 const ROOT = resolve(import.meta.dir, '../..')
 // Under `.tmp/` like the real compile entry, so `@core/*` paths resolve the same way.
 const WORK_DIR = join(ROOT, '.tmp', 'server-artifact-plugins-test')
+const HOST = `bun-${process.platform}-${process.arch}`
+const ESBUILD_PACKAGE = `${process.platform === 'win32' ? 'win32' : process.platform}-${process.arch}`
+const ESBUILD_FILE = process.platform === 'win32' ? 'esbuild.exe' : 'bin/esbuild'
+const ESBUILD_VERSION = (JSON.parse(readFileSync(join(ROOT, 'node_modules', 'esbuild', 'package.json'), 'utf-8')) as { version: string }).version
 
-// Boots the production sanitizer the way `server/index.ts` does, with one addition:
-// reading any `node_modules` path throws. Inside a compiled binary such a read can only
-// mean a build-machine path was baked in, and on the build machine that read would
-// otherwise succeed and hide the defect, which is how v0.0.19 shipped unbootable.
-const ENTRY = `
+// Every entry starts like this: reading any `node_modules` path throws. Inside a
+// compiled binary such a read can only mean a build-machine path was baked in, and
+// on the build machine that read would otherwise succeed and hide the defect, which
+// is how v0.0.19 shipped unbootable.
+const DENY_NODE_MODULES = `
 import fs from 'node:fs'
 const readFileSync = fs.readFileSync
 fs.readFileSync = ((path, ...rest) => {
   if (String(path).includes('node_modules')) throw new Error('compiled binary read a build-machine path: ' + path)
   return readFileSync(path, ...rest)
 }) as typeof fs.readFileSync
-await import('../../server/richtextSanitizer')
-const { sanitizeRichtext } = await import('../../src/core/sanitize')
-console.log(JSON.stringify(sanitizeRichtext('<p>kept</p><img src=x onerror=alert(1)><script>alert(1)</script>')))
 `
+
+/**
+ * Compile `source` with the artifact plugins, reject any binary that still
+ * contains this machine's `node_modules` path, then run it from an unrelated
+ * cwd and return its stdout. The structural check comes first because
+ * `require.resolve` bake-ins bypass `fs` and would pass the run here, where
+ * the path exists.
+ */
+async function compileAndRun(name: string, source: string): Promise<string> {
+  await mkdir(WORK_DIR, { recursive: true })
+  const entry = join(WORK_DIR, `${name}.ts`)
+  const outfile = join(WORK_DIR, `${name}-binary`)
+  await writeFile(entry, source, 'utf-8')
+
+  const build = await Bun.build({
+    entrypoints: [entry],
+    compile: { outfile, target: HOST },
+    plugins: serverArtifactPlugins(ROOT),
+  })
+  expect(build.logs.map(String)).toEqual([])
+  expect(build.success).toBe(true)
+
+  // Bake-ins carry resolved paths, and a worktree's `node_modules` is a symlink.
+  const buildNodeModules = Buffer.from(realpathSync(join(ROOT, 'node_modules')) + sep)
+  const binary = Buffer.from(await Bun.file(outfile).arrayBuffer())
+  const bakedAt = binary.indexOf(buildNodeModules)
+  if (bakedAt !== -1) {
+    throw new Error(`build-machine path baked into ${name}: ${binary.subarray(Math.max(0, bakedAt - 80), bakedAt + 160).toString()}`)
+  }
+
+  const run = Bun.spawnSync({ cmd: [outfile], cwd: tmpdir(), stdout: 'pipe', stderr: 'pipe' })
+  if (run.exitCode !== 0) throw new Error(`${name} exited ${run.exitCode}:\n${run.stderr.toString()}`)
+  return run.stdout.toString().trim()
+}
 
 describe('serverArtifactPlugins', () => {
   afterAll(() => rm(WORK_DIR, { recursive: true, force: true }))
 
   it("compiles a server binary that boots the jsdom sanitizer without the build machine's files", async () => {
-    await mkdir(WORK_DIR, { recursive: true })
-    const entry = join(WORK_DIR, 'entry.ts')
-    const outfile = join(WORK_DIR, 'sanitizer-binary')
-    await writeFile(entry, ENTRY, 'utf-8')
-
-    const build = await Bun.build({
-      entrypoints: [entry],
-      compile: { outfile, target: `bun-${process.platform}-${process.arch}` },
-      plugins: serverArtifactPlugins(ROOT),
-    })
-    expect(build.logs.map(String)).toEqual([])
-    expect(build.success).toBe(true)
-
-    // Structural check first: no absolute path into the build machine's
-    // `node_modules` may survive into the binary. `require.resolve` bake-ins
-    // bypass `fs`, so the boot below passes them on the build machine, where
-    // the path exists; this catches them anywhere.
-    // The real location: bake-ins carry resolved paths, and a worktree's
-    // `node_modules` is a symlink into the main checkout.
-    const buildNodeModules = Buffer.from(realpathSync(join(ROOT, 'node_modules')) + sep)
-    const binary = Buffer.from(await Bun.file(outfile).arrayBuffer())
-    const bakedAt = binary.indexOf(buildNodeModules)
-    if (bakedAt !== -1) {
-      throw new Error(`build-machine path baked into the binary: ${binary.subarray(Math.max(0, bakedAt - 80), bakedAt + 160).toString()}`)
-    }
-
-    // Run from an unrelated cwd: the binary must carry everything it needs.
-    const run = Bun.spawnSync({ cmd: [outfile], cwd: tmpdir(), stdout: 'pipe', stderr: 'pipe' })
-    const stderr = run.stderr.toString()
-    if (run.exitCode !== 0) throw new Error(`compiled sanitizer exited ${run.exitCode}:\n${stderr}`)
-
-    const sanitized = JSON.parse(run.stdout.toString().trim()) as string
+    const stdout = await compileAndRun('sanitizer', `${DENY_NODE_MODULES}
+await import('../../server/richtextSanitizer')
+const { sanitizeRichtext } = await import('../../src/core/sanitize')
+console.log(JSON.stringify(sanitizeRichtext('<p>kept</p><img src=x onerror=alert(1)><script>alert(1)</script>')))
+`)
+    const sanitized = JSON.parse(stdout) as string
     expect(sanitized).toContain('<p>kept</p>')
     expect(sanitized).not.toContain('<script')
     expect(sanitized).not.toContain('onerror')
   }, 60_000)
+
+  it("compiles a server binary that bundles site runtime scripts without the build machine's files", async () => {
+    // The same preamble the artifact entry generates: embed esbuild's binary
+    // and extract it before anything imports esbuild. A module script drives
+    // esbuild.build, a classic script drives the esbuild.transform syntax check.
+    const stdout = await compileAndRun('runtime-scripts', `// @ts-expect-error file embed
+import esbuildBinaryPath from '../../node_modules/@esbuild/${ESBUILD_PACKAGE}/${ESBUILD_FILE}' with { type: 'file' }
+import { installEsbuildBinary } from '../../scripts/lib/serverArtifactRuntime'
+${DENY_NODE_MODULES}
+await installEsbuildBinary(esbuildBinaryPath, '${ESBUILD_VERSION}', '${ESBUILD_FILE.split('/').pop()}')
+const { DEFAULT_SCRIPT_RUNTIME_CONFIG } = await import('../../src/core/site-runtime')
+const { createDefaultSiteExplorerOrganization, DEFAULT_SITE_SETTINGS } = await import('../../src/core/page-tree')
+const { buildSiteRuntimeScripts } = await import('../../server/publish/runtime/bundleScripts')
+const page = { id: 'page-1', slug: 'index', title: 'Index', rootNodeId: 'root', nodes: { root: { id: 'root', moduleId: 'base.body', props: {}, children: [], breakpointOverrides: {}, classIds: [], locked: false, hidden: false } } }
+const file = (id, path, content) => ({ id, path, type: 'script', content, createdAt: 1, updatedAt: 1 })
+const site = {
+  id: 'site-1', name: 'Artifact Test Site', pages: [page], visualComponents: [], layouts: [],
+  breakpoints: [{ id: 'desktop', label: 'Desktop', width: 1440, icon: 'monitor' }],
+  settings: structuredClone(DEFAULT_SITE_SETTINGS), styleRules: {},
+  files: [file('app', 'assets/js/app.js', 'export const answer = 6 * 7; console.log(answer)'), file('legacy', 'assets/js/legacy.js', 'window.legacy = 1')],
+  explorer: createDefaultSiteExplorerOrganization(), packageJson: { dependencies: {}, devDependencies: {} },
+  runtime: { dependencyLock: { version: 1, packages: {}, updatedAt: 0 }, styles: {}, scripts: { app: { ...DEFAULT_SCRIPT_RUNTIME_CONFIG }, legacy: { ...DEFAULT_SCRIPT_RUNTIME_CONFIG, format: 'classic' } } },
+  createdAt: 1, updatedAt: 1,
+}
+const result = await buildSiteRuntimeScripts({ site, page, target: 'publish', assetBasePath: '/_instatic/assets/version-1/' })
+console.log(JSON.stringify({ errors: result.diagnostics.filter((d) => d.severity === 'error'), formats: result.runtimeAssets.scripts.map((s) => s.format).sort(), files: result.files.map((f) => f.path) }))
+`)
+    const built = JSON.parse(stdout) as { errors: unknown[]; formats: string[]; files: string[] }
+    expect(built.errors).toEqual([])
+    expect(built.formats).toEqual(['classic', 'module'])
+    expect(built.files.some((path) => path.includes('entries/'))).toBe(true)
+  }, 120_000)
 })

--- a/scripts/lib/serverArtifactPlugins.ts
+++ b/scripts/lib/serverArtifactPlugins.ts
@@ -24,7 +24,13 @@ import type { BunPlugin } from 'bun'
  * boots it with `node_modules` reads denied.
  */
 export function serverArtifactPlugins(root: string): BunPlugin[] {
-  return [forceSharpCjs(root), forceCssTreeCjs(root), inlineJsdomDefaultStylesheet(), disableJsdomSyncXhrWorker()]
+  return [
+    forceSharpCjs(root),
+    forceCssTreeCjs(root),
+    inlineJsdomDefaultStylesheet(),
+    disableJsdomSyncXhrWorker(),
+    relocateEsbuildEntry(),
+  ]
 }
 
 /**
@@ -126,6 +132,35 @@ function disableJsdomSyncXhrWorker(): BunPlugin {
             newWorker,
             '(() => { throw new Error("Synchronous XMLHttpRequest is not available inside the compiled Instatic server binary") })()',
           )
+        return { contents, loader: 'js' }
+      })
+    },
+  }
+}
+
+/**
+ * `esbuild/lib/main.js` checks that it still lives at `esbuild/lib/main.js`
+ * and, without `ESBUILD_BINARY_PATH`, looks for its Go binary relative to
+ * `__dirname`. Bundled, both names are the build machine's absolute paths.
+ * The artifact entry sets `ESBUILD_BINARY_PATH` to an extracted copy
+ * (`serverArtifactRuntime.ts`), so those paths are never followed; rewriting
+ * them to fixed `/$bunfs` locations keeps esbuild's own location check true
+ * and leaves no build-machine path in the binary.
+ */
+function relocateEsbuildEntry(): BunPlugin {
+  return {
+    name: 'relocate-esbuild-entry',
+    setup(build) {
+      build.onLoad({ filter: /[\\/]esbuild[\\/]lib[\\/]main\.js$/ }, (args) => {
+        const source = readFileSync(args.path, 'utf-8')
+        if (!source.includes('process.env.ESBUILD_BINARY_PATH') || !/\b__dirname\b/.test(source) || !/\b__filename\b/.test(source)) {
+          throw new Error(
+            `${args.path} no longer locates its binary as expected; update relocateEsbuildEntry in scripts/lib/serverArtifactPlugins.ts`,
+          )
+        }
+        const contents = source
+          .replace(/\b__filename\b/g, () => '"/$bunfs/root/node_modules/esbuild/lib/main.js"')
+          .replace(/\b__dirname\b/g, () => '"/$bunfs/root/node_modules/esbuild/lib"')
         return { contents, loader: 'js' }
       })
     },

--- a/scripts/lib/serverArtifactRuntime.ts
+++ b/scripts/lib/serverArtifactRuntime.ts
@@ -1,0 +1,48 @@
+/**
+ * Code that runs inside the compiled server binary before the server boots.
+ * Kept out of the generated compile entry so the artifact and its test share
+ * one implementation.
+ *
+ * Two native pieces cannot be used straight from the binary's embedded files:
+ * the Windows loader resolves libvips DLLs by name, and esbuild spawns its Go
+ * binary as a child process. Both need a real file on disk. Extraction goes
+ * to a per-version directory under the OS temp dir, is idempotent across
+ * restarts, and tolerates a running sibling server that already holds the
+ * same file (rewriting a mapped DLL is a sharing violation on Windows).
+ */
+import { chmodSync, mkdirSync, renameSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+export async function extractEmbeddedFile(dir: string, name: string, embedded: string, mode?: number): Promise<string> {
+  mkdirSync(dir, { recursive: true })
+  const target = join(dir, name)
+  const source = Bun.file(embedded)
+  const existing = Bun.file(target)
+  if ((await existing.exists()) && existing.size === source.size) return target
+  const tmp = `${target}.${process.pid}.tmp`
+  try {
+    await Bun.write(tmp, source)
+    if (mode !== undefined) chmodSync(tmp, mode)
+    renameSync(tmp, target)
+  } catch (err) {
+    rmSync(tmp, { force: true })
+    // A sibling process holds the same version of this file; it is identical
+    // on disk, so use it as is.
+    if (!(await existing.exists())) throw err
+  }
+  return target
+}
+
+/**
+ * esbuild locates its Go binary relative to `__dirname` unless
+ * `ESBUILD_BINARY_PATH` names one. Inside the compiled server `__dirname` is
+ * the build machine's path, so the binary is embedded at compile time and
+ * extracted here. Must run before anything imports `esbuild`: the package
+ * reads the variable at module load.
+ */
+export async function installEsbuildBinary(embedded: string, version: string, fileName: string): Promise<void> {
+  const dir = join(tmpdir(), 'instatic-native', `esbuild-${version}`)
+  const mode = fileName.endsWith('.exe') ? undefined : 0o755
+  process.env.ESBUILD_BINARY_PATH = await extractEmbeddedFile(dir, fileName, embedded, mode)
+}


### PR DESCRIPTION
## Summary

esbuild locates its Go binary relative to `__dirname`, which a compiled binary bakes as the build machine's path. In an artifact install the publisher could not start the bundler, so publishing a site with runtime scripts would fail. Boot was fixed in #524; this is the publish-time half.

The compile entry now embeds the target's esbuild binary, extracts it at boot to a per-version temp directory (`scripts/lib/serverArtifactRuntime.ts`, which the Windows DLL extraction now shares), and sets `ESBUILD_BINARY_PATH` before the server loads. esbuild's entry module is rewritten so no build-machine path remains, and `build-server-artifact.ts` fails the build if the finished binary contains this machine's `node_modules` path. A second test case compiles `buildSiteRuntimeScripts` with the same preamble and bundles a module and a classic script with `node_modules` reads denied.

## Verification

- [x] `bun run build` clean
- [x] `bun test` 6853 pass, 0 fail (100 s)
- [x] `bun run lint` clean
- [x] `bun run release:server-artifacts darwin-arm64` passes its own scan, boots with `node_modules` hidden, extracts esbuild 0.28.0 at boot; both tests fail with the relocation or the env var removed

## Checklist

- [x] Tests cover behavior changes.
- [x] Docs were updated when behavior, config, deployment, or public surfaces changed.
- [x] No compatibility shim was added for old pre-release behavior.
- [x] No secrets, local databases, uploads, or generated artifacts are included.
