### PR TITLE
fix(dev): refuse Bun older than 1.4.1 instead of hanging the editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ What comes out the other end is plain HTML and compact CSS, all the way down. No
 
 ## Quick start
 
-You need [Bun](https://bun.sh). Nothing else. The default dev setup runs on SQLite, so there are no extra services to stand up.
+You need [Bun](https://bun.sh) 1.4.1 or newer (`bun upgrade` if yours is older; `bun run dev` refuses an older one because its Vite proxy needs that release to forward the editor's WebSocket). Nothing else. The default dev setup runs on SQLite, so there are no extra services to stand up.
 
 ```sh
 git clone https://github.com/corebunch/instatic.git

--- a/docs/deployment/vps.md
+++ b/docs/deployment/vps.md
@@ -205,6 +205,8 @@ docker compose -f compose.prod.yml -f compose.sqlite.yml up -d
 
 ## Without Docker (Direct Bun Install)
 
+This is the one install path that uses your own Bun. Keep it inside `engines.bun` in `package.json` (`>=1.4.0 <1.5.0` for this release): the Docker image and the Desktop server bundle carry that Bun themselves, and it is the only one releases are built and tested on. Bun does not enforce the range, so the server checks it at boot (`server/bunVersion.ts`) and logs `[server] Bun <version> is outside the supported range …` before continuing; `bun run dev` refuses a Bun older than 1.4.1 outright, because its Vite proxy needs that release to forward the editor's WebSocket. `bun upgrade` moves an older install forward.
+
 The CMS runs directly on the host without Docker. From a source checkout:
 
 ```sh

--- a/docs/server.md
+++ b/docs/server.md
@@ -8,7 +8,7 @@ The server is a single `Bun.serve` process that boots the DB, runs migrations, a
 
 ## TL;DR
 
-- **Entrypoint:** `server/index.ts` (boots DB → migrations → role sync → plugin activation → `Bun.serve`).
+- **Entrypoint:** `server/index.ts` (boots DB → migrations → role sync → plugin activation → `Bun.serve`). Its first act is `unsupportedBunWarning(Bun.version)` from `server/bunVersion.ts`: when the runtime is outside `SUPPORTED_BUN_RANGE` (a constant mirroring `engines.bun`, gated by `bunVersion.test.ts`) it logs one `[server]` warning and boots anyway. The dev launchers use the same module's `devStackBunError` and refuse a Bun older than 1.4.1.
 - **Router:** `server/router.ts` — ordered route table, first-match wins. Each route is a `tryServeX(req, runtime, url, pathname)` function returning `Response | null`.
 - **CMS API:** every `/admin/api/cms/*` request goes through `server/handlers/cms/index.ts`, which runs a CSRF origin check and dispatches to per-resource handler groups.
 - **Auth:** session cookie (`SESSION_COOKIE_NAME`) → `findUserBySessionHash` → `requireCapability(req, db, 'site.read')`. Every state-changing handler starts with one of these guards.

--- a/scripts/dev.ts
+++ b/scripts/dev.ts
@@ -30,6 +30,7 @@
 import { mkdir } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { isSqliteUrl } from '../server/db'
+import { devStackBunError } from '../server/bunVersion'
 import { bunCommand, viteCommand } from './lib/bunCommand'
 import { ensureDependencies } from './lib/ensureDependencies'
 import { ensurePortFree } from './lib/freePort'
@@ -209,6 +210,11 @@ async function waitForPostgresReady(timeoutMs = 60_000): Promise<void> {
 }
 
 // --- main -----------------------------------------------------------------
+
+// Refuse before touching anything: on a Bun older than the Vite proxy needs,
+// the stack comes up looking healthy and the editor never connects.
+const bunError = devStackBunError(Bun.version)
+if (bunError) fail(bunError)
 
 if (isSqliteUrl(DATABASE_URL)) {
   const dbPath = DATABASE_URL.replace(/^sqlite:|^file:/, '')

--- a/scripts/e2e-dev.ts
+++ b/scripts/e2e-dev.ts
@@ -15,6 +15,7 @@
 import { mkdir, rm } from 'node:fs/promises'
 import { bunCommand, viteCommand } from './lib/bunCommand'
 import { ensureDependencies } from './lib/ensureDependencies'
+import { devStackBunError } from '../server/bunVersion'
 
 const DATABASE_PATH = './.tmp/e2e-agent.db'
 const UPLOADS_DIR = './.tmp/e2e-uploads'
@@ -24,6 +25,12 @@ const VITE_PORT = process.env.E2E_VITE_PORT ?? '5174'
 // Same guard as `bun run dev`: Playwright starts this stack right after a
 // `git pull`, and a stale node_modules would otherwise surface as a CMS crash
 // on its first import instead of a missing install.
+const bunError = devStackBunError(Bun.version)
+if (bunError) {
+  console.error(`[e2e-dev] ${bunError}`)
+  process.exit(1)
+}
+
 await ensureDependencies((msg) => console.error(`[e2e-dev] ${msg}`))
 
 await mkdir('./.tmp', { recursive: true })

--- a/server/bunVersion.ts
+++ b/server/bunVersion.ts
@@ -1,0 +1,51 @@
+/**
+ * Which Bun this server is built and tested on, and what to do when it runs
+ * on something else.
+ *
+ * Every documented install path carries its own runtime: the Docker image is
+ * built `FROM oven/bun:<version>` and the Desktop server artifact is a
+ * `bun build --compile` binary with Bun embedded. Only a direct install
+ * (`bun run server/index.ts` on the operator's machine) uses whatever Bun is
+ * on PATH, and nothing in Bun enforces `engines.bun`, so this module is where
+ * the range is checked at runtime.
+ *
+ * `SUPPORTED_BUN_RANGE` duplicates `engines.bun` from package.json on purpose:
+ * the compiled artifact ships without package.json. `bunVersion.test.ts`
+ * keeps the two identical.
+ */
+import { lt as semverLt, satisfies as semverSatisfies } from 'semver'
+
+/** Mirrors `engines.bun` in package.json (gated by `bunVersion.test.ts`). */
+export const SUPPORTED_BUN_RANGE = '>=1.4.0 <1.5.0'
+
+/**
+ * The oldest Bun `bun run dev` accepts. 1.4.1 fixed the `node:http` upgrade
+ * and socket-lifecycle bugs the Vite dev proxy relies on (`ws: true` on
+ * `/admin/api` in vite.config.ts); on an older Bun the editor's collab socket
+ * hangs in CONNECTING forever with nothing in the log, which is why the dev
+ * launchers refuse to start instead of letting that happen.
+ */
+export const DEV_STACK_MIN_BUN = '1.4.1'
+
+/**
+ * The production server keeps booting on an unsupported Bun; a direct install
+ * must not go down over a version skew. It logs this line once so the
+ * operator finds the cause in the supervisor log, not by bisecting a bug.
+ */
+export function unsupportedBunWarning(version: string): string | null {
+  if (semverSatisfies(version, SUPPORTED_BUN_RANGE, { includePrerelease: true })) return null
+  return (
+    `[server] Bun ${version} is outside the supported range ${SUPPORTED_BUN_RANGE}. ` +
+    'Instatic starts anyway, but releases are built and tested inside that range; ' +
+    'run `bun upgrade` to move to a supported Bun.'
+  )
+}
+
+/** The dev launchers exit on this message instead of starting a stack whose editor cannot connect. */
+export function devStackBunError(version: string): string | null {
+  if (!semverLt(version, DEV_STACK_MIN_BUN)) return null
+  return (
+    `Bun ${version} is too old for the dev stack: the Vite proxy forwards the editor's ` +
+    `WebSocket, which needs Bun ${DEV_STACK_MIN_BUN} or newer. Run \`bun upgrade\` and start again.`
+  )
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -6,6 +6,12 @@ import { readServerConfig } from './config'
 import { DEV_ORIGIN_ALLOWLIST, configurePublicOrigins, configureTrustedProxyCidrs, stampSocketIp } from './auth/security'
 import { applySecurityHeaders } from './securityHeaders'
 import { startConversationPurgeTick } from './ai/boot'
+import { unsupportedBunWarning } from './bunVersion'
+
+// Before anything that could fail for a version-related reason, say which
+// Bun this is when it is not one a release was tested on. Boot continues.
+const bunWarning = unsupportedBunWarning(Bun.version)
+if (bunWarning) console.warn(bunWarning)
 
 await import('./richtextSanitizer')
 const { handleServerRequest } = await import('./router')

--- a/src/__tests__/devWorkflow.test.ts
+++ b/src/__tests__/devWorkflow.test.ts
@@ -134,3 +134,22 @@ describe('development workflow', () => {
     expect(compose).toContain('image: postgres:16')
   })
 })
+
+describe('Bun version guard wiring', () => {
+  // The guard is worthless unless every launcher actually calls it, and the
+  // server must only warn: a direct install must keep serving on an old Bun.
+  it('both dev launchers refuse an old Bun before starting anything', () => {
+    for (const script of ['scripts/dev.ts', 'scripts/e2e-dev.ts']) {
+      const src = readSiteFile(script)
+      expect(src).toContain("from '../server/bunVersion'")
+      expect(src).toContain('devStackBunError(Bun.version)')
+    }
+  })
+
+  it('the server logs the unsupported-Bun warning and boots anyway', () => {
+    const src = readSiteFile('server/index.ts')
+    expect(src).toContain('unsupportedBunWarning(Bun.version)')
+    expect(src).toContain('console.warn(bunWarning)')
+    expect(src).not.toContain('devStackBunError')
+  })
+})

--- a/src/__tests__/server/bunVersion.test.ts
+++ b/src/__tests__/server/bunVersion.test.ts
@@ -1,0 +1,48 @@
+/**
+ * The runtime version guard.
+ *
+ * Nothing in Bun enforces `engines.bun`, so the server and the dev launchers
+ * check `Bun.version` themselves. The server only warns (a direct install must
+ * keep serving across a version skew); `bun run dev` refuses, because on a Bun
+ * older than the Vite proxy needs the editor's socket hangs with no error.
+ */
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { satisfies } from 'semver'
+import {
+  DEV_STACK_MIN_BUN,
+  SUPPORTED_BUN_RANGE,
+  devStackBunError,
+  unsupportedBunWarning,
+} from '../../../server/bunVersion'
+
+describe('Bun version guard', () => {
+  it('the server constant mirrors engines.bun in package.json', () => {
+    const pkg = JSON.parse(readFileSync('package.json', 'utf8')) as { engines: { bun: string } }
+    expect(SUPPORTED_BUN_RANGE).toBe(pkg.engines.bun)
+  })
+
+  it('the dev-stack minimum sits inside the supported range', () => {
+    expect(satisfies(DEV_STACK_MIN_BUN, SUPPORTED_BUN_RANGE)).toBe(true)
+  })
+
+  it('the server stays quiet on a supported Bun and warns outside the range', () => {
+    expect(unsupportedBunWarning('1.4.2')).toBeNull()
+    expect(unsupportedBunWarning('1.4.9-canary.3')).toBeNull()
+    const old = unsupportedBunWarning('1.3.11')
+    expect(old).toContain('Bun 1.3.11')
+    expect(old).toContain(SUPPORTED_BUN_RANGE)
+    expect(old).toContain('bun upgrade')
+    expect(unsupportedBunWarning('1.5.0')).not.toBeNull()
+  })
+
+  it('the dev launchers refuse anything older than the Vite proxy fix', () => {
+    expect(devStackBunError('1.4.1')).toBeNull()
+    expect(devStackBunError('1.4.2')).toBeNull()
+    // Inside engines.bun, but before the node:http upgrade fix: still refused.
+    expect(devStackBunError('1.4.0')).toContain('1.4.1')
+    const old = devStackBunError('1.3.11')
+    expect(old).toContain('Bun 1.3.11')
+    expect(old).toContain('bun upgrade')
+  })
+})


### PR DESCRIPTION
## The bug

After #503 the dev stack needs Bun 1.4.1 (the Vite proxy now forwards the editor's WebSocket), but nothing enforces `engines.bun`. On Bun 1.3.x `bun run dev` comes up looking healthy and the editor's collab socket hangs in CONNECTING with no error. No doc stated a Bun version either.

## The fix

`server/bunVersion.ts` holds the supported range (mirrors `engines.bun`, gated by a test) and the dev-stack minimum. `bun run dev` and `bun run e2e:dev` exit with a one-line message on an older Bun before touching ports or dependencies. The server logs one `[server]` warning outside the range and boots anyway: a direct install must not go down over a version skew. Docker images and Desktop bundles carry their own Bun and are unaffected. The README, `vps.md`, and `server.md` now state the requirement.

## Verification

```
bun test                         # 6866 pass, 0 fail (Bun 1.4.2)
bun run build && bun run lint    # clean (Bun 1.4.2)
bun run dev         (Bun 1.3.11) # exits 1: "Bun 1.3.11 is too old for the dev stack ..."
bun server/index.ts (Bun 1.3.11) # logs the warning, then Listening; GET / -> 302
```
